### PR TITLE
Document CSS mapping for BuildStyle and ResultsStyle

### DIFF
--- a/doc/CCPP.md
+++ b/doc/CCPP.md
@@ -68,6 +68,7 @@ Use sparingly, only when the reason is not obvious.
 // Choice: Use CSS hover for previews instead of JS listeners
 // Consequence: Less JS complexity; no previews on touch devices
 // ADR: header-hover-001   // optional
+Promote a Decision note to a standalone ADR when the rationale spans multiple paragraphs, introduces cross-team dependencies, or affects more than one configuration. Longer decisions live alongside other records in doc/decisions/*.md; reference the ADR id from the inline note once it exists.
 3.6 TODO with expiry
 // TODO(@owner, 2025-12-01): Wire openDoc(docId) to docs modal shell
 Must always have owner and date.
@@ -81,6 +82,8 @@ No payload; just reference.
 TS/TSX/JS: /** ... */ for file header; // ... for everything else.
 
 CSS: /* ... */ for file and atomic comments; still match NL numbers.
+
+Remember the concern-to-file mapping: Build/Results use `.tsx` structure files, BuildStyle/ResultsStyle are CSS or CSS-Module files that consume the anchors emitted by those structures, Logic lives in `.ts`/`.tsx` modules, and Knowledge is `.ts` data. Comment styles must match the host language.
 
 JSON: no comments; if needed, keep a .meta or .md doc instead.
 
@@ -141,13 +144,13 @@ Build file:
 // Concern: Build · Catalog: layout.shell
 export function GlobalHeaderShell() { ... }
 BuildStyle file:
-/* 
+/*
  * Configuration: cfg-tabNavigation (Tab Navigation)
  * Concern File: BuildStyle
  * Source NL: doc/nl-config/cfg-tabNavigation.md
  * Responsibility: Visual styling of header tab strip (no structure)
  * Invariants: Tabs remain single-line; scroll instead of wrap
- */
+*/
 
 /* [4.2.1] cfg-tabNavigation · Primitive · "Tab Item Base Rule"
    Matches Build primitive [3.3.4–3.3.7] (tab buttons)
@@ -155,6 +158,17 @@ BuildStyle file:
 .globalHeader__tab {
   /* ... */
 }
+
+Bad vs. good atomic comments
+
+- Bad:
+  - `// handles tab click`
+  - `const handleClick = () => setActive(tabId);`
+  (Narrates the obvious and lacks NL reference.)
+- Good:
+  - `// [5.2.2] cfg-tabNavigation · Primitive · "handleTabSelect"`
+  - `// Concern: Logic · Parent: "Tab Navigation Logic" · Notes: syncs active tab state`
+  - `const handleTabSelect = (tabId: string) => setActiveTab(tabId);`
 
 8. Maintenance Rules
 On every structural change:

--- a/doc/CSCS.md
+++ b/doc/CSCS.md
@@ -6,7 +6,7 @@ A Configuration is a semantic module (e.g. “Global Header Shell”, “Tab Nav
 
 It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
 
-Code lives in six concern files; the configuration is defined by its NL skeleton, not its file layout.
+Code lives in six concern files; the configuration is defined by its NL skeleton, not its file layout. The canonical section layout and numbering for NL skeletons is defined in General-NL-Skeletons.md and every configuration or shell document must follow it exactly.
 
 NL Skeleton as the ordering source
 
@@ -39,6 +39,17 @@ Knowledge – copy, constants, reference tables; no state mutation, no layout, n
 Results – derived outputs / readouts; no structure creation beyond what Build defines.
 
 ResultsStyle – styling of results; no structure, no logic.
+
+Folder mapping
+
+- Build → files like src/configs/<configId>/<ConfigName>.build.tsx or src/shells/<shellId>/<ShellName>.build.tsx
+- BuildStyle → CSS or CSS-Module files like src/configs/<configId>/<ConfigName>.build.module.css or src/shells/<shellId>/<ShellName>.build.css
+- Logic → files like src/configs/<configId>/<ConfigName>.logic.ts (or `.logic.tsx` when React hooks are required)
+- Knowledge → files like src/configs/<configId>/<ConfigName>.knowledge.ts
+- Results → files like src/configs/<configId>/<ConfigName>.results.ts (or `.results.tsx` when JSX is emitted)
+- ResultsStyle → CSS or CSS-Module files like src/configs/<configId>/<ConfigName>.results.module.css or src/shells/<shellId>/<ShellName>.results.css
+
+Shells follow the same pattern within src/shells/<shellId>/, sharing the same base name across all concern files. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files; the corresponding Build and Results `.tsx` components expose the class names and data attributes that those styles consume.
 
 Structure source and fallbacks
 
@@ -167,11 +178,15 @@ It cannot operate meaningfully without that parent structure.
 
 It never reorders or replaces the parent’s anchors.
 
+Example: The global header shell includes a nested tab-strip configuration that mounts directly into the header’s Build anchors.
+
 Sibling configuration otherwise:
 
 It uses the same frame (shell) but defines its own Build structure and anchors.
 
 Promote from nested → sibling when a feature gains its own structure, reuse, or lifecycle.
+
+Example: cfg-intro, cfg-q-motivations, and cfg-buildSurface coexist as siblings that the spa host shell swaps within the same main-pane frame.
 
 6. Change Management
 When you change a configuration:

--- a/doc/ConfigurationArchitectureSummary.md
+++ b/doc/ConfigurationArchitectureSummary.md
@@ -16,23 +16,36 @@ Calculogic delivers three experiences in parallel:
 3. **No-Code Interface** – Dropdowns and toggles provide guardrails, while syntax and reference validation prevent errors.
 
 ## Architectural Principles
-- **Layer Order** – Build → View → Logic → Knowledge → Results.
-- **Directional Dependencies** – Build feeds View and Logic; Logic feeds Results; Knowledge informs every layer; cycles are forbidden.
+- **Layer Order** – Build → BuildStyle → Logic → Knowledge → Results → ResultsStyle.
+- **Directional Dependencies** – Build feeds BuildStyle and Logic; Logic feeds Results; Knowledge informs every layer; Results in turn inform ResultsStyle; cycles are forbidden.
 - **Stable Anchors** – Every layer exposes deliberate anchors (names, classes, or data attributes) for downstream references.
-- **Layer Purity** – Build handles structure, View handles appearance, Logic handles interaction/state, Knowledge handles reference content, and Results handles derived feedback.
+- **Layer Purity** – Build handles structure, BuildStyle handles appearance of configuration surfaces, Logic handles interaction/state, Knowledge handles reference content, Results handles derived feedback, and ResultsStyle handles presentation of those results.
+- **Implementation Mapping** – Build and Results concerns are implemented in `.tsx` structure files (for example `Something.build.tsx` or `Something.results.tsx`), BuildStyle and ResultsStyle live in CSS or CSS-Module files (for example `Something.build.module.css` or `Something.results.css`), Logic sits in `.ts`/`.tsx` logic files, and Knowledge resides in `.ts` static data modules. BuildStyle and ResultsStyle rely on class names and data attributes emitted by the React structure concerns.
 - **Locality & Monotonic Diffs** – Each concern is self-contained, and changes cascade predictably in a single direction.
 
 ## JSON-First Operation
 Guided natural-language templates generate JSON as the single source of truth. Beginners work with plain sentences, intermediates manipulate syntax-aware templates, and advanced users export the JSON for integration elsewhere.
 
+In earlier drafts, “View” referred to visual treatment across both configuration and results experiences; this is now split into BuildStyle (for configuration surfaces) and ResultsStyle (for result surfaces).
+
 ## Versioning & Cloning
-Cloning behaves like Git branching. Users fork Build, View, Logic, and Knowledge data from an existing configuration, edit safely, and optionally merge improvements without mutating the source.
+Cloning behaves like Git branching. Users fork Build, BuildStyle, Logic, and Knowledge data from an existing configuration, edit safely, and optionally merge improvements without mutating the source.
 
 ## Practical Example: Enneagram Test
 - **Build Tab** – Assemble configurations (e.g., checkbox + slider) and validate identifiers and trait links.
+- **BuildStyle Tab** – Customize appearance of configuration surfaces via atomic CSS properties maintained in CSS or CSS-Module files.
 - **Logic Tab** – Define conditionals, such as `slider-empathy.value > 7`.
-- **View Tab** – Customize appearance via atomic CSS properties.
+- **Knowledge Tab** – Centralize reference data and static instructional copy for the configuration.
 - **Results Tab** – Calculate personality outcomes from user responses.
+- **ResultsStyle Tab** – Present computed outcomes in a consistent, styled surface by applying CSS or CSS-Module styling hooks exposed by the Results structures.
 
 ## Educational & Systemic Goals
 Calculogic transforms form building into a hands-on coding lesson. Each tab enforces separation of concerns while guaranteeing interoperability, supporting sharing, cloning, and officialization across the system.
+
+## Related Docs / Reading Order
+1. ConfigurationArchitectureSummary.md (this document)
+2. CSCS.md (Concern semantics and file mappings)
+3. General-NL-Skeletons.md (Canonical NL skeleton templates)
+4. NL-First-Workflow.md (Authoring workflow)
+5. CCPP.md (Comment and provenance protocol)
+6. doc/nl-config/*.md and doc/nl-shell/*.md (Per-configuration and shell specifications built from the skeletons)

--- a/doc/General-NL-Skeletons.md
+++ b/doc/General-NL-Skeletons.md
@@ -1,3 +1,11 @@
+Purpose / Usage
+
+This doc defines the canonical NL skeleton templates used by all configuration (doc/nl-config/*.md) and shell (doc/nl-shell/*.md) documents. Section numbers (1–10) and concern ordering are considered stable contracts.
+
+Changing this doc
+
+If you change top-level sections or numbering here, you must also update NL-First-Workflow.md, CSCS.md, and CCPP.md to keep the system consistent.
+
 1) General NL Skeleton – Configuration-Level
 Use this for things like “Motivations question,” individual sections, etc.
 Configuration: [Config Name] ([config-id])
@@ -12,7 +20,7 @@ A Configuration is a semantic module, not a file.
 It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
 
 
-At export, its atomic components are merged with other configurations into the six project-level files (project.build.tsx, project.logic.ts, etc.).
+Per-configuration implementation files live under paths like src/configs/<configId>/<ConfigName>.build.tsx (structure), src/configs/<configId>/<ConfigName>.build.module.css (configuration styling), and the other concern files with matching base names. The engine or build step may merge those into project-level bundles such as src/projects/<projectId>/Project.build.tsx. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files that target the anchors emitted by the Build and Results `.tsx` concerns.
 
 
 All content of a configuration is expressed as Atomic Components.
@@ -281,14 +289,14 @@ Styling for debug overlays/panels.
 
 9. Assembly Pattern
 9.1 File Structure (implementation pattern; configuration still semantic)
-/[feature]/[ConfigName]/
+/src/configs/[config-id]/[ConfigName]/
   [ConfigName].build.tsx
-  [ConfigName].build.css
+  [ConfigName].build.module.css
   [ConfigName].logic.ts
   [ConfigName].knowledge.ts
-  [ConfigName].results.tsx
-  [ConfigName].results.css
-  index.tsx
+  [ConfigName].results.ts
+  [ConfigName].results.module.css
+  index.ts
 9.2 Assembly Logic
 index.tsx wires concerns together and exports a single component that implements this configuration.
 
@@ -476,14 +484,14 @@ Tab change messages, mode change messages.
 
 9. Assembly Pattern
 9.1 File Structure
-/src/components/[ShellName]/
+/src/shells/[shell-id]/[ShellName]/
   [ShellName].build.tsx
-  [ShellName].build.css
+  [ShellName].build.module.css
   [ShellName].logic.ts
   [ShellName].knowledge.ts
   [ShellName].results.tsx
-  [ShellName].results.css
-  index.tsx
+  [ShellName].results.module.css
+  index.ts
 9.2 Assembly Logic
 Hook for logic, build component for structure, knowledge/constants, optional results debug.
 

--- a/doc/NL-First-Workflow.md
+++ b/doc/NL-First-Workflow.md
@@ -1,5 +1,5 @@
 NL-First Workflow (What the AI Does First)
-Golden rule: Before generating or editing any code for a configuration or shell, the AI must create or update the NL skeleton text file for it.
+Golden rule: Before generating or editing any code for a configuration or shell, instantiate the appropriate NL skeleton template from General-NL-Skeletons.md (Configuration-Level or ProjectShell-Level) and create or update the NL skeleton text file for it.
 0. NL Skeleton Step (Mandatory First Step)
 When starting work on a feature, configuration, or shell:
 Decide the type:
@@ -14,9 +14,9 @@ doc/nl-shell/shell-[name].md
 
 Create (or update) the NL skeleton file using the correct template:
 
-Configuration-Level → “General NL Skeleton – Configuration-Level”
-
-ProjectShell-Level → “General NL Skeleton – ProjectShell-Level”
+- Skeleton templates:
+  - General-NL-Skeletons.md → Section 1.x–10.x under “General NL Skeleton – Configuration-Level” for configurations
+  - General-NL-Skeletons.md → Section 1.x–10.x under “General NL Skeleton – ProjectShell-Level” for shells
 
 Fill it out in prose:
 
@@ -31,6 +31,8 @@ Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle
 Atomic Components (Containers, Subcontainers, Primitives) with numbering (3.1, 3.2.1, 3.3.1, etc.)
 
 Assembly pattern and implementation passes
+
+Implementation reminder: Build and Results concerns are authored in `.tsx` structure files, BuildStyle and ResultsStyle live in CSS or CSS-Module files, Logic occupies `.ts`/`.tsx` logic modules, and Knowledge resides in `.ts` static data modules. BuildStyle and ResultsStyle rely on the class names and data attributes emitted by their paired structure concerns.
 
 Only after the NL file exists and is filled in may the AI:
 
@@ -68,3 +70,19 @@ The change to code is reflected in NL, and the numbering matches.
 All new functions/components/blocks have the correct [sectionNumber] cfg-id · type · name comments.
 
 No concern file contains “orphan” code that isn’t mentioned in the NL skeleton.
+
+Example alignment
+
+- NL excerpt:
+  - [3.2.1] Subcontainer “Center Zone – Tab Strip” (Build)
+  - [5.2.2] Handler “handleTabSelect” (Logic)
+- Code comments:
+  - `// [3.2.1] cfg-buildSurface · Subcontainer · "Center Zone – Tab Strip"`
+  - `// [5.2.2] cfg-buildSurface · Primitive · "handleTabSelect"`
+- Code stub:
+  - ```ts
+    // [5.2.2] cfg-buildSurface · Primitive · "handleTabSelect"
+    const handleTabSelect = (tabId: string) => {
+      setActiveTab(tabId);
+    };
+    ```

--- a/doc/nl-config/cfg-appFrame.md
+++ b/doc/nl-config/cfg-appFrame.md
@@ -1,63 +1,160 @@
 # cfg-appFrame – App Frame Configuration
 
-## 1. Purpose
+This document is an instance of the Configuration-Level NL Skeleton defined in ../General-NL-Skeletons.md.
+
+## 1. Purpose and Scope
+### 1.1 Purpose
 Provide the global frame for the Calculogic application, expose the theme toggle, and host the Build tab configuration within a stable anchor structure.
 
-## 2. Scope
-### In-Scope
-- Rendering the outer application shell and theme toggle control.
-- Managing the user's dark mode preference and syncing it to the document body.
-- Styling the frame container and toggle affordance, including dark-mode CSS variables.
+### 1.2 Context
+Appears as the persistent outer shell that wraps all configuration tabs within the single-page host.
 
-### Out-of-Scope
-- Tab routing logic beyond mounting the Build tab.
-- Application-wide data fetching or persistence unrelated to theme preference.
-- Nested configuration styling handled by downstream configs (e.g., Build surface).
+### 1.3 Interactions
+Embeds the Build tab configuration via a mount anchor and coordinates with the global header shell for navigation.
 
-## 3. Concern Responsibilities
-- **Build (3)**: Render the frame container, theme toggle button, and embed the Build tab configuration.
-- **BuildStyle (4)**: Style the frame shell and toggle, and provide dark-mode variable overrides.
-- **Logic (5)**: Derive, persist, and toggle the dark-mode preference while mutating the body class.
-- **Knowledge / Results / ResultsStyle (6–8)**: Not present.
+## 2. Configuration Contracts
+### 2.1 TypeScript Interfaces
+- `AppFrameProps` – Props for mounting downstream configurations (currently empty placeholder for future extension).
+- `AppFrameState` – Local dark-mode preference boolean.
 
-## 4. Anchors
-- `app-frame` – Root container for the application frame.
-- `theme-toggle` – Control for switching themes.
+### 2.2 Data & State Requirements
+- Local state: `isDarkMode` derived from `window.matchMedia('(prefers-color-scheme: dark)')` with user override.
+- Global context: None.
+- External data sources: Browser color scheme preference only.
 
-## 5. Inputs
-- `window.matchMedia('(prefers-color-scheme: dark)')` for initial preference.
-- User interaction with the theme toggle button.
+### 2.3 Dependencies
+- UI libs: React, including `useState` and `useEffect`.
+- Routing: None (routing handled by shells).
+- Shared hooks / utilities: None initially; future context sharing noted in Assembly notes.
 
-## 6. Outputs
-- Frame structure hosting the Build tab configuration.
-- Body class `dark` when dark mode is active.
-- CSS custom property overrides when dark mode is active.
+## 3. Build Concern (Structure)
+### 3.0 Dependencies & Hierarchy Notes
+- Requires hosting from shell-spaHost to mount into the document body.
+- Provides anchors `app-frame` (root) and `theme-toggle` (control) for other concerns.
 
-## 7. Invariants
-- Theme toggle remains mounted and accessible regardless of theme state.
-- Body class accurately reflects the current dark mode boolean.
-- Build tab remains mounted inside the frame to simplify routing.
+### 3.1 Atomic Components — Containers (Build)
+- **[3.1.1] Container – "App Frame Shell"**
+  - Catalog base: layout.shell
+  - Anchor: `data-anchor="app-frame"`
+  - Children: `[3.3.1] Theme Toggle Primitive`, `[3.3.2] Build Tab Mount Primitive`
 
-## 8. Dependencies
-- React state/effect hooks.
-- Document body classList for theme propagation.
+### 3.2 Atomic Components — Subcontainers (Build)
+- None.
 
-## 9. Atomic Components
-### 3. Build – cfg-appFrame
-- **[3.1] Container – "App Frame Shell"**: Wraps the entire application UI and hosts theme toggle plus Build tab.
-- **[3.2] Primitive – "Theme Toggle Control"**: Button enabling light/dark mode switching.
-- **[3.3] Primitive – "Build Tab Mount"**: Embeds the Build tab configuration within the frame.
+### 3.3 Atomic Components — Primitives (Build)
+- **[3.3.1] Primitive – "Theme Toggle Control"**
+  - Catalog base: ui.button
+  - Anchor: `data-anchor="theme-toggle"`
+  - Props: `aria-pressed`, icon slot, label from Knowledge concern.
+- **[3.3.2] Primitive – "Build Tab Mount"**
+  - Catalog base: layout.slot
+  - Purpose: Stable mount point for cfg-buildSurface (and future tabs).
 
-### 4. BuildStyle – cfg-appFrame
-- **[4.1] Container – "Frame Surface Styling"**: Sets viewport fill, typography, and color tokens for the frame.
-- **[4.2] Primitive – "Theme Toggle Styling"**: Positions and styles the toggle button, including focus treatment.
-- **[4.3] Primitive – "Dark Theme Variables"**: Defines CSS custom property overrides when `body.dark` is present.
+## 4. BuildStyle Concern (Visual Styling of Structure)
+### 4.0 Dependencies
+- Consumes project tokens for color, spacing, typography.
+- Implemented in CSS or CSS-Module files that target anchors emitted by the Build concern.
 
-### 5. Logic – cfg-appFrame
-- **[5.1] Primitive – "Theme Preference State"**: Initializes dark-mode state from media query.
-- **[5.2] Primitive – "Body Class Synchronization"**: Effects that mirror the theme boolean to `body`.
-- **[5.3] Primitive – "Toggle Handler"**: Inverts the theme boolean when the control is activated.
+### 4.1 Atomic Components — Containers / Groups (BuildStyle)
+- **[4.1.1] Container – "Frame Surface Styling"**
+  - Selector: `[data-anchor="app-frame"]`
+  - Layout: Column flex, full viewport height, brand background tokens.
 
-## 10. Assembly & Implementation Notes
-- Keep theme state local to the frame; share via context in future features if additional tabs need access.
-- Body mutation is the only side effect; ensure cleanup is unnecessary by always toggling on render.
+### 4.2 Atomic Components — Primitives (BuildStyle)
+- **[4.2.1] Primitive – "Theme Toggle Styling"**
+  - Selector: `[data-anchor="theme-toggle"]`
+  - Notes: Rounded toggle pill, focus outline, high-contrast icon color.
+- **[4.2.2] Primitive – "Dark Theme Variables"**
+  - Selector: `body.dark`
+  - Notes: Overrides surface/background tokens, updates icon treatment.
+
+### 4.3 Responsive Rules
+- At min-width 768px widen frame padding and align toggle to top-right without overlap.
+
+### 4.4 Interaction Styles
+- Hover: Slight background tint on toggle.
+- Focus: Visible outline referencing Knowledge-provided label.
+- Active: Depressed button effect.
+
+## 5. Logic Concern (Workflow)
+### 5.0 Dependencies
+- Uses `window.matchMedia` for initial preference detection.
+
+### 5.1 Atomic Components — Containers (Logic)
+- None (primitives sufficient for current workflow).
+
+### 5.2 Atomic Components — Primitives (Logic)
+- **[5.2.1] Primitive – "Theme Preference State"**
+  - State: `const [isDarkMode, setIsDarkMode] = useState<boolean>(...)`.
+- **[5.2.2] Primitive – "Toggle Handler"**
+  - Function: `const handleToggle = () => setIsDarkMode(!isDarkMode);`
+- **[5.2.3] Primitive – "Body Class Synchronization"**
+  - Effect: Adds/removes `dark` class on `document.body` when `isDarkMode` changes.
+
+### 5.2.3 Derived Values
+- None currently; future derived theme tokens will be captured here.
+
+### 5.2.4 Side Effects
+- Covered by `[5.2.3]` effect; no additional subscriptions.
+
+### 5.2.5 Workflows
+- Toggle workflow: User clicks control → `[5.2.2]` updates state → `[5.2.3]` syncs body class.
+
+## 6. Knowledge Concern (Reference Data)
+### 6.1 Maps / Dictionaries
+- None (no enumerations required yet).
+
+### 6.2 Constants
+- **[6.2.1] Primitive – "Theme Toggle Copy"**
+  - Label string and aria-label for the toggle control.
+- **[6.2.2] Primitive – "Theme Icon Descriptions"**
+  - Text alternatives for light/dark icons.
+
+### 6.3 Shared / Global Reference
+- All static text and aria strings for the toggle must live here; component files must import instead of inlining.
+
+## 7. Results Concern (Outputs)
+### 7.1 User-Facing Outputs
+- Not present; the frame does not compute derived results.
+
+### 7.2 Dev / Debug Outputs
+- None.
+
+### 7.3 Accessibility Outputs
+- None beyond Knowledge-provided aria content.
+
+## 8. ResultsStyle Concern (Output Styling)
+### 8.1 Results Layout Styles
+- Not present.
+
+### 8.2 Debug Display Styles
+- Not present.
+
+## 9. Assembly Pattern
+### 9.1 File Structure
+- src/configs/appFrame/AppFrame.build.tsx
+- src/configs/appFrame/AppFrame.build.module.css
+- src/configs/appFrame/AppFrame.logic.ts
+- src/configs/appFrame/AppFrame.knowledge.ts
+- (No Results/ResultsStyle files until required)
+- src/configs/appFrame/index.ts
+
+### 9.2 Assembly Logic
+- `index.ts` re-exports the frame component assembled from Build + Logic and wires BuildStyle CSS modules and Knowledge imports.
+
+### 9.3 Integration
+- Mounted by shell-spaHost within the root application container; provides mount slot for cfg-buildSurface and other main-pane configs.
+
+## 10. Implementation Passes
+### 10.1 Pass Mapping
+- Pass 0: Author NL skeleton and stub files with anchors.
+- Pass 1: Implement Build and BuildStyle concerns.
+- Pass 2: Implement Logic concern and Knowledge copy.
+- Pass 3+: Add Results concerns when the frame surfaces derived telemetry.
+
+### 10.2 Export Checklist
+- Build anchors `app-frame` and `theme-toggle` exist.
+- BuildStyle selectors reference anchors only.
+- Logic toggles body class without leaks.
+- Knowledge exports label text consumed by Build and BuildStyle.
+- No Results concerns required; verify absence is intentional.

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -1,132 +1,259 @@
 # cfg-buildSurface – Build Surface Configuration
 
-## 1. Purpose
-Present the Calculogic Build tab surface, including navigation chrome, the catalog of configuration panels, the preview canvas, and the inspector column, while exposing stable anchors for styling and logic concerns.
+This document is an instance of the Configuration-Level NL Skeleton defined in ../General-NL-Skeletons.md.
 
-## 2. Scope
-### In-Scope
-- Structural composition of the Build tab shell and its resizable panes.
-- Logic for panel sizing, persistence, collapse, and section ordering.
-- Anchor registry shared by Build, BuildStyle, and Logic concerns.
-- Styling for header chrome, catalog panels, preview canvas, and inspector.
+## 1. Purpose and Scope
+### 1.1 Purpose
+Present the Calculogic Build tab surface, including navigation chrome, the catalog of configuration panels, the preview canvas, and the inspector column.
 
-### Out-of-Scope
-- Actual configuration data loading or server communication.
-- Rendering of dynamic form previews beyond placeholder content.
-- Publishing workflows, notifications, or cross-tab navigation behavior.
+### 1.2 Context
+Mounted within cfg-appFrame and displayed when the Build tab is active inside shell-globalHeader navigation.
 
-## 3. Concern Responsibilities
-- **Build (3)**: Provide the DOM structure, anchors, and reusable panel components for the Build tab.
-- **BuildStyle (4)**: Skin the Build shell, catalog panels, preview area, and inspector without altering structure.
-- **Logic (5)**: Manage local panel state, persisted heights/widths, and bind accessible resize/collapse affordances.
-- **Knowledge (6)**: Centralize anchor naming contracts for reuse across concerns.
-- **Results (7)** / **ResultsStyle (8)**: Not present.
+### 1.3 Interactions
+Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-spaHost for layout sizing, and consumes bindings from its Logic concern for interactive affordances.
 
-## 4. Anchors
-- `builder-root`, `builder-header`, `builder-tabs`, `builder-tab-<id>` – Global surface chrome.
-- `builder-layout`, `builder-left-panel`, `builder-left-grip`, `builder-right-grip`, `builder-right-panel` – Pane layout anchors.
-- `builder-section-<id>`, `builder-section-<id>-content`, `builder-section-<id>-grip` – Catalog section anchors.
-- `builder-center-panel`, `builder-center-inner` – Preview area anchors.
-- `builder-right-content` – Inspector content anchor.
-- `builder-button-group-<id>`, `builder-placeholder-<id>`, `builder-list-<id>` – Utility anchors for section content.
+## 2. Configuration Contracts
+### 2.1 TypeScript Interfaces
+- `BuildSurfaceProps` – Props for initial section ordering, persisted dimensions, and injection points for nested configs.
+- `SectionBinding` – Contract describing collapse, grip, and content anchors for each catalog section.
+- `BuildSurfaceBindings` – Aggregate binding object returned by Logic for Build to consume.
 
-## 5. Inputs
-- React props supplied by `useBuildSurfaceLogic()` (anchor map, section order, binding objects).
-- LocalStorage for persisted panel dimensions and collapse state.
-- DOM pointer/keyboard events for resize interactions.
+### 2.2 Data & State Requirements
+- Local state: Panel widths/heights, collapse states per section, hover/focus state for grips.
+- Global context: Theme tokens inherited from cfg-appFrame; routing context determines active tab.
+- External data sources: `localStorage` for persistence of dimensions and collapse preferences.
 
-## 6. Outputs
-- Rendered Build tab surface with interactive collapsible panels and resizable panes.
-- Structured bindings consumed by Build for consistent ARIA attributes and event handlers.
-- Stable anchors for styling and downstream instrumentation.
+### 2.3 Dependencies
+- UI libs: React, including `useState`, `useEffect`, and refs for DOM measurements.
+- Routing: shell-globalHeader tab state (read-only).
+- Shared hooks / utilities: Utility functions for clamp logic and keyboard handling.
 
-## 7. Invariants
-- Section order remains stable unless explicitly changed in logic and Build simultaneously.
-- Panel widths/heights clamp to readable ranges and persist between sessions.
-- BuildStyle never introduces new anchors or DOM nodes.
-- Anchor registry stays deterministic; concerns refer only to defined anchors.
+## 3. Build Concern (Structure)
+### 3.0 Dependencies & Hierarchy Notes
+- Requires anchors from cfg-appFrame for outer shell mounting.
+- Owns all `builder-*` anchors consumed by downstream concerns.
+- Reading / implementation guide: Implement Build first, then BuildStyle, Logic, Knowledge, Results, and ResultsStyle in numeric order to maintain anchor fidelity.
 
-## 8. Dependencies
-- React state/effect hooks for interaction logic.
-- Browser LocalStorage API for persistence.
-- Standard DOM keyboard/mouse/touch events for resizing.
+### 3.1 Atomic Components — Containers (Build)
+- **[3.1.1] Container – "Build Tab Forwarder"**
+  - Catalog base: layout.shell
+  - Responsibility: Barrel export that keeps `src/tabs/BuildTab.tsx` stable while delegating to the build folder.
+- **[3.1.2] Container – "Build Surface Layout"**
+  - Catalog base: layout.split
+  - Anchor: `data-anchor="builder-root"`
+  - Children: `[3.2.1] Build Surface Composer`, `[3.2.2] Header Chrome`, `[3.2.3] Catalog Column`, `[3.2.4] Preview Stage`, `[3.2.5] Inspector Column`.
 
-## 9. Atomic Components
-### 3. Build – cfg-buildSurface
-- **[3.1] Container – "Build Tab Forwarder"**: Barrel export that keeps App imports stable while delegating to the build folder (`src/tabs/BuildTab.tsx`).
-- **[3.1.1] Subcontainer – "Build Surface Composer"**: Default export binding logic to the Build surface view (`src/tabs/build/index.tsx`).
-- **[3.2] Primitive – "Chevron Left Icon"**: SVG primitive used by collapsible headers (`BuildSurface.build.tsx`).
-- **[3.3] Primitive – "Chevron Right Icon"**: SVG primitive mirroring the left icon (`BuildSurface.build.tsx`).
-- **[3.4] Primitive – "Section Content Catalog"**: Declarative mapping of section anchors to placeholder content (`BuildSurface.build.tsx`).
-- **[3.5] Subcontainer – "Section Panel Template"**: Renders collapsible section shells with resize grips (`BuildSurface.build.tsx`).
-- **[3.6] Container – "Build Surface Layout"**: Assembles header chrome, catalog panel column, preview stage, and inspector (`BuildSurface.build.tsx`).
-  - **[3.6.1] Subcontainer – "Header Chrome"**: Title, navigation tabs, and publish CTA within the surface header.
-  - **[3.6.2] Subcontainer – "Catalog Column"**: Left panel wrapper that renders section panels with resizable width.
-  - **[3.6.3] Primitive – "Catalog Grip"**: Separator element exposing left panel resize grip anchors.
-  - **[3.6.4] Subcontainer – "Preview Stage"**: Placeholder main region for future canvas rendering.
-  - **[3.6.5] Primitive – "Inspector Grip"**: Resize handle separating preview and inspector regions.
-  - **[3.6.6] Subcontainer – "Inspector Column"**: Collapsible inspector structure hosting settings placeholder content.
+### 3.2 Atomic Components — Subcontainers (Build)
+- **[3.2.1] Subcontainer – "Build Surface Composer"**
+  - Location: src/tabs/build/index.tsx
+  - Purpose: Default export binding Logic to Build surface view.
+- **[3.2.2] Subcontainer – "Header Chrome"**
+  - Anchor: `data-anchor="builder-header"`
+  - Children: tab list, publish CTA, header title.
+- **[3.2.3] Subcontainer – "Catalog Column"**
+  - Anchor: `data-anchor="builder-left-panel"`
+  - Children: Section panel template instances and `[3.3.5] Catalog Grip`.
+- **[3.2.4] Subcontainer – "Preview Stage"**
+  - Anchor: `data-anchor="builder-center-panel"`
+  - Children: `[3.3.6] Preview Placeholder` and nested configuration slot.
+- **[3.2.5] Subcontainer – "Inspector Column"**
+  - Anchor: `data-anchor="builder-right-panel"`
+  - Children: Inspector header, content wrapper, `[3.3.7] Inspector Grip`.
+- **[3.2.6] Subcontainer – "Section Panel Template"**
+  - Anchor pattern: `builder-section-<id>`
+  - Purpose: Collapsible panel shell repeated for each catalog section.
 
-### 4. BuildStyle – cfg-buildSurface
-- **[4.1] Container – "Surface Chrome Styling"**: Styles root container, header, and navigation tabs.
-  - **[4.1.1] Primitive – "Root Surface"**: Base layout for `builder-root`.
-  - **[4.1.2] Primitive – "Header Bar"**: Header shell styling and divider.
-  - **[4.1.3] Primitive – "Header Title"**: Typography treatment for the builder title.
-  - **[4.1.4] Primitive – "Tab List Container"**: Layout for navigation container.
-  - **[4.1.5] Primitive – "Tab Button Base"**: Base styling for tab buttons.
-  - **[4.1.6] Primitive – "Active Tab"**: Visual state for current tab.
-  - **[4.1.7] Primitive – "Publish CTA"**: Accent styling for publish button.
-  - **[4.1.8] Primitive – "Surface Layout Shell"**: Flex shell for left/center/right panes.
-- **[4.2] Container – "Catalog Column Styling"**: Layout/styling rules for left panel, section headers, and content.
-  - **[4.2.1] Primitive – "Catalog Column"**: Wrapper constraints for the left column.
-  - **[4.2.2] Primitive – "Section Wrapper"**: Baseline for section containers.
-  - **[4.2.3] Primitive – "Section Header Bar"**: Header alignment and background.
-  - **[4.2.4] Primitive – "Section Header Title"**: Typography for section labels.
-  - **[4.2.5] Primitive – "Section Chevron Button"**: Chrome for collapse button.
-  - **[4.2.6] Primitive – "Chevron Focus Treatment"**: Shared focus outline rules.
-  - **[4.2.7] Primitive – "Section Hidden State"**: Hides collapsed content anchors.
-  - **[4.2.8] Primitive – "Section Content"**: Scrollable content container styling.
-  - **[4.2.9] Primitive – "Section Content Buttons"**: Button sizing within content.
-  - **[4.2.10] Primitive – "Section Content List"**: UL spacing rules.
-  - **[4.2.11] Primitive – "Section Content List Item"**: LI margin spacing.
-  - **[4.2.12] Primitive – "Section Box Sizing"**: Box-sizing cascade for nested anchors.
-- **[4.3] Primitive – "Grip Icon Styling"**: Shared pseudo-element styling for resize grips.
-  - **[4.3.1] Primitive – "Section Grip Base"**: Structural styling for section separators.
-  - **[4.3.2] Primitive – "Section Grip Icon"**: Decorative pseudo-element for section grips.
-  - **[4.3.3] Primitive – "Section Grip Hover"**: Hover/focus background change.
-  - **[4.3.4] Primitive – "Grip Focus Ring"**: Shared focus outline for all grips.
-  - **[4.3.5] Primitive – "Side Panel Grips"**: Vertical separator styling for side panels.
-  - **[4.3.6] Primitive – "Side Panel Grip Icon"**: Icon orientation for side panel grips.
-- **[4.4] Container – "Center Preview Styling"**: Visual treatment for preview canvas placeholder.
-  - **[4.4.1] Primitive – "Preview Shell"**: Layout for center panel container.
-  - **[4.4.2] Primitive – "Preview Inner Frame"**: Dashed placeholder box styling.
-  - **[4.4.3] Primitive – "Preview Placeholder Text"**: Typography for placeholder copy.
-- **[4.5] Container – "Inspector Column Styling"**: Layout rules for right inspector, button groups, and placeholders.
-  - **[4.5.1] Primitive – "Inspector Column"**: Column constraints and background.
-  - **[4.5.2] Primitive – "Inspector Header"**: Header spacing and divider.
-  - **[4.5.3] Primitive – "Inspector Header Title"**: Typography for header label.
-  - **[4.5.4] Primitive – "Inspector Chevron"**: Collapse button chrome.
-  - **[4.5.5] Primitive – "Inspector Content"**: Padding and type color for content body.
-  - **[4.5.6] Primitive – "Button Group"**: Horizontal layout for grouped buttons.
-  - **[4.5.7] Primitive – "Button Group Item"**: Individual button styling.
-  - **[4.5.8] Primitive – "Button Group Hover"**: Hover feedback for grouped buttons.
-  - **[4.5.9] Primitive – "Placeholder Panel"**: Reusable placeholder panel styling.
-  - **[4.5.10] Primitive – "Anchor List Reset"**: Neutral list baseline.
-  - **[4.5.11] Primitive – "Anchor List Item"**: Per-item padding and rounding.
-  - **[4.5.12] Primitive – "Anchor List Alternation"**: Zebra striping for anchor lists.
+### 3.3 Atomic Components — Primitives (Build)
+- **[3.3.1] Primitive – "Chevron Left Icon"**
+  - Catalog base: ui.icon
+  - File: src/tabs/build/BuildSurface.build.tsx (left collapse icon).
+- **[3.3.2] Primitive – "Chevron Right Icon"**
+  - Catalog base: ui.icon
+  - File: src/tabs/build/BuildSurface.build.tsx (right collapse icon).
+- **[3.3.3] Primitive – "Section Content Catalog"**
+  - Catalog base: layout.map
+  - Description: Declarative map of section anchors to placeholder content and nested configuration slots.
+- **[3.3.4] Primitive – "Section Header"**
+  - Anchor: `builder-section-<id>-header`
+  - Contains title, collapse button, and icon.
+- **[3.3.5] Primitive – "Catalog Grip"**
+  - Anchor: `builder-left-grip`
+  - Purpose: Left panel resize handle.
+- **[3.3.6] Primitive – "Preview Placeholder"**
+  - Anchor: `builder-center-inner`
+  - Placeholder canvas awaiting dynamic rendering.
+- **[3.3.7] Primitive – "Inspector Grip"**
+  - Anchor: `builder-right-grip`
+  - Purpose: Separator enabling inspector resizing.
+- **[3.3.8] Primitive – "Inspector Content Wrapper"**
+  - Anchor: `builder-right-content`
+  - Hosts settings placeholders and future nested configs.
 
-### 5. Logic – cfg-buildSurface
-- **[5.1] Container – "Section Contracts"**: Type definitions, section order constant, and helper utilities.
-- **[5.2] Container – "Section Logic Hook"**: `useSectionLogic` managing individual section height/collapse.
-- **[5.3] Container – "Left Panel Logic"**: `useLeftPanelLogic` handling width persistence and resizing.
-- **[5.4] Container – "Right Panel Logic"**: `useRightPanelLogic` managing inspector width/collapse state.
-- **[5.5] Container – "Surface Bindings"**: `useBuildSurfaceLogic` aggregator producing Build bindings.
+## 4. BuildStyle Concern (Visual Styling of Structure)
+### 4.0 Dependencies
+- Consumes project tokens for colors, typography, spacing, and border radii.
+- Implemented in CSS or CSS-Module files that target anchors emitted by the Build concern.
 
-### 6. Knowledge – cfg-buildSurface
-- **[6.1] Primitive – "Anchor Registry"**: `BUILD_ANCHORS` map exposing string factories.
-- **[6.2] Primitive – "Anchor Type Alias"**: `BuildAnchorId` type derived from the registry.
+### 4.1 Atomic Components — Containers / Groups (BuildStyle)
+- **[4.1.1] Container – "Surface Chrome Styling"**
+  - Selector: `[data-anchor="builder-root"]`
+  - Layout: Column flex with full-height shell.
+- **[4.1.2] Container – "Catalog Column Styling"**
+  - Selector: `[data-anchor="builder-left-panel"]`
+  - Layout: Scrollable column with section spacing.
+- **[4.1.3] Container – "Center Preview Styling"**
+  - Selector: `[data-anchor="builder-center-panel"]`
+  - Layout: Flexible middle pane with centered canvas.
+- **[4.1.4] Container – "Inspector Column Styling"**
+  - Selector: `[data-anchor="builder-right-panel"]`
+  - Layout: Right column with stacked utilities.
 
-## 10. Assembly & Implementation Notes
-- Build and Logic concerns must evolve together; any anchor changes require synchronized updates across all concerns.
-- Resizable interactions rely on global pointer event listeners; ensure cleanup in hooks to avoid leaks.
-- Placeholder content may be replaced by nested configurations later but must respect existing anchors.
+### 4.2 Atomic Components — Primitives (BuildStyle)
+- **[4.2.1] Primitive – "Root Surface"**
+  - Applies base background, typography, and gap rules.
+- **[4.2.2] Primitive – "Header Bar"**
+  - Styles `[data-anchor="builder-header"]` with border and alignment.
+- **[4.2.3] Primitive – "Header Title"**
+  - Typography treatment for builder title element.
+- **[4.2.4] Primitive – "Tab List Container"**
+  - Flex layout and spacing for `[data-anchor="builder-tabs"]`.
+- **[4.2.5] Primitive – "Tab Button Base"**
+  - Base button styles shared across tab anchors.
+- **[4.2.6] Primitive – "Active Tab"**
+  - Highlight and underline for active tab state.
+- **[4.2.7] Primitive – "Publish CTA"**
+  - Accent styling for publish button anchor.
+- **[4.2.8] Primitive – "Section Wrapper"**
+  - Box styles for `builder-section-<id>` containers.
+- **[4.2.9] Primitive – "Section Header Bar"**
+  - Layout for section header row and collapse affordance.
+- **[4.2.10] Primitive – "Section Chevron Button"**
+  - Icon button chrome for collapse icons.
+- **[4.2.11] Primitive – "Section Hidden State"**
+  - Utility class toggling `display`/`height` for collapsed content.
+- **[4.2.12] Primitive – "Section Content"**
+  - Scroll behavior and padding for `builder-section-<id>-content`.
+- **[4.2.13] Primitive – "Section Content Buttons"**
+  - Shared width and gap rules for button groups.
+- **[4.2.14] Primitive – "Section Content List"**
+  - List reset for `builder-list-<id>` anchors.
+- **[4.2.15] Primitive – "Grip Icon Styling"**
+  - Visual chrome for resize grips, including pseudo-elements.
+- **[4.2.16] Primitive – "Preview Placeholder Text"**
+  - Typography for `[data-anchor="builder-center-inner"]` placeholder copy.
+- **[4.2.17] Primitive – "Inspector Content"**
+  - Padding and text styling for `builder-right-content`.
+- **[4.2.18] Primitive – "Anchor List Item"**
+  - Item-level spacing for anchor registry lists.
+
+### 4.3 Responsive Rules
+- At min-width 1440px widen left/right panels and clamp preview canvas for readability.
+- At max-width 960px collapse inspector column by default while keeping anchors present.
+
+### 4.4 Interaction Styles
+- Hover/focus states for grips reuse `[4.2.15]` pseudo-elements.
+- Tabs and buttons use focus outlines sourced from Knowledge-defined tokens.
+
+## 5. Logic Concern (Workflow)
+### 5.0 Dependencies
+- Relies on browser pointer and keyboard events for resizing.
+- Uses `localStorage` to persist panel states.
+
+### 5.1 Atomic Components — Containers (Logic)
+- **[5.1.1] Container – "Section Contracts"**
+  - Defines section order constants, types, and helper utilities.
+- **[5.1.2] Container – "Section Logic Hook"**
+  - `useSectionLogic` managing per-section collapse and height.
+- **[5.1.3] Container – "Left Panel Logic"**
+  - `useLeftPanelLogic` controlling width persistence and resize gestures.
+- **[5.1.4] Container – "Right Panel Logic"**
+  - `useRightPanelLogic` handling inspector state.
+- **[5.1.5] Container – "Surface Bindings"**
+  - `useBuildSurfaceLogic` aggregator returning `BuildSurfaceBindings`.
+
+### 5.2 Atomic Components — Primitives (Logic)
+- **[5.2.1] Primitive – "Clamp Utility"**
+  - Helper ensuring panel sizes stay within min/max bounds.
+- **[5.2.2] Primitive – "Keyboard Resize Handler"**
+  - Responds to arrow keys on grips for accessible resizing.
+- **[5.2.3] Primitive – "Pointer Resize Handler"**
+  - Manages pointerdown/move/up events across grips.
+- **[5.2.4] Primitive – "Persistence Effect"**
+  - Syncs panel dimensions and collapse state to `localStorage`.
+- **[5.2.5] Primitive – "Bindings Memo"**
+  - Memoized object mapping anchors to handlers/aria attributes consumed by Build.
+
+### 5.2.3 Derived Values
+- Derived booleans for collapsed states, computed widths/heights.
+
+### 5.2.4 Side Effects
+- Global pointer event subscription for resizing, cleaned up on unmount.
+- `localStorage` updates triggered by state changes.
+
+### 5.2.5 Workflows
+- Resize workflow: Grip interaction → `[5.2.3]` updates dimensions → `[5.2.4]` persists values → Build re-renders with new sizes.
+- Collapse workflow: Toggle click → Section state updates → `[5.2.5]` memo recalculates bindings for Build.
+
+## 6. Knowledge Concern (Reference Data)
+### 6.1 Maps / Dictionaries
+- **[6.1.1] Primitive – "Anchor Registry"**
+  - `BUILD_ANCHORS` map exposing anchor factories for reuse across concerns.
+
+### 6.2 Constants
+- **[6.2.1] Primitive – "Section Labels"**
+  - Display strings for catalog section headers.
+- **[6.2.2] Primitive – "Grip Aria Labels"**
+  - Accessible labels for resize grips.
+- **[6.2.3] Primitive – "Placeholder Copy"**
+  - Text for preview and inspector placeholder panels.
+
+### 6.3 Shared / Global Reference
+- Provides canonical anchor string literals for use by other configurations.
+
+## 7. Results Concern (Outputs)
+### 7.1 User-Facing Outputs
+- Not present; Build surface focuses on structure and interaction.
+
+### 7.2 Dev / Debug Outputs
+- Optional debug panel for anchor inspection deferred to future iteration.
+
+### 7.3 Accessibility Outputs
+- Live region hooks (future) will surface here when builder emits status messages.
+
+## 8. ResultsStyle Concern (Output Styling)
+### 8.1 Results Layout Styles
+- Not present until Results concern is implemented.
+
+### 8.2 Debug Display Styles
+- Not present.
+
+## 9. Assembly Pattern
+### 9.1 File Structure
+- src/tabs/build/BuildSurface.build.tsx
+- src/tabs/build/BuildSurface.build.module.css
+- src/tabs/build/BuildSurface.logic.ts
+- src/tabs/build/BuildSurface.knowledge.ts
+- (Results and ResultsStyle files will be added when outputs exist.)
+- src/tabs/build/index.ts
+
+### 9.2 Assembly Logic
+- `src/tabs/build/index.tsx` composes Build with Logic bindings, imports BuildStyle CSS modules for side effects, and re-exports the assembled component.
+
+### 9.3 Integration
+- Imported by cfg-appFrame via its `[3.3.2]` Build Tab Mount primitive and swapped by shell-globalHeader navigation.
+
+## 10. Implementation Passes
+### 10.1 Pass Mapping
+- Pass 0: Author NL skeleton and establish anchor registry in Knowledge.
+- Pass 1: Implement Build containers and primitives.
+- Pass 2: Implement BuildStyle styling groups.
+- Pass 3: Implement Logic hooks for resizing and persistence.
+- Pass 4: Expand Knowledge with copy/aria tokens.
+- Pass 5+: Add Results/ResultsStyle when builder emits analytics or summaries.
+
+### 10.2 Export Checklist
+- All Build anchors match Knowledge registry.
+- BuildStyle selectors reference anchors without introducing structure.
+- Logic handlers clean up pointer listeners and persist state safely.
+- Knowledge exports copy strings consumed by Build and BuildStyle.
+- Results concerns remain absent by design; confirm omission when reviewing changes.

--- a/doc/nl-shell/shell-globalHeader.md
+++ b/doc/nl-shell/shell-globalHeader.md
@@ -1,137 +1,252 @@
 # shell-globalHeader – Global Header Shell
 
-## 1. Purpose
+This document is an instance of the ProjectShell-Level NL Skeleton defined in ../General-NL-Skeletons.md.
+
+## 1. Purpose and Scope
+### 1.1 Purpose
 Provide a reusable header shell that anchors Calculogic experiences with brand identity, primary concern navigation, and a publish action surface.
 
-## 2. Scope
-### In-Scope
-- Three-zone header frame covering brand, concern tabs, and publish action.
-- Responsive visibility and layout adjustments across desktop, tablet, and mobile breakpoints.
-- Debug surface exposing live header state when requested.
+### 1.2 Context
+Wraps the top of the single-page application hosted by shell-spaHost and appears above cfg-appFrame.
 
-### Out-of-Scope
-- Downstream concern bodies, configuration dashboards, or document modals triggered from header actions.
-- Theme token definitions beyond local CSS variables.
-- Global routing or application-level state beyond header interaction state.
+### 1.3 Interactions
+Coordinates with cfg-appFrame to mount the active configuration, routes publish actions to downstream handlers, and exposes navigation state to other shells.
 
-## 3. Concern Responsibilities
-- **Build**: Compose semantic DOM structure for the header frame, tab interactions, and publish CTA.
-- **BuildStyle**: Style the header shell, zones, and interactive affordances across breakpoints.
-- **Logic**: Manage active/hovered tabs, breakpoint detection, document toggles, and publish dispatching.
-- **Knowledge**: Define canonical tabs, copy, and breakpoint metadata consumed by the shell.
-- **Results**: Render optional debug panel reflecting the shell's live interaction state.
-- **ResultsStyle**: Style the debug panel to align with the shell's aesthetic without overpowering core UI.
+## 2. Configuration Contracts
+### 2.1 TypeScript Interfaces
+- `GlobalHeaderProps` – Props for supplying publish callbacks and optional debug toggles.
+- `GlobalHeaderState` – Shape describing active tab, hovered tab, breakpoint flags, and debug state.
 
-## 4. Anchors
-- `global-header` – root header shell wrapper.
-- `global-header.brand` – brand identity zone container.
-- `global-header.brand-logo` – brand glyph span for iconography.
-- `global-header.brand-wordmark` – textual brand label.
-- `global-header.brand-tagline` – optional supporting copy.
-- `global-header.tabs` – navigation zone for concern tabs.
-- `global-header.tab-{id}` – individual tab row wrapper.
-- `global-header.tab-info` – info icon exposing hover summary content.
-- `global-header.publish` – publish zone wrapper.
-- `global-header.publish-button` – actionable publish trigger.
-- `global-header.debug` – debug panel container (results concern).
+### 2.2 Global State Requirements
+- Consumes optional `onPublish` handler provided by parent shell or host.
+- Reads responsive breakpoint information derived from window size (local to this shell).
 
-## 5. Inputs
-- `HEADER_TAB_DEFINITIONS` knowledge constants describing concern tabs.
-- Breakpoint definitions for desktop, tablet, and mobile widths.
-- Brand copy constants for wordmark, tagline, tooltip, and home route.
-- Optional `onPublish` callback supplied by downstream host.
+### 2.3 Routing & Context
+- Relies on shell-spaHost for SPA routing; does not manipulate URLs directly.
+- Exposes selected concern id for cfg-appFrame to mount the matching configuration.
 
-## 6. Outputs
-- Header DOM structure with correctly annotated anchors and ARIA roles.
-- Responsive CSS ensuring header readability and interaction affordances.
-- Publish handler invocation or console notice when callback absent.
-- Debug panel surface (when enabled) presenting active header state.
+## 3. Build Concern (Structure)
+### 3.0 Dependencies & Hierarchy Notes
+- Mounts within shell-spaHost and sits above cfg-appFrame.
+- Provides anchors `global-header.*` for styling, logic, and Results concerns.
 
-## 7. Invariants
-- Tab order always matches knowledge definitions after sort by `order`.
-- Exactly one tab is marked active; hovered tab resets on selection and close events.
-- Publish button remains accessible with semantic `<button>` element.
-- Breakpoint detection relies exclusively on viewport width and updates on resize.
-- Debug panel remains hidden by default and mirrors build concern state when shown.
+### 3.1 Atomic Components — Containers (Build)
+- **[3.1.1] Container – "Global Header Shell Frame"**
+  - Element: `<header>`
+  - Anchor: `data-anchor="global-header"`
+  - Children: `[3.2.1] Brand Identity Zone`, `[3.2.2] Tab Navigation Zone`, `[3.2.3] Publish Action Zone`.
+- **[3.1.2] Container – "Tab List Track"**
+  - Element: `<div role="tablist">`
+  - Anchor: `data-anchor="global-header.tabs"`
+  - Children: `[3.2.4] Tab Item Row` instances.
 
-## 8. Dependencies
-- React with hooks (`useState`, `useEffect`, `useCallback`, `useMemo`).
-- Browser `window` API for resize events (guarded for SSR).
-- CSS custom properties supplied by host theme (fallbacks included).
+### 3.2 Atomic Components — Subcontainers (Build)
+- **[3.2.1] Subcontainer – "Brand Identity Zone"**
+  - Anchor: `data-anchor="global-header.brand"`
+  - Children: `[3.3.1] Brand Home Link`, `[3.3.2] Brand Logo Glyph`, `[3.3.3] Brand Wordmark`, `[3.3.4] Brand Tagline`.
+- **[3.2.2] Subcontainer – "Tab Navigation Zone"**
+  - Anchor: `data-anchor="global-header.tabs-zone"`
+  - Purpose: Flex wrapper aligning tab list between brand and publish zones.
+- **[3.2.3] Subcontainer – "Publish Action Zone"**
+  - Anchor: `data-anchor="global-header.publish"`
+  - Children: `[3.3.8] Publish Button`.
+- **[3.2.4] Subcontainer – "Tab Item Row"**
+  - Anchor pattern: `data-anchor="global-header.tab-{id}"`
+  - Children: `[3.3.5] Primary Tab Button`, `[3.3.6] Tab Info Icon`.
+- **[3.2.5] Subcontainer – "Debug Panel Container"**
+  - Anchor: `data-anchor="global-header.debug"`
+  - Purpose: Hosts Results concern output when enabled.
 
-## 9. Atomic Components
-### 3. Build – shell-globalHeader
-- **[3.1] Container – "Global Header Shell Frame"**: `<header>` root establishing shell anchors and landmark semantics.
-- **[3.2] Subcontainer – "Brand Identity Zone"**: Brand zone wrapper balancing glyph, wordmark, and optional tagline.
-- **[3.3] Primitive – "Brand Home Link"**: Anchor routing to home with tooltip and accessible labeling.
-- **[3.4] Primitive – "Brand Logo Glyph"**: Emoji span providing recognizable glyph, hidden from assistive tech.
-- **[3.5] Primitive – "Brand Wordmark Label"**: Text span presenting the Calculogic name.
-- **[3.6] Primitive – "Brand Tagline"**: Optional supporting copy hidden on constrained breakpoints.
-- **[3.7] Subcontainer – "Tab Navigation Zone"**: Wrapper aligning tab list centrally while flexing between brand/publish zones.
-- **[3.8] Subcontainer – "Tab List Track"**: `role="tablist"` container enabling keyboard navigation semantics.
-- **[3.9] Subcontainer – "Tab Item Row"**: Wrapper combining tab button and info icon per concern.
-- **[3.10] Primitive – "Primary Tab Button"**: `role="tab"` button toggling active concern.
-- **[3.11] Primitive – "Tab Info Icon"**: Button exposing hover summary and reinforcing accessible labeling.
-- **[3.12] Subcontainer – "Publish Action Zone"**: Right-aligned zone holding the publish CTA.
-- **[3.13] Primitive – "Publish Button"**: High-contrast CTA dispatching publish intent.
+### 3.3 Atomic Components — Primitives (Build)
+- **[3.3.1] Primitive – "Brand Home Link"**
+  - Element: `<a>`
+  - Attributes: `href="/"`, `aria-label` from Knowledge.
+- **[3.3.2] Primitive – "Brand Logo Glyph"**
+  - Element: `<span aria-hidden="true">`
+  - Content: Emoji or SVG glyph.
+- **[3.3.3] Primitive – "Brand Wordmark Label"**
+  - Element: `<span>` with accessible text.
+- **[3.3.4] Primitive – "Brand Tagline"**
+  - Element: `<span>` optional supporting copy with `data-anchor="global-header.brand-tagline"`.
+- **[3.3.5] Primitive – "Primary Tab Button"**
+  - Element: `<button role="tab">`
+  - Data attributes: `data-tab-id`.
+- **[3.3.6] Primitive – "Tab Info Icon"**
+  - Element: `<button>`
+  - Purpose: Displays hover tooltip and additional info.
+- **[3.3.7] Primitive – "Tab Tooltip Portal"**
+  - Optional structure for richer hover content anchored near the info icon.
+- **[3.3.8] Primitive – "Publish Button"**
+  - Element: `<button>`
+  - Attributes: `type="button"`, `data-anchor="global-header.publish-button"`.
 
-### 4. BuildStyle – shell-globalHeader
-- **[4.1] Container – "Shell Frame Layout"**: Flex alignment, spacing, and baseline border for header frame.
-- **[4.2] Subcontainer – "Zone Layout Baseline"**: Shared flex alignment and spacing for each zone.
-- **[4.3] Subcontainer – "Brand Zone Alignment"**: Prevents brand zone from stretching while preserving layout stability.
-- **[4.4] Subcontainer – "Tab Zone Alignment"**: Centers tab navigation and allows it to flex.
-- **[4.5] Subcontainer – "Publish Zone Alignment"**: Right-justifies publish zone without flex bleed.
-- **[4.6] Primitive – "Brand Link Styling"**: Typography and spacing for brand anchor and inline content.
-- **[4.7] Primitive – "Brand Logo Scaling"**: Enlarges glyph for legibility.
-- **[4.8] Primitive – "Brand Tagline Styling"**: Lightweight typography and truncation safeguards.
-- **[4.9] Subcontainer – "Tab List Track Styling"**: Horizontal scrollable rail for tab buttons.
-- **[4.10] Subcontainer – "Tab Item Row Styling"**: Inline alignment for button + info icon pair.
-- **[4.11] Primitive – "Tab Button Baseline"**: Neutral button visuals supporting active/hover modifiers.
-- **[4.12] Primitive – "Tab Button Active State"**: Elevates selected tab via background and border.
-- **[4.13] Primitive – "Tab Button Hover State"**: Soft highlight for hovered but inactive tabs.
-- **[4.14] Primitive – "Info Icon Baseline"**: Icon button hit target and hover transition.
-- **[4.15] Primitive – "Info Icon Focus/Hover"**: Visual affordance on hover or keyboard focus.
-- **[4.16] Primitive – "Publish Button Baseline"**: Gradient CTA styling with weighty typography.
-- **[4.17] Primitive – "Publish Button Hover State"**: Lift and shadow feedback on interaction.
-- **[4.18] Variation – "Tablet Layout Adjustments"**: Reduces padding and hides tagline on <=1023px widths.
-- **[4.19] Variation – "Mobile Layout Adjustments"**: Tightens spacing and font sizing for <=767px widths.
+## 4. BuildStyle Concern (Visual Styling of Structure)
+### 4.0 Dependencies
+- Consumes design tokens for spacing, typography, and color from cfg-appFrame knowledge exports.
+- Implemented in CSS or CSS-Module files that target anchors emitted by the Build concern.
 
-### 5. Logic – shell-globalHeader
-- **[5.1] Primitive – "Viewport Breakpoint Heuristic"**: Helper mapping viewport widths to named breakpoints.
-- **[5.2] Container – "Global Header Logic Hook"**: Primary hook producing build/results bindings.
-  - **[5.2.1] Primitive – "State Initialization & Bootstrapping"**: `useState` initialization with SSR-safe defaults.
-  - **[5.2.2] Primitive – "Viewport Resize Subscription"**: `useEffect` listener updating breakpoints responsively.
-  - **[5.2.3] Primitive – "Tab Selection Handler"**: Callback resetting hovered tab and active modes on selection.
-  - **[5.2.4] Primitive – "Tab Hover Handler"**: Callback storing hovered tab id while avoiding redundant updates.
-  - **[5.2.5] Primitive – "Publish Trigger Handler"**: Callback invoking provided `onPublish` or logging fallback.
-  - **[5.2.6] Primitive – "Doc Visibility Controls"**: Callbacks controlling contextual document panel visibility.
-  - **[5.2.7] Primitive – "Tab Definition Ordering"**: Memo ensuring deterministic order from knowledge definitions.
-  - **[5.2.8] Primitive – "Viewport Flag Derivation"**: Booleans for desktop/tablet/mobile convenience.
-  - **[5.2.9] Primitive – "Build Bindings Assembly"**: Bundles build concern data and handlers.
-  - **[5.2.10] Primitive – "Results Bindings Assembly"**: Packages results concern state snapshot.
-  - **[5.2.11] Primitive – "Hook Return Envelope"**: Returns build/results bundles for shell consumption.
+### 4.1 Atomic Components — Containers / Groups (BuildStyle)
+- **[4.1.1] Container – "Shell Frame Layout"**
+  - Selector: `[data-anchor="global-header"]`
+  - Layout: Flex row with baseline border.
+- **[4.1.2] Container – "Zone Alignment Baseline"**
+  - Selector: `[data-anchor="global-header.brand"], [data-anchor="global-header.tabs-zone"], [data-anchor="global-header.publish"]`
+  - Purpose: Shared alignment system for zones.
+- **[4.1.3] Container – "Tab List Track Styling"**
+  - Selector: `[data-anchor="global-header.tabs"]`
+  - Behavior: Horizontal scroll with overflow guards.
+- **[4.1.4] Container – "Debug Panel Styling"**
+  - Selector: `[data-anchor="global-header.debug"]`
+  - Layout: Inline status banner.
 
-### 6. Knowledge – shell-globalHeader
-- **[6.1] Primitive – "Header Tab Identifier Types"**: Type aliases enumerating valid tab and mode ids.
-- **[6.2] Primitive – "Header Tab Definition Schema"**: Interface describing tab definition payloads.
-- **[6.3] Primitive – "Header Tab Knowledge Base"**: Ordered array of concern tab definitions with hover summaries.
-- **[6.4] Primitive – "Breakpoint Definition Schema"**: Interface describing breakpoint metadata.
-- **[6.5] Primitive – "Responsive Breakpoint Catalog"**: Array describing desktop/tablet/mobile breakpoints.
-- **[6.6] Primitive – "Brand Wordmark Copy"**: Constant providing Calculogic wordmark.
-- **[6.7] Primitive – "Brand Tagline Copy"**: Constant providing supporting tagline text.
-- **[6.8] Primitive – "Brand Tooltip Copy"**: Constant for brand link tooltip.
-- **[6.9] Primitive – "Publish Label Copy"**: Constant for publish button text.
+### 4.2 Atomic Components — Primitives (BuildStyle)
+- **[4.2.1] Primitive – "Brand Link Styling"**
+  - Typography, spacing, and inline alignment for brand anchor.
+- **[4.2.2] Primitive – "Brand Logo Scaling"**
+  - Sets font size and baseline alignment for glyph.
+- **[4.2.3] Primitive – "Brand Tagline Styling"**
+  - Lightweight typography and truncation safeguards.
+- **[4.2.4] Primitive – "Tab Button Baseline"**
+  - Neutral button visuals supporting focus/active modifiers.
+- **[4.2.5] Primitive – "Tab Button Active State"**
+  - Underline and background adjustments for selected tab.
+- **[4.2.6] Primitive – "Tab Button Hover State"**
+  - Soft highlight for hovered but inactive tabs.
+- **[4.2.7] Primitive – "Info Icon Baseline"**
+  - Icon size, padding, and hit target.
+- **[4.2.8] Primitive – "Info Icon Focus/Hover"**
+  - Outline and color adjustments on interaction.
+- **[4.2.9] Primitive – "Publish Button Baseline"**
+  - Gradient CTA styling with strong contrast.
+- **[4.2.10] Primitive – "Publish Button Hover State"**
+  - Lift and shadow feedback for pointer/keyboard interaction.
+- **[4.2.11] Primitive – "Debug Panel Typography"**
+  - Text treatment for debug readouts.
 
-### 7. Results – shell-globalHeader
-- **[7.1] Container – "Global Header Debug Panel"**: Results component rendering diagnostic grid.
-- **[7.2] Primitive – "Debug Visibility Gate"**: Guard preventing render unless debug is enabled.
-- **[7.3] Primitive – "Debug State Rows"**: Structured rows exposing live header state fields.
+### 4.3 Responsive Rules
+- Tablet breakpoint (≤1023px): Reduce padding, hide tagline, compress tab spacing.
+- Mobile breakpoint (≤767px): Stack zones vertically and convert tab list to horizontal scroll chips.
 
-### 8. ResultsStyle – shell-globalHeader
-- **[8.1] Primitive – "Debug Panel Styling"**: Visual treatment for debug surface including background, typography, and spacing.
+### 4.4 Interaction Styles
+- Focus outlines use Knowledge-provided tokens; ensure visible contrast.
+- Hover states align with Build-defined anchors only.
 
-## 10. Assembly & Implementation Notes
-- `info` buttons and publish CTA remain `<button>` elements for keyboard accessibility; avoid replacing with anchors.
-- Hover summaries rely on JS-driven hover state to support both icon and button interactions.
-- Debug panel remains opt-in; expose toggles through higher-level configurations when required.
-- Breakpoint thresholds should stay synchronized with broader design system tokens before release.
+## 5. Logic Concern (Workflow)
+### 5.0 Dependencies
+- Uses React hooks for state management and window resize listeners (SSR guarded).
+
+### 5.1 Atomic Components — Containers (Logic)
+- **[5.1.1] Container – "Global Header Logic Hook"**
+  - `useGlobalHeader` producing Build and Results bindings.
+
+### 5.2 Atomic Components — Primitives (Logic)
+- **[5.2.1] Primitive – "State Initialization"**
+  - Sets default active tab based on Knowledge order.
+- **[5.2.2] Primitive – "Viewport Resize Subscription"**
+  - Listens for window resize to update breakpoint flags.
+- **[5.2.3] Primitive – "Tab Selection Handler"**
+  - Updates active tab and resets hover state.
+- **[5.2.4] Primitive – "Tab Hover Handler"**
+  - Stores hovered tab id while avoiding redundant updates.
+- **[5.2.5] Primitive – "Publish Trigger Handler"**
+  - Invokes `onPublish` or logs fallback notice.
+- **[5.2.6] Primitive – "Debug Toggle Handler"**
+  - Enables/disables Results concern display.
+- **[5.2.7] Primitive – "Knowledge Ordering Memo"**
+  - Memoizes sorted tab definitions for Build consumption.
+- **[5.2.8] Primitive – "Breakpoint Flag Derivation"**
+  - Derives desktop/tablet/mobile booleans from viewport width.
+- **[5.2.9] Primitive – "Build Bindings Assembly"**
+  - Maps Knowledge definitions and handlers into Build-ready props.
+- **[5.2.10] Primitive – "Results Snapshot Assembly"**
+  - Packages state summary for Results concern.
+
+### 5.2.3 Derived Values
+- Derived booleans for viewport categories and debug enablement.
+
+### 5.2.4 Side Effects
+- Window resize listener attaches/detaches on mount/unmount.
+- Console warning emitted when publish callback is absent.
+
+### 5.2.5 Workflows
+- Tab switch: `[5.2.3]` updates active tab → `[5.2.7]` ensures deterministic ordering → `[5.2.9]` provides Build bindings → Build updates selected state.
+- Publish action: `[5.2.5]` triggers callback → Results snapshot logs latest timestamp when debug enabled.
+
+## 6. Knowledge Concern (Reference Data)
+### 6.1 Maps / Dictionaries
+- **[6.1.1] Primitive – "Header Tab Identifier Types"**
+  - Type aliases enumerating valid tab ids (build, logic, knowledge, results, resultsStyle).
+- **[6.1.2] Primitive – "Breakpoint Definition Schema"**
+  - Interface describing breakpoint metadata for responsive logic.
+
+### 6.2 Constants
+- **[6.2.1] Primitive – "Header Tab Knowledge Base"**
+  - Ordered array of concern tab definitions with hover summaries.
+- **[6.2.2] Primitive – "Brand Wordmark Copy"**
+  - Display string for Calculogic wordmark.
+- **[6.2.3] Primitive – "Brand Tagline Copy"**
+  - Optional supporting copy string.
+- **[6.2.4] Primitive – "Brand Tooltip Copy"**
+  - Tooltip text for brand home link.
+- **[6.2.5] Primitive – "Publish Label Copy"**
+  - Label for publish button.
+- **[6.2.6] Primitive – "Breakpoint Catalog"**
+  - Array of desktop/tablet/mobile breakpoint definitions.
+
+### 6.3 Shared / Global Reference
+- Exposes tab ordering and copy for cfg-appFrame to reference when rendering nested surfaces.
+
+## 7. Results Concern (Outputs)
+### 7.1 User-Facing Outputs
+- **[7.1.1] Container – "Global Header Debug Panel"**
+  - Displays live header state when debug mode enabled.
+
+### 7.2 Dev / Debug Outputs
+- **[7.2.1] Primitive – "Debug Visibility Gate"**
+  - Guards render until debug toggle is true.
+- **[7.2.2] Primitive – "Debug State Rows"**
+  - Lists active tab, hovered tab, breakpoint flags, and publish readiness.
+
+### 7.3 Accessibility Outputs
+- Provide `aria-live="polite"` announcements when publish action completes (future extension).
+
+## 8. ResultsStyle Concern (Output Styling)
+ResultsStyle styling lives in CSS or CSS-Module files that target the debug/result anchors emitted by the Results concern.
+### 8.1 Results Layout Styles
+- **[8.1.1] Primitive – "Debug Panel Styling"**
+  - Visual treatment for debug panel: background tint, typography, spacing.
+
+### 8.2 Debug Display Styles
+- Additional states not yet required.
+
+## 9. Assembly Pattern
+### 9.1 File Structure
+- src/shells/globalHeader/GlobalHeader.build.tsx
+- src/shells/globalHeader/GlobalHeader.build.module.css
+- src/shells/globalHeader/GlobalHeader.logic.ts
+- src/shells/globalHeader/GlobalHeader.knowledge.ts
+- src/shells/globalHeader/GlobalHeader.results.tsx
+- src/shells/globalHeader/GlobalHeader.results.module.css
+- src/shells/globalHeader/index.ts
+
+### 9.2 Assembly Logic
+- `src/shells/globalHeader/index.ts` composes Build with Logic hook outputs, imports BuildStyle CSS modules for side effects, and exports Results components alongside optional ResultsStyle CSS modules.
+
+### 9.3 Integration
+- Mounted inside shell-spaHost above cfg-appFrame; publishes selected concern id to cfg-appFrame for tab swapping.
+
+## 10. Implementation Passes
+### 10.1 Pass Mapping
+- Pass 0: Author NL skeleton and stub Build anchors.
+- Pass 1: Implement Build containers and primitives.
+- Pass 2: Apply BuildStyle responsive rules.
+- Pass 3: Implement Logic hook and knowledge constants.
+- Pass 4: Implement Results panel and styling.
+- Pass 5+: Extend Knowledge/Results when new tabs or diagnostics emerge.
+
+### 10.2 Export Checklist
+- Build anchors align with Knowledge definitions and BuildStyle selectors.
+- Logic hook guards window access for SSR and cleans up listeners.
+- Results panel renders only when debug is enabled.
+- BuildStyle references tokens from Knowledge or cfg-appFrame as needed.
+- Publish actions bubble through provided callback or log fallback message.

--- a/doc/nl-shell/shell-spaHost.md
+++ b/doc/nl-shell/shell-spaHost.md
@@ -1,50 +1,130 @@
 # shell-spaHost – SPA Host Shell
 
-## 1. Purpose
+This document is an instance of the ProjectShell-Level NL Skeleton defined in ../General-NL-Skeletons.md.
+
+## 1. Purpose and Scope
+### 1.1 Purpose
 Host the Calculogic single-page application within the browser by mounting the React tree into `#root` and establishing the baseline document styling contract required by downstream shells and configurations.
 
-## 2. Scope
-### In-Scope
-- React root bootstrap logic and StrictMode mounting semantics.
-- Global CSS reset that guarantees full-height layout participation and neutral typography defaults.
+### 1.2 Context
+Wraps the entire experience at the document root and mounts cfg-appFrame and shell-globalHeader within its rendered tree.
 
-### Out-of-Scope
-- Application routing, tab selection, or business logic (handled by downstream configurations).
-- Theme tokens, visual palettes, or component-level styling (delegated to other configurations).
+### 1.3 Interactions
+Coordinates with build tooling to ensure hydration entry points, but delegates navigation and configuration rendering to nested shells.
 
-## 3. Concern Responsibilities
-- **Build**: Acquire the DOM root, create the React root, and mount the application entry component under StrictMode.
-- **BuildStyle**: Normalize document-level layout primitives (html, body, #root) without introducing visual branding or component styling.
-- **Logic / Knowledge / Results / ResultsStyle**: Not present in this shell.
+## 2. Configuration Contracts
+### 2.1 TypeScript Interfaces
+- `SpaHostProps` – Placeholder for future hydration metadata.
+- `SpaHostState` – Not currently used (stateless shell).
 
-## 4. Anchors
-- `#root` – Sole structural anchor exposed by the shell for downstream configurations.
+### 2.2 Global State Requirements
+- None; the shell only consumes the static DOM root.
 
-## 5. Inputs
-- Browser-provided `document` with an element matching `#root`.
-- Application entry component (`<App />`) exported from `src/App.tsx`.
+### 2.3 Routing & Context
+- Provides React root for router providers defined in downstream shells; no direct routing responsibilities.
 
-## 6. Outputs
-- React root instance rendering `<App />` with StrictMode instrumentation.
-- Document-level CSS rules ensuring the React root stretches to fill the viewport.
+## 3. Build Concern (Structure)
+### 3.0 Dependencies & Hierarchy Notes
+- Requires an element with id `root` to exist in index.html.
+- Owns creation of the React root and StrictMode wrapper.
 
-## 7. Invariants
-- React root creation occurs exactly once per page load.
-- StrictMode always wraps the application tree to catch lifecycle regressions.
-- html, body, and #root all maintain `height: 100%` to unblock full-viewport layouts.
+### 3.1 Atomic Components — Containers (Build)
+- None; structure is a single primitive mount operation.
 
-## 8. Dependencies
-- React DOM client API (`createRoot`).
-- Global CSS cascade; no framework-specific CSS tooling.
+### 3.2 Atomic Components — Subcontainers (Build)
+- None.
 
-## 9. Atomic Components
-### 3. Build – shell-spaHost
-- **[3.1] Primitive – "React Root Mount"**: Invoke `createRoot` on `#root` and render `<App />` within `<StrictMode>`.
+### 3.3 Atomic Components — Primitives (Build)
+- **[3.3.1] Primitive – "React Root Mount"**
+  - Calls `createRoot(document.getElementById('root')!)`.
+  - Renders `<StrictMode><App /></StrictMode>`.
 
-### 4. BuildStyle – shell-spaHost
-- **[4.1] Primitive – "Document Baseline Reset"**: Apply zero margins, border-box sizing, and typography defaults to `html` and `body`.
-- **[4.2] Primitive – "Root Flex Column"**: Force `#root` to occupy full height and expose a flex column container for child configurations.
+## 4. BuildStyle Concern (Visual Styling of Structure)
+### 4.0 Dependencies
+- No theme tokens; uses neutral baseline values only.
+- Implemented in CSS or CSS-Module files that target document/root anchors emitted by the Build concern.
 
-## 10. Assembly & Implementation Notes
-- Bootstrap logic remains synchronous to satisfy Vite's expectations; no async dynamic imports at the shell level.
-- CSS reset must avoid interfering with downstream component namespaces; limit selectors to `html`, `body`, and `#root`.
+### 4.1 Atomic Components — Containers / Groups (BuildStyle)
+- None.
+
+### 4.2 Atomic Components — Primitives (BuildStyle)
+- **[4.2.1] Primitive – "Document Baseline Reset"**
+  - Applies zero margins, border-box sizing, and neutral typography to `html` and `body`.
+- **[4.2.2] Primitive – "Root Flex Column"**
+  - Forces `#root` to occupy full height and expose a flex column container for nested shells.
+
+### 4.3 Responsive Rules
+- Not required; baseline rules are invariant across viewports.
+
+### 4.4 Interaction Styles
+- None.
+
+## 5. Logic Concern (Workflow)
+### 5.0 Dependencies
+- None beyond React DOM client utilities.
+
+### 5.1 Atomic Components — Containers (Logic)
+- Not present.
+
+### 5.2 Atomic Components — Primitives (Logic)
+- Not present.
+
+### 5.2.3 Derived Values
+- Not present.
+
+### 5.2.4 Side Effects
+- Not present beyond Build's mount (handled in Build to keep Logic empty).
+
+### 5.2.5 Workflows
+- Not applicable.
+
+## 6. Knowledge Concern (Reference Data)
+### 6.1 Maps / Dictionaries
+- Not present.
+
+### 6.2 Constants
+- Not present.
+
+### 6.3 Shared / Global Reference
+- Not present.
+
+## 7. Results Concern (Outputs)
+### 7.1 User-Facing Outputs
+- Not present.
+
+### 7.2 Dev / Debug Outputs
+- Not present.
+
+### 7.3 Accessibility Outputs
+- Not present.
+
+## 8. ResultsStyle Concern (Output Styling)
+### 8.1 Results Layout Styles
+- Not present.
+
+### 8.2 Debug Display Styles
+- Not present.
+
+## 9. Assembly Pattern
+### 9.1 File Structure
+- src/shells/spaHost/SpaHost.build.tsx
+- src/shells/spaHost/SpaHost.build.css
+- src/shells/spaHost/index.ts
+
+### 9.2 Assembly Logic
+- `src/shells/spaHost/index.ts` calls the Build primitive to mount the React tree and imports the BuildStyle CSS file for global baseline rules.
+
+### 9.3 Integration
+- Entry point referenced by src/main.tsx (or equivalent) to bootstrap the Calculogic application.
+
+## 10. Implementation Passes
+### 10.1 Pass Mapping
+- Pass 0: Author NL skeleton and confirm `#root` anchor availability.
+- Pass 1: Implement Build mount primitive.
+- Pass 2: Implement BuildStyle baseline reset.
+- Pass 3+: No additional passes expected unless Knowledge/Results concerns become necessary.
+
+### 10.2 Export Checklist
+- Build successfully mounts `<App />` under StrictMode.
+- BuildStyle touches only `html`, `body`, and `#root` selectors.
+- No extra concerns introduced; confirm absence is intentional each review.


### PR DESCRIPTION
## Summary
- clarify in architecture and workflow docs that BuildStyle and ResultsStyle are implemented via CSS or CSS Modules
- update concern-to-file mappings in skeleton and NL configuration docs to reference CSS file extensions for style concerns
- adjust config and shell NL specs to describe importing CSS modules alongside structure and logic files

## Testing
- not run (documentation-only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916afa1ae288331a8745a5ce8a08c08)