### PR TITLE
Align shell-spaHost comments with CCPP structure

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,18 +1,11 @@
 /*
- * Concern: GlobalReset
- * Layer: View
- * BuildIndex: 00.00
- * AttachesTo: html, body, #root
- * Responsibility: Provide a predictable baseline for the SPA container.
- * Invariants: Box-sizing remains border-box, root stretches full viewport height.
+ * CCPP: shell-spaHost
+ * Concern: BuildStyle
+ * Reference: doc/nl-shell/shell-spaHost.md
+ * Responsibility: Normalize document-level layout primitives for the shell host.
  */
 
-/* [Section 00.10] DocumentBaseline
- * Purpose: Normalize root element sizing and typography defaults.
- * Inputs: Browser UA stylesheet
- * Outputs: Global reset rules
- * Constraints: Preserve 100% height for layout primitives.
- */
+/* [4.1] Document Baseline Reset — Apply zero margins, border-box sizing, and typography defaults to html and body. */
 body, html {
   margin: 0;
   padding: 0;
@@ -21,12 +14,7 @@ body, html {
   font-family: sans-serif;
 }
 
-/* [Section 00.20] RootContainer
- * Purpose: Ensure the React root participates in flex layouts consistently.
- * Inputs: Document baseline rules
- * Outputs: Flex column root container
- * Constraints: Keep height 100% for downstream full-height layouts.
- */
+/* [4.2] Root Flex Column — Ensure #root occupies full height and exposes a flex column container for downstream shells. */
 #root {
   height: 100%;
   display: flex;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,22 +1,16 @@
 /**
- * Concern: ClientBootstrap
- * Layer: Build
- * BuildIndex: 00.00
- * AttachesTo: #root
- * Responsibility: Mount the Calculogic React tree with StrictMode safeguards.
- * Invariants: Root element exists before mount, StrictMode wraps the entire tree.
+ * CCPP: shell-spaHost
+ * Concern: Build
+ * Reference: doc/nl-shell/shell-spaHost.md
+ * Responsibility: Acquire the #root anchor and mount <App /> within <StrictMode>.
  */
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-// [Section 00.10] ReactRootMount
-// Purpose: Provide deterministic bootstrapping for the single-page app.
-// Inputs: document.getElementById('root')
-// Outputs: React root rendering of <App />
-// Constraints: Remains synchronous to satisfy Vite's client hydration.
-
+// [3] Build — shell-spaHost
+// [3.1] React Root Mount — Invoke createRoot on #root and render <App /> inside <StrictMode>.
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- update the shell-spaHost Build header in `src/main.tsx` to use the CCPP format and annotate the [3] Build primitive
- refresh the BuildStyle header in `src/index.css` to reference the NL skeleton and mark the [4.1] and [4.2] primitives

## Testing
- not run (comment-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691542028bd883319b41240204d757a6)