### PR TITLE
Add Doc Engine documentation hub with core specs

### DIFF
--- a/doc/DocEngine/Content-Drawer-MVP-Spec.md
+++ b/doc/DocEngine/Content-Drawer-MVP-Spec.md
@@ -1,0 +1,41 @@
+# Content Drawer MVP Spec
+
+## Goal
+
+Provide a right-side drawer that renders Doc Engine ContentNode details for the currently selected context in the app.
+
+## MVP user outcomes
+
+- Open contextual docs without leaving current workflow.
+- Navigate parent/child/related links quickly.
+- View source attribution for trust and debugging.
+
+## Inputs
+
+- `activeNodeId: string | null`
+- `nodeById: Record<string, ContentNode>`
+- `onNavigate(nodeId: string): void`
+- `onClose(): void`
+
+## Rendering requirements
+
+1. Header: node title, kind badge, status badge (if present).
+2. Body: summary then full body text (markdown rendering optional in MVP).
+3. Relationships:
+   - Parent link (if present).
+   - Child list (if any).
+   - Related list (if any).
+4. Source footer: provider ID, external ID, uri (if available).
+
+## Interaction requirements
+
+- Drawer opens when `activeNodeId` is set and exists in `nodeById`.
+- Drawer closes on explicit close action.
+- Relationship links call `onNavigate` and update drawer content.
+- Missing node fallback: show “Content unavailable” placeholder.
+
+## Non-goals (MVP)
+
+- Editing documentation content.
+- Version comparison UI.
+- Multi-select or split-view content panes.

--- a/doc/DocEngine/ContentNode-Schema.md
+++ b/doc/DocEngine/ContentNode-Schema.md
@@ -1,0 +1,47 @@
+# ContentNode Schema
+
+## Intent
+
+`ContentNode` is the canonical schema used by Doc Engine to represent resolved, render-ready documentation entities.
+
+## Type definition (MVP)
+
+```ts
+export interface ContentNode {
+  id: string; // globally unique, stable across refresh when source is unchanged
+  kind: 'topic' | 'section' | 'example' | 'reference' | 'note';
+  title: string;
+  summary?: string;
+  body?: string; // markdown/plain text for MVP
+
+  parentId?: string;
+  childIds?: string[];
+  relatedIds?: string[];
+
+  tags?: string[];
+  status?: 'draft' | 'published' | 'deprecated';
+
+  source: {
+    providerId: string;
+    externalId: string;
+    uri?: string;
+    version?: string;
+    updatedAt?: string;
+  };
+
+  metadata?: Record<string, unknown>;
+}
+```
+
+## Field requirements
+
+- Required: `id`, `kind`, `title`, `source.providerId`, `source.externalId`.
+- Optional but recommended: `summary`, `body`, `relatedIds`, `tags`.
+- `id` must remain stable for unchanged provider content to support caching and UI state retention.
+
+## Validation rules (MVP)
+
+- `childIds` cannot include `id` (no self-reference).
+- `parentId` must reference an existing node when present.
+- `relatedIds` may reference missing nodes but should emit a resolver warning.
+- Unknown `metadata` fields are allowed.

--- a/doc/DocEngine/Overview-Architecture.md
+++ b/doc/DocEngine/Overview-Architecture.md
@@ -1,0 +1,38 @@
+# Overview + Architecture
+
+## Purpose
+
+Doc Engine provides a normalized way to load, resolve, and render structured documentation content in the UI while keeping source-specific logic isolated.
+
+## Scope
+
+- Gather content from one or more providers.
+- Resolve references and relationships into display-ready nodes.
+- Provide deterministic rendering inputs to consumer UI (e.g., Content Drawer).
+
+## High-level architecture
+
+```text
+[Provider(s)] --> [Resolver Pipeline] --> [ContentNode Graph] --> [UI Consumer]
+      |                   |                    |                    |
+  fetch/raw          normalize/link        typed schema         render state
+```
+
+## Core layers
+
+1. **Provider layer**
+   - Reads source content (local files, APIs, generated docs).
+   - Emits provider-native payloads.
+2. **Resolver layer**
+   - Transforms provider payloads into ContentNode entities.
+   - Resolves links, parents/children, and metadata inheritance.
+3. **Presentation layer**
+   - Consumes ContentNode graph.
+   - Renders in context-specific surfaces (drawer, panels, full-page docs).
+
+## Design goals
+
+- **Provider-agnostic core:** UI and downstream tooling depend on ContentNode, not provider internals.
+- **Composable resolution:** Multiple resolvers can run in sequence with clear boundaries.
+- **Traceability:** Every node includes source metadata for debugging and provenance.
+- **Incremental adoption:** Can bootstrap with one provider and expand without schema churn.

--- a/doc/DocEngine/Provider-Resolver-Contract.md
+++ b/doc/DocEngine/Provider-Resolver-Contract.md
@@ -1,0 +1,64 @@
+# Provider / Resolver Contract
+
+## Contract summary
+
+Providers and resolvers communicate through explicit interfaces to keep source ingestion and semantic normalization decoupled.
+
+## Provider responsibilities
+
+A provider must:
+
+- Expose a unique `providerId`.
+- Return raw content units with stable `externalId` values.
+- Include minimal source metadata (`uri`, `version`, `updatedAt` when available).
+- Avoid view-specific transformations.
+
+### Provider output shape (conceptual)
+
+```ts
+interface ProviderRecord {
+  providerId: string;
+  externalId: string;
+  type: string;
+  title?: string;
+  body?: unknown;
+  links?: Array<{ rel: string; targetExternalId: string }>;
+  source: {
+    uri: string;
+    version?: string;
+    updatedAt?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+```
+
+## Resolver responsibilities
+
+A resolver must:
+
+- Accept a list of `ProviderRecord` entries.
+- Emit one or more valid `ContentNode` entries.
+- Map provider-specific types into canonical node kinds.
+- Resolve relationships and preserve provenance.
+- Report recoverable issues (e.g., dangling links) without hard-failing entire batches.
+
+### Resolver output shape (conceptual)
+
+```ts
+interface ResolverResult {
+  nodes: ContentNode[];
+  warnings?: Array<{
+    code: string;
+    message: string;
+    providerId?: string;
+    externalId?: string;
+  }>;
+}
+```
+
+## Compatibility rules
+
+- Contract changes must be additive when possible.
+- Any breaking change requires version bump in both provider and resolver package boundaries.
+- Resolvers should ignore unknown provider fields.
+- Providers should tolerate resolver-side optional metadata extensions.

--- a/doc/DocEngine/README.md
+++ b/doc/DocEngine/README.md
@@ -1,0 +1,15 @@
+# Doc Engine Hub
+
+This folder is the **Doc Engine documentation hub** for the Calculogic app.
+
+## Contents
+
+- [Overview + Architecture](./Overview-Architecture.md)
+- [Provider / Resolver Contract](./Provider-Resolver-Contract.md)
+- [ContentNode Schema](./ContentNode-Schema.md)
+- [Content Drawer MVP Spec](./Content-Drawer-MVP-Spec.md)
+- [Standards Pack Links](./Standards-Pack-Links.md)
+
+## Portability note
+
+File names are intentionally stable and portable so this folder can be moved into a standalone `doc-engine` repository without renaming.

--- a/doc/DocEngine/Standards-Pack-Links.md
+++ b/doc/DocEngine/Standards-Pack-Links.md
@@ -1,0 +1,14 @@
+# Standards Pack Links
+
+This page indexes standards documents used by the Doc Engine workstream.
+
+## Current links
+
+- CCPP (Calculogic Core Principles Pack): [`doc/CCPP.md`](../CCPP.md)
+- CSCS (Calculogic Style and Conventions Set): [`doc/CSCS.md`](../CSCS.md)
+- Configuration architecture summary: [`doc/ConfigurationArchitectureSummary.md`](../ConfigurationArchitectureSummary.md)
+- NL-first workflow: [`doc/NL-First-Workflow.md`](../NL-First-Workflow.md)
+
+## Maintenance note
+
+When standards docs move, keep this index updated and preserve link labels for stable references.


### PR DESCRIPTION
### Motivation

- Provide a centralized Doc Engine documentation hub to describe how documentation content is ingested, normalized, and presented. 
- Capture a stable, portable set of filenames so the docs can be moved into a standalone `doc-engine` repo without renaming. 
- Define clear contracts and an MVP UI spec to enable provider/resolver implementations and a minimal Content Drawer consumer.

### Description

- Add a new documentation folder at `doc/DocEngine/` with an index `README.md` that lists the included sections. 
- Add `Overview-Architecture.md` which describes purpose, scope, high-level architecture, core layers, and design goals. 
- Add `Provider-Resolver-Contract.md` that specifies provider output shape, resolver responsibilities, and compatibility rules (conceptual TypeScript interfaces included). 
- Add `ContentNode-Schema.md`, the canonical MVP `ContentNode` shape, required fields, and validation rules, plus `Content-Drawer-MVP-Spec.md` with inputs, rendering and interaction requirements; and add `Standards-Pack-Links.md` indexing related standards docs.

### Testing

- Verified the new files are present using `rg --files doc/DocEngine` which returned the expected files. 
- Ran `git diff --check` to ensure no whitespace or diff errors and observed no issues. 
- Confirmed working tree status with `git status --short` which shows the new `doc/DocEngine/` files ready in the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9a9750c08331b2ff2b971b15f50c)