### PR TITLE
Include default modes in header menus

### DIFF
--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -232,12 +232,10 @@ export function GlobalHeaderShell({
   // Concern: Build · Parent: "Brand Identity Zone" · Catalog: content.copy
   // Notes: Controlled here to suppress tagline on mobile breakpoints.
   const showTagline = !isMobile;
-  const buildModeItems = modeSequence.build
-    .map(modeId => modeMetadata.build[modeId])
-    .filter(mode => mode.id !== 'default');
-  const resultsModeItems = modeSequence.results
-    .map(modeId => modeMetadata.results[modeId])
-    .filter(mode => mode.id !== 'default');
+  const buildModeItems = modeSequence.build.map(modeId => modeMetadata.build[modeId]);
+  const resultsModeItems = modeSequence.results.map(
+    modeId => modeMetadata.results[modeId],
+  );
 
   return (
     // [3.1] shell-globalHeader · Container · "Global Header Shell Frame"


### PR DESCRIPTION
## Summary
- include the default mode definition when preparing build and results mode menus so both pills render
- retain the existing ModeMenuItem data attributes so the active mode receives the blue styling

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint/no-explicit-any violations in BuildSurface.logic.ts)*
- Manual UI verification in Vite dev server: toggled Build/Results mode menus to confirm the blue state follows the active option

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915947f475483319ba6ffd75b3926e9)