### PR TITLE
docs: apply CCPP documentation to build tab

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,18 @@
+/*
+ * Concern: AppFrameView
+ * Layer: View
+ * BuildIndex: 01.00
+ * AttachesTo: [data-anchor="app-frame"]
+ * Responsibility: Skin the global frame and expose accessible theming affordances.
+ * Invariants: Frame fills viewport, theme toggle maintains focus treatment.
+ */
+
+/* [Section 01.10] FrameSurface
+ * Purpose: Establish full-viewport shell and default color variables.
+ * Inputs: CSS custom properties, body theme variables
+ * Outputs: App frame layout styling
+ * Constraints: Maintain responsive fill and readable contrast.
+ */
 [data-anchor="app-frame"] {
   height: 100vh;
   font-family: sans-serif;
@@ -6,6 +21,12 @@
   position: relative;
 }
 
+/* [Section 01.20] ThemeToggle
+ * Purpose: Position and style the theme toggle control.
+ * Inputs: App frame positioning context
+ * Outputs: Styled toggle button
+ * Constraints: Keep focus ring visible and button discoverable.
+ */
 [data-anchor="theme-toggle"] {
   position: absolute;
   top: 0.5rem;
@@ -24,6 +45,12 @@
   outline-offset: 2px;
 }
 
+/* [Section 01.30] DarkThemeVariables
+ * Purpose: Override design tokens when dark mode is active.
+ * Inputs: body.dark class
+ * Outputs: Alternate CSS custom property values
+ * Constraints: Preserve adequate contrast with base text.
+ */
 body.dark {
   --app-surface: #0f172a;
   --app-foreground: #e2e8f0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,20 @@
+/**
+ * Concern: AppFrame
+ * Layer: Build
+ * BuildIndex: 01.00
+ * AttachesTo: #root
+ * Responsibility: Provide the top-level frame and theme toggle that hosts Calculogic tabs.
+ * Invariants: Body class mirrors theme state, Build tab is always mounted.
+ */
 import { useEffect, useState } from 'react';
 import BuildTab from './tabs/BuildTab';
 import './App.css';
+
+// [Section 01.10] ThemeState
+// Purpose: Derive and persist the user's dark-mode preference.
+// Inputs: prefers-color-scheme media query, toggle intent
+// Outputs: dark boolean state, body class mutation
+// Constraints: Never flicker on first paint; body mutation stays side-effect only.
 
 export default function App() {
   const [dark, setDark] = useState(() =>
@@ -15,6 +29,11 @@ export default function App() {
     setDark(prev => !prev);
   }
 
+  // [Section 01.20] BuilderHost
+  // Purpose: Expose anchors for downstream layers and render the Build tab shell.
+  // Inputs: dark state, toggle handler
+  // Outputs: App frame structure, theme toggle control
+  // Constraints: Theme toggle remains accessible, Build tab stays mounted for routing simplicity.
   return (
     <div data-anchor="app-frame">
       <button

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,18 @@
-/* Reset and global styles */
+/*
+ * Concern: GlobalReset
+ * Layer: View
+ * BuildIndex: 00.00
+ * AttachesTo: html, body, #root
+ * Responsibility: Provide a predictable baseline for the SPA container.
+ * Invariants: Box-sizing remains border-box, root stretches full viewport height.
+ */
+
+/* [Section 00.10] DocumentBaseline
+ * Purpose: Normalize root element sizing and typography defaults.
+ * Inputs: Browser UA stylesheet
+ * Outputs: Global reset rules
+ * Constraints: Preserve 100% height for layout primitives.
+ */
 body, html {
   margin: 0;
   padding: 0;
@@ -7,6 +21,12 @@ body, html {
   font-family: sans-serif;
 }
 
+/* [Section 00.20] RootContainer
+ * Purpose: Ensure the React root participates in flex layouts consistently.
+ * Inputs: Document baseline rules
+ * Outputs: Flex column root container
+ * Constraints: Keep height 100% for downstream full-height layouts.
+ */
 #root {
   height: 100%;
   display: flex;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,21 @@
+/**
+ * Concern: ClientBootstrap
+ * Layer: Build
+ * BuildIndex: 00.00
+ * AttachesTo: #root
+ * Responsibility: Mount the Calculogic React tree with StrictMode safeguards.
+ * Invariants: Root element exists before mount, StrictMode wraps the entire tree.
+ */
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx'; // Ensure this path is correct
 import './index.css';
+
+// [Section 00.10] ReactRootMount
+// Purpose: Provide deterministic bootstrapping for the single-page app.
+// Inputs: document.getElementById('root')
+// Outputs: React root rendering of <App />
+// Constraints: Remains synchronous to satisfy Vite's client hydration.
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/tabs/BuildTab.tsx
+++ b/src/tabs/BuildTab.tsx
@@ -1,1 +1,15 @@
+/**
+ * Concern: BuildTabEntrypoint
+ * Layer: Build
+ * BuildIndex: 10.00
+ * AttachesTo: builder-root
+ * Responsibility: Re-export the Build tab assembly for the App frame without exposing folder structure.
+ * Invariants: Default export stays stable for routing, underlying build module is proxied as-is.
+ */
+
+// [Section 10.10] SurfaceForwarder
+// Purpose: Keep the App shell decoupled from internal build folder layout.
+// Inputs: ./build module export
+// Outputs: Default Build tab component
+// Constraints: Remains a pure barrel with no side effects.
 export { default } from './build';

--- a/src/tabs/build/BuildSurface.build.tsx
+++ b/src/tabs/build/BuildSurface.build.tsx
@@ -1,7 +1,21 @@
+/**
+ * Concern: BuildSurfaceStructure
+ * Layer: Build
+ * BuildIndex: 20.00
+ * AttachesTo: builder-root
+ * Responsibility: Render the Build tab's structural layout and anchor map.
+ * Invariants: Section order aligns with logic bindings, resizable panes respect anchor contracts.
+ */
 import type { ReactNode } from 'react';
 import { BUILD_ANCHORS } from './anchors';
 import type { BuildSurfaceBindings, SectionId, SectionLogicBinding } from './BuildSurface.logic';
 import { sectionTitle } from './BuildSurface.logic';
+
+// [Section 20.10] PanelChrome
+// Purpose: Provide reusable iconography for collapsible controls.
+// Inputs: Panel collapsed state
+// Outputs: Chevron icon components
+// Constraints: Icons remain accessible and purely presentational.
 
 function ChevronLeftIcon() {
   return (
@@ -33,6 +47,11 @@ function ChevronRightIcon() {
   );
 }
 
+// [Section 20.20] SectionCatalog
+// Purpose: Describe left-panel sections and their structural anchors.
+// Inputs: SectionId order from logic bindings
+// Outputs: Structured React nodes bound to BUILD_ANCHORS
+// Constraints: Anchor names stay deterministic; placeholders preserve layout spacing.
 interface SectionContentConfig {
   id: SectionId;
   render: () => ReactNode;
@@ -92,6 +111,11 @@ function renderSectionContent(id: SectionId) {
   return match ? match.render() : null;
 }
 
+// [Section 20.30] SectionPanels
+// Purpose: Render individual catalog panels with collapse and resize affordances.
+// Inputs: SectionLogicBinding from logic layer
+// Outputs: Section markup bound to anchors and ARIA contracts
+// Constraints: Header buttons stay accessible; grip hidden when logic disallows drag.
 function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
   const title = sectionTitle(binding.id);
   return (
@@ -124,6 +148,11 @@ function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
   );
 }
 
+// [Section 20.40] SurfaceLayout
+// Purpose: Assemble the builder frame, navigation chrome, and pane layout.
+// Inputs: BuildSurfaceBindings including anchors, sections, and panel states
+// Outputs: Complete Build tab DOM structure
+// Constraints: Anchor contracts stay intact; layout transitions remain CSS-driven.
 export function BuildSurface({
   anchors,
   sectionOrder,

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -1,6 +1,20 @@
+/**
+ * Concern: BuildSurfaceLogic
+ * Layer: Logic
+ * BuildIndex: 20.00
+ * AttachesTo: builder-root
+ * Responsibility: Manage pane sizing, persistence, and bindings for the Build surface.
+ * Invariants: Anchor usage mirrors Build structure, persisted dimensions stay within safe bounds.
+ */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent, MouseEvent, TouchEvent, RefObject } from 'react';
 import { BUILD_ANCHORS } from './anchors';
+
+// [Section 20.10] SectionContracts
+// Purpose: Define identifiers and binding shapes shared with the Build layer.
+// Inputs: Build surface structure requirements
+// Outputs: SectionId union, binding interfaces, default ordering
+// Constraints: Section order remains stable for persisted state.
 
 export type SectionId = 'configurations' | 'atomic-components' | 'search-configurations';
 
@@ -107,6 +121,11 @@ export function sectionTitle(id: SectionId) {
   }
 }
 
+// [Section 20.20] SectionState
+// Purpose: Handle height, collapse, and persistence for catalog sections.
+// Inputs: SectionId, localStorage snapshot
+// Outputs: SectionLogicBinding consumed by Build layer
+// Constraints: Keyboard resizing stays accessible; storage failures are non-fatal.
 function useSectionLogic(
   id: SectionId,
   { initialHeight, storageKey, gripVisible = true }: SectionLogicOptions
@@ -261,6 +280,11 @@ function useSectionLogic(
   };
 }
 
+// [Section 20.30] LeftPanelState
+// Purpose: Persist and manage the resizable left panel width.
+// Inputs: localStorage width value, pointer/keyboard interactions
+// Outputs: Left panel binding with grip props
+// Constraints: Width stays within readable bounds; drag restores pointer selection post-interaction.
 function useLeftPanelLogic(): LeftPanelLogic {
   const STORAGE_KEY = 'left-panel-width';
   const [width, setWidth] = useState(() => {
@@ -370,6 +394,11 @@ function useLeftPanelLogic(): LeftPanelLogic {
   };
 }
 
+// [Section 20.40] RightPanelState
+// Purpose: Persist inspector width and collapse state for the right panel.
+// Inputs: localStorage state, pointer/keyboard interactions
+// Outputs: Right panel binding with collapse toggle
+// Constraints: Collapsing preserves last width; width clamps avoid overlap with center panel.
 function useRightPanelLogic(): RightPanelLogic {
   const STORAGE_KEY = 'right-panel-state';
   const [state, setState] = useState<RightPanelState>(() => {
@@ -501,6 +530,11 @@ function useRightPanelLogic(): RightPanelLogic {
   };
 }
 
+// [Section 20.50] SurfaceBindings
+// Purpose: Aggregate panel and section bindings for the Build surface view.
+// Inputs: Section logic hooks, panel state hooks
+// Outputs: BuildSurfaceBindings consumed by Build layer
+// Constraints: Returned object remains referentially stable aside from intended memoized fields.
 export function useBuildSurfaceLogic(): BuildSurfaceBindings {
   const configurations = useSectionLogic('configurations', {
     initialHeight: 180,

--- a/src/tabs/build/BuildSurface.view.css
+++ b/src/tabs/build/BuildSurface.view.css
@@ -1,3 +1,18 @@
+/*
+ * Concern: BuildSurfaceView
+ * Layer: View
+ * BuildIndex: 20.00
+ * AttachesTo: builder-root
+ * Responsibility: Style the Build surface chrome, catalog, preview, and inspector panes.
+ * Invariants: Resizable grips stay visible, flex layout honors anchor boundaries.
+ */
+
+/* [Section 20.10] SurfaceChrome
+ * Purpose: Style the root container, header, and tab navigation chrome.
+ * Inputs: Build surface structure anchors
+ * Outputs: Flex layout and header presentation
+ * Constraints: Maintain sticky header height and clear CTA prominence.
+ */
 [data-anchor="builder-root"] {
   display: flex;
   flex-direction: column;
@@ -58,6 +73,12 @@
   overflow: hidden;
 }
 
+/* [Section 20.20] SectionCatalog
+ * Purpose: Style the collapsible catalog column and its resize affordances.
+ * Inputs: Builder left panel anchors
+ * Outputs: Panel layout, section headers, and grip treatments
+ * Constraints: Maintain readable typography and accessible focus states.
+ */
 [data-anchor="builder-left-panel"] {
   display: flex;
   flex-direction: column;
@@ -200,6 +221,12 @@
   transform: rotate(90deg);
 }
 
+/* [Section 20.30] CenterPreview
+ * Purpose: Style the preview canvas placeholder and maintain balanced spacing.
+ * Inputs: Builder center panel anchors
+ * Outputs: Flexible preview area styling
+ * Constraints: Preserve neutral background and dashed placeholder affordance.
+ */
 [data-anchor="builder-center-panel"] {
   flex: 1 1 auto;
   min-width: 0;
@@ -227,6 +254,12 @@
   color: rgba(30, 41, 59, 0.7);
 }
 
+/* [Section 20.40] RightInspector
+ * Purpose: Style the inspector column, including collapse control and content area.
+ * Inputs: Builder right panel anchors
+ * Outputs: Inspector layout and typography rules
+ * Constraints: Keep minimum width for readability and consistent focus treatments.
+ */
 [data-anchor="builder-right-panel"] {
   display: flex;
   flex-direction: column;

--- a/src/tabs/build/anchors.ts
+++ b/src/tabs/build/anchors.ts
@@ -1,3 +1,17 @@
+/**
+ * Concern: BuildSurfaceAnchors
+ * Layer: Build
+ * BuildIndex: 20.00
+ * AttachesTo: builder-root
+ * Responsibility: Centralize public anchor contracts shared across Build layers.
+ * Invariants: Anchor names remain stable, builder-root stays the ordering source.
+ */
+
+// [Section 20.10] AnchorRegistry
+// Purpose: Define the canonical selectors that other layers attach to.
+// Inputs: Build surface structure requirements
+// Outputs: BUILD_ANCHORS constant map
+// Constraints: Only expose stable anchors; computed segments remain pure.
 export const BUILD_ANCHORS = {
   root: 'builder-root',
   header: 'builder-header',
@@ -19,4 +33,9 @@ export const BUILD_ANCHORS = {
   list: (id: string) => `builder-list-${id}`,
 } as const;
 
+// [Section 20.20] AnchorTypes
+// Purpose: Export a type union for downstream compile-time safety.
+// Inputs: BUILD_ANCHORS constant
+// Outputs: BuildAnchorId type alias
+// Constraints: Must stay in sync with anchor registry.
 export type BuildAnchorId = typeof BUILD_ANCHORS[keyof typeof BUILD_ANCHORS];

--- a/src/tabs/build/index.tsx
+++ b/src/tabs/build/index.tsx
@@ -1,7 +1,20 @@
+/**
+ * Concern: BuildSurfaceAssembly
+ * Layer: Build
+ * BuildIndex: 20.00
+ * AttachesTo: builder-root
+ * Responsibility: Bind the Build surface view to its logic and scoped styles.
+ * Invariants: BuildSurface receives a full binding object, stylesheet import remains colocated.
+ */
 import { BuildSurface } from './BuildSurface.build';
 import { useBuildSurfaceLogic } from './BuildSurface.logic';
 import './BuildSurface.view.css';
 
+// [Section 20.05] SurfaceBootstrap
+// Purpose: Compose the Build surface with live bindings for rendering.
+// Inputs: useBuildSurfaceLogic hook
+// Outputs: BuildSurface element tree
+// Constraints: No side effects beyond hook execution; component stays synchronous.
 export default function BuildTab() {
   const bindings = useBuildSurfaceLogic();
   return <BuildSurface {...bindings} />;


### PR DESCRIPTION
## Summary
- add CCPP-compliant file headers and section documentation to build-related TypeScript and CSS files
- document global app frame and entrypoint with BOS-aligned comments
- describe anchor contracts and logic bindings to preserve structural provenance

## Testing
- not run (documentation-only)


------
https://chatgpt.com/codex/tasks/task_e_68fa672427b483319c126be771749c69