### PR TITLE
docs: add Doc-Engine workflow lockstep note to ConfigurationArchitectureSummary

### DIFF
--- a/doc/ConfigurationArchitectureSummary.md
+++ b/doc/ConfigurationArchitectureSummary.md
@@ -49,3 +49,10 @@ Calculogic transforms form building into a hands-on coding lesson. Each tab enfo
 4. NL-First-Workflow.md (Authoring workflow)
 5. CCPP.md (Comment and provenance protocol)
 6. doc/nl-config/*.md and doc/nl-shell/*.md (Per-configuration and shell specifications built from the skeletons)
+
+## Doc-Engine Standards Pack: Workflow Note
+- Update the NL skeleton first.
+- Then update code + CCPP comments to match.
+- Reject changes that add structure not present in NL.
+
+This ensures doc-engine changes stay in lockstep with NL standards.


### PR DESCRIPTION
### Motivation
- Ensure doc-engine edits follow the NL-first discipline by requiring NL skeleton updates before code/CCPP changes and rejecting structural changes not described in NL.

### Description
- Added a `Doc-Engine Standards Pack: Workflow Note` section to `doc/ConfigurationArchitectureSummary.md` that lists the three-step workflow: update NL skeleton first, then update code + CCPP comments, and reject structural additions not present in NL.

### Testing
- Validated the change with `git diff -- doc/ConfigurationArchitectureSummary.md`, `git status --short`, and a successful commit; all commands completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9a551b348331abb21198b23624c0)