### PR TITLE
Add documentation state handling to GlobalHeaderShell

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -98,6 +98,7 @@
   gap: 0.5rem;
   overflow-x: auto;
   padding: 0.25rem 0;
+  white-space: nowrap;
 }
 
 /* [4.10] shell-globalHeader · Subcontainer · "Tab Item Row Styling"

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -19,12 +19,22 @@ import type { GlobalHeaderShellBuildBindings } from './GlobalHeaderShell.logic';
 // Notes: Shares hover state with tab button while exposing hover summary.
 function InfoIcon({
   label,
+  docId,
   onMouseEnter,
   onMouseLeave,
+  onFocus,
+  onBlur,
+  openDoc,
+  closeDoc,
 }: {
   label: string;
+  docId: string;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  openDoc: (docId: string) => void;
+  closeDoc: () => void;
 }) {
   return (
     <button
@@ -35,6 +45,14 @@ function InfoIcon({
       data-anchor="global-header.tab-info"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onFocus={() => {
+        onFocus();
+        openDoc(docId);
+      }}
+      onBlur={() => {
+        onBlur();
+        closeDoc();
+      }}
     >
       ℹ️
     </button>
@@ -51,6 +69,8 @@ function TabButton({
   onSelect,
   onMouseEnter,
   onMouseLeave,
+  onFocus,
+  onBlur,
 }: {
   label: string;
   isActive: boolean;
@@ -58,6 +78,8 @@ function TabButton({
   onSelect: () => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
 }) {
   return (
     <button
@@ -71,6 +93,8 @@ function TabButton({
       onClick={onSelect}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
     >
       {label}
     </button>
@@ -91,6 +115,8 @@ export function GlobalHeaderShell({
   triggerPublish,
   isMobile,
   isTablet,
+  openDoc,
+  closeDoc,
 }: GlobalHeaderShellBuildBindings) {
   // [3.6] shell-globalHeader · Primitive · "Brand Tagline"
   // Concern: Build · Parent: "Brand Identity Zone" · Catalog: content.copy
@@ -160,11 +186,24 @@ export function GlobalHeaderShell({
                   onSelect={() => selectTab(tab.id)}
                   onMouseEnter={() => hoverTab(tab.id)}
                   onMouseLeave={() => hoverTab(null)}
+                  onFocus={() => hoverTab(tab.id)}
+                  onBlur={() => hoverTab(null)}
                 />
                 <InfoIcon
                   label={tab.hoverSummary}
-                  onMouseEnter={() => hoverTab(tab.id)}
-                  onMouseLeave={() => hoverTab(null)}
+                  docId={tab.docId}
+                  onMouseEnter={() => {
+                    hoverTab(tab.id);
+                    openDoc(tab.docId);
+                  }}
+                  onMouseLeave={() => {
+                    hoverTab(null);
+                    closeDoc();
+                  }}
+                  onFocus={() => hoverTab(tab.id)}
+                  onBlur={() => hoverTab(null)}
+                  openDoc={openDoc}
+                  closeDoc={closeDoc}
                 />
               </div>
             );

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts
@@ -64,7 +64,7 @@ export interface GlobalHeaderShellResultsBindings {
     visible: boolean;
     state: Pick<
       GlobalHeaderShellState,
-      'activeTab' | 'activeModeByTab' | 'viewportBreakpoint' | 'hoveredTab'
+      'activeTab' | 'activeModeByTab' | 'viewportBreakpoint' | 'hoveredTab' | 'activeDocId'
     >;
   };
 }
@@ -258,6 +258,7 @@ export function useGlobalHeaderShellLogic({ onPublish }: GlobalHeaderShellProps 
         activeModeByTab: state.activeModeByTab,
         viewportBreakpoint: state.viewportBreakpoint,
         hoveredTab: state.hoveredTab,
+        activeDocId: state.activeDocId,
       },
     },
   };

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx
@@ -45,6 +45,9 @@ export function GlobalHeaderShellResults({ debugPanel }: GlobalHeaderShellResult
       <div>
         <strong>Hovered tab:</strong> {debugPanel.state.hoveredTab ?? 'none'}
       </div>
+      <div>
+        <strong>Active doc:</strong> {debugPanel.state.activeDocId ?? 'none'}
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- extend GlobalHeaderShell tab and info icon interactions to manage hover and documentation state
- surface the active documentation identifier in debug outputs and prevent tab wrapping in the header strip

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154ba95f548331a471554f5c5da165)