### PR TITLE
docs: add doc-engine ↔ CSCS concern mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ It guarantees architectural purity and predictable diffs across the codebase.
 
 📘 See [`docs/CSCS.md`](docs/CSCS.md) for the full rubric.
 
+For doc-engine modules, use [`doc/DocEngine-CSCS-Mapping.md`](doc/DocEngine-CSCS-Mapping.md) as the concern mapping + naming checklist.
+
 ---
 
 ## **Comment & Provenance Protocol (CCPP)**

--- a/doc/DocEngine-CSCS-Mapping.md
+++ b/doc/DocEngine-CSCS-Mapping.md
@@ -1,0 +1,45 @@
+# Doc Engine ↔ CSCS Concern Mapping
+
+This note defines how **doc-engine modules** map to CSCS concerns so file naming and layer boundaries stay consistent.
+
+## 1) Mapping Table
+
+| CSCS Concern | Doc-engine modules | Scope |
+| --- | --- | --- |
+| **Build** | `drawer`, `renderer` | UI composition, anchors, visible structure only. |
+| **Logic** | `resolver`, `providerRegistry`, `useOrchestration*` hooks | Dependency resolution, provider lookup, orchestration flow/state. |
+| **Knowledge** | `contentCatalog*`, `contentSchema*`, `*Definition*` | Static catalogs, schema contracts, declarative definitions. |
+| **Results** | `diagnostics*`, `telemetry*` surfaces | Read-only debug/readout output (if present). |
+
+## 2) File Naming Rules
+
+Use concern-first suffixes to make ownership obvious:
+
+- Build: `*.build.tsx` (or `*.build.ts` for non-React helpers)
+- Logic: `*.logic.ts` / `*.logic.tsx`
+- Knowledge: `*.knowledge.ts`
+- Results: `*.results.ts` / `*.results.tsx`
+
+For doc-engine module names, keep the concern signal in the base name:
+
+- Build examples: `DocEngineDrawer.build.tsx`, `DocEngineRenderer.build.tsx`
+- Logic examples: `DocEngineResolver.logic.ts`, `DocEngineProviderRegistry.logic.ts`, `useDocEngineOrchestration.logic.ts`
+- Knowledge examples: `DocEngineContentCatalog.knowledge.ts`, `DocEngineContentSchema.knowledge.ts`, `DocEngineDefinitions.knowledge.ts`
+- Results examples: `DocEngineDiagnostics.results.tsx`, `DocEngineTelemetry.results.ts`
+
+## 3) Layering Guardrails
+
+- **Build** may render structure and anchors; it must not resolve providers or mutate orchestration state.
+- **Logic** may compute and coordinate behavior; it must not define copy catalogs or schemas.
+- **Knowledge** is declarative-only (catalog/schema/definitions); it must not run orchestration.
+- **Results** is readout-only diagnostics/telemetry; it must not feed state back into Logic.
+
+## 4) Dependency Direction (enforced)
+
+- Build can depend on Logic + Knowledge for inputs.
+- Logic can depend on Knowledge.
+- Results can depend on Logic + Knowledge.
+- Knowledge depends on none of the other concerns.
+- No upward/cyclic flow (especially `Results -> Logic`).
+
+Use this file as the naming + review checklist for any new doc-engine modules.


### PR DESCRIPTION
### Motivation

- Provide a concise, reviewable mapping that aligns doc-engine module roles to the Calculogic Concern System (CSCS) to enforce consistent naming and layering. 
- Make it easy for reviewers and authors to pick correct file suffixes and avoid cross-layer coupling for doc-engine work.

### Description

- Add `doc/DocEngine-CSCS-Mapping.md` that maps doc-engine modules to CSCS concerns (Build: `drawer`/`renderer`; Logic: `resolver`/`providerRegistry`/orchestration hooks; Knowledge: catalogs/schemas/definitions; Results: diagnostics/telemetry) and includes naming examples. 
- Add explicit layering guardrails and dependency-direction rules to prevent upward/cyclic imports and to clarify concern purity. 
- Link the new mapping from the CSCS section in `README.md` so the guidance is discoverable.

### Testing

- Ran a production build with `npm run build`, which completed successfully and produced the Vite build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9a104e3c833191b9df571150cd1f)