### PR TITLE
Remove legacy BuildSurface header now handled globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,8 @@
  * Responsibility: Provide the top-level frame and theme toggle that hosts Calculogic tabs.
  * Invariants: Body class mirrors theme state, Build tab is always mounted.
  */
-import { useEffect, useState } from 'react';
 import BuildTab from './tabs/BuildTab';
+import GlobalHeaderShell from './components/GlobalHeaderShell';
 import { useAppFrameLogic } from './App.logic';
 import './App.css';
 
@@ -45,6 +45,7 @@ export default function App() {
   // Constraints: Theme toggle remains accessible, Build tab stays mounted for routing simplicity.
   return (
     <div data-anchor="app-frame">
+      <GlobalHeaderShell />
       {themeToggle}
       {buildTabMount}
     </div>

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -1,0 +1,147 @@
+.global-header-shell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  background: var(--gh-background, #101322);
+  color: var(--gh-foreground, #f5f7ff);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 1rem;
+}
+
+.global-header-shell__zone {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.global-header-shell__zone--brand {
+  flex: 0 0 auto;
+}
+
+.global-header-shell__zone--tabs {
+  flex: 1 1 auto;
+  justify-content: center;
+}
+
+.global-header-shell__zone--publish {
+  flex: 0 0 auto;
+  justify-content: flex-end;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.brand-logo {
+  font-size: 1.35rem;
+}
+
+.brand-tagline {
+  font-size: 0.75rem;
+  opacity: 0.8;
+  white-space: nowrap;
+}
+
+.tab-list {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.25rem 0;
+}
+
+.tab-list__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.tab-button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.16s ease, color 0.16s ease, border-color 0.16s ease;
+}
+
+.tab-button[data-active='true'] {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+
+.tab-button[data-hovered='true'][data-active='false'] {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.info-icon {
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.2rem;
+  border-radius: 50%;
+  transition: background 0.16s ease;
+}
+
+.info-icon:hover,
+.info-icon:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.publish-button {
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, #6c5ce7, #00cec9);
+  color: #0a0c12;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.publish-button:hover,
+.publish-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
+}
+
+@media (max-width: 1023px) {
+  .global-header-shell {
+    padding: 0.65rem 1rem;
+  }
+
+  .brand-tagline {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .global-header-shell {
+    flex-wrap: nowrap;
+    gap: 0.75rem;
+  }
+
+  .brand-wordmark {
+    font-size: 0.95rem;
+  }
+
+  .tab-list {
+    gap: 0.35rem;
+  }
+
+  .publish-button {
+    padding: 0.45rem 1rem;
+  }
+}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -1,0 +1,133 @@
+import type { GlobalHeaderShellBuildBindings } from './GlobalHeaderShell.logic';
+
+function InfoIcon({
+  label,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  label: string;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="info-icon"
+      aria-label={label}
+      title={label}
+      data-anchor="global-header.tab-info"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      ℹ️
+    </button>
+  );
+}
+
+function TabButton({
+  label,
+  isActive,
+  isHovered,
+  onSelect,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  label: string;
+  isActive: boolean;
+  isHovered: boolean;
+  onSelect: () => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="tab-button"
+      data-active={isActive ? 'true' : 'false'}
+      data-hovered={isHovered ? 'true' : 'false'}
+      role="tab"
+      aria-selected={isActive}
+      aria-current={isActive ? 'page' : undefined}
+      onClick={onSelect}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function GlobalHeaderShell({
+  tabs,
+  activeTab,
+  hoveredTab,
+  brand,
+  publishLabel,
+  selectTab,
+  hoverTab,
+  triggerPublish,
+  isMobile,
+  isTablet,
+}: GlobalHeaderShellBuildBindings) {
+  const showTagline = !(isMobile || isTablet);
+
+  return (
+    <header data-anchor="global-header" className="global-header-shell">
+      <div className="global-header-shell__zone global-header-shell__zone--brand" data-anchor="global-header.brand">
+        <a
+          href={brand.homeHref}
+          className="brand-link"
+          aria-label="Calculogic home"
+          title={brand.tooltip}
+        >
+          <span aria-hidden="true" className="brand-logo" data-anchor="global-header.brand-logo">
+            🧮
+          </span>
+          <span className="brand-wordmark" data-anchor="global-header.brand-wordmark">
+            {brand.wordmark}
+          </span>
+        </a>
+        {showTagline && (
+          <span className="brand-tagline" data-anchor="global-header.brand-tagline">
+            {brand.tagline}
+          </span>
+        )}
+      </div>
+      <div className="global-header-shell__zone global-header-shell__zone--tabs" data-anchor="global-header.tabs">
+        <div className="tab-list" role="tablist" aria-label="Primary builder concerns">
+          {tabs.map(tab => {
+            const isActive = tab.id === activeTab;
+            const isHovered = hoveredTab === tab.id;
+            return (
+              <div key={tab.id} className="tab-list__item" data-anchor={`global-header.tab-${tab.id}`}>
+                <TabButton
+                  label={tab.label}
+                  isActive={isActive}
+                  isHovered={isHovered}
+                  onSelect={() => selectTab(tab.id)}
+                  onMouseEnter={() => hoverTab(tab.id)}
+                  onMouseLeave={() => hoverTab(null)}
+                />
+                <InfoIcon
+                  label={tab.hoverSummary}
+                  onMouseEnter={() => hoverTab(tab.id)}
+                  onMouseLeave={() => hoverTab(null)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="global-header-shell__zone global-header-shell__zone--publish" data-anchor="global-header.publish">
+        <button
+          type="button"
+          className="publish-button"
+          data-anchor="global-header.publish-button"
+          onClick={triggerPublish}
+        >
+          {publishLabel}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
@@ -1,0 +1,58 @@
+export type HeaderTabId = 'build' | 'logic' | 'knowledge' | 'results';
+export type HeaderModeId = 'default' | 'style';
+
+export interface HeaderTabDefinition {
+  id: HeaderTabId;
+  label: string;
+  order: number;
+  docId: string;
+  hoverSummary: string;
+}
+
+export const HEADER_TAB_DEFINITIONS: HeaderTabDefinition[] = [
+  {
+    id: 'build',
+    label: 'Build',
+    order: 1,
+    docId: 'doc-build',
+    hoverSummary: 'Define and arrange containers, sub-containers, and atomic components.',
+  },
+  {
+    id: 'logic',
+    label: 'Logic',
+    order: 2,
+    docId: 'doc-logic',
+    hoverSummary: 'Add calculations, conditions, and interaction rules.',
+  },
+  {
+    id: 'knowledge',
+    label: 'Knowledge',
+    order: 3,
+    docId: 'doc-knowledge',
+    hoverSummary: 'Store reusable traits, constants, and reference schemas.',
+  },
+  {
+    id: 'results',
+    label: 'Results',
+    order: 4,
+    docId: 'doc-results',
+    hoverSummary: 'Design and inspect derived outputs, scores, and summaries.',
+  },
+];
+
+export interface BreakpointDefinition {
+  name: 'desktop' | 'tablet' | 'mobile';
+  minWidth: number;
+}
+
+export const BREAKPOINTS: BreakpointDefinition[] = [
+  { name: 'desktop', minWidth: 1024 },
+  { name: 'tablet', minWidth: 768 },
+  { name: 'mobile', minWidth: 0 },
+];
+
+export const BRAND_WORDMARK = 'Calculogic';
+export const BRAND_TAGLINE = 'a system for creating systems';
+export const BRAND_TOOLTIP = 'Return to Calculogic home / dashboard.';
+
+export const PUBLISH_LABEL = 'Publish';

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  BRAND_TAGLINE,
+  BRAND_TOOLTIP,
+  BRAND_WORDMARK,
+  BREAKPOINTS,
+  HEADER_TAB_DEFINITIONS,
+  PUBLISH_LABEL,
+  type HeaderModeId,
+  type HeaderTabDefinition,
+  type HeaderTabId,
+} from './GlobalHeaderShell.knowledge';
+
+export interface GlobalHeaderShellState {
+  activeTab: HeaderTabId;
+  activeModeByTab: {
+    build: HeaderModeId;
+    results: HeaderModeId;
+  };
+  hoveredTab: HeaderTabId | null;
+  viewportBreakpoint: 'desktop' | 'tablet' | 'mobile';
+  activeDocId: string | null;
+}
+
+export interface GlobalHeaderShellProps {
+  onPublish?: () => void;
+}
+
+export interface GlobalHeaderShellBuildBindings extends GlobalHeaderShellState {
+  tabs: HeaderTabDefinition[];
+  isDesktop: boolean;
+  isTablet: boolean;
+  isMobile: boolean;
+  brand: {
+    wordmark: string;
+    tagline: string;
+    tooltip: string;
+    homeHref: string;
+  };
+  publishLabel: string;
+  selectTab: (tab: HeaderTabId) => void;
+  hoverTab: (tab: HeaderTabId | null) => void;
+  triggerPublish: () => void;
+  openDoc: (docId: string) => void;
+  closeDoc: () => void;
+}
+
+export interface GlobalHeaderShellResultsBindings {
+  debugPanel: {
+    visible: boolean;
+    state: Pick<
+      GlobalHeaderShellState,
+      'activeTab' | 'activeModeByTab' | 'viewportBreakpoint' | 'hoveredTab'
+    >;
+  };
+}
+
+export interface GlobalHeaderShellBindings {
+  build: GlobalHeaderShellBuildBindings;
+  results: GlobalHeaderShellResultsBindings;
+}
+
+const DEFAULT_STATE: GlobalHeaderShellState = {
+  activeTab: 'build',
+  activeModeByTab: {
+    build: 'default',
+    results: 'default',
+  },
+  hoveredTab: null,
+  viewportBreakpoint: 'desktop',
+  activeDocId: null,
+};
+
+function determineBreakpoint(width: number): 'desktop' | 'tablet' | 'mobile' {
+  if (width >= BREAKPOINTS[0].minWidth) return 'desktop';
+  if (width >= BREAKPOINTS[1].minWidth) return 'tablet';
+  return 'mobile';
+}
+
+export function useGlobalHeaderShellLogic({ onPublish }: GlobalHeaderShellProps = {}): GlobalHeaderShellBindings {
+  const [state, setState] = useState<GlobalHeaderShellState>(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_STATE;
+    }
+    return {
+      ...DEFAULT_STATE,
+      viewportBreakpoint: determineBreakpoint(window.innerWidth),
+    };
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    const handleResize = () => {
+      setState(prev => {
+        const nextBreakpoint = determineBreakpoint(window.innerWidth);
+        if (prev.viewportBreakpoint === nextBreakpoint) {
+          return prev;
+        }
+        return {
+          ...prev,
+          viewportBreakpoint: nextBreakpoint,
+        };
+      });
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const selectTab = useCallback((tab: HeaderTabId) => {
+    setState(prev => {
+      const nextActiveModeByTab = { ...prev.activeModeByTab };
+      if (tab === 'build') {
+        nextActiveModeByTab.build = 'default';
+      }
+      if (tab === 'results') {
+        nextActiveModeByTab.results = 'default';
+      }
+      return {
+        ...prev,
+        activeTab: tab,
+        hoveredTab: null,
+        activeModeByTab: nextActiveModeByTab,
+      };
+    });
+  }, []);
+
+  const hoverTab = useCallback((tab: HeaderTabId | null) => {
+    setState(prev => {
+      if (prev.hoveredTab === tab) {
+        return prev;
+      }
+      return {
+        ...prev,
+        hoveredTab: tab,
+      };
+    });
+  }, []);
+
+  const triggerPublish = useCallback(() => {
+    if (onPublish) {
+      onPublish();
+    } else {
+      // eslint-disable-next-line no-console
+      console.info('Publish triggered from GlobalHeaderShell.');
+    }
+  }, [onPublish]);
+
+  const openDoc = useCallback((docId: string) => {
+    setState(prev => {
+      if (prev.activeDocId === docId) {
+        return prev;
+      }
+      return {
+        ...prev,
+        activeDocId: docId,
+      };
+    });
+  }, []);
+
+  const closeDoc = useCallback(() => {
+    setState(prev => {
+      if (!prev.activeDocId) {
+        return prev;
+      }
+      return {
+        ...prev,
+        activeDocId: null,
+      };
+    });
+  }, []);
+
+  const tabs = useMemo(() => [...HEADER_TAB_DEFINITIONS].sort((a, b) => a.order - b.order), []);
+
+  const { viewportBreakpoint } = state;
+  const isDesktop = viewportBreakpoint === 'desktop';
+  const isTablet = viewportBreakpoint === 'tablet';
+  const isMobile = viewportBreakpoint === 'mobile';
+
+  const buildBindings: GlobalHeaderShellBuildBindings = {
+    ...state,
+    tabs,
+    isDesktop,
+    isTablet,
+    isMobile,
+    brand: {
+      wordmark: BRAND_WORDMARK,
+      tagline: BRAND_TAGLINE,
+      tooltip: BRAND_TOOLTIP,
+      homeHref: '/',
+    },
+    publishLabel: PUBLISH_LABEL,
+    selectTab,
+    hoverTab,
+    triggerPublish,
+    openDoc,
+    closeDoc,
+  };
+
+  const resultsBindings: GlobalHeaderShellResultsBindings = {
+    debugPanel: {
+      visible: false,
+      state: {
+        activeTab: state.activeTab,
+        activeModeByTab: state.activeModeByTab,
+        viewportBreakpoint: state.viewportBreakpoint,
+        hoveredTab: state.hoveredTab,
+      },
+    },
+  };
+
+  return {
+    build: buildBindings,
+    results: resultsBindings,
+  };
+}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.results.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.results.css
@@ -1,0 +1,9 @@
+.global-header-shell__debug {
+  background: rgba(16, 19, 34, 0.85);
+  color: rgba(245, 247, 255, 0.85);
+  padding: 0.75rem 1rem;
+  font-size: 0.8rem;
+  display: grid;
+  gap: 0.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx
@@ -1,0 +1,27 @@
+import type { GlobalHeaderShellResultsBindings } from './GlobalHeaderShell.logic';
+
+export function GlobalHeaderShellResults({ debugPanel }: GlobalHeaderShellResultsBindings) {
+  if (!debugPanel.visible) {
+    return null;
+  }
+
+  return (
+    <aside className="global-header-shell__debug" data-anchor="global-header.debug">
+      <div>
+        <strong>Active tab:</strong> {debugPanel.state.activeTab}
+      </div>
+      <div>
+        <strong>Build mode:</strong> {debugPanel.state.activeModeByTab.build}
+      </div>
+      <div>
+        <strong>Results mode:</strong> {debugPanel.state.activeModeByTab.results}
+      </div>
+      <div>
+        <strong>Breakpoint:</strong> {debugPanel.state.viewportBreakpoint}
+      </div>
+      <div>
+        <strong>Hovered tab:</strong> {debugPanel.state.hoveredTab ?? 'none'}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/GlobalHeaderShell/index.tsx
+++ b/src/components/GlobalHeaderShell/index.tsx
@@ -1,0 +1,18 @@
+import { GlobalHeaderShell } from './GlobalHeaderShell.build';
+import './GlobalHeaderShell.build.css';
+import { useGlobalHeaderShellLogic, type GlobalHeaderShellProps } from './GlobalHeaderShell.logic';
+import { GlobalHeaderShellResults } from './GlobalHeaderShell.results';
+import './GlobalHeaderShell.results.css';
+
+export default function GlobalHeaderShellComponent(props: GlobalHeaderShellProps) {
+  const bindings = useGlobalHeaderShellLogic(props);
+
+  return (
+    <>
+      <GlobalHeaderShell {...bindings.build} />
+      <GlobalHeaderShellResults {...bindings.results} />
+    </>
+  );
+}
+
+export type { HeaderTabId, HeaderModeId } from './GlobalHeaderShell.knowledge';

--- a/src/tabs/build/BuildSurface.build.tsx
+++ b/src/tabs/build/BuildSurface.build.tsx
@@ -174,35 +174,7 @@ export function BuildSurface({
   leftPanel,
   rightPanel,
 }: BuildSurfaceBindings) {
-  // [3.6.1] cfg-buildSurface · Subcontainer · "Header Chrome"
-  // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.header
-  // Notes: Hosts title, primary nav tabs, and publish CTA with fixed anchor IDs.
-  const headerChrome = (
-    <header data-anchor={anchors.header}>
-      <h1>🔧 Calculogic Builder</h1>
-      <nav data-anchor={anchors.tabList} aria-label="Builder navigation">
-        {['Build', 'Calculogic', 'View', 'Knowledge', 'Results'].map(tab => (
-          <button
-            key={tab}
-            type="button"
-            data-anchor={anchors.tabButton(tab.toLowerCase())}
-            aria-current={tab === 'Build' ? 'page' : undefined}
-          >
-            {tab}
-          </button>
-        ))}
-        <button
-          type="button"
-          data-anchor={anchors.tabButton('publish')}
-          className="publish"
-        >
-          Publish
-        </button>
-      </nav>
-    </header>
-  );
-
-  // [3.6.2] cfg-buildSurface · Subcontainer · "Catalog Column"
+  // [3.6.1] cfg-buildSurface · Subcontainer · "Catalog Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column
   // Notes: Lists section panels in logic-supplied order with live resize affordances.
   const catalogColumn = (
@@ -219,12 +191,12 @@ export function BuildSurface({
     </aside>
   );
 
-  // [3.6.3] cfg-buildSurface · Primitive · "Catalog Grip"
+  // [3.6.2] cfg-buildSurface · Primitive · "Catalog Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Exposes left panel resize separator connected to logic grip props.
   const catalogGrip = <div data-anchor={anchors.leftGrip} {...leftPanel.gripProps} />;
 
-  // [3.6.4] cfg-buildSurface · Subcontainer · "Preview Stage"
+  // [3.6.3] cfg-buildSurface · Subcontainer · "Preview Stage"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.region
   // Notes: Placeholder canvas for future form preview anchored to center panel IDs.
   const previewStage = (
@@ -235,12 +207,12 @@ export function BuildSurface({
     </main>
   );
 
-  // [3.6.5] cfg-buildSurface · Primitive · "Inspector Grip"
+  // [3.6.4] cfg-buildSurface · Primitive · "Inspector Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Provides resize handle between preview stage and inspector column.
   const inspectorGrip = <div data-anchor={anchors.rightGrip} {...rightPanel.gripProps} />;
 
-  // [3.6.6] cfg-buildSurface · Subcontainer · "Inspector Column"
+  // [3.6.5] cfg-buildSurface · Subcontainer · "Inspector Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column
   // Notes: Collapsible inspector with settings placeholder anchored to logic-provided IDs.
   const inspectorColumn = (
@@ -278,7 +250,6 @@ export function BuildSurface({
 
   return (
     <div data-anchor={anchors.root}>
-      {headerChrome}
       <div data-anchor={anchors.layout}>
         {catalogColumn}
         {catalogGrip}

--- a/src/tabs/build/BuildSurface.view.css
+++ b/src/tabs/build/BuildSurface.view.css
@@ -8,10 +8,10 @@
  */
 
 /* [Section 20.10] SurfaceChrome
- * Purpose: Style the root container, header, and tab navigation chrome.
+ * Purpose: Style the root container and layout chrome for the Build tab.
  * Inputs: Build surface structure anchors
- * Outputs: Flex layout and header presentation
- * Constraints: Maintain sticky header height and clear CTA prominence.
+ * Outputs: Flex layout for resizable panes
+ * Constraints: Maintain flex stability and accessible overflow behavior.
  */
 [data-anchor="builder-root"] {
   display: flex;
@@ -21,67 +21,11 @@
   background: #fff;
 }
 
-/* [4.1.2] cfg-buildSurface · Primitive · "Header Bar"
-   Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: surface.header */
-[data-anchor="builder-header"] {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-  padding: 0 1.25rem;
-  height: 60px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(248, 250, 252, 0.9);
-}
-
-/* [4.1.3] cfg-buildSurface · Primitive · "Header Title"
-   Concern: BuildStyle · Parent: "Header Bar" · Catalog: typography.heading */
-[data-anchor="builder-header"] h1 {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-/* [4.1.4] cfg-buildSurface · Primitive · "Tab List Container"
-   Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: layout.nav */
-[data-anchor="builder-tabs"] {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex: 1;
-}
-
-/* [4.1.5] cfg-buildSurface · Primitive · "Tab Button Base"
-   Concern: BuildStyle · Parent: "Tab List Container" · Catalog: control.tab */
-[data-anchor="builder-tabs"] button {
-  border: none;
-  background: transparent;
-  padding: 0.5rem 1rem;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-  font-size: 0.95rem;
-}
-
-/* [4.1.6] cfg-buildSurface · Primitive · "Active Tab"
-   Concern: BuildStyle · Parent: "Tab Button Base" · Catalog: control.state */
-[data-anchor="builder-tabs"] button[aria-current="page"] {
-  border-bottom-color: #2563eb;
-  font-weight: 600;
-}
-
-/* [4.1.7] cfg-buildSurface · Primitive · "Publish CTA"
-   Concern: BuildStyle · Parent: "Tab List Container" · Catalog: control.cta */
-[data-anchor="builder-tabs"] .publish {
-  margin-left: auto;
-  background: #2563eb;
-  color: #fff;
-  border-radius: 4px;
-}
-
 /* [4.1.8] cfg-buildSurface · Primitive · "Surface Layout Shell"
    Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: layout.shell */
 [data-anchor="builder-layout"] {
   display: flex;
-  height: calc(100vh - 60px);
+  flex: 1 1 auto;
   min-height: 0;
   align-items: stretch;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- remove the obsolete builder header markup from the BuildSurface layout now that GlobalHeaderShell owns navigation
- simplify BuildSurface styling by deleting unused header/tab rules and letting the layout flex to fill the remaining space

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69152269003c8331b56d30b7ed4b69c7)