### PR TITLE
Add CCPP headers and NL-aligned atomic comments for doc-engine concern files

### DIFF
--- a/src/components/ContentDrawer/ContentDrawer.css
+++ b/src/components/ContentDrawer/ContentDrawer.css
@@ -1,10 +1,22 @@
 /*
- * ProjectShell/Config: Content Drawer (content-drawer)
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
  * Concern File: BuildStyle
- * Responsibility: Provide visual styling for the shared content drawer surface.
- * Invariants: Styles remain scoped to data-anchor hooks and component class names.
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Style drawer shell, header, and body presentation while preserving build anchors.
+ * Invariants: Drawer remains fixed on right desktop edge, body remains scrollable, selectors stay component-scoped.
  */
 
+/* ─────────────────────────────────────────────
+   4. BuildStyle – cfg-contentDrawer (Content Drawer Configuration)
+   NL Sections: §4.1–§4.2 in cfg-contentDrawer.md
+   Purpose: Apply visual shell and typography/overflow styling for content drawer presentation.
+   Constraints: Keep style-only concern boundaries; do not introduce structural coupling.
+   ───────────────────────────────────────────── */
+
+/* [4.1] cfg-contentDrawer · Container · "Drawer Visual Shell"
+   Concern: BuildStyle · Parent: "Content Drawer Configuration" · Catalog: layout.surface
+   Notes: Fixed-position shell reserves right-side panel placement.
+*/
 .content-drawer {
   position: fixed;
   right: 1.5rem;
@@ -17,6 +29,10 @@
   pointer-events: auto;
 }
 
+/* [4.2] cfg-contentDrawer · Primitive · "Header + Body Styling"
+   Concern: BuildStyle · Parent: "Drawer Visual Shell" · Catalog: visual.card
+   Notes: Shared card chrome across header and body card regions.
+*/
 .content-drawer__card,
 .content-drawer__header {
   background: var(--surface-card, #ffffff);

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -1,8 +1,27 @@
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Build
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Render the content drawer shell, header, and body structure for resolved content nodes.
+ * Invariants: Drawer anchor remains stable, header always exposes close control, body sections use deterministic anchors.
+ * Notes: Includes anchor-jump orchestration colocated with structure.
+ */
+
 import { useEffect, useMemo, useRef } from 'react';
 import { resolveContent } from '../../content/contentProviders';
 import { useContentState } from '../../content/ContentContext';
 import './ContentDrawer.css';
 
+// ─────────────────────────────────────────────
+// 3. Build – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §3.1–§3.4 in cfg-contentDrawer.md
+// Purpose: Provide shell, header, body, and anchor-target structure for drawer content.
+// Constraints: Keep anchor identifiers deterministic and preserve right-side shell wrapper.
+// ─────────────────────────────────────────────
+
+// [3.4] cfg-contentDrawer · Primitive · "Anchor Jump Target"
+// Concern: Build · Parent: "Drawer Body" · Catalog: navigation.anchor
+// Notes: Mirrors section headings into deterministic ids for hash-like in-drawer jumps.
 function toAnchorId(value: string) {
   return value
     .toLowerCase()
@@ -11,14 +30,28 @@ function toAnchorId(value: string) {
     .replace(/\s+/g, '-');
 }
 
+// ─────────────────────────────────────────────
+// 5. Logic – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §5.2–§5.3 in cfg-contentDrawer.md
+// Purpose: Resolve content by namespace and scroll to requested anchor on open.
+// Constraints: Resolution remains deterministic; anchor scrolling only runs when target exists.
+// ─────────────────────────────────────────────
+
 export default function ContentDrawer() {
   const { activeContentId, activeContentAnchorId, closeContent, openContent } = useContentState();
   const drawerRef = useRef<HTMLDivElement | null>(null);
+
+  // [5.2] cfg-contentDrawer · Subcontainer · "Resolver Pipeline"
+  // Concern: Logic · Parent: "Drawer State Orchestrator" · Catalog: resolver.pipeline
+  // Notes: Active content id is resolved lazily and memoized per id transition.
   const resolution = useMemo(
     () => (activeContentId ? resolveContent(activeContentId) : null),
     [activeContentId],
   );
 
+  // [5.3] cfg-contentDrawer · Primitive · "Anchor Scroll Handler"
+  // Concern: Logic · Parent: "Resolver Pipeline" · Catalog: navigation.scroll
+  // Notes: Scrolls only after content/anchor settle and a concrete HTMLElement target is found.
   useEffect(() => {
     if (!activeContentAnchorId || !drawerRef.current) {
       return;
@@ -37,7 +70,13 @@ export default function ContentDrawer() {
 
   if (!resolution) {
     return (
+      // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
+      // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
+      // Notes: Fallback shell preserves placement when no provider can resolve the id.
       <aside className="content-drawer" data-anchor="content-drawer">
+        {/* [3.2] cfg-contentDrawer · Subcontainer · "Drawer Header"
+            Concern: Build · Parent: "Content Drawer Shell" · Catalog: layout.header
+            Notes: Announces unavailable state while keeping close affordance visible. */}
         <div className="content-drawer__header">
           <div>
             <p className="content-drawer__eyebrow">Content</p>
@@ -56,7 +95,13 @@ export default function ContentDrawer() {
 
   if (resolution.kind === 'missing') {
     return (
+      // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
+      // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
+      // Notes: Missing-resolution shell mirrors standard framing for predictable UX.
       <aside className="content-drawer" data-anchor="content-drawer">
+        {/* [3.2] cfg-contentDrawer · Subcontainer · "Drawer Header"
+            Concern: Build · Parent: "Content Drawer Shell" · Catalog: layout.header
+            Notes: Shows not-found summary and recovery control. */}
         <div className="content-drawer__header">
           <div>
             <p className="content-drawer__eyebrow">Content</p>
@@ -76,8 +121,17 @@ export default function ContentDrawer() {
   if (resolution.kind === 'doc') {
     const doc = resolution.doc;
     return (
+      // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
+      // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
+      // Notes: Primary shell path for successfully resolved documentation payloads.
       <aside className="content-drawer" data-anchor="content-drawer">
+        {/* [3.3] cfg-contentDrawer · Subcontainer · "Drawer Body"
+            Concern: Build · Parent: "Content Drawer Shell" · Catalog: content.body
+            Notes: Hosts scrollable content card and section anchors. */}
         <div className="content-drawer__card" ref={drawerRef}>
+          {/* [3.2] cfg-contentDrawer · Subcontainer · "Drawer Header"
+              Concern: Build · Parent: "Content Drawer Shell" · Catalog: layout.header
+              Notes: Renders concern context, title, and close action. */}
           <div className="content-drawer__header">
             <div>
               <p className="content-drawer__eyebrow">{doc.concern} documentation</p>

--- a/src/content-drawer/contentTypes.ts
+++ b/src/content-drawer/contentTypes.ts
@@ -1,3 +1,21 @@
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Knowledge
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Define normalized content node schemas and block primitives consumed by drawer concerns.
+ * Invariants: Every content node includes metadata and either top-level blocks or section collections.
+ */
+
+// ─────────────────────────────────────────────
+// 6. Knowledge – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §6.1 in cfg-contentDrawer.md
+// Purpose: Capture shared type contracts for content payload normalization.
+// Constraints: Keep schema framework-agnostic and serializable.
+// ─────────────────────────────────────────────
+
+// [6.1] cfg-contentDrawer · Container · "ContentNode Schema"
+// Concern: Knowledge · Parent: "Content Drawer Configuration" · Catalog: schema.metadata
+// Notes: Metadata model enables retrieval, ranking, and governance attributes.
 export type ContentMeta = {
   tags: string[];
   keywords: string[];

--- a/src/content-drawer/providers/docsProvider.ts
+++ b/src/content-drawer/providers/docsProvider.ts
@@ -1,3 +1,11 @@
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Knowledge
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Materialize static documentation registry entries for docs namespace resolution.
+ * Invariants: Registry keys are docs-prefixed ids and every unresolved lookup returns a deterministic fallback node.
+ */
+
 import { HEADER_DOC_DEFINITIONS } from '../../components/GlobalHeaderShell/GlobalHeaderShell.knowledge';
 
 export interface ContentSection {
@@ -23,6 +31,16 @@ export interface ContentNode {
 
 const DOCS_PREFIX = 'docs:';
 
+// ─────────────────────────────────────────────
+// 6. Knowledge – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §6.2 in cfg-contentDrawer.md
+// Purpose: Build static docs registry and resolver fallback used by drawer content pipelines.
+// Constraints: Keep registry deterministic and side-effect free.
+// ─────────────────────────────────────────────
+
+// [6.2] cfg-contentDrawer · Subcontainer · "Static Docs Registry"
+// Concern: Knowledge · Parent: "ContentNode Schema" · Catalog: data.fallback
+// Notes: Fallback node guarantees user-facing guidance when a doc id misses registry entries.
 export const NotFound: ContentNode = {
   id: `${DOCS_PREFIX}not-found`,
   title: 'Documentation Not Found',
@@ -51,11 +69,11 @@ function headerDocToContentNode(docId: string): ContentNode {
     summary: doc.summary,
     concern: doc.concern,
     recommendedWorkflows: doc.recommendedWorkflows,
-    sections: doc.sections.map((section) => ({
+    sections: doc.sections.map(section => ({
       heading: section.heading,
       body: [...section.body],
     })),
-    links: doc.links?.map((link) => ({
+    links: doc.links?.map(link => ({
       label: link.label,
       id: toDocsId(link.docId),
       description: link.description,
@@ -63,6 +81,9 @@ function headerDocToContentNode(docId: string): ContentNode {
   };
 }
 
+// [6.2] cfg-contentDrawer · Container · "Static Docs Registry"
+// Concern: Knowledge · Parent: "Content Drawer Configuration" · Catalog: data.registry
+// Notes: Seeds docs namespace with transformed header-doc payloads.
 export const DOCS_REGISTRY: Record<string, ContentNode> = Object.keys(HEADER_DOC_DEFINITIONS).reduce(
   (registry, docId) => {
     registry[toDocsId(docId)] = headerDocToContentNode(docId);
@@ -71,6 +92,9 @@ export const DOCS_REGISTRY: Record<string, ContentNode> = Object.keys(HEADER_DOC
   {} as Record<string, ContentNode>,
 );
 
+// [6.2] cfg-contentDrawer · Primitive · "Registry Resolver"
+// Concern: Knowledge · Parent: "Static Docs Registry" · Catalog: data.lookup
+// Notes: Performs id lookup and falls back to deterministic NotFound node.
 export function resolveDocsContentNode(id: string): ContentNode {
   return DOCS_REGISTRY[id] ?? NotFound;
 }

--- a/src/content/ContentContext.tsx
+++ b/src/content/ContentContext.tsx
@@ -1,3 +1,11 @@
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Logic
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Manage active drawer content state and expose open/close orchestration APIs.
+ * Invariants: Only one active content id at a time, anchor ids normalize to null when absent.
+ */
+
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
 
 export interface ActiveContentPayload {
@@ -17,12 +25,25 @@ interface ContentContextValue extends ActiveContentState {
 
 const ContentContext = createContext<ContentContextValue | undefined>(undefined);
 
+// ─────────────────────────────────────────────
+// 5. Logic – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §5.1 in cfg-contentDrawer.md
+// Purpose: Expose state orchestrator for drawer open/close lifecycles.
+// Constraints: Preserve referential stability for callbacks used by consuming concerns.
+// ─────────────────────────────────────────────
+
+// [5.1] cfg-contentDrawer · Container · "Drawer State Orchestrator"
+// Concern: Logic · Parent: "Content Drawer Configuration" · Catalog: state.container
+// Notes: Provides source-of-truth state and controlled mutations for drawer visibility/content.
 export function ContentProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<ActiveContentState>({
     activeContentId: null,
     activeContentAnchorId: null,
   });
 
+  // [5.1] cfg-contentDrawer · Primitive · "Open Drawer Mutation"
+  // Concern: Logic · Parent: "Drawer State Orchestrator" · Catalog: state.mutation
+  // Notes: Deduplicates id/anchor updates to avoid unnecessary rerender churn.
   const openContent = useCallback(({ contentId, anchorId }: ActiveContentPayload) => {
     setState(prev => {
       if (prev.activeContentId === contentId && prev.activeContentAnchorId === (anchorId ?? null)) {
@@ -35,6 +56,9 @@ export function ContentProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  // [5.1] cfg-contentDrawer · Primitive · "Close Drawer Mutation"
+  // Concern: Logic · Parent: "Drawer State Orchestrator" · Catalog: state.mutation
+  // Notes: Resets both identifiers atomically so consumers observe a clean close transition.
   const closeContent = useCallback(() => {
     setState(prev => {
       if (!prev.activeContentId && !prev.activeContentAnchorId) {

--- a/src/content/ContentProviderRegistry.ts
+++ b/src/content/ContentProviderRegistry.ts
@@ -1,3 +1,11 @@
+/**
+ * Configuration: cfg-contentResolver (Doc Engine Content Resolver Configuration)
+ * Concern File: Build
+ * Source NL: doc/nl-doc-engine/cfg-contentResolver.md
+ * Responsibility: Provide a namespaced provider registry and resolver pipeline for normalized content nodes.
+ * Invariants: Content ids must include namespace prefix, registered providers are keyed by namespace, unresolved ids return NotFound.
+ */
+
 import { HEADER_DOC_DEFINITIONS } from '../components/GlobalHeaderShell/GlobalHeaderShell.knowledge';
 
 export interface ContentResolutionRequest<Context = unknown> {
@@ -25,18 +33,37 @@ export interface ContentProvider<Context = unknown, Payload = unknown> {
   resolveContent: (request: ContentResolutionRequest<Context>) => ContentNode<Payload> | NotFound;
 }
 
+// ─────────────────────────────────────────────
+// 3. Build – cfg-contentResolver (Doc Engine Content Resolver Configuration)
+// NL Sections: §3.1.1–§3.3.9 in cfg-contentResolver.md
+// Purpose: Implement service-oriented resolver pipeline with namespace parsing and provider dispatch.
+// Constraints: Avoid side effects; preserve deterministic request/response mapping.
+// ─────────────────────────────────────────────
+
+// [3.1.1] cfg-contentResolver · Container · "Resolver Pipeline"
+// Concern: Build · Parent: "Doc Engine Content Resolver Configuration" · Catalog: service.pipeline
+// Notes: Registry owns provider map and executes request intake through output composition.
 export class ContentProviderRegistry {
   private providers = new Map<string, ContentProvider>();
 
+  // [3.3.8] cfg-contentResolver · Primitive · "Cache Write"
+  // Concern: Build · Parent: "Resolver Pipeline" · Catalog: registry.mutation
+  // Notes: Provider map registration stores namespace-to-adapter binding for future resolution.
   registerProvider(namespace: string, provider: ContentProvider) {
     this.providers.set(namespace, provider);
   }
 
+  // [3.2.5] cfg-contentResolver · Subcontainer · "Output Stage"
+  // Concern: Build · Parent: "Resolver Pipeline" · Catalog: resolver.output
+  // Notes: Emits either content payload from provider or typed NotFound response.
   resolveContent<Context = unknown>({
     contentId,
     anchorId,
     context,
   }: ContentResolutionRequest<Context>): ContentNode | NotFound {
+    // [3.2.1] cfg-contentResolver · Subcontainer · "Request Intake"
+    // Concern: Build · Parent: "Resolver Pipeline" · Catalog: resolver.input
+    // Notes: Namespace parser validates incoming identifiers before provider dispatch.
     const { namespace, resolvedId } = splitNamespace(contentId);
 
     if (!namespace || !resolvedId) {
@@ -47,6 +74,9 @@ export class ContentProviderRegistry {
       };
     }
 
+    // [3.2.2] cfg-contentResolver · Subcontainer · "Adapter Dispatch"
+    // Concern: Build · Parent: "Resolver Pipeline" · Catalog: resolver.dispatch
+    // Notes: Selects provider by namespace and delegates downstream normalization logic.
     const provider = this.providers.get(namespace);
 
     if (!provider) {
@@ -88,6 +118,9 @@ const DOCS_PROVIDER: ContentProvider = {
 export const contentProviderRegistry = new ContentProviderRegistry();
 contentProviderRegistry.registerProvider('docs', DOCS_PROVIDER);
 
+// [3.3.2] cfg-contentResolver · Primitive · "Scope Parser"
+// Concern: Build · Parent: "Request Intake" · Catalog: resolver.parse
+// Notes: Splits content id into namespace and provider-local identifier.
 function splitNamespace(contentId: string): { namespace: string | null; resolvedId: string | null } {
   const [namespace, ...rest] = contentId.split(':');
   const resolvedId = rest.join(':');

--- a/src/content/contentProviders.ts
+++ b/src/content/contentProviders.ts
@@ -1,4 +1,15 @@
-import { resolveHeaderDoc, type HeaderDocDefinition } from '../components/GlobalHeaderShell/GlobalHeaderShell.knowledge';
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Logic
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Resolve namespaced content ids through deterministic provider selection.
+ * Invariants: Provider lookup is prefix-based, unknown providers return null, missing docs return typed missing payload.
+ */
+
+import {
+  resolveHeaderDoc,
+  type HeaderDocDefinition,
+} from '../components/GlobalHeaderShell/GlobalHeaderShell.knowledge';
 
 export type ContentResolution =
   | {
@@ -17,6 +28,16 @@ interface ContentProvider {
   resolve: (contentId: string) => ContentResolution | null;
 }
 
+// ─────────────────────────────────────────────
+// 5. Logic – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §5.2 in cfg-contentDrawer.md
+// Purpose: Build resolver pipeline with docs namespace provider and deterministic routing.
+// Constraints: Keep resolver pure and side-effect free.
+// ─────────────────────────────────────────────
+
+// [5.2] cfg-contentDrawer · Subcontainer · "Resolver Pipeline"
+// Concern: Logic · Parent: "Drawer State Orchestrator" · Catalog: resolver.provider
+// Notes: Docs provider handles namespaced doc lookups and emits missing sentinel when unknown.
 const docsProvider: ContentProvider = {
   id: 'docs',
   canResolve: contentId => contentId.startsWith('docs:'),
@@ -39,6 +60,9 @@ const docsProvider: ContentProvider = {
 
 const CONTENT_PROVIDERS: ContentProvider[] = [docsProvider];
 
+// [5.2] cfg-contentDrawer · Primitive · "Provider Resolution"
+// Concern: Logic · Parent: "Resolver Pipeline" · Catalog: resolver.dispatch
+// Notes: Selects first capable provider and delegates actual content resolution.
 export function resolveContent(contentId: string): ContentResolution | null {
   const provider = CONTENT_PROVIDERS.find(entry => entry.canResolve(contentId));
   if (!provider) {


### PR DESCRIPTION
### Motivation
- Bring recently touched doc-engine concern files into compliance with the Calculogic Comment & Provenance Protocol (CCPP) and mirror NL skeleton ordering from `doc/CCPP.md` and the corresponding NL documents.
- Make atomic comment anchors explicit so NL → code traceability is deterministic for the Content Drawer and resolver concerns.

### Description
- Added full CCPP file headers (including `Source NL`, `Responsibility`, and `Invariants`) to Build/BuildStyle/Logic/Knowledge concern files associated with the doc-engine surface. 
- Inserted NL-ordered section header blocks and atomic comments immediately above Containers/Subcontainers/Primitives, and synchronized NL numbering to `doc/nl-doc-engine/cfg-contentDrawer.md` and `doc/nl-doc-engine/cfg-contentResolver.md`.
- Files updated: `src/components/ContentDrawer/ContentDrawer.tsx`, `src/components/ContentDrawer/ContentDrawer.css`, `src/content/ContentContext.tsx`, `src/content/contentProviders.ts`, `src/content/ContentProviderRegistry.ts`, `src/content-drawer/contentTypes.ts`, and `src/content-drawer/providers/docsProvider.ts`.
- No runtime logic or behavioral changes were introduced; comments and headers only (preserve existing code paths and APIs).

### Testing
- Ran `npm run build`; build failed due to a pre-existing export mismatch in `src/components/ContentDrawer/index.tsx` (not introduced by these comment/header changes).
- Ran `npm run lint`; linting failed due to pre-existing `@typescript-eslint/no-explicit-any` errors in `src/tabs/build/BuildSurface.logic.ts` and one `react-refresh/only-export-components` warning for `src/content/ContentContext.tsx` (these issues are outside the scope of the CCPP comment changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aabf65b0c8331b5c4de9b8fb9e37b)