### PR TITLE
Align Build surface comments with cfg-buildSurface

### DIFF
--- a/src/tabs/BuildTab.tsx
+++ b/src/tabs/BuildTab.tsx
@@ -1,15 +1,19 @@
 /**
- * Concern: BuildTabEntrypoint
- * Layer: Build
- * BuildIndex: 10.00
- * AttachesTo: builder-root
- * Responsibility: Re-export the Build tab assembly for the App frame without exposing folder structure.
- * Invariants: Default export stays stable for routing, underlying build module is proxied as-is.
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: Build
+ * Source NL: doc/nl-config/cfg-buildSurface.md
+ * Responsibility: Forward the Build tab entry point without exposing internal module layout.
+ * Invariants: Default export remains stable; barrel stays side-effect free.
  */
 
-// [Section 10.10] SurfaceForwarder
-// Purpose: Keep the App shell decoupled from internal build folder layout.
-// Inputs: ./build module export
-// Outputs: Default Build tab component
-// Constraints: Remains a pure barrel with no side effects.
+// ─────────────────────────────────────────────
+// 3. Build – cfg-buildSurface (Build Surface Configuration)
+// NL Sections: §3.1 in cfg-buildSurface.md
+// Purpose: Keep the App shell decoupled through a focused Build tab barrel.
+// Constraints: Barrel stays stateless and transparent.
+// ─────────────────────────────────────────────
+
+// [3.1] cfg-buildSurface · Container · "Build Tab Forwarder"
+// Concern: Build · Catalog: composition.forwarder
+// Notes: Re-exports the build assembly to preserve the App router contract.
 export { default } from './build';

--- a/src/tabs/build/BuildSurface.build.tsx
+++ b/src/tabs/build/BuildSurface.build.tsx
@@ -1,22 +1,25 @@
 /**
- * Concern: BuildSurfaceStructure
- * Layer: Build
- * BuildIndex: 20.00
- * AttachesTo: builder-root
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: Build
+ * Source NL: doc/nl-config/cfg-buildSurface.md
  * Responsibility: Render the Build tab's structural layout and anchor map.
- * Invariants: Section order aligns with logic bindings, resizable panes respect anchor contracts.
+ * Invariants: Section order mirrors logic bindings; resizable panes respect anchor contracts.
  */
 import type { ReactNode } from 'react';
 import { BUILD_ANCHORS } from './anchors';
 import type { BuildSurfaceBindings, SectionId, SectionLogicBinding } from './BuildSurface.logic';
 import { sectionTitle } from './BuildSurface.logic';
 
-// [Section 20.10] PanelChrome
-// Purpose: Provide reusable iconography for collapsible controls.
-// Inputs: Panel collapsed state
-// Outputs: Chevron icon components
-// Constraints: Icons remain accessible and purely presentational.
+// ─────────────────────────────────────────────
+// 3. Build – cfg-buildSurface (Build Surface Configuration)
+// NL Sections: §3.2–§3.6 in cfg-buildSurface.md
+// Purpose: Assemble Build surface structure, reusable chrome, and anchored layout.
+// Constraints: No styling or state mutations beyond structural composition.
+// ─────────────────────────────────────────────
 
+// [3.2] cfg-buildSurface · Primitive · "Chevron Left Icon"
+// Concern: Build · Parent: "Section Panel Template" · Catalog: chrome.icon
+// Notes: Points inward to signal an expanded panel state within catalog shells.
 function ChevronLeftIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
@@ -34,7 +37,7 @@ function ChevronLeftIcon() {
 
 // [3.3] cfg-buildSurface · Primitive · "Chevron Right Icon"
 // Concern: Build · Parent: "Section Panel Template" · Catalog: chrome.icon
-// Notes: Points outward to indicate collapsing behavior for section panels.
+// Notes: Points outward to communicate collapsed panel affordances.
 function ChevronRightIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
@@ -50,11 +53,6 @@ function ChevronRightIcon() {
   );
 }
 
-// [Section 20.20] SectionCatalog
-// Purpose: Describe left-panel sections and their structural anchors.
-// Inputs: SectionId order from logic bindings
-// Outputs: Structured React nodes bound to BUILD_ANCHORS
-// Constraints: Anchor names stay deterministic; placeholders preserve layout spacing.
 interface SectionContentConfig {
   id: SectionId;
   render: () => ReactNode;
@@ -62,7 +60,7 @@ interface SectionContentConfig {
 
 // [3.4] cfg-buildSurface · Primitive · "Section Content Catalog"
 // Concern: Build · Parent: "Section Panel Template" · Catalog: layout.catalog
-// Notes: Supplies placeholder markup for each section using deterministic anchors.
+// Notes: Maps section identifiers to anchored placeholder content for catalog panels.
 const SECTION_CONTENT: SectionContentConfig[] = [
   {
     id: 'configurations',
@@ -125,11 +123,9 @@ function renderSectionContent(id: SectionId) {
   return match ? match.render() : null;
 }
 
-// [Section 20.30] SectionPanels
-// Purpose: Render individual catalog panels with collapse and resize affordances.
-// Inputs: SectionLogicBinding from logic layer
-// Outputs: Section markup bound to anchors and ARIA contracts
-// Constraints: Header buttons stay accessible; grip hidden when logic disallows drag.
+// [3.5] cfg-buildSurface · Subcontainer · "Section Panel Template"
+// Concern: Build · Parent: "Catalog Column" · Catalog: layout.section
+// Notes: Wraps section headers, content, and grips with deterministic anchors and ARIA bindings.
 function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
   const title = sectionTitle(binding.id);
   return (
@@ -162,11 +158,9 @@ function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
   );
 }
 
-// [Section 20.40] SurfaceLayout
-// Purpose: Assemble the builder frame, navigation chrome, and pane layout.
-// Inputs: BuildSurfaceBindings including anchors, sections, and panel states
-// Outputs: Complete Build tab DOM structure
-// Constraints: Anchor contracts stay intact; layout transitions remain CSS-driven.
+// [3.6] cfg-buildSurface · Container · "Build Surface Layout"
+// Concern: Build · Parent: "Build Surface Composer" · Catalog: layout.shell
+// Notes: Coordinates header chrome, catalog panels, preview stage, and inspector anchors.
 export function BuildSurface({
   anchors,
   sectionOrder,
@@ -174,7 +168,35 @@ export function BuildSurface({
   leftPanel,
   rightPanel,
 }: BuildSurfaceBindings) {
-  // [3.6.1] cfg-buildSurface · Subcontainer · "Catalog Column"
+  // [3.6.1] cfg-buildSurface · Subcontainer · "Header Chrome"
+  // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.header
+  // Notes: Provides builder title, navigation tabs, and publish CTA tied to header anchors.
+  const headerChrome = (
+    <header data-anchor={anchors.header}>
+      <h1>Calculogic Builder</h1>
+      <nav data-anchor={anchors.tabList} aria-label="Builder tabs">
+        <button
+          type="button"
+          data-anchor={anchors.tabButton('build')}
+          data-active="true"
+          aria-current="page"
+        >
+          Build
+        </button>
+        <button type="button" data-anchor={anchors.tabButton('logic')} aria-current={false}>
+          Logic
+        </button>
+        <button type="button" data-anchor={anchors.tabButton('knowledge')} aria-current={false}>
+          Knowledge
+        </button>
+      </nav>
+      <button type="button" className="publish">
+        Publish
+      </button>
+    </header>
+  );
+
+  // [3.6.2] cfg-buildSurface · Subcontainer · "Catalog Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column
   // Notes: Lists section panels in logic-supplied order with live resize affordances.
   const catalogColumn = (
@@ -191,12 +213,12 @@ export function BuildSurface({
     </aside>
   );
 
-  // [3.6.2] cfg-buildSurface · Primitive · "Catalog Grip"
+  // [3.6.3] cfg-buildSurface · Primitive · "Catalog Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Exposes left panel resize separator connected to logic grip props.
   const catalogGrip = <div data-anchor={anchors.leftGrip} {...leftPanel.gripProps} />;
 
-  // [3.6.3] cfg-buildSurface · Subcontainer · "Preview Stage"
+  // [3.6.4] cfg-buildSurface · Subcontainer · "Preview Stage"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.region
   // Notes: Placeholder canvas for future form preview anchored to center panel IDs.
   const previewStage = (
@@ -207,12 +229,12 @@ export function BuildSurface({
     </main>
   );
 
-  // [3.6.4] cfg-buildSurface · Primitive · "Inspector Grip"
+  // [3.6.5] cfg-buildSurface · Primitive · "Inspector Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Provides resize handle between preview stage and inspector column.
   const inspectorGrip = <div data-anchor={anchors.rightGrip} {...rightPanel.gripProps} />;
 
-  // [3.6.5] cfg-buildSurface · Subcontainer · "Inspector Column"
+  // [3.6.6] cfg-buildSurface · Subcontainer · "Inspector Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column
   // Notes: Collapsible inspector with settings placeholder anchored to logic-provided IDs.
   const inspectorColumn = (
@@ -250,6 +272,7 @@ export function BuildSurface({
 
   return (
     <div data-anchor={anchors.root}>
+      {headerChrome}
       <div data-anchor={anchors.layout}>
         {catalogColumn}
         {catalogGrip}

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -1,21 +1,24 @@
 /**
- * Concern: BuildSurfaceLogic
- * Layer: Logic
- * BuildIndex: 20.00
- * AttachesTo: builder-root
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: Logic
+ * Source NL: doc/nl-config/cfg-buildSurface.md
  * Responsibility: Manage pane sizing, persistence, and bindings for the Build surface.
- * Invariants: Anchor usage mirrors Build structure, persisted dimensions stay within safe bounds.
+ * Invariants: Anchor usage mirrors Build structure; persisted dimensions stay within safe bounds.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent, MouseEvent, TouchEvent, RefObject } from 'react';
 import { BUILD_ANCHORS } from './anchors';
 
-// [Section 20.10] SectionContracts
-// Purpose: Define identifiers and binding shapes shared with the Build layer.
-// Inputs: Build surface structure requirements
-// Outputs: SectionId union, binding interfaces, default ordering
-// Constraints: Section order remains stable for persisted state.
+// ─────────────────────────────────────────────
+// 5. Logic – cfg-buildSurface (Build Surface Configuration)
+// NL Sections: §5.1–§5.5 in cfg-buildSurface.md
+// Purpose: Supply persistent panel state, binding helpers, and aggregated Build surface logic.
+// Constraints: Hooks stay local to the Build tab and clean up global listeners.
+// ─────────────────────────────────────────────
 
+// [5.1] cfg-buildSurface · Container · "Section Contracts"
+// Concern: Logic · Catalog: contract.section
+// Notes: Declares section identifiers, binding shapes, order, and helpers shared with Build.
 export type SectionId = 'configurations' | 'atomic-components' | 'search-configurations';
 
 interface SectionState {
@@ -121,11 +124,9 @@ export function sectionTitle(id: SectionId) {
   }
 }
 
-// [Section 20.20] SectionState
-// Purpose: Handle height, collapse, and persistence for catalog sections.
-// Inputs: SectionId, localStorage snapshot
-// Outputs: SectionLogicBinding consumed by Build layer
-// Constraints: Keyboard resizing stays accessible; storage failures are non-fatal.
+// [5.2] cfg-buildSurface · Container · "Section Logic Hook"
+// Concern: Logic · Parent: "Section Contracts" · Catalog: hook.section
+// Notes: Persists section height/collapse state and emits ARIA-aware bindings.
 function useSectionLogic(
   id: SectionId,
   { initialHeight, storageKey, gripVisible = true }: SectionLogicOptions
@@ -280,11 +281,9 @@ function useSectionLogic(
   };
 }
 
-// [Section 20.30] LeftPanelState
-// Purpose: Persist and manage the resizable left panel width.
-// Inputs: localStorage width value, pointer/keyboard interactions
-// Outputs: Left panel binding with grip props
-// Constraints: Width stays within readable bounds; drag restores pointer selection post-interaction.
+// [5.3] cfg-buildSurface · Container · "Left Panel Logic"
+// Concern: Logic · Parent: "Section Logic Hook" · Catalog: hook.panel
+// Notes: Persists catalog column width and exposes accessible grip bindings.
 function useLeftPanelLogic(): LeftPanelLogic {
   const STORAGE_KEY = 'left-panel-width';
   const [width, setWidth] = useState(() => {
@@ -394,11 +393,9 @@ function useLeftPanelLogic(): LeftPanelLogic {
   };
 }
 
-// [Section 20.40] RightPanelState
-// Purpose: Persist inspector width and collapse state for the right panel.
-// Inputs: localStorage state, pointer/keyboard interactions
-// Outputs: Right panel binding with collapse toggle
-// Constraints: Collapsing preserves last width; width clamps avoid overlap with center panel.
+// [5.4] cfg-buildSurface · Container · "Right Panel Logic"
+// Concern: Logic · Parent: "Left Panel Logic" · Catalog: hook.panel
+// Notes: Manages inspector width persistence, collapse toggles, and grip bindings.
 function useRightPanelLogic(): RightPanelLogic {
   const STORAGE_KEY = 'right-panel-state';
   const [state, setState] = useState<RightPanelState>(() => {
@@ -530,11 +527,9 @@ function useRightPanelLogic(): RightPanelLogic {
   };
 }
 
-// [Section 20.50] SurfaceBindings
-// Purpose: Aggregate panel and section bindings for the Build surface view.
-// Inputs: Section logic hooks, panel state hooks
-// Outputs: BuildSurfaceBindings consumed by Build layer
-// Constraints: Returned object remains referentially stable aside from intended memoized fields.
+// [5.5] cfg-buildSurface · Container · "Surface Bindings"
+// Concern: Logic · Parent: "Right Panel Logic" · Catalog: hook.aggregator
+// Notes: Bundles anchor map, ordered sections, and panel bindings for the Build layout.
 export function useBuildSurfaceLogic(): BuildSurfaceBindings {
   const configurations = useSectionLogic('configurations', {
     initialHeight: 180,

--- a/src/tabs/build/BuildSurface.view.css
+++ b/src/tabs/build/BuildSurface.view.css
@@ -1,24 +1,92 @@
 /*
- * Concern: BuildSurfaceView
- * Layer: View
- * BuildIndex: 20.00
- * AttachesTo: builder-root
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: BuildStyle
+ * Source NL: doc/nl-config/cfg-buildSurface.md
  * Responsibility: Style the Build surface chrome, catalog, preview, and inspector panes.
- * Invariants: Resizable grips stay visible, flex layout honors anchor boundaries.
+ * Invariants: Resizable grips stay visible; flex layout honors anchor boundaries.
  */
 
-/* [Section 20.10] SurfaceChrome
- * Purpose: Style the root container and layout chrome for the Build tab.
- * Inputs: Build surface structure anchors
- * Outputs: Flex layout for resizable panes
- * Constraints: Maintain flex stability and accessible overflow behavior.
+/* ─────────────────────────────────────────────
+ * 4. BuildStyle – cfg-buildSurface (Build Surface Configuration)
+ * NL Sections: §4.1–§4.5 in cfg-buildSurface.md
+ * Purpose: Skin Build structural anchors without altering DOM composition.
+ * Constraints: Styling stays anchor-driven; no new nodes or IDs.
+ * ─────────────────────────────────────────────
  */
+
+/* [4.1] cfg-buildSurface · Container · "Surface Chrome Styling"
+   Concern: BuildStyle · Catalog: surface.chrome */
+
+/* [4.1.1] cfg-buildSurface · Primitive · "Root Surface"
+   Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: layout.root */
 [data-anchor="builder-root"] {
   display: flex;
   flex-direction: column;
   height: 100%;
   width: 100%;
   background: #fff;
+}
+
+/* [4.1.2] cfg-buildSurface · Primitive · "Header Bar"
+   Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: surface.header */
+[data-anchor="builder-header"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(241, 245, 249, 0.9);
+  gap: 1rem;
+}
+
+/* [4.1.3] cfg-buildSurface · Primitive · "Header Title"
+   Concern: BuildStyle · Parent: "Header Bar" · Catalog: typography.title */
+[data-anchor="builder-header"] h1 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+/* [4.1.4] cfg-buildSurface · Primitive · "Tab List Container"
+   Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: layout.group */
+[data-anchor="builder-tabs"] {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* [4.1.5] cfg-buildSurface · Primitive · "Tab Button Base"
+   Concern: BuildStyle · Parent: "Tab List Container" · Catalog: control.button */
+[data-anchor="builder-tabs"] button {
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+/* [4.1.6] cfg-buildSurface · Primitive · "Active Tab"
+   Concern: BuildStyle · Parent: "Tab Button Base" · Catalog: control.state */
+[data-anchor="builder-tabs"] button[data-active="true"] {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+/* [4.1.7] cfg-buildSurface · Primitive · "Publish CTA"
+   Concern: BuildStyle · Parent: "Surface Chrome Styling" · Catalog: control.cta */
+[data-anchor="builder-header"] .publish {
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 12px rgba(37, 99, 235, 0.25);
 }
 
 /* [4.1.8] cfg-buildSurface · Primitive · "Surface Layout Shell"
@@ -31,12 +99,8 @@
   overflow: hidden;
 }
 
-/* [Section 20.20] SectionCatalog
- * Purpose: Style the collapsible catalog column and its resize affordances.
- * Inputs: Builder left panel anchors
- * Outputs: Panel layout, section headers, and grip treatments
- * Constraints: Maintain readable typography and accessible focus states.
- */
+/* [4.2] cfg-buildSurface · Container · "Catalog Column Styling"
+   Concern: BuildStyle · Catalog: surface.catalog */
 [data-anchor="builder-left-panel"] {
   display: flex;
   flex-direction: column;
@@ -216,12 +280,11 @@
   transform: rotate(90deg);
 }
 
-/* [Section 20.30] CenterPreview
- * Purpose: Style the preview canvas placeholder and maintain balanced spacing.
- * Inputs: Builder center panel anchors
- * Outputs: Flexible preview area styling
- * Constraints: Preserve neutral background and dashed placeholder affordance.
- */
+/* [4.4] cfg-buildSurface · Container · "Center Preview Styling"
+   Concern: BuildStyle · Catalog: surface.preview */
+
+/* [4.4.1] cfg-buildSurface · Primitive · "Preview Shell"
+   Concern: BuildStyle · Parent: "Center Preview Styling" · Catalog: layout.region */
 [data-anchor="builder-center-panel"] {
   flex: 1 1 auto;
   min-width: 0;
@@ -253,12 +316,11 @@
   color: rgba(30, 41, 59, 0.7);
 }
 
-/* [Section 20.40] RightInspector
- * Purpose: Style the inspector column, including collapse control and content area.
- * Inputs: Builder right panel anchors
- * Outputs: Inspector layout and typography rules
- * Constraints: Keep minimum width for readability and consistent focus treatments.
- */
+/* [4.5] cfg-buildSurface · Container · "Inspector Column Styling"
+   Concern: BuildStyle · Catalog: surface.inspector */
+
+/* [4.5.1] cfg-buildSurface · Primitive · "Inspector Column"
+   Concern: BuildStyle · Parent: "Inspector Column Styling" · Catalog: layout.column */
 [data-anchor="builder-right-panel"] {
   display: flex;
   flex-direction: column;

--- a/src/tabs/build/anchors.ts
+++ b/src/tabs/build/anchors.ts
@@ -1,17 +1,21 @@
 /**
- * Concern: BuildSurfaceAnchors
- * Layer: Build
- * BuildIndex: 20.00
- * AttachesTo: builder-root
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: Knowledge
+ * Source NL: doc/nl-config/cfg-buildSurface.md
  * Responsibility: Centralize public anchor contracts shared across Build layers.
- * Invariants: Anchor names remain stable, builder-root stays the ordering source.
+ * Invariants: Anchor names remain stable; builder-root stays the ordering source.
  */
 
-// [Section 20.10] AnchorRegistry
-// Purpose: Define the canonical selectors that other layers attach to.
-// Inputs: Build surface structure requirements
-// Outputs: BUILD_ANCHORS constant map
-// Constraints: Only expose stable anchors; computed segments remain pure.
+// ─────────────────────────────────────────────
+// 6. Knowledge – cfg-buildSurface (Build Surface Configuration)
+// NL Sections: §6.1–§6.2 in cfg-buildSurface.md
+// Purpose: Publish anchor naming contracts for reuse across concerns.
+// Constraints: Anchor registry stays deterministic and pure.
+// ─────────────────────────────────────────────
+
+// [6.1] cfg-buildSurface · Primitive · "Anchor Registry"
+// Concern: Knowledge · Catalog: contract.anchor
+// Notes: Enumerates public anchor factories consumed by Build, BuildStyle, and Logic.
 export const BUILD_ANCHORS = {
   root: 'builder-root',
   header: 'builder-header',
@@ -33,9 +37,7 @@ export const BUILD_ANCHORS = {
   list: (id: string) => `builder-list-${id}`,
 } as const;
 
-// [Section 20.20] AnchorTypes
-// Purpose: Export a type union for downstream compile-time safety.
-// Inputs: BUILD_ANCHORS constant
-// Outputs: BuildAnchorId type alias
-// Constraints: Must stay in sync with anchor registry.
+// [6.2] cfg-buildSurface · Primitive · "Anchor Type Alias"
+// Concern: Knowledge · Parent: "Anchor Registry" · Catalog: contract.type
+// Notes: Provides union of anchor identifiers for compile-time validation.
 export type BuildAnchorId = typeof BUILD_ANCHORS[keyof typeof BUILD_ANCHORS];

--- a/src/tabs/build/index.tsx
+++ b/src/tabs/build/index.tsx
@@ -1,20 +1,24 @@
 /**
- * Concern: BuildSurfaceAssembly
- * Layer: Build
- * BuildIndex: 20.00
- * AttachesTo: builder-root
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: Build
+ * Source NL: doc/nl-config/cfg-buildSurface.md
  * Responsibility: Bind the Build surface view to its logic and scoped styles.
- * Invariants: BuildSurface receives a full binding object, stylesheet import remains colocated.
+ * Invariants: BuildSurface receives a full binding object; stylesheet import remains colocated.
  */
 import { BuildSurface } from './BuildSurface.build';
 import { useBuildSurfaceLogic } from './BuildSurface.logic';
 import './BuildSurface.view.css';
 
-// [Section 20.05] SurfaceBootstrap
-// Purpose: Compose the Build surface with live bindings for rendering.
-// Inputs: useBuildSurfaceLogic hook
-// Outputs: BuildSurface element tree
-// Constraints: No side effects beyond hook execution; component stays synchronous.
+// ─────────────────────────────────────────────
+// 3. Build – cfg-buildSurface (Build Surface Configuration)
+// NL Sections: §3.1.1 in cfg-buildSurface.md
+// Purpose: Pair Build logic bindings with the structural surface renderer.
+// Constraints: Composition stays synchronous and side-effect free.
+// ─────────────────────────────────────────────
+
+// [3.1.1] cfg-buildSurface · Subcontainer · "Build Surface Composer"
+// Concern: Build · Parent: "Build Tab Forwarder" · Catalog: composition.composer
+// Notes: Invokes logic hook once and forwards bindings to the view.
 export default function BuildTab() {
   const bindings = useBuildSurfaceLogic();
   return <BuildSurface {...bindings} />;


### PR DESCRIPTION
## Summary
- apply CCPP file headers and NL-aligned section scaffolding across Build, BuildStyle, Logic, and Knowledge concerns for the Build surface
- annotate each cfg-buildSurface atomic element with targeted comments and add missing header chrome structure so anchors are present in markup
- expand Build tab styling to cover header chrome, tab list, and publish CTA while maintaining catalog, preview, and inspector styling references

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154292329c83319173fc148b56b56e)