### PR TITLE
docs: add Doc Engine increment audit note

### DIFF
--- a/doc/nl-doc-engine/Increment-Audit-2026-02-10.md
+++ b/doc/nl-doc-engine/Increment-Audit-2026-02-10.md
@@ -1,0 +1,28 @@
+# Doc Engine Increment Audit — 2026-02-10
+
+Scope: `doc/nl-doc-engine/` NL atomics vs currently implemented doc-engine code paths.
+
+## Verification checks
+- Every NL atomic has a matching code atomic comment in the right concern file.
+- No code atomics exist without NL declaration.
+- Section order in code matches NL order.
+
+## Findings (mismatches)
+1. **Concern-file mismatch (all configs)**
+   - NL assembly paths for concern files under `src/docEngine/...` are not present yet.
+   - Current implementation lives under `src/content/...`, `src/content-drawer/...`, and `src/components/ContentDrawer/...`.
+
+2. **NL → Code atomic mapping gap (all configs)**
+   - `cfg-contentNodeSchema.md`: declared atomics exist in NL, but there are **no matching CCPP atomic comments** in implementation files.
+   - `cfg-contentResolver.md`: declared atomics exist in NL, but there are **no matching CCPP atomic comments** in implementation files.
+   - `cfg-providerRegistry.md`: declared atomics exist in NL, but there are **no matching CCPP atomic comments** in implementation files.
+   - `cfg-contentDrawer.md`: declared section atoms exist in NL, but there are **no matching CCPP atomic comments** in implementation files.
+
+3. **Code → NL atomic drift check**
+   - No CCPP-style code atomic comments were found in the current implementation files, so there are currently **no undeclared code atomics**.
+
+4. **Order check status**
+   - Section-order parity cannot be verified because required NL-numbered atomic comments are currently absent from code concern files.
+
+## Merge gate note
+Before merge, add NL-numbered atomic comments to the corresponding concern files (Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle) and keep comment ordering aligned with NL section ordering.


### PR DESCRIPTION
### Motivation
- Capture a small, per-increment verification of NL atomic declarations under `doc/nl-doc-engine/` against the current code layout and call out immediate mismatches and merge-gate guidance.

### Description
- Add `doc/nl-doc-engine/Increment-Audit-2026-02-10.md` containing a verification checklist, findings that NL-numbered CCPP atomic comments are missing from the implementation, a note about assembly-path drift (implementation under `src/content*` vs NL `src/docEngine/...`), and a merge-gate reminder to add NL-numbered atomic comments and preserve NL ordering before merging.

### Testing
- Ran `python` script to enumerate NL atomic IDs in `doc/nl-doc-engine/*.md`, `rg` searches for CCPP/NL atomic comment markers in implementation paths, and searches for expected `src/docEngine/...` assembly paths; all checks completed and returned the findings reported in the audit note.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aacc3fc6483318720b62e2b70386d)