### PR TITLE
docs: add standards compliance audit and alignment plan

### DIFF
--- a/doc/ComplianceAudit-2026-02-10.md
+++ b/doc/ComplianceAudit-2026-02-10.md
@@ -1,0 +1,151 @@
+# Compliance Audit — CSCS / CCPP / General NL Skeletons / NL-First
+
+Date: 2026-02-10  
+Scope: recently changed configurations/shells identified from git history and mapped to current project paths.
+
+## Inputs reviewed
+- `doc/CSCS.md`
+- `doc/CCPP.md`
+- `doc/General-NL-Skeletons.md`
+- `doc/NL-First-Workflow.md`
+- `doc/nl-config/cfg-appFrame.md`
+- `doc/nl-config/cfg-buildSurface.md`
+- `doc/nl-shell/shell-globalHeader.md`
+- `doc/nl-shell/shell-spaHost.md`
+- Related concern files under `src/`
+
+## Changed configurations/shells identified
+1. `cfg-appFrame`
+2. `cfg-buildSurface`
+3. `shell-globalHeader`
+4. `shell-spaHost`
+
+---
+
+## 1) cfg-appFrame
+
+### Violations found
+- **Build (NL → Code numbering mismatch)**
+  - File: `src/App.tsx`
+  - NL sections affected: `[3.1.1]`, `[3.3.1]`, `[3.3.2]`
+  - Code uses `[3.1]`, `[3.2]`, `[3.3]` and does not mirror NL atomic numbering.
+- **Build (NL contract mismatch)**
+  - File: `src/App.tsx`
+  - NL section affected: `[3.3.1] Theme Toggle Control`
+  - `aria-pressed` contract declared in NL is missing in code.
+- **Knowledge purity (NL → Code missing concern file usage)**
+  - Files: `src/App.tsx`, `doc/nl-config/cfg-appFrame.md`
+  - NL sections affected: `[6.2.1]`, `[6.2.2]`, `§6.3`
+  - Toggle copy/icon descriptors are inlined in Build instead of imported from Knowledge.
+- **Logic (NL → Code numbering mismatch)**
+  - File: `src/App.logic.ts`
+  - NL sections affected: `[5.2.1]`, `[5.2.2]`, `[5.2.3]`
+  - Code comments use `[5.1]`, `[5.2]`, `[5.3]`.
+- **BuildStyle (NL → Code numbering mismatch)**
+  - File: `src/App.css`
+  - NL sections affected: `[4.1.1]`, `[4.2.1]`, `[4.2.2]`
+  - Code comments use flattened numbering and do not mirror NL atomic ids.
+
+### Minimal fix required
+1. Update `doc/nl-config/cfg-appFrame.md` only if contracts are intentionally changed.
+2. Add `src/App.knowledge.ts` for toggle copy/icon descriptors.
+3. Update `src/App.tsx` to import Knowledge constants and add `aria-pressed` on toggle.
+4. Renumber CCPP atomic comments in `src/App.tsx`, `src/App.logic.ts`, `src/App.css` to exact NL ids.
+
+---
+
+## 2) cfg-buildSurface
+
+### Violations found
+- **Build (NL → Code missing declared subcontainer)**
+  - File: `src/tabs/build/BuildSurface.build.tsx`
+  - NL section affected: `[3.2.2] Header Chrome`
+  - NL declares Header Chrome, but Build file renders no header chrome node.
+- **BuildStyle attachment leak (CSCS concern dependency)**
+  - File: `src/tabs/build/BuildSurface.view.css`
+  - NL/Code sections affected: `[4.2.2]..[4.2.7]` targeting `builder-header`, `builder-tabs`, publish CTA.
+  - Build concern does not emit those anchors, so BuildStyle contains orphan selectors not attached to Build structure.
+- **Knowledge (NL → Code missing declared primitives)**
+  - Files: `src/tabs/build/anchors.ts`, `src/tabs/build/BuildSurface.logic.ts`, `src/tabs/build/BuildSurface.build.tsx`
+  - NL sections affected: `[6.2.1] Section Labels`, `[6.2.2] Grip Aria Labels`, `[6.2.3] Placeholder Copy`
+  - Section labels/aria labels/placeholders are in Logic/Build inline strings instead of Knowledge module.
+
+### Minimal fix required
+1. Update `doc/nl-config/cfg-buildSurface.md` first if Header Chrome is intentionally deferred/removed.
+2. Either:
+   - implement `[3.2.2] Header Chrome` in Build and keep matching BuildStyle selectors, or
+   - remove/renumber header-related BuildStyle atoms from NL and CSS.
+3. Add Knowledge exports (labels, aria copy, placeholder copy) and import into Build/Logic.
+4. Renumber atomic comments to exact NL ids where mismatched.
+
+---
+
+## 3) shell-globalHeader
+
+### Violations found
+- **Build (Code → NL drift)**
+  - File: `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`
+  - NL sections affected: `3.x`
+  - Code includes mode menus (`BuildModeMenu`, `ResultsModeMenu`, `ModeMenuItem`) that are not represented in NL skeleton atoms/subcontainers.
+- **Build (NL → Code missing declared primitive)**
+  - File: `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`
+  - NL section affected: `[3.3.7] Tab Tooltip Portal`
+  - Declared primitive is not present as explicit structure.
+- **Logic (Code → NL drift)**
+  - File: `src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts`
+  - NL sections affected: `[5.2.1]..[5.2.10]`
+  - Code includes doc state/open/close and tab-mode selection flows not reflected by NL primitive list.
+- **Knowledge (Code → NL drift)**
+  - File: `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`
+  - NL sections affected: `6.x`
+  - Extensive doc definition catalog and mode metadata exceed current NL declarations.
+- **ResultsStyle (NL → Code numbering mismatch)**
+  - File: `src/components/GlobalHeaderShell/GlobalHeaderShell.results.css`
+  - NL section affected: `[8.1.1]`
+  - Code defines an additional `[8.2] Live Region Anchor` not represented in NL.
+
+### Minimal fix required
+1. Update `doc/nl-shell/shell-globalHeader.md` first to include mode menus, doc resolution state, and live region style primitive.
+2. Keep concern purity by ensuring new knowledge/data structures remain in Knowledge and only consumed by Build/Logic.
+3. Align CCPP atomic numbering in all concern files to updated NL numbering.
+
+---
+
+## 4) shell-spaHost
+
+### Violations found
+- **CCPP file-header format violation**
+  - Files: `src/main.tsx`, `src/index.css`
+  - Current headers use abbreviated `CCPP:` style, not required file-header fields from CCPP.
+- **Section/atomic comment format mismatch**
+  - Files: `src/main.tsx`, `src/index.css`
+  - CCPP expects full section headers and atomic comment format with NL section ids.
+- **Assembly path drift (NL → Code)**
+  - NL references `src/shells/spaHost/...`; implementation currently uses `src/main.tsx` + `src/index.css`.
+
+### Minimal fix required
+1. Update `doc/nl-shell/shell-spaHost.md` assembly section to actual paths (or move files to NL paths).
+2. Rewrite `src/main.tsx` and `src/index.css` comment headers/sections/atomics to full CCPP format.
+3. Preserve shell purity (Build mount primitive only; BuildStyle global resets only).
+
+---
+
+## Single Alignment PR change set (order enforced)
+
+### Step A — NL-first updates
+1. Update `doc/nl-config/cfg-appFrame.md` (knowledge extraction + exact numbering expectations).
+2. Update `doc/nl-config/cfg-buildSurface.md` (header chrome presence decision + BuildStyle attachments).
+3. Update `doc/nl-shell/shell-globalHeader.md` (mode menu, doc state/resolution, live-region styling primitives).
+4. Update `doc/nl-shell/shell-spaHost.md` (actual assembly paths and comment expectations).
+
+### Step B — Concern file alignment
+1. `cfg-appFrame`: `src/App.tsx`, `src/App.logic.ts`, `src/App.css`, add `src/App.knowledge.ts`.
+2. `cfg-buildSurface`: `src/tabs/build/BuildSurface.build.tsx`, `src/tabs/build/BuildSurface.view.css`, `src/tabs/build/BuildSurface.logic.ts`, `src/tabs/build/anchors.ts` (or new knowledge file).
+3. `shell-globalHeader`: all concern files under `src/components/GlobalHeaderShell/`.
+4. `shell-spaHost`: `src/main.tsx`, `src/index.css` (or move to shell path and update imports).
+
+### Step C — Verification gates
+- NL → Code section-by-section parity check.
+- Code → NL drift check (no undeclared atoms).
+- CSCS dependency/purity check (Build anchors as attach sources; no upward concern dependencies).
+- CCPP header/section/atomic format check.

--- a/doc/DocEngineExtractionPlan.md
+++ b/doc/DocEngineExtractionPlan.md
@@ -1,0 +1,106 @@
+# Documentation Engine Extraction Plan
+
+This document maps the current documentation engine signals in the builder UI and proposes a clean extraction boundary for moving the doc engine to a dedicated repository in the future.
+
+## Inventory: Current Doc Engine Touchpoints
+
+### Knowledge layer (content model + source of truth)
+- `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`
+  - Structured doc content model (`HeaderDocDefinition`, sections, links).
+  - Tab definitions include `docId` and `hoverSummary`.
+  - `resolveHeaderDoc` provides a lookup accessor.
+
+### Logic layer (state + orchestration)
+- `src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts`
+  - `activeDocId` tracked in state.
+  - `openDoc` and `closeDoc` handlers exposed via bindings.
+  - Doc state is already decoupled from rendering.
+
+### Build layer (UI entry points)
+- `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`
+  - `InfoIcon` triggers `openDoc(tab.docId)`.
+  - Tab metadata surfaces `hoverSummary`.
+
+### Results layer (diagnostics)
+- `src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx`
+  - Debug panel + live region uses the same shell state; can optionally surface doc state later.
+
+## Extraction Boundary (Proposed)
+
+### 1) New doc-engine package responsibilities
+Create a dedicated package/repo that owns the following:
+- Doc content model and types (definitions, sections, links).
+- Doc catalogs (the actual content data).
+- Accessors/resolvers (e.g., `resolveHeaderDoc`).
+- Optional helpers for search, indexing, and content normalization.
+
+**Suggested module boundary (future package):**
+```
+@calculogic/doc-engine
+├─ src
+│  ├─ types.ts              // HeaderDocDefinition, Section, Link
+│  ├─ catalog.ts            // HEADER_DOC_DEFINITIONS (or equivalent registry)
+│  ├─ resolvers.ts          // resolveHeaderDoc
+│  └─ index.ts              // public exports
+```
+
+### 2) Builder UI responsibilities (this repo)
+Keep UI wiring and interactions here:
+- Doc entry points (icons, buttons, hover summaries).
+- `openDoc/closeDoc` state management (or delegate to a hook that consumes the doc-engine).
+- Modal or panel rendering (when added).
+
+## Transitional Refactor Steps (Low-risk)
+
+1. **Extract types + catalog**
+   - Move doc-related types and data from `GlobalHeaderShell.knowledge.ts` into a dedicated module (even inside this repo first, e.g., `src/doc-engine/`).
+2. **Replace inline imports**
+   - Swap local `resolveHeaderDoc` and doc definitions with imports from the new module.
+3. **Promote to standalone repo**
+   - Lift `src/doc-engine/` into the separate repo and repoint imports to the package.
+
+## Why this boundary is clean
+
+- The doc content is already isolated in a single knowledge file.
+- The UI only needs `docId` and `hoverSummary` metadata plus a lookup resolver.
+- Logic is already expressed via `openDoc/closeDoc`, so the rendering surface can evolve independently.
+
+## Notes for plugin architecture alignment
+
+If the builder tabs become plugin-defined later, the doc-engine can support:
+- Plugin-supplied doc catalogs merged at runtime.
+- Namespace or owner fields in doc IDs.
+- Registration APIs to append docs without modifying core UI code.
+
+## CCPP Alignment Checklist for Doc Engine Work
+
+When you add or refactor doc-engine code, keep these CCPP requirements in scope:
+- File headers must include the NL source, responsibility, and invariants.
+- Section headers must mirror NL skeleton ordering.
+- Atomic comments must precede each Container/Subcontainer/Primitive.
+- Decision notes and TODOs must follow the CCPP format (owner + date).
+- Provenance blocks only when external sources influence logic.
+
+Reference: `doc/CCPP.md`.
+
+## Modal MVP Plan (Before Extraction)
+
+To validate the doc engine inside this repo, implement a minimal modal flow:
+1. **Trigger**: reuse `openDoc(docId)` from the header shell logic.
+2. **Resolve**: call the doc resolver for a `HeaderDocDefinition` payload.
+3. **Render**: show title, summary, and sections (heading + body list).
+4. **Close**: add `closeDoc()` handler, escape key support, and focus return.
+5. **Accessibility**: apply `role="dialog"`, `aria-modal="true"`, and focus trap.
+
+This keeps the UI and doc engine behavior stable before extracting the catalog into a separate package/repo.
+
+## Doc-Engine Standards and Documentation Hub
+
+A dedicated in-repo documentation hub now exists for standards alignment and implementation planning:
+- `doc/doc-engine/README.md`
+- `doc/doc-engine/StandardsSummary.md`
+- `doc/doc-engine/ContributionChecklist.md`
+- `doc/doc-engine/Architecture.md`
+- `doc/doc-engine/Contracts.md`
+- `doc/doc-engine/ContentDrawerMVP.md`
+- `doc/nl-doc-engine/cfg-contentDrawer.md`

--- a/doc/doc-engine/Architecture.md
+++ b/doc/doc-engine/Architecture.md
@@ -1,0 +1,34 @@
+# Doc Engine Architecture (Interface Repo Phase)
+
+## Goal
+Deliver a fully operational right-side generic Content Drawer in the Interface repo before extracting doc-engine code to another repository.
+
+## Boundary
+### Stays in Interface repo
+- Drawer shell/UI composition
+- Open/close state orchestration
+- Provider registration wiring
+
+### Moves to doc-engine repo later
+- Content schema package
+- Providers (docs, knowledge DB, config/form/quiz extraction)
+- Resolver and normalization utilities
+
+## Core components
+1. **Content Drawer UI**
+   - Generic renderer for normalized `ContentNode` blocks/sections.
+2. **Provider Registry**
+   - Namespace-routed providers (`docs:*`, `knowledge:*`, etc.).
+3. **Resolver**
+   - Deterministic `resolveContent` pipeline returning `ContentNode | NotFound`.
+4. **Static Docs Provider (Phase 0)**
+   - In-memory registry for builder docs.
+5. **Future Providers (Phase 1+)**
+   - Governed Knowledge DB provider.
+   - Config/form/quiz metadata extraction provider.
+
+## Deterministic routing model
+- Parse namespace from `contentId`.
+- Resolve via matching provider.
+- Apply optional anchor targeting.
+- Return normalized output; do not mutate provider source.

--- a/doc/doc-engine/ContentDrawerMVP.md
+++ b/doc/doc-engine/ContentDrawerMVP.md
@@ -1,0 +1,26 @@
+# Content Drawer MVP (Interface Repo)
+
+## Objective
+Implement a fully operational right-side drawer that can render generic `ContentNode` payloads from a namespace-routed resolver.
+
+## MVP behavior
+1. Open via `openContent({ contentId, anchorId?, context? })`.
+2. Resolve content through provider registry.
+3. Render title, summary, headings/blocks, and internal links.
+4. Scroll to `anchorId` when present.
+5. Close via close button, Escape, and background/overlay action.
+6. Restore focus to the trigger control.
+
+## Accessibility
+- `role="dialog"`
+- `aria-modal="true"`
+- Labelled by drawer title element
+- Keyboard trap while open
+
+## Phase-0 provider
+- In-memory docs provider for existing header docs.
+
+## Expansion path
+- Add governed knowledge provider.
+- Add config/form/quiz extractor provider.
+- Keep resolver + `ContentNode` unchanged to minimize refactors.

--- a/doc/doc-engine/Contracts.md
+++ b/doc/doc-engine/Contracts.md
@@ -1,0 +1,31 @@
+# Doc Engine Contracts
+
+## Content Addressing
+- `contentId`: stable identifier with namespace prefix.
+  - Examples: `docs.builder.logic.overview`, `knowledge.public.naming.guide`
+- `anchorId`: optional stable heading/block identifier.
+
+## Provider interface (conceptual)
+- `supports(contentId: string): boolean`
+- `resolve(input: { contentId: string; anchorId?: string; context?: Record<string, unknown> }): ContentNode | NotFound`
+
+## Resolver interface (conceptual)
+- `resolveContent(input) -> ContentNode | NotFound`
+- Deterministic behavior, no side effects.
+
+## Normalized ContentNode shape (minimum)
+- `contentId: string`
+- `meta: { title, summary?, artifactType, tags[], keywords[], conceptIds[], intentTags[], sourceTier, visibility, status, scope, version }`
+- `content: { headings[], blocks[] }`
+
+## Context envelope (optional)
+Used for analytics and routing without changing content identity.
+
+```
+{
+  "uiArea": "builder.logic",
+  "controlId": "logicRuleEditor",
+  "projectType": "form",
+  "mode": "edit"
+}
+```

--- a/doc/doc-engine/ContributionChecklist.md
+++ b/doc/doc-engine/ContributionChecklist.md
@@ -1,0 +1,33 @@
+# Doc Engine Contribution Checklist
+
+Use this checklist on every doc-engine PR in the Interface repository.
+
+## Standards gates
+- [ ] CCPP checked against `doc/CCPP.md`
+- [ ] CSCS checked against `doc/CSCS.md`
+- [ ] General NL Skeleton alignment checked against `doc/General-NL-Skeletons.md`
+- [ ] NL-First sequence followed from `doc/NL-First-Workflow.md`
+
+## NL-first gates
+- [ ] NL doc added/updated first (`doc/nl-doc-engine/...`)
+- [ ] NL section numbers and code comments are synchronized
+- [ ] No structural code added without NL section coverage
+
+## CCPP comment gates
+- [ ] File headers present in each concern file
+- [ ] Section headers present in NL order
+- [ ] Atomic comments above each Container/Subcontainer/Primitive
+- [ ] TODO entries include owner + date
+- [ ] Decision notes include context/choice/consequence
+
+## Architecture gates
+- [ ] Uses normalized `ContentNode` shape
+- [ ] Uses provider registry/resolver interfaces (no hard-coded single provider)
+- [ ] `contentId` and `anchorId` are stable and deterministic
+- [ ] Namespace routing is respected (`docs:*`, future providers)
+
+## Accessibility gates (drawer)
+- [ ] `role="dialog"` + `aria-modal="true"`
+- [ ] Escape closes drawer
+- [ ] Focus returns to trigger on close
+- [ ] Anchor navigation works when `anchorId` provided

--- a/doc/doc-engine/README.md
+++ b/doc/doc-engine/README.md
@@ -1,0 +1,22 @@
+# Doc Engine Documentation Hub
+
+This hub defines the in-repo standards and architecture for the Interface/Builder doc engine before extraction into a dedicated repository.
+
+## Scope
+- Generic right-side Content Drawer
+- Provider/Resolver contract with namespace routing
+- Normalized `ContentNode` schema
+- CCPP/CSCS/NL-first governance for all doc-engine modules
+
+## Standards References
+- `doc/CCPP.md`
+- `doc/CSCS.md`
+- `doc/General-NL-Skeletons.md`
+- `doc/NL-First-Workflow.md`
+
+## Documents in this hub
+- `StandardsSummary.md`
+- `ContributionChecklist.md`
+- `Architecture.md`
+- `Contracts.md`
+- `ContentDrawerMVP.md`

--- a/doc/doc-engine/StandardsSummary.md
+++ b/doc/doc-engine/StandardsSummary.md
@@ -1,0 +1,31 @@
+# Doc Engine Standards Summary
+
+This summary applies CCPP, CSCS, General NL Skeletons, and NL-First Workflow to doc-engine work in the Interface repository.
+
+## CCPP requirements (mandatory)
+1. Every TS/TSX/CSS concern file includes a file header with:
+   - Concern label
+   - Source NL path
+   - Responsibility and invariants
+2. Every concern section uses a section header in NL order.
+3. Every Container/Subcontainer/Primitive has an atomic comment with NL section number.
+4. Decision notes and TODOs follow CCPP formatting.
+5. Provenance blocks are required when external references influence implementation decisions.
+
+## CSCS requirements (mandatory)
+- Build: drawer shell structure and anchors
+- BuildStyle: drawer visual layer
+- Logic: provider registry, resolver orchestration, open/close state
+- Knowledge: content catalogs, content schemas, concept mappings
+- Results: diagnostics panels, instrumentation readouts
+
+## General NL Skeleton requirements
+- A dedicated NL config must exist for each doc-engine config before structural implementation.
+- NL hierarchy should be mirrored in code comments.
+- New structural primitives must be added to NL first.
+
+## NL-First workflow requirements
+1. Draft/update NL skeleton.
+2. Implement/adjust concern files.
+3. Mirror NL numbering in CCPP comments.
+4. Validate comments, order, and concern boundaries before merge.

--- a/doc/nl-doc-engine/cfg-contentDrawer.md
+++ b/doc/nl-doc-engine/cfg-contentDrawer.md
@@ -1,0 +1,42 @@
+# cfg-contentDrawer (Content Drawer Configuration)
+
+## 3. Build
+### §3.1 Container — "Content Drawer Shell"
+- Right-side drawer container with stable anchor.
+
+### §3.2 Subcontainer — "Drawer Header"
+- Title, summary, close control.
+
+### §3.3 Subcontainer — "Drawer Body"
+- Scrollable content region.
+
+### §3.4 Primitive — "Anchor Jump Target"
+- Deterministic anchor alignment for `anchorId` navigation.
+
+## 4. BuildStyle
+### §4.1 Container — "Drawer Visual Shell"
+- Right-side fixed layout, transitions, and spacing.
+
+### §4.2 Primitive — "Header + Body Styling"
+- Header typography and body overflow styling.
+
+## 5. Logic
+### §5.1 Container — "Drawer State Orchestrator"
+- Open/close state and focus return.
+
+### §5.2 Subcontainer — "Resolver Pipeline"
+- Namespace routing and deterministic provider resolution.
+
+### §5.3 Primitive — "Anchor Scroll Handler"
+- Scroll to anchor when content resolves.
+
+## 6. Knowledge
+### §6.1 Container — "ContentNode Schema"
+- Normalized node shape and metadata contract.
+
+### §6.2 Subcontainer — "Static Docs Registry"
+- Initial in-memory doc provider entries.
+
+## 7. Results
+### §7.1 Container — "Drawer Diagnostics"
+- Optional debug info for resolver/provider selection.


### PR DESCRIPTION
## Summary
- add a standards compliance audit for recently changed configurations/shells
- list violations by concern file with NL section references and minimal fixes
- provide a single ordered Alignment PR change set (NL-first, then concern files, then verification gates)

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b0bd798c8331af583a8b2c9ca5e0)