### PR TITLE
Adjust hover bridge for mode menu dropdown

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -219,10 +219,10 @@
   content: "";
   position: absolute;
   left: 50%;
-  top: -0.35rem; /* reach just enough toward the tab */
+  top: -0.6rem; /* extend further to keep hover active when moving toward the menu */
   transform: translateX(-50%);
-  width: calc(100% + 0.25rem); /* smaller bridge so text remains the primary target */
-  height: 0.35rem;
+  width: calc(100% + 0.6rem); /* widen bridge so pointer can travel without exiting hover */
+  height: 0.6rem;
   background: transparent;
   pointer-events: auto;
   z-index: 0;


### PR DESCRIPTION
## Summary
- extend the invisible hover bridge for the unpinned mode menu so the pointer can move into the dropdown without breaking hover

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691582b095c083319d3ce1c478bc7e81)