### PR TITLE
Simplify style mode tab highlight

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.css
@@ -162,10 +162,9 @@
 }
 
 .tab-button[data-active='true'][data-mode='style'] {
-  background: rgba(126, 158, 255, 0.28);
-  border-color: rgba(126, 158, 255, 0.72);
-  box-shadow: 0 0 0 1px rgba(126, 158, 255, 0.35);
-  color: #f8f9ff;
+  background: #7ba1ff;
+  border-color: #7ba1ff;
+  color: #0a0c12;
 }
 
 /* [4.13] shell-globalHeader · Primitive · "Tab Button Hover State"
@@ -274,24 +273,6 @@
   color: #0a0c12;
 }
 
-.tab-mode-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.7rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  background: rgba(126, 158, 255, 0.18);
-  color: rgba(230, 236, 255, 0.95);
-  box-shadow: 0 0 0 1px rgba(126, 158, 255, 0.35);
-}
-
-.tab-list__item[data-mode='style'] .tab-mode-indicator {
-  background: rgba(126, 158, 255, 0.26);
-  box-shadow: 0 0 0 1px rgba(126, 158, 255, 0.45);
-}
 
 /* [4.14] shell-globalHeader · Primitive · "Info Icon Baseline"
    Concern: BuildStyle · Catalog: action.icon

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -307,9 +307,6 @@ export function GlobalHeaderShell({
               : isResultsTab
               ? modeMetadata.results[activeModeId ?? 'default']
               : null;
-            const shouldShowModeIndicator =
-              (isBuildTab || isResultsTab) && activeModeDefinition && activeModeId === 'style';
-
             return (
               // [3.9] shell-globalHeader · Subcontainer · "Tab Item Row"
               // Concern: Build · Parent: "Tab List Track" · Catalog: layout.row
@@ -318,7 +315,11 @@ export function GlobalHeaderShell({
                 key={tab.id}
                 className={`tab-list__item${shouldShowModeMenu ? ' tab-list__item--has-menu' : ''}`}
                 data-anchor={`global-header.tab-${tab.id}`}
-                data-mode={shouldShowModeIndicator ? activeModeDefinition.id : undefined}
+                data-mode={
+                  (isBuildTab || isResultsTab) && activeModeDefinition?.id === 'style'
+                    ? activeModeDefinition.id
+                    : undefined
+                }
                 onMouseEnter={() => hoverTab(tab.id)}
                 onMouseLeave={() => hoverTab(null)}
                 onFocus={() => hoverTab(tab.id)}
@@ -350,15 +351,6 @@ export function GlobalHeaderShell({
                 <span id={infoLabelId} className="visually-hidden">
                   {tab.hoverSummary}
                 </span>
-                {shouldShowModeIndicator && activeModeDefinition && (
-                  <span
-                    className="tab-mode-indicator"
-                    data-anchor={`global-header.tab-${tab.id}.mode-indicator`}
-                    aria-live={isActive ? 'polite' : undefined}
-                  >
-                    {activeModeDefinition.label} mode active
-                  </span>
-                )}
                 {isBuildTab && shouldShowModeMenu && (
                   <BuildModeMenu
                     activeMode={activeModeByTab.build}


### PR DESCRIPTION
## Summary
- remove the style-mode underline halo on build/results tab items
- keep the style-mode emphasis limited to the active tab with a blue background treatment

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in src/tabs/build/BuildSurface.logic.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158ccfaa348331a27e95e7521b907c)