### PR TITLE
Reduce mode menu dropdown width

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -203,7 +203,7 @@
   box-shadow:
     0 16px 40px rgba(5, 8, 20, 0.35),
     0 0 0 1px rgba(255, 255, 255, 0.16);
-  min-width: 5.2rem; /* increased from 4.5rem */
+  min-width: 4.5rem; /* reduced from 5.2rem so dropdown matches tab width */
   width: auto; /* allow menu to fit content while honoring min-width */
   z-index: 3; /* raise so it sits above adjacent UI */
   white-space: normal;


### PR DESCRIPTION
## Summary
- decrease the mode menu min-width to align the hover dropdown with its tab
- update the inline comment to document the narrower dimension

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915809ffc848331bc1865c21e97d720)