### PR TITLE
Add ContentDrawer component

### DIFF
--- a/src/components/ContentDrawer/ContentDrawer.css
+++ b/src/components/ContentDrawer/ContentDrawer.css
@@ -1,0 +1,94 @@
+.content-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(420px, 100vw);
+  background: rgba(248, 250, 252, 0.98);
+  border-left: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: -8px 0 24px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  z-index: 40;
+  outline: none;
+}
+
+.content-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.98);
+}
+
+.content-drawer__eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(71, 85, 105, 0.7);
+}
+
+.content-drawer__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.content-drawer__summary {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.content-drawer__close {
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: rgba(30, 41, 59, 0.8);
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.content-drawer__close:hover {
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.content-drawer__body {
+  padding: 1rem 1.25rem 1.5rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.content-drawer__block {
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.content-drawer__empty {
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  color: rgba(71, 85, 105, 0.7);
+  background: rgba(248, 250, 252, 0.8);
+}
+
+@media (max-width: 720px) {
+  .content-drawer {
+    width: 100vw;
+  }
+}

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { ReactNode } from 'react';
+import './ContentDrawer.css';
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export interface ContentNode {
+  id?: string;
+  title: string;
+  summary?: string;
+  blocks: ReactNode[];
+}
+
+export interface ContentDrawerProps {
+  open: boolean;
+  content?: ContentNode | null;
+  contentId?: string;
+  anchorId?: string;
+  onClose: () => void;
+  onResolveContent?: (contentId: string) => ContentNode | null | undefined;
+}
+
+export function ContentDrawer({
+  open,
+  content,
+  contentId,
+  anchorId,
+  onClose,
+  onResolveContent,
+}: ContentDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+
+  const resolvedContent = useMemo(() => {
+    if (content) return content;
+    if (contentId && onResolveContent) {
+      return onResolveContent(contentId) ?? null;
+    }
+    return null;
+  }, [content, contentId, onResolveContent]);
+
+  useEffect(() => {
+    if (!open) return;
+    const drawer = drawerRef.current;
+    if (!drawer) return;
+
+    const previousActive = document.activeElement as HTMLElement | null;
+    const focusable = Array.from(drawer.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    const focusTarget = focusable[0] ?? drawer;
+    focusTarget.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab' || focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousActive?.focus();
+    };
+  }, [onClose, open]);
+
+  useEffect(() => {
+    if (!open || !anchorId) return;
+    const drawer = drawerRef.current;
+    if (!drawer) return;
+
+    const anchorTarget =
+      drawer.querySelector<HTMLElement>(`#${CSS.escape(anchorId)}`) ??
+      drawer.querySelector<HTMLElement>(`[data-anchor="${anchorId}"]`);
+
+    anchorTarget?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  }, [anchorId, open, resolvedContent]);
+
+  if (!open) return null;
+
+  const titleId = resolvedContent?.id ? `${resolvedContent.id}-title` : 'content-drawer-title';
+  const summaryId = resolvedContent?.id
+    ? `${resolvedContent.id}-summary`
+    : 'content-drawer-summary';
+
+  return (
+    <aside
+      className="content-drawer"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={resolvedContent?.summary ? summaryId : undefined}
+      ref={drawerRef}
+      tabIndex={-1}
+    >
+      <header className="content-drawer__header">
+        <div>
+          <p className="content-drawer__eyebrow">Content Detail</p>
+          <h2 id={titleId} className="content-drawer__title">
+            {resolvedContent?.title ?? 'Content'}
+          </h2>
+          {resolvedContent?.summary && (
+            <p id={summaryId} className="content-drawer__summary">
+              {resolvedContent.summary}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          className="content-drawer__close"
+          onClick={onClose}
+          aria-label="Close content drawer"
+        >
+          ✕
+        </button>
+      </header>
+      <div className="content-drawer__body">
+        {resolvedContent ? (
+          resolvedContent.blocks.map((block, index) => (
+            <section key={`${resolvedContent.id ?? 'block'}-${index}`} className="content-drawer__block">
+              {block}
+            </section>
+          ))
+        ) : (
+          <div className="content-drawer__empty">
+            Select a content item to review its details.
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/ContentDrawer/index.tsx
+++ b/src/components/ContentDrawer/index.tsx
@@ -1,0 +1,2 @@
+export { ContentDrawer } from './ContentDrawer';
+export type { ContentDrawerProps, ContentNode } from './ContentDrawer';


### PR DESCRIPTION
### Motivation
- Provide a right-docked panel for inspecting content items that matches the builder inspector layout and visual treatment.
- Surface `ContentNode` details (title, summary, blocks) with accessible dialog semantics, keyboard focus management, and anchor scrolling.

### Description
- Add `ContentDrawer` implementation in `src/components/ContentDrawer/ContentDrawer.tsx` that renders a resolved `ContentNode` (via `content` or `contentId` + `onResolveContent`) and maps `blocks` to body sections.
- Implement accessible dialog semantics with `role="dialog"`, `aria-modal`, labelled/description IDs, Escape-to-close handling, and a focus trap that cycles tabbable elements inside the drawer.
- Support anchor scrolling by locating an element by `#id` or `data-anchor` inside the drawer and calling `scrollIntoView` when `anchorId` or content changes.
- Add styling in `src/components/ContentDrawer/ContentDrawer.css` to match the right-side docked builder panel and export the component and types via `src/components/ContentDrawer/index.tsx` (`ContentDrawer`, `ContentDrawerProps`, `ContentNode`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8d71dbe08331a151faec1a00315b)