### PR TITLE
Adjust tab list overflow handling

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -107,8 +107,7 @@
   display: inline-flex;
   align-items: flex-start;
   gap: 0.75rem;
-  overflow-x: auto;
-  overflow-y: visible;
+  overflow: visible;
   padding: 0.25rem 0;
   white-space: nowrap;
 }
@@ -336,6 +335,8 @@
 
   .tab-list {
     gap: 0.35rem;
+    overflow-x: auto;
+    overflow-y: visible;
   }
 
   .mode-menu[data-pinned='true'] {


### PR DESCRIPTION
## Summary
- allow the desktop tab list track to expose dropdown content by default
- restore horizontal scrolling for narrow viewports via the mobile breakpoint rule

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157866a58083319ebc1da2b0b7d434)