### PR TITLE
Add doc-engine standards folder with overview, summary, and checklist

### DIFF
--- a/docs/doc-engine/standards/Doc-Engine-Contribution-Checklist.md
+++ b/docs/doc-engine/standards/Doc-Engine-Contribution-Checklist.md
@@ -1,0 +1,39 @@
+# Doc-Engine Contribution Checklist
+
+Use this checklist before opening or approving a doc-engine PR.
+
+## Linked Standards (Required)
+
+- [ ] **CCPP** reviewed and applied: `doc/CCPP.md`
+- [ ] **CSCS** reviewed and applied: `doc/CSCS.md`
+- [ ] **General NL Skeletons** template/numbering followed: `doc/General-NL-Skeletons.md`
+- [ ] **NL-First Workflow** enforced (NL updated before code): `doc/NL-First-Workflow.md`
+
+## NL-First and Ordering
+
+- [ ] NL skeleton exists at `doc/nl-config/cfg-*.md` or `doc/nl-shell/shell-*.md`.
+- [ ] NL sections are complete and concern numbering is correct (3–8 mapping).
+- [ ] Code/comment ordering mirrors NL top-down ordering.
+
+## CCPP Comment Compliance
+
+- [ ] Exactly one file header exists per concern file and includes Source NL.
+- [ ] Section headers are present for each concern section in use.
+- [ ] Atomic comments precede every Container/Subcontainer/Primitive block.
+- [ ] Atomic comments use the required three-line structure and correct section IDs.
+- [ ] TODO comments include owner + date when used.
+
+## CSCS Concern Purity
+
+- [ ] Build files contain structure only.
+- [ ] BuildStyle/ResultsStyle files contain style rules only.
+- [ ] Logic files contain behavior/state only.
+- [ ] Knowledge files contain static content/constants only.
+- [ ] Results files contain derived outputs/readouts only.
+- [ ] No non-Build concern creates or reorders structure.
+
+## Final Consistency Checks
+
+- [ ] NL numbering and code comment numbering match exactly.
+- [ ] Anchors referenced outside Build are defined in Build.
+- [ ] Any decisions/todos/provenance notes are minimal and valid per CCPP.

--- a/docs/doc-engine/standards/Doc-Engine-Standards-Summary.md
+++ b/docs/doc-engine/standards/Doc-Engine-Standards-Summary.md
@@ -1,0 +1,92 @@
+# Doc-Engine Standards Summary
+
+This summary restates required conventions for doc-engine implementation work. It is a local, practical restatement of the canonical standards in `doc/CCPP.md`, `doc/CSCS.md`, `doc/General-NL-Skeletons.md`, and `doc/NL-First-Workflow.md`.
+
+## 1) Required File Header (CCPP)
+
+Every concern file should begin with a single file header that identifies:
+
+- configuration/shell identity,
+- concern file type,
+- source NL skeleton path,
+- responsibility,
+- invariants,
+- optional notes.
+
+Reference shape:
+
+```ts
+/**
+ * Configuration: cfg-[id] ([Name])
+ * Concern File: Build | BuildStyle | Logic | Knowledge | Results | ResultsStyle
+ * Source NL: doc/nl-config/cfg-[id].md (or doc/nl-shell/shell-[id].md)
+ * Responsibility: <one-sentence concern responsibility>
+ * Invariants: <comma-separated truths>
+ * Notes: <optional>
+ */
+```
+
+## 2) Required Section Headers (CCPP + Skeleton Alignment)
+
+Within each concern file, add section headers in NL order and keep numbering aligned with the NL skeleton.
+
+- Concern numbering contract:
+  - `3` Build
+  - `4` BuildStyle
+  - `5` Logic
+  - `6` Knowledge
+  - `7` Results
+  - `8` ResultsStyle
+- Section header includes concern name, NL section span, purpose, and constraints.
+
+Reference shape:
+
+```ts
+// ─────────────────────────────────────────────
+// 3. Build – cfg-[id] ([Name])
+// NL Sections: §3.0–3.x in cfg-[id].md
+// Purpose: <short purpose>
+// Constraints: <key constraints>
+// ─────────────────────────────────────────────
+```
+
+## 3) Required Atomic Comments (CCPP)
+
+Add atomic comments immediately before each Container/Subcontainer/Primitive implementation block.
+
+Required structure:
+
+1. `[sectionNumber] cfg-id · HierarchicalType · "Atomic Name"`
+2. `Concern`, parent context (if applicable), and catalog/base id
+3. concise intent or constraint note
+
+Reference shape:
+
+```ts
+// [3.2.2] cfg-[id] · Subcontainer · "[Atomic Name]"
+// Concern: Build · Parent: "[Parent Name]" · Catalog: layout.group
+// Notes: <intent / constraints>
+```
+
+## 4) Doc-Engine Concern Boundaries (CSCS)
+
+Keep concern purity strict:
+
+- **Build**: structure only
+- **BuildStyle**: styling only
+- **Logic**: behavior/state only
+- **Knowledge**: static content/maps/constants
+- **Results**: derived readouts
+- **ResultsStyle**: styling of results
+
+Non-structural concerns must not invent or reorder DOM structure defined by Build.
+
+## 5) NL-First Requirement (Workflow)
+
+Before code edits:
+
+1. Create/update the corresponding NL skeleton file (`doc/nl-config/...` or `doc/nl-shell/...`).
+2. Ensure sections 1–10 and concern atom numbering are up to date.
+3. Then implement concern files and comments to match NL numbering.
+
+If behavior/structure changes, update NL first, then code.

--- a/docs/doc-engine/standards/README.md
+++ b/docs/doc-engine/standards/README.md
@@ -1,0 +1,17 @@
+# Doc-Engine Standards Overview
+
+This folder provides quick-start guidance for doc-engine work and points to the canonical standards documents that govern structure, ordering, and traceability.
+
+## Canonical Standards
+
+- **CCPP (Calculogic Comment & Provenance Protocol)**: `doc/CCPP.md`
+- **CSCS (Calculogic Concern System, NL-Aligned)**: `doc/CSCS.md`
+- **General NL Skeletons**: `doc/General-NL-Skeletons.md`
+- **NL-First Workflow**: `doc/NL-First-Workflow.md`
+
+## Local Companion Docs
+
+- [Doc-Engine Standards Summary](./Doc-Engine-Standards-Summary.md)
+- [Doc-Engine Contribution Checklist](./Doc-Engine-Contribution-Checklist.md)
+
+Use this folder as a contributor-facing entry point; defer to the source docs above as the final authority.


### PR DESCRIPTION
### Motivation

- Provide a discoverable doc-engine entry point that consolidates the repository's canonical documentation standards.
- Make it easier for contributors to apply CCPP/CSCS/General NL Skeletons/NL‑First Workflow conventions when authoring NL skeletons and concern files.
- Surface a concise contribution checklist to reduce review friction and ensure NL-first and comment/concern compliance.

### Description

- Add `docs/doc-engine/standards/README.md` which links to the canonical standards: `doc/CCPP.md`, `doc/CSCS.md`, `doc/General-NL-Skeletons.md`, and `doc/NL-First-Workflow.md`.
- Add `docs/doc-engine/standards/Doc-Engine-Standards-Summary.md` that restates required file headers, section headers, atomic comments, concern purity rules, and the NL-first workflow in a local, practical form.
- Add `docs/doc-engine/standards/Doc-Engine-Contribution-Checklist.md` that references the four standards by name and provides a pre-PR checklist for doc-engine changes.

### Testing

- Verified the three files exist at `docs/doc-engine/standards/` using filesystem presence checks and confirmed they contain the expected sections.
- Confirmed the change is documentation-only and does not modify source code.
- No additional automated test suites were required; the presence checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a984d0fc88331a44828277603170d)