### PR TITLE
Align App frame comments with cfg-appFrame CCPP

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,17 +1,14 @@
 /*
- * Concern: AppFrameView
- * Layer: View
- * BuildIndex: 01.00
- * AttachesTo: [data-anchor="app-frame"]
- * Responsibility: Skin the global frame and expose accessible theming affordances.
- * Invariants: Frame fills viewport, theme toggle maintains focus treatment.
+ * Configuration: cfg-appFrame (App Frame)
+ * Concern File: BuildStyle
+ * Source NL: doc/nl-config/cfg-appFrame.md
+ * Responsibility: Skin the app frame container and expose accessible theming affordances.
+ * Invariants: Frame fills the viewport; theme toggle keeps a visible focus state; dark variables track theme state.
  */
 
-/* [Section 01.10] FrameSurface
- * Purpose: Establish full-viewport shell and default color variables.
- * Inputs: CSS custom properties, body theme variables
- * Outputs: App frame layout styling
- * Constraints: Maintain responsive fill and readable contrast.
+/* [4.1] cfg-appFrame · Container · "Frame Surface Styling"
+ * Concern: BuildStyle · Parent: "—" · Catalog: surface.container
+ * Notes: Fills the viewport and applies default surface/foreground tokens for the frame shell.
  */
 [data-anchor="app-frame"] {
   height: 100vh;
@@ -21,11 +18,9 @@
   position: relative;
 }
 
-/* [Section 01.20] ThemeToggle
- * Purpose: Position and style the theme toggle control.
- * Inputs: App frame positioning context
- * Outputs: Styled toggle button
- * Constraints: Keep focus ring visible and button discoverable.
+/* [4.2] cfg-appFrame · Primitive · "Theme Toggle Styling"
+ * Concern: BuildStyle · Parent: "Frame Surface Styling" · Catalog: control.skin
+ * Notes: Positions the toggle and establishes baseline affordance styling within the frame.
  */
 [data-anchor="theme-toggle"] {
   position: absolute;
@@ -41,19 +36,17 @@
 }
 
 /* [4.2.1] cfg-appFrame · Primitive · "Theme Toggle Focus Ring"
-   Concern: BuildStyle · Parent: "Theme Toggle Styling" · Catalog: control.focus
-   Notes: Guarantees accessible focus outline for keyboard users.
+ * Concern: BuildStyle · Parent: "Theme Toggle Styling" · Catalog: control.focus
+ * Notes: Guarantees accessible focus outline for keyboard users.
  */
 [data-anchor="theme-toggle"]:focus-visible {
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }
 
-/* [Section 01.30] DarkThemeVariables
- * Purpose: Override design tokens when dark mode is active.
- * Inputs: body.dark class
- * Outputs: Alternate CSS custom property values
- * Constraints: Preserve adequate contrast with base text.
+/* [4.3] cfg-appFrame · Primitive · "Dark Theme Variables"
+ * Concern: BuildStyle · Parent: "Frame Surface Styling" · Catalog: tokens.theme
+ * Notes: Overrides surface tokens when body.dark is applied to mirror dark-mode state.
  */
 body.dark {
   --app-surface: #0f172a;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,24 @@
 /**
- * Concern: AppFrame
- * Layer: Build
- * BuildIndex: 01.00
- * AttachesTo: #root
+ * Configuration: cfg-appFrame (App Frame)
+ * Concern File: Build
+ * Source NL: doc/nl-config/cfg-appFrame.md
  * Responsibility: Provide the top-level frame and theme toggle that hosts Calculogic tabs.
- * Invariants: Body class mirrors theme state, Build tab is always mounted.
+ * Invariants: Body class mirrors theme state; Build tab remains mounted inside the frame.
  */
 import BuildTab from './tabs/BuildTab';
 import GlobalHeaderShell from './components/GlobalHeaderShell';
 import { useAppFrameLogic } from './App.logic';
 import './App.css';
 
-// [Section 01.10] ThemeState
-// Purpose: Derive and persist the user's dark-mode preference.
-// Inputs: prefers-color-scheme media query, toggle intent
-// Outputs: dark boolean state, body class mutation
-// Constraints: Never flicker on first paint; body mutation stays side-effect only.
-
 export default function App() {
   const { dark, toggleDark } = useAppFrameLogic();
+
+  // ─────────────────────────────────────────────
+  // 3. Build – cfg-appFrame (App Frame)
+  // NL Sections: §3.1–3.3 in cfg-appFrame.md
+  // Purpose: Assemble the frame container, theme toggle, and Build tab mount.
+  // Constraints: Keep the Build tab mounted and expose the toggle within the frame shell.
+  // ─────────────────────────────────────────────
 
   // [3.2] cfg-appFrame · Primitive · "Theme Toggle Control"
   // Concern: Build · Parent: "App Frame Shell" · Catalog: control.toggle
@@ -38,11 +38,9 @@ export default function App() {
   // Notes: Always renders the Build tab to keep routing simple and anchors stable.
   const buildTabMount = <BuildTab />;
 
-  // [Section 01.20] BuilderHost
-  // Purpose: Expose anchors for downstream layers and render the Build tab shell.
-  // Inputs: dark state, toggle handler
-  // Outputs: App frame structure, theme toggle control
-  // Constraints: Theme toggle remains accessible, Build tab stays mounted for routing simplicity.
+  // [3.1] cfg-appFrame · Container · "App Frame Shell"
+  // Concern: Build · Parent: "—" · Catalog: layout.container
+  // Notes: Hosts the global header, theme toggle, and persistent Build tab mount.
   return (
     <div data-anchor="app-frame">
       <GlobalHeaderShell />


### PR DESCRIPTION
## Summary
- adopt the cfg-appFrame CCPP header and section scaffolding within the App build concern
- align App frame BuildStyle comments with cfg-appFrame atomic numbering and documentation references

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154172a8b083319a9524e34e5cb333)