### PR TITLE
Implement documentation modal for GlobalHeaderShell

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -98,6 +98,7 @@
   gap: 0.5rem;
   overflow-x: auto;
   padding: 0.25rem 0;
+  white-space: nowrap;
 }
 
 /* [4.10] shell-globalHeader · Subcontainer · "Tab Item Row Styling"
@@ -172,6 +173,21 @@
   color: #0a0c12;
   cursor: pointer;
   transition: transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+/* [4.16.a] shell-globalHeader · Utility · "Visually Hidden Text"
+   Concern: BuildStyle · Catalog: utility.accessibility
+   Notes: Preserves tooltip copy for assistive tech without affecting layout. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* [4.17] shell-globalHeader · Primitive · "Publish Button Hover State"

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -21,20 +21,33 @@ function InfoIcon({
   label,
   onMouseEnter,
   onMouseLeave,
+  onFocus,
+  onBlur,
+  onClick,
+  describedById,
 }: {
   label: string;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  onClick: () => void;
+  describedById?: string;
 }) {
   return (
     <button
       type="button"
       className="info-icon"
       aria-label={label}
+      aria-haspopup="dialog"
+      aria-describedby={describedById}
       title={label}
       data-anchor="global-header.tab-info"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onClick={onClick}
     >
       ℹ️
     </button>
@@ -51,6 +64,8 @@ function TabButton({
   onSelect,
   onMouseEnter,
   onMouseLeave,
+  onFocus,
+  onBlur,
 }: {
   label: string;
   isActive: boolean;
@@ -58,6 +73,8 @@ function TabButton({
   onSelect: () => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
 }) {
   return (
     <button
@@ -71,6 +88,8 @@ function TabButton({
       onClick={onSelect}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
     >
       {label}
     </button>
@@ -91,6 +110,7 @@ export function GlobalHeaderShell({
   triggerPublish,
   isMobile,
   isTablet,
+  openDoc,
 }: GlobalHeaderShellBuildBindings) {
   // [3.6] shell-globalHeader · Primitive · "Brand Tagline"
   // Concern: Build · Parent: "Brand Identity Zone" · Catalog: content.copy
@@ -148,6 +168,7 @@ export function GlobalHeaderShell({
           {tabs.map(tab => {
             const isActive = tab.id === activeTab;
             const isHovered = hoveredTab === tab.id;
+            const infoLabelId = `global-header-tab-${tab.id}-summary`;
             return (
               // [3.9] shell-globalHeader · Subcontainer · "Tab Item Row"
               // Concern: Build · Parent: "Tab List Track" · Catalog: layout.row
@@ -160,12 +181,25 @@ export function GlobalHeaderShell({
                   onSelect={() => selectTab(tab.id)}
                   onMouseEnter={() => hoverTab(tab.id)}
                   onMouseLeave={() => hoverTab(null)}
+                  onFocus={() => hoverTab(tab.id)}
+                  onBlur={() => hoverTab(null)}
                 />
                 <InfoIcon
                   label={tab.hoverSummary}
-                  onMouseEnter={() => hoverTab(tab.id)}
-                  onMouseLeave={() => hoverTab(null)}
+                  onMouseEnter={() => {
+                    hoverTab(tab.id);
+                  }}
+                  onMouseLeave={() => {
+                    hoverTab(null);
+                  }}
+                  onFocus={() => hoverTab(tab.id)}
+                  onBlur={() => hoverTab(null)}
+                  onClick={() => openDoc(tab.docId)}
+                  describedById={infoLabelId}
                 />
+                <span id={infoLabelId} className="visually-hidden">
+                  {tab.hoverSummary}
+                </span>
               </div>
             );
           })}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
@@ -30,6 +30,36 @@ export interface HeaderTabDefinition {
   hoverSummary: string;
 }
 
+// [6.2.a] shell-globalHeader · Primitive · "Header Documentation Link Schema"
+// Concern: Knowledge · Catalog: schema.definition
+// Notes: Associates documentation links for cross-navigation inside modal output.
+export interface HeaderDocLink {
+  label: string;
+  docId: string;
+  description?: string;
+}
+
+// [6.2.b] shell-globalHeader · Primitive · "Header Documentation Section Schema"
+// Concern: Knowledge · Catalog: schema.definition
+// Notes: Breaks documentation body into digestible headings and copy blocks.
+export interface HeaderDocSection {
+  heading: string;
+  body: string[];
+}
+
+// [6.2.c] shell-globalHeader · Primitive · "Header Documentation Definition"
+// Concern: Knowledge · Catalog: schema.definition
+// Notes: Source of truth for documentation payload consumed by results concern modal.
+export interface HeaderDocDefinition {
+  id: string;
+  concern: 'Build' | 'Logic' | 'Knowledge' | 'Results';
+  title: string;
+  summary: string;
+  recommendedWorkflows?: string[];
+  sections: HeaderDocSection[];
+  links?: HeaderDocLink[];
+}
+
 // [6.3] shell-globalHeader · Primitive · "Header Tab Knowledge Base"
 // Concern: Knowledge · Catalog: data.collection
 // Notes: Canonical list of header tabs sorted by `order`.
@@ -100,3 +130,184 @@ export const BRAND_TOOLTIP = 'Return to Calculogic home / dashboard.';
 // Concern: Knowledge · Catalog: content.copy
 // Notes: Publish CTA text consumed by build concern.
 export const PUBLISH_LABEL = 'Publish';
+
+// [6.10] shell-globalHeader · Primitive · "Header Documentation Definitions"
+// Concern: Knowledge · Catalog: data.collection
+// Notes: Encodes contextual documentation surfaced via info icon modal per concern.
+export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
+  'doc-build': {
+    id: 'doc-build',
+    concern: 'Build',
+    title: 'Build Concern Overview',
+    summary:
+      'Assemble layouts with containers, sub-containers, and atomic components. Build/Style/ applies theming to the same structure.',
+    recommendedWorkflows: [
+      'Start from an official Configuration and customize anchors, containers, and atomic placements.',
+      'Switch to Build/Style/ to adjust spacing, typography, and color tokens for the active structure.',
+    ],
+    sections: [
+      {
+        heading: 'What lives in Build/',
+        body: [
+          'Define top-level containers, identify sub-containers, and anchor atomic components. Every structural decision rolls up into this concern.',
+          'When you keep Build/ authoritative, cloning configurations stays predictable and documentation tags stay in sync.',
+        ],
+      },
+      {
+        heading: 'When to use Build/Style/',
+        body: [
+          'Use Build/Style/ to adjust the presentation of the same structure without mutating the canonical container tree.',
+          'Preview Style directly from the tab hover if you are working from another concern and need a quick check on presentation.',
+        ],
+      },
+      {
+        heading: 'Tips for getting started',
+        body: [
+          'Use anchors (data-anchor) consistently so downstream automation and documentation stay linked.',
+          'Leverage the guidance panel on the canvas to remind collaborators which structural pieces belong here versus Logic or Results.',
+        ],
+      },
+    ],
+    links: [
+      {
+        label: 'Jump to Logic guidance',
+        docId: 'doc-logic',
+        description: 'Add state handling and conditional rules once structure is in place.',
+      },
+      {
+        label: 'Review Results outputs',
+        docId: 'doc-results',
+        description: 'Confirm derived data and presentation targets before publishing.',
+      },
+    ],
+  },
+  'doc-logic': {
+    id: 'doc-logic',
+    concern: 'Logic',
+    title: 'Logic Concern Overview',
+    summary: 'Add calculations, conditions, and interaction rules. Keep heavy math in helpers and orchestrate workflows here.',
+    recommendedWorkflows: [
+      'Use Logic/ to react to user input, validate data, and orchestrate cross-configuration communication.',
+      'Pair Logic rules with Knowledge traits to stay consistent across similar builds.',
+    ],
+    sections: [
+      {
+        heading: 'Responsibilities',
+        body: [
+          'Bind to viewport state, configuration context, and orchestrate actions like publish or docs modal control.',
+          'React to tab changes by setting active modes for Build and Results, ensuring breadcrumbs stay accurate.',
+        ],
+      },
+      {
+        heading: 'What stays out',
+        body: [
+          'Do not encode styling tokens here; those belong in Build/Style/ or Results/Style/.',
+          'Leave persistent data definitions to Knowledge/. Import them as needed instead of redefining them locally.',
+        ],
+      },
+      {
+        heading: 'Publishing pipeline hook',
+        body: [
+          'Trigger onPublish when the header publish CTA is pressed. The pipeline can evolve without changing the header shell.',
+        ],
+      },
+    ],
+    links: [
+      {
+        label: 'See Knowledge reference',
+        docId: 'doc-knowledge',
+        description: 'Understand how shared schemas and traits feed your logic flows.',
+      },
+    ],
+  },
+  'doc-knowledge': {
+    id: 'doc-knowledge',
+    concern: 'Knowledge',
+    title: 'Knowledge Concern Overview',
+    summary: 'Store reusable traits, constants, and reference schemas to keep builds consistent.',
+    recommendedWorkflows: [
+      'Centralize enumerations, scoring tables, and shared text snippets.',
+      'Expose documentation variables to automatically populate configuration guidance.',
+    ],
+    sections: [
+      {
+        heading: 'Why Knowledge matters',
+        body: [
+          'Knowledge/ is the bridge between reusable data and the live builder experience. It feeds hover summaries, doc payloads, and automation tags.',
+          'Keep meta.summary and doc descriptors updated so every ℹ️ icon stays trustworthy.',
+        ],
+      },
+      {
+        heading: 'Documentation propagation',
+        body: [
+          'Use documentationVariables to keep cloned configurations coherent. Built-in tags like {{name}} and {{#atomicComponents}} update automatically.',
+          'Plan for future sync tooling that can reconcile atomicDoc changes back into cloned configs when requested.',
+        ],
+      },
+    ],
+    links: [
+      {
+        label: 'Review Build structure',
+        docId: 'doc-build',
+        description: 'See how Knowledge summaries surface within the structural concern.',
+      },
+      {
+        label: 'Inspect Results outputs',
+        docId: 'doc-results',
+        description: 'Confirm how Knowledge data feeds final reporting.',
+      },
+    ],
+  },
+  'doc-results': {
+    id: 'doc-results',
+    concern: 'Results',
+    title: 'Results Concern Overview',
+    summary: 'Design and inspect derived outputs, scores, and summaries. Results/Style/ fine-tunes their presentation.',
+    recommendedWorkflows: [
+      'Define scoring formulas and narrative summaries in Results/.',
+      'Switch to Results/Style/ to control layout, chart framing, and typography for the same payload.',
+    ],
+    sections: [
+      {
+        heading: 'Outputs first',
+        body: [
+          'Treat Results/ as the source of truth for derived data structures. Keep transformations transparent for auditing.',
+          'Leverage the debug panel (when enabled) to confirm which modes and breakpoints are active during testing.',
+        ],
+      },
+      {
+        heading: 'Styling the outcomes',
+        body: [
+          'Use Results/Style/ to control cards, analytics surfaces, and score highlights without redefining calculations.',
+          'Coordinate with Build/Style/ so that shared tokens stay synchronized across the experience.',
+        ],
+      },
+      {
+        heading: 'Publish readiness',
+        body: [
+          'Before triggering publish, confirm Results outputs are populated and narrative copy is proofed.',
+          'Cross-check Knowledge definitions to ensure referenced schemas are current and unambiguous.',
+        ],
+      },
+    ],
+    links: [
+      {
+        label: 'Open Build guidance',
+        docId: 'doc-build',
+        description: 'Verify structural anchors before styling outcomes.',
+      },
+      {
+        label: 'Reference Knowledge data',
+        docId: 'doc-knowledge',
+        description: 'Ensure shared traits and constants align with your reporting.',
+      },
+    ],
+  },
+};
+
+// [6.11] shell-globalHeader · Primitive · "Header Documentation Resolver"
+// Concern: Knowledge · Catalog: data.accessor
+// Notes: Provides safe lookup for modal consumption with null fallback when docId is unknown.
+export function resolveHeaderDoc(docId: string): HeaderDocDefinition | null {
+  return HEADER_DOC_DEFINITIONS[docId] ?? null;
+}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.results.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.results.css
@@ -25,3 +25,158 @@
   gap: 0.25rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
+
+/* [8.2] shell-globalHeader · Primitive · "Documentation Overlay"
+   Concern: ResultsStyle · Catalog: modal.overlay
+   Notes: Dimmed backdrop and scroll container for documentation modal. */
+.global-header-shell__doc-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 12, 18, 0.78);
+  backdrop-filter: blur(2px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 4rem 1.5rem 2rem;
+  z-index: 1000;
+  overflow-y: auto;
+}
+
+/* [8.3] shell-globalHeader · Primitive · "Documentation Modal"
+   Concern: ResultsStyle · Catalog: modal.panel
+   Notes: Card-like panel with comfortable typography and spacing. */
+.global-header-shell__doc-modal {
+  position: relative;
+  width: min(640px, 100%);
+  background: #101322;
+  color: #f5f7ff;
+  border-radius: 1rem;
+  box-shadow: 0 24px 48px rgba(4, 6, 12, 0.45);
+  padding: 2.25rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* [8.4] shell-globalHeader · Primitive · "Documentation Header"
+   Concern: ResultsStyle · Catalog: modal.header
+   Notes: Typography hierarchy aligning concern label, title, and summary. */
+.global-header-shell__doc-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.global-header-shell__doc-concern {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: rgba(245, 247, 255, 0.65);
+}
+
+.global-header-shell__doc-summary {
+  margin: 0;
+  color: rgba(245, 247, 255, 0.85);
+  line-height: 1.45;
+}
+
+/* [8.5] shell-globalHeader · Primitive · "Documentation Sections"
+   Concern: ResultsStyle · Catalog: modal.section
+   Notes: Ensures readable rhythm for section headings and paragraphs. */
+.global-header-shell__doc-section {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.global-header-shell__doc-section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.global-header-shell__doc-section p {
+  margin: 0;
+  color: rgba(245, 247, 255, 0.78);
+  line-height: 1.6;
+}
+
+.global-header-shell__doc-section ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  color: rgba(245, 247, 255, 0.78);
+}
+
+/* [8.6] shell-globalHeader · Primitive · "Documentation Close Button"
+   Concern: ResultsStyle · Catalog: modal.close
+   Notes: Places close affordance without stealing focus from content. */
+.global-header-shell__doc-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: rgba(245, 247, 255, 0.12);
+  color: #f5f7ff;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.16s ease, transform 0.16s ease;
+}
+
+.global-header-shell__doc-close:hover,
+.global-header-shell__doc-close:focus-visible {
+  background: rgba(245, 247, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+/* [8.7] shell-globalHeader · Primitive · "Documentation Links"
+   Concern: ResultsStyle · Catalog: modal.links
+   Notes: Styled list of buttons allowing navigation to sibling docs. */
+.global-header-shell__doc-link-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.global-header-shell__doc-link {
+  width: 100%;
+  text-align: left;
+  background: rgba(245, 247, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(245, 247, 255, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.2rem;
+  cursor: pointer;
+  transition: background 0.16s ease, border-color 0.16s ease;
+}
+
+.global-header-shell__doc-link:hover,
+.global-header-shell__doc-link:focus-visible {
+  background: rgba(245, 247, 255, 0.16);
+  border-color: rgba(245, 247, 255, 0.32);
+}
+
+.global-header-shell__doc-link-label {
+  font-weight: 600;
+}
+
+.global-header-shell__doc-link-desc {
+  font-size: 0.85rem;
+  color: rgba(245, 247, 255, 0.72);
+}
+
+@media (max-width: 767px) {
+  .global-header-shell__doc-modal {
+    padding: 1.75rem 1.5rem;
+    border-radius: 0.85rem;
+  }
+
+  .global-header-shell__doc-overlay {
+    padding-top: 3rem;
+  }
+}

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx
@@ -5,6 +5,7 @@
  * Responsibility: Render optional debug panel mirroring live header state.
  * Invariants: Debug remains hidden unless enabled; output stays read-only diagnostic copy.
  */
+import { useEffect, useMemo } from 'react';
 import type { GlobalHeaderShellResultsBindings } from './GlobalHeaderShell.logic';
 
 // ─────────────────────────────────────────────
@@ -17,18 +18,27 @@ import type { GlobalHeaderShellResultsBindings } from './GlobalHeaderShell.logic
 // [7.1] shell-globalHeader · Container · "Global Header Debug Panel"
 // Concern: Results · Catalog: diagnostics.panel
 // Notes: Wraps optional debug rows for shell instrumentation.
-export function GlobalHeaderShellResults({ debugPanel }: GlobalHeaderShellResultsBindings) {
-  // [7.2] shell-globalHeader · Primitive · "Debug Visibility Gate"
-  // Concern: Results · Parent: "Global Header Debug Panel" · Catalog: logic.guard
-  // Notes: Avoids DOM allocation unless debug is explicitly enabled.
-  if (!debugPanel.visible) {
-    return null;
-  }
+export function GlobalHeaderShellResults({ debugPanel, docModal }: GlobalHeaderShellResultsBindings) {
+  // [7.2] shell-globalHeader · Primitive · "Escape Key Close Handler"
+  // Concern: Results · Parent: "Global Header Debug Panel" · Catalog: interaction.handler
+  // Notes: Closes documentation modal when Escape is pressed.
+  useEffect(() => {
+    if (!docModal.visible) {
+      return undefined;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        docModal.closeDoc();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [docModal.visible, docModal.closeDoc]);
 
-  // [7.3] shell-globalHeader · Primitive · "Debug State Rows"
-  // Concern: Results · Parent: "Global Header Debug Panel" · Catalog: diagnostics.readout
-  // Notes: Surface current shell state values for developer inspection.
-  return (
+  const debugContent = debugPanel.visible ? (
+    // [7.3] shell-globalHeader · Primitive · "Debug State Rows"
+    // Concern: Results · Parent: "Global Header Debug Panel" · Catalog: diagnostics.readout
+    // Notes: Surface current shell state values for developer inspection.
     <aside className="global-header-shell__debug" data-anchor="global-header.debug">
       <div>
         <strong>Active tab:</strong> {debugPanel.state.activeTab}
@@ -45,6 +55,92 @@ export function GlobalHeaderShellResults({ debugPanel }: GlobalHeaderShellResult
       <div>
         <strong>Hovered tab:</strong> {debugPanel.state.hoveredTab ?? 'none'}
       </div>
+      <div>
+        <strong>Active doc:</strong> {debugPanel.state.activeDocId ?? 'none'}
+      </div>
     </aside>
+  ) : null;
+
+  const docTitleId = useMemo(() => (docModal.doc ? `global-header-doc-title-${docModal.doc.id}` : undefined), [docModal.doc]);
+  const docSummaryId = useMemo(
+    () => (docModal.doc ? `global-header-doc-summary-${docModal.doc.id}` : undefined),
+    [docModal.doc],
+  );
+
+  const modalContent = docModal.visible && docModal.doc ? (
+    <div className="global-header-shell__doc-overlay" role="presentation" onClick={docModal.closeDoc}>
+      <div
+        className="global-header-shell__doc-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={docTitleId}
+        aria-describedby={docSummaryId}
+        onClick={event => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="global-header-shell__doc-close"
+          onClick={docModal.closeDoc}
+          aria-label="Close documentation"
+        >
+          ×
+        </button>
+        <header className="global-header-shell__doc-header">
+          <p className="global-header-shell__doc-concern">{docModal.doc.concern}</p>
+          <h2 id={docTitleId}>{docModal.doc.title}</h2>
+          <p id={docSummaryId} className="global-header-shell__doc-summary">
+            {docModal.doc.summary}
+          </p>
+        </header>
+        {docModal.doc.recommendedWorkflows && docModal.doc.recommendedWorkflows.length > 0 && (
+          <section className="global-header-shell__doc-section" aria-labelledby={`${docTitleId}-workflows`}>
+            <h3 id={`${docTitleId}-workflows`}>Recommended workflows</h3>
+            <ul>
+              {docModal.doc.recommendedWorkflows.map(workflow => (
+                <li key={workflow}>{workflow}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {docModal.doc.sections.map(section => (
+          <section key={section.heading} className="global-header-shell__doc-section">
+            <h3>{section.heading}</h3>
+            {section.body.map(paragraph => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </section>
+        ))}
+        {docModal.doc.links && docModal.doc.links.length > 0 && (
+          <section className="global-header-shell__doc-section" aria-labelledby={`${docTitleId}-links`}>
+            <h3 id={`${docTitleId}-links`}>Cross-links</h3>
+            <ul className="global-header-shell__doc-link-list">
+              {docModal.doc.links.map(link => (
+                <li key={link.docId}>
+                  <button
+                    type="button"
+                    className="global-header-shell__doc-link"
+                    onClick={() => docModal.openDoc(link.docId)}
+                  >
+                    <span className="global-header-shell__doc-link-label">{link.label}</span>
+                    {link.description && <span className="global-header-shell__doc-link-desc">{link.description}</span>}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </div>
+  ) : null;
+
+  if (!debugContent && !modalContent) {
+    return null;
+  }
+
+  return (
+    <>
+      {debugContent}
+      {modalContent}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add knowledge catalog entries for each header concern and expose a resolver for doc payloads
- wire info icons to open their documentation and surface the payload through the logic bindings
- render and style a documentation modal with cross-links plus accessibility affordances, alongside the existing debug panel

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154ba95f548331a471554f5c5da165)