### PR TITLE
Add provider-agnostic content drawer types

### DIFF
--- a/src/content-drawer/contentTypes.ts
+++ b/src/content-drawer/contentTypes.ts
@@ -1,0 +1,79 @@
+export type ContentMeta = {
+  tags: string[];
+  keywords: string[];
+  intentTags: string[];
+  conceptIds: string[];
+  sourceTier?: 'tier-1' | 'tier-2' | 'tier-3' | string;
+  visibility?: 'public' | 'internal' | 'private' | string;
+  status?: 'draft' | 'review' | 'published' | 'archived' | string;
+  scope?: 'global' | 'team' | 'project' | string;
+  version?: string;
+};
+
+type ContentNodeBase = {
+  contentId: string;
+  anchorId?: string;
+  meta: ContentMeta;
+};
+
+export type ParagraphBlock = {
+  type: 'paragraph';
+  text: string;
+};
+
+export type HeadingBlock = {
+  type: 'heading';
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  text: string;
+};
+
+export type CalloutBlock = {
+  type: 'callout';
+  tone?: 'info' | 'warning' | 'success' | 'danger' | string;
+  title?: string;
+  body: string;
+};
+
+export type StepsBlock = {
+  type: 'steps';
+  steps: Array<{
+    title?: string;
+    body: string;
+  }>;
+};
+
+export type CodeBlock = {
+  type: 'code';
+  language?: string;
+  code: string;
+  caption?: string;
+};
+
+export type GlossaryRefBlock = {
+  type: 'glossaryRef';
+  termId: string;
+  label?: string;
+};
+
+export type ContentBlock =
+  | ParagraphBlock
+  | HeadingBlock
+  | CalloutBlock
+  | StepsBlock
+  | CodeBlock
+  | GlossaryRefBlock;
+
+export type ContentSection = {
+  sectionId: string;
+  anchorId?: string;
+  title?: string;
+  blocks: ContentBlock[];
+};
+
+export type ContentNode =
+  | (ContentNodeBase & {
+      blocks: ContentBlock[];
+    })
+  | (ContentNodeBase & {
+      sections: ContentSection[];
+    });


### PR DESCRIPTION
### Motivation

- Provide a stable, provider-agnostic TypeScript contract for content used by the content drawer so the same shape can back docs, knowledge DB entries, and config artifacts later. 
- Capture metadata and modular content structure (either flat `blocks` or nested `sections`) to support rendering, linking, and indexing.

### Description

- Add a new file `src/content-drawer/contentTypes.ts` containing the type definitions. 
- Introduce `ContentMeta` with fields aligned to living-doc style metadata such as `tags`, `keywords`, `intentTags`, `conceptIds`, `sourceTier`, `visibility`, `status`, `scope`, and `version`.
- Add `ContentNodeBase` with `contentId`, optional `anchorId`, and `meta`, and a `ContentNode` union that supports either `blocks: ContentBlock[]` or `sections: ContentSection[]`.
- Define block/section types and the `ContentBlock` union including `paragraph`, `heading`, `callout`, `steps`, `code`, and `glossaryRef` blocks and the `ContentSection` shape.

### Testing

- This is a type-only addition and no automated tests were run.  
- The change is isolated to new type declarations and introduces no runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8c4b058883319b50fb58658f3a36)