### PR TITLE
Simplify header mode menus

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -229,8 +229,12 @@ export function GlobalHeaderShell({
   // Concern: Build · Parent: "Brand Identity Zone" · Catalog: content.copy
   // Notes: Controlled here to suppress tagline on mobile breakpoints.
   const showTagline = !isMobile;
-  const buildModeItems = modeSequence.build.map(modeId => modeMetadata.build[modeId]);
-  const resultsModeItems = modeSequence.results.map(modeId => modeMetadata.results[modeId]);
+  const buildModeItems = modeSequence.build
+    .map(modeId => modeMetadata.build[modeId])
+    .filter(mode => mode.id !== 'default');
+  const resultsModeItems = modeSequence.results
+    .map(modeId => modeMetadata.results[modeId])
+    .filter(mode => mode.id !== 'default');
 
   return (
     // [3.1] shell-globalHeader · Container · "Global Header Shell Frame"

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts
@@ -163,18 +163,31 @@ export function useGlobalHeaderShellLogic({ onPublish }: GlobalHeaderShellProps 
   const selectTab = useCallback((tab: HeaderTabId) => {
     setState(prev => {
       const nextModeMenuVisibleForTab = isModeMenuTab(tab) ? tab : null;
+      const shouldResetMode =
+        isModeMenuTab(tab) && prev.activeModeByTab[tab] !== 'default';
+
       if (
         prev.activeTab === tab &&
         prev.hoveredTab === null &&
-        prev.modeMenuVisibleForTab === nextModeMenuVisibleForTab
+        prev.modeMenuVisibleForTab === nextModeMenuVisibleForTab &&
+        !shouldResetMode
       ) {
         return prev;
       }
+
+      const nextActiveModeByTab = shouldResetMode
+        ? {
+            ...prev.activeModeByTab,
+            [tab]: 'default',
+          }
+        : prev.activeModeByTab;
+
       return {
         ...prev,
         activeTab: tab,
         hoveredTab: null,
         modeMenuVisibleForTab: nextModeMenuVisibleForTab,
+        activeModeByTab: nextActiveModeByTab,
       };
     });
   }, []);


### PR DESCRIPTION
## Summary
- hide redundant Build/Results entries from the global header mode menus so only Style remains in each dropdown
- reset the active mode to the default layout when a user re-selects the Build or Results tabs to keep navigation intuitive

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in tabs/build/BuildSurface.logic.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691587ce4f60833182255143024e014d)