### PR TITLE
Update concern and comment protocols

### DIFF
--- a/doc/CCPP.md
+++ b/doc/CCPP.md
@@ -1,208 +1,171 @@
-Calculogic Comment & Provenance Protocol (CCPP).
-1) Purpose
-Comments carry intent, rationale, and provenance—never restate code. They mirror the Build order so readers traverse files the same way the UI is structured.
-2) Types (use only these)
-File Header (one per file)
+Calculogic Comment & Provenance Protocol (CCPP, NL-Aligned)
+1. Purpose
+Comments encode intent, structure, and provenance in a way that:
+Mirrors the NL skeleton order,
 
+Helps AI reconstruct or extend code from NL,
 
-What this file is, where it sits in Build order, what it attaches to.
+And keeps files navigable top-down.
 
+Comments are not narration of obvious code; they are a projection of the NL skeleton and decisions into the codebase.
 
-Section Header (top of each major section, in Build order)
+2. Comment Types (Use Only These)
+File Header – one per file.
 
+Section Header – top of each config section inside a file.
 
-What this section does and its constraints.
+Atomic Comment – immediately before a Container/Subcontainer/Primitive.
 
+Inline Rationale – rare; why a non-obvious line/block exists.
 
-Inline Rationale (rare; next to non-obvious code)
+Decision Note – tiny ADR embedded in code.
 
+TODO with expiry – actionable, owner + date.
 
-Why this line/block exists (not what it does).
+Provenance Block – when external logic/content influences code (no payload).
 
-
-Decision Note (lightweight ADR)
-
-
-Record of a local trade-off with date & link/id.
-
-
-TODO with expiry
-
-
-Actionable, owner, deadline; auto-fails lint if stale.
-
-
-Provenance Block (when pulling external logic/content)
-
-
-Source URL, access time, hash; no payload.
-
-
-3) Required fields & format
-3.1 File Header (all languages)
+3. Required Fields & Format
+3.1 File Header (TS/TSX/TS, etc.)
 /**
- * Concern: <Name>
- * Layer: Build | View | Logic | Knowledge | Results
- * BuildIndex: <NN.MM>          // ordering source index
- * AttachesTo: <anchor/selector> // if not Build
- * Responsibility: <one sentence>
+ * ProjectShell/Config: Global Header Shell (shell-globalHeader)
+ * Concern File: Build | BuildStyle | Logic | Knowledge | Results | ResultsStyle
+ * Source NL: doc/nl-shell/shell-globalHeader.md
+ * Responsibility: <one sentence for this concern file>
  * Invariants: <comma-separated truths>
- * LastDecision: <ADR-<id> or link> (optional)
+ * Notes: <optional; ADR id, link, or short note>
+ */
+For non-shell configs, replace ProjectShell/Config with Configuration: cfg-....
+3.2 Section Header (per configuration inside a concern file)
+// ─────────────────────────────────────────────
+// 3. Build – cfg-tabNavigation (Tab Navigation)
+// NL Sections: §3.0–3.3 in cfg-tabNavigation.md
+// Purpose: <short purpose>
+// Constraints: <key constraints or perf/a11y notes>
+// ─────────────────────────────────────────────
+The leading number (3. here) matches the NL skeleton’s concern index.
+
+3.3 Atomic Comment (Container / Subcontainer / Primitive)
+// [3.2.2] cfg-tabNavigation · Subcontainer · "Center Zone – Tab Strip"
+// Concern: Build · Parent: "Global Header Shell" · Catalog: layout.group
+// Notes: hosts 4 tabs and info icons; no reordering; center-aligned
+function GlobalHeaderTabStripZone() {
+  ...
+}
+Rules:
+First line: [NLSectionNumber] cfg-id · HierarchicalType · "Name".
+
+Second line: Concern, Parent (if any), Catalog id.
+
+Third line: short intent/constraint note.
+
+These should read like compressed NL bullets and are the main thing AI should preserve.
+3.4 Inline Rationale
+// WHY: Avoids focus loss when switching tabs via keyboard
+Use sparingly, only when the reason is not obvious.
+3.5 Decision Note
+// DECISION: Tab hover previews via CSS only | 2025-11-05
+// Context: Keep Logic lightweight for header interactions
+// Choice: Use CSS hover for previews instead of JS listeners
+// Consequence: Less JS complexity; no previews on touch devices
+// ADR: header-hover-001   // optional
+3.6 TODO with expiry
+// TODO(@owner, 2025-12-01): Wire openDoc(docId) to docs modal shell
+Must always have owner and date.
+3.7 Provenance Block
+// SOURCE: https://example.org/a11y/tabs
+// Accessed: 2025-11-05T14:22:00Z
+// Note: Pattern used as reference for keyboard tab navigation; no content copied
+No payload; just reference.
+
+4. Language & Mapping
+TS/TSX/JS: /** ... */ for file header; // ... for everything else.
+
+CSS: /* ... */ for file and atomic comments; still match NL numbers.
+
+JSON: no comments; if needed, keep a .meta or .md doc instead.
+
+Markdown docs: NL skeletons themselves.
+
+5. NL Skeleton Alignment
+Every concern file must have:
+
+A file header linking to its NL doc.
+
+Section headers for each configuration in NL order.
+
+Atomic comments for each Container/Subcontainer/Primitive referenced in NL.
+
+The NL skeleton is the source:
+
+When a number changes in NL (e.g. 3.2.1 → 3.2.2), comments should be updated to match.
+
+When a new atomic is added to NL, a new atomic comment + code block is added in the same position.
+
+6. Strict Do / Don’t
+Do
+Use NL section numbers [3.2.1] consistently across files.
+
+Explain why something exists, not what it does.
+
+Keep comments short and structured (good for humans and AI).
+
+Update NL + comments in the same change as code.
+
+Don’t
+Narrate obvious code.
+
+Add code that doesn’t correspond to a skeleton section (unless you add it to NL first).
+
+Use unlabeled TODO:.
+
+Copy external content into comments.
+
+7. Minimal Examples
+Build file:
+/**
+ * Configuration: cfg-tabNavigation (Tab Navigation)
+ * Concern File: Build
+ * Source NL: doc/nl-config/cfg-tabNavigation.md
+ * Responsibility: Header tab strip structure (no styling, no behavior)
+ * Invariants: Tabs never wrap; center zone stays in single row
  */
 
-3.2 Section Header (mirrors Build order)
-// [Section 20.10] <SectionName>
-// Purpose: <short purpose>
-// Inputs: <signals/props/events>
-// Outputs: <signals/events>
-// Constraints: <key constraints or perf/a11y notes>
+// ─────────────────────────────────────────────
+// 3. Build – cfg-tabNavigation (Tab Navigation)
+// NL Sections: §3.0–3.3 in cfg-tabNavigation.md
+// Purpose: Provide 4 canonical tabs in fixed order
+// Constraints: Order fixed: Build, Logic, Knowledge, Results
+// ─────────────────────────────────────────────
 
-3.3 Inline Rationale
-// WHY: <reason that isn’t obvious from code/tests>
+// [3.1] cfg-tabNavigation · Container · "Global Header Shell"
+// Concern: Build · Catalog: layout.shell
+export function GlobalHeaderShell() { ... }
+BuildStyle file:
+/* 
+ * Configuration: cfg-tabNavigation (Tab Navigation)
+ * Concern File: BuildStyle
+ * Source NL: doc/nl-config/cfg-tabNavigation.md
+ * Responsibility: Visual styling of header tab strip (no structure)
+ * Invariants: Tabs remain single-line; scroll instead of wrap
+ */
 
-3.4 Decision Note (micro-ADR in code)
-// DECISION: <title> | <YYYY-MM-DD>
-// Context: <1 line>
-// Choice: <A over B because C>
-// Consequence: <1 line>
-// ADR: <id or link>    // optional
-
-3.5 TODO with expiry
-// TODO(@owner, YYYY-MM-DD): <actionable task>
-
-3.6 Provenance Block (external reference; no content retention)
-// SOURCE: <url>
-// Accessed: <UTC timestamp>
-// Hash: sha256:<...>
-// License: <string>
-// Note: evidence retained ephemerally; see logs
-
-4) Language & export mapping
-Target
-Line
-Block
-TS/JS
-//
-/** ... */
-CSS
-/* ... */
-/* ... */
-HTML
-<!-- ... -->
-<!-- ... -->
-Python
-#
-"""docblock""" (module/func/class)
-JSON
-(no inline comments)
-Sidecar: <file>.meta.json with the same headers; or embed under "__doc" keys if allowed
-Markdown docs
-> NOTE:
-fenced blocks
-
-JSON rule: never put comments in JSON; use <file>.meta.json with:
-{
-  "file": "thing.json",
-  "header": { "Concern":"...", "Layer":"...", "BuildIndex":"..." },
-  "sections": [{ "index":"20.10", "name":"...", "purpose":"..." }]
+/* [4.2.1] cfg-tabNavigation · Primitive · "Tab Item Base Rule"
+   Matches Build primitive [3.3.4–3.3.7] (tab buttons)
+*/
+.globalHeader__tab {
+  /* ... */
 }
 
-5) BOS alignment (Build-as-Order Source)
-File Header must include BuildIndex.
+8. Maintenance Rules
+On every structural change:
+Update the NL skeleton first.
 
+Then update code and comments to match:
 
-Section Headers must appear in ascending Build order.
+Keep section headers in NL order.
 
+Keep atomic comments synchronized with NL numbers.
 
-View/Logic/Knowledge/Results may not introduce new structural sections—only attach via AttachesTo.
+Remove or update any Decision notes that no longer apply (add new ones instead of rewriting history).
 
-
-6) Strict do/don’t
-Do
-Explain why, list invariants, cite decisions, add expiry to TODOs, include provenance for externals.
- Don’t
-
-
-Narrate obvious code, duplicate names/types, leave TODOs without owner/date, paste external payloads.
-
-
-7) Lint & CI checks (lightweight)
-Headers present (File + every Section).
-
-
-Monotonic order of [Section NN.MM].
-
-
-TODO expiry not past due.
-
-
-No plain “TODO:” without owner/date.
-
-
-No comments in JSON (enforce sidecar).
-
-
-Provenance required when external refs detected (e.g., http/https in strings).
-
-
-8) Knowledge integration
-Treat Knowledge as the upstream source of comment text.
-
-
-On export, render Knowledge entries into the appropriate comment syntax per target.
-
-
-Keep Knowledge canonical; code comments are projections.
-
-
-9) Minimal examples
-TSX (View)
-/**
- * Concern: BuilderShell
- * Layer: View
- * BuildIndex: 01.00
- * AttachesTo: .builder-shell
- * Responsibility: Responsive frame chrome (no behavior)
- * Invariants: No overflow; keyboard focus ring visible
- */
-export function BuilderShellView(){...}
-
-// [Section 01.10] Header
-// Purpose: Global header chrome & tabs
-// Inputs: layoutMode
-// Outputs: none
-// Constraints: sticky; min-height 56px
-
-Logic (TS)
-/**
- * Concern: AtomicComponents
- * Layer: Logic
- * BuildIndex: 20.00
- * AttachesTo: #atoms-canvas
- * Responsibility: DnD + selection
- * Invariants: No structure mutation; anchors are stable
- * LastDecision: ADR-042
- */
-
-// DECISION: Keyboard reordering over mouse-only | 2025-10-20
-// Context: a11y requirement
-// Choice: Arrow+Enter beats drag-only
-// Consequence: extra focus mgmt; simpler pointer code
-
-Provenance
-// SOURCE: https://example.org/a11y/drag-guidance
-// Accessed: 2025-10-20T15:04:12Z
-// Hash: sha256:9b7c…3ad
-// License: CC-BY 4.0
-
-10) Maintenance rules
-When structure changes in Build, update Section Headers and BuildIndex across layers in the same PR.
-
-
-When a Decision changes, append a new DECISION block; don’t edit history.
-
-
-Purge or convert stale TODOs during each release cut.
-
-
-That’s the whole method: five comment types, Build-ordered structure, language-aware export, sidecar for JSON, lintable rules, and Knowledge as the single source for comment content.
+Clean up or close TODOs on each release cut.

--- a/doc/CSCS.md
+++ b/doc/CSCS.md
@@ -1,208 +1,202 @@
-Calculogic-Style Concern System (Codebase-Level)
-1) First Principles
-Canonical Layer Order: Build → View → Logic → Knowledge → Results.
+Calculogic Concern System (CCS, NL-Aligned, Codebase-Level)
+1. First Principles
+Configuration is semantic, not a file
 
+A Configuration is a semantic module (e.g. “Global Header Shell”, “Tab Navigation”).
 
-Ordering Source (BOS): The highest present layer in that order becomes the structural reference for the concern. All lower layers mirror its top-down order.
+It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
 
+Code lives in six concern files; the configuration is defined by its NL skeleton, not its file layout.
 
-Attachment-Only for Non-Sources: Layers that are not the ordering source attach to declared anchors; they do not create or reorder structure.
+NL Skeleton as the ordering source
 
+Each configuration has an NL Configuration Skeleton (or ProjectShell skeleton).
 
-Stable Anchors: Every part exposes a stable, public anchor (name/class/data-attr). All layers refer to anchors—never to incidental DOM.
+The skeleton’s numbered sections (3 = Build, 4 = BuildStyle, 5 = Logic, 6 = Knowledge, 7 = Results, 8 = ResultsStyle) define the canonical top-down order for all concerns.
 
+Code in all concern files must follow this order and mirror the same numbering in comments.
 
-Directional Dependencies: Build feeds View/Logic; Logic feeds Results; Knowledge informs all. No cycles; no reaching “up” the stack.
+Concerns vs. hierarchical types (orthogonal axes)
 
+Every Atomic Component has:
 
-Purity Per Layer:
+A Concern: Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle, and
 
+A Hierarchical type: Container, Subcontainer, or Primitive.
 
-Build = structure only
+These axes are independent: you can have a Logic Container, a Build Primitive, a ResultsStyle Primitive, etc.
 
+Purity per concern
 
-View = appearance only
+Build – structure only (containers, subcontainers, primitives; no state, no visual design tokens).
 
+BuildStyle – styling of structure only (layout, spacing, responsive rules; no DOM creation, no state).
 
-Logic = interaction/state only
+Logic – interaction, workflows, state, derived flags; no DOM, no CSS.
 
+Knowledge – copy, constants, reference tables; no state mutation, no layout, no behavior.
 
-Knowledge = guidance/reference only
+Results – derived outputs / readouts; no structure creation beyond what Build defines.
 
+ResultsStyle – styling of results; no structure, no logic.
 
-Results = derived feedback only
+Structure source and fallbacks
 
+Build is the default structural source for any UI configuration or shell.
 
-Locality: Keep code for a concern co-located; nested concerns live inside their parent’s folder but follow the same rules independently.
+Non-structural concerns (BuildStyle, Logic, Knowledge, Results, ResultsStyle) never create or reorder structure; they attach to anchors defined by Build.
 
+Fallback (rare): if a configuration has no Build (e.g. a pure data concern), use the highest present non-style concern as the mental ordering source (Logic → Knowledge → Results), but it still must not invent DOM structure.
 
-Monotonic Diffs: A change to the ordering source appears in the same top-down sequence across its sibling layer files.
+Anchors are stable
 
+Every visible piece of structure exposes stable anchors (class, data-anchor, or id).
 
-Minimal Surface Area: Each concern exposes a tiny interface (anchors, events, and read-only signals). Internal details stay private.
+All non-Build concerns refer to these anchors, never to incidental DOM or query patterns.
 
+Directional dependencies
 
+Build → BuildStyle / Logic / ResultsStyle.
 
-2) Concern Definition Protocol (CDP)
-Use this as a one-page template for any concern before you write code.
-Name: Short, unambiguous.
+Logic → Results.
 
+Knowledge informs all but depends on none.
 
-Purpose (1 sentence): What outcome this concern provides.
+No upward or cyclic imports (e.g., Results cannot feed Logic, Logic cannot define anchors).
 
+Locality
 
-In-Scope / Out-of-Scope: Bulleted boundaries.
+Code for one configuration’s concerns lives in its folder under builder/configs/ or builder/shells/.
 
+Nested configurations (e.g., a shell zone as its own config) live inside the parent’s folder but obey all the same rules independently.
 
-Ordering Source: Build | View | Logic | Knowledge | Results (choose the highest present).
+Monotonic diffs
 
+When you change structure in the NL skeleton for a configuration, corresponding changes in Build, BuildStyle, Logic, Knowledge, Results, and ResultsStyle must appear in the same top-down order when you read each file.
 
-Anchors: The public selectors/IDs this concern owns or attaches to.
+2. Configuration Definition Template (Per Configuration or Shell)
+Use this before writing code or asking AI to generate code.
+NL Skeleton:
+Create doc/nl-config/cfg-*.md or doc/nl-shell/shell-*.md using the General NL Skeleton – Configuration-Level or ProjectShell-Level.
 
+That document is the canonical contract for:
 
-Inputs: Events, props, or data it consumes (read-only).
+Purpose and scope,
 
+Per-concern responsibilities,
 
-Outputs: Events, derived values, or UI it emits (no side effects outside scope).
+Containers/Subcontainers/Primitives and their order,
 
+Numbering (3.x.y, 4.x.y, 5.x.y, etc.).
 
-Invariants: Facts that must always hold true (e.g., “never reorders sibling regions”).
+Concern entry (per configuration):
+Name: Short, unambiguous; use cfg-* for configs, shell-* for shells.
 
+Purpose (1 sentence): What outcome this configuration achieves.
 
-Dependencies: Lower layers/foundations only; no upward imports.
+In-Scope / Out-of-Scope: Boundaries for behavior and structure.
 
+Concerns present: Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle (which apply).
 
-Acceptance: 3–5 observable criteria to declare the concern “done.”
+Anchors: The structural anchors owned by this configuration (Build).
 
+Inputs: Props/context/events it consumes.
 
+Outputs: Events, derived values, results, or debug UI it emits.
 
-3) Decision Rules (what belongs where)
-Frame vs. Items:
+Invariants: Truths that must always hold (e.g. “Tabs never wrap; scroll instead”).
 
+Dependencies: Only on lower-level utilities, shared hooks, or Knowledge; no cross-concern cheating.
 
-Changes to page frame, regions, or section layout → Build (structure concern).
+3. Atomic Components (per concern)
+For each concern in the NL skeleton, list:
+Containers – top-level roots for that concern in this configuration.
 
+Subcontainers – nested encapsulations inside Containers.
 
-Creation/move/reorder/select of items (atoms/configs/etc.) → Logic in an item-owner concern.
+Primitives – leaves: individual fields, rules, styles, state atoms, maps, result lines.
 
+Rules:
+A concern can have one or more Containers at the top level.
 
-No Structure? Use Fallback: If a concern has no Build, View sets order; if no View, Logic; then Knowledge; then Results.
+Subcontainers only appear inside Containers (never at the root of a concern).
 
+Primitives never contain anything else.
 
-Results Belongs Where Data Ends: If something is purely a derived readout (counts, previews), it’s Results—never creates structure or state.
+Containers may be:
+Flat roots (contain only primitives), or
 
+Hierarchical roots (contain subcontainers and primitives).
 
-Knowledge Is Guidance, Not Behavior: Tooltips/help text/reference tables live in Knowledge and do not mutate state or structure.
+4. Decision Rules (What Belongs Where, NL-Aware)
+Use these to keep responsibilities clean:
+Structure vs interaction vs readout
 
+Changes to regions, zones, section layout → Build.
 
+Visual variants, responsiveness, spacing → BuildStyle / ResultsStyle.
 
-4) Nested vs. Sibling Concerns (classification)
-Nested if ALL are true:
+State, validation, transitions, routing → Logic.
 
+Copy, labels, options, thresholds → Knowledge.
 
-It attaches to specific parent anchors that must exist.
+Counters, scores, derived summaries → Results.
 
+No structure in non-structural concerns
 
-It cannot operate outside the parent’s structure.
+BuildStyle, Logic, Knowledge, Results, ResultsStyle must not introduce new DOM or change sibling ordering. They attach to anchors established in Build.
 
+Results is “where data ends”
 
-It never alters the parent’s structural order.
+Once you are just showing derived information (e.g., state summaries, counts, debug), it belongs in Results / ResultsStyle; it cannot mutate structure or state.
 
+Knowledge is guidance, not behavior
 
-Otherwise, it’s a Sibling concern: it renders within the same frame but manages its own internal anchors and lifecycle.
+Tooltips, doc text, label maps, thresholds live in Knowledge and do not contain side effects or layout code.
 
+Use the NL hierarchy to split or merge
 
+If you can’t describe a section of behavior/structure in a single NL bullet under one concern, it’s a sign you have multiple concerns tangled together—split them.
 
-5) The Four Tests (split/merge decisions)
-Run these before adding code, refactoring, or scoping tickets.
-Single Reason to Change: Will most changes to this code happen for the same reason?
+5. Nested vs Sibling Configurations
+Nested configuration if all are true:
 
+It attaches to specific anchors owned by a parent configuration.
 
-Yes → keep together. No → split into separate concerns.
+It cannot operate meaningfully without that parent structure.
 
+It never reorders or replaces the parent’s anchors.
 
-Boundary of Effects: Can this code change without forcing structural or behavioral changes outside its scope?
+Sibling configuration otherwise:
 
+It uses the same frame (shell) but defines its own Build structure and anchors.
 
-If not, you’re leaking responsibilities—split.
+Promote from nested → sibling when a feature gains its own structure, reuse, or lifecycle.
 
+6. Change Management
+When you change a configuration:
+Update its NL skeleton first:
 
-Ordering Consistency: Can lower layers mirror the ordering source 1:1 without re-grouping?
+Adjust the numbering and text for any moved/added/removed Container/Subcontainer/Primitive.
 
+Then update code:
 
-If not, you’ve mixed concerns—separate the parts.
+Adjust Build to match the new NL order.
 
+Update BuildStyle, Logic, Knowledge, Results, ResultsStyle in the same pass, keeping the same ordering and comment numbers.
 
-User-Visible Contract: Can you describe its inputs/outputs in one short paragraph?
+Preserve anchors if possible:
 
+If anchors must change, treat that as a deliberate breaking change and update all attached concerns.
 
-If not, you’ve bundled multiple concerns—split.
+Acceptance (per PR):
 
+NL skeleton updated and committed.
 
+Build matches NL structure and order.
 
-6) Change Management Rules
-Promotions: When a nested concern gains its own structure or broad usage, promote it to a sibling concern with its own ordering source.
+All other concerns follow the same ordering via comments.
 
+Concerns respect purity and directional dependencies.
 
-Deprecations: When two concerns always change together and share the same ordering and anchors, merge them.
-
-
-Renames: Preserve anchors; if they must change, provide an adapter layer and update all attachments in one PR.
-
-
-Spec Drift Guard: If a concern’s code requires new anchors, update the ordering source first, then mirror changes down the stack.
-
-
-
-7) Interfaces & Contracts (tiny but strict)
-Anchors: The only cross-layer selectors.
-
-
-Events: Named, scoped (“atomic:reordered”, “panel:collapsed”).
-
-
-Signals (read-only): Derived flags exposed by Logic to Results (e.g., isDragging, count).
-
-
-No Hidden Coupling: No direct DOM poking; no style reads in Logic; no state in Knowledge; no DOM creation in Logic/Results.
-
-
-
-8) Acceptance Checklist (applied to every PR)
-One (and only one) ordering source selected for the concern.
-
-
-All present layers mirror the source’s order.
-
-
-Non-source layers attach via declared anchors only.
-
-
-Roles respected (Build/View/Logic/Knowledge/Results purity).
-
-
-No upward or cyclic dependencies.
-
-
-Tests cover the concern’s acceptance criteria.
-
-
-Diffs read top-down consistently across files.
-
-
-
-9) Example classification (generic)
-Structure & Responsiveness: Concern = frame, panes, sections (Ordering source: Build; View mirrors; no DnD).
-
-
-Atomic Components (current): Concern = atom list/canvas interactions (Ordering source: Build for the atom list; DnD in Logic attaches to those anchors).
-
-
-Configurations (future): Concern = config blocks + persistence (its own Build order; Logic handles block-level DnD; Results show derived summaries).
-
-
-Search/Browse: Concern = find/filter UI (Build for list; Logic for queries; Results for counts; never alters frame order).
-
-
-
-This is the go/no-go rubric before coding anything. It’s brief enough to keep next to editor, strict enough to prevent drift, and flexible enough to apply to any feature while preserving coherence across the codebase.
+Comments (file headers + section headers + atomic comments) present and consistent.

--- a/doc/NL-First-Workflow.md
+++ b/doc/NL-First-Workflow.md
@@ -1,0 +1,70 @@
+NL-First Workflow (What the AI Does First)
+Golden rule: Before generating or editing any code for a configuration or shell, the AI must create or update the NL skeleton text file for it.
+0. NL Skeleton Step (Mandatory First Step)
+When starting work on a feature, configuration, or shell:
+Decide the type:
+
+If it’s a normal configuration (e.g. “Tab Navigation”, “Brand Block”), use:
+
+doc/nl-config/cfg-[name].md
+
+If it’s a global shell (e.g. “Global Header Shell”), use:
+
+doc/nl-shell/shell-[name].md
+
+Create (or update) the NL skeleton file using the correct template:
+
+Configuration-Level → “General NL Skeleton – Configuration-Level”
+
+ProjectShell-Level → “General NL Skeleton – ProjectShell-Level”
+
+Fill it out in prose:
+
+Sections 1–10, including:
+
+Purpose and scope
+
+Configuration contracts
+
+Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle
+
+Atomic Components (Containers, Subcontainers, Primitives) with numbering (3.1, 3.2.1, 3.3.1, etc.)
+
+Assembly pattern and implementation passes
+
+Only after the NL file exists and is filled in may the AI:
+
+Create or edit any concern files under src/builder/...
+
+Add or update code comments referencing [3.x.y], [4.x.y], etc.
+
+Never add new code that isn’t described in the NL skeleton first.
+
+If new behavior/structure is needed, AI must update the NL file first, then code.
+
+1. Code Generation Step (After NL)
+Once the NL skeleton file is in place:
+Read cfg-*.md or shell-*.md top to bottom.
+
+For each concern, in order:
+
+Add/adjust the file header (with link to the NL file).
+
+Add/adjust section headers (3. Build – cfg-..., 4. BuildStyle – cfg-..., etc.).
+
+Implement Containers/Subcontainers/Primitives in the same numeric order as NL.
+
+Prepend each with an atomic comment:
+
+// [3.2.2] cfg-tabNavigation · Subcontainer · "Center Zone – Tab Strip"
+// Concern: Build · Parent: "Global Header Shell" · Catalog: layout.group
+
+2. Enforcement Checklist (For AI / You)
+Any time code is generated or changed for a config/shell:
+NL skeleton file exists in doc/nl-config or doc/nl-shell.
+
+The change to code is reflected in NL, and the numbering matches.
+
+All new functions/components/blocks have the correct [sectionNumber] cfg-id · type · name comments.
+
+No concern file contains “orphan” code that isn’t mentioned in the NL skeleton.


### PR DESCRIPTION
## Summary
- replace the Calculogic Concern System documentation with the NL-aligned CCS guidance
- update the Calculogic Comment & Provenance Protocol to the latest NL-aware comment standard
- add a dedicated NL-First Workflow reference that explains the required sequencing of NL skeletons and code

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151177e80483318cb672b2a019aec6)