### PR TITLE
Stabilize README reality/plans split and add baseline unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,64 @@
-# **Calculogic React App**
+# Calculogic React App
 
-A modular, JSON-driven form-builder in React.
-Design, preview, and publish dynamic questionnaires through a five-stage UI.
-Built for creators, educators, and system designers who want full transparency and control.
+A modular React + TypeScript builder shell for composing configuration-driven workflows. The current app includes a global header shell, a build workspace with resizable panels, and a content drawer backed by namespaced content resolution.
 
 ---
 
-## **Table of Contents**
+## Table of Contents
 
-1. [Features](#features)
-2. [Tech Stack](#tech-stack)
-3. [Getting Started](#getting-started)
-4. [Development](#development)
-5. [Building for Production](#building-for-production)
-6. [Project Structure](#project-structure)
-7. [Configuration Architecture](#configuration-architecture)
-8. [Calculogic-Style Concern System (CSCS)](#calculogic-style-concern-system-cscs)
-9. [Comment & Provenance Protocol (CCPP)](#comment--provenance-protocol-ccpp)
-10. [Contributing](#contributing)
-11. [License](#license)
-
----
-
-## **Features**
-
-**Five-tab builder:**
-
-* **Build** – drag-and-drop containers, fields, and sub-containers
-* **View** – style and layout controls
-* **Logic** – define conditional behavior
-* **Knowledge** – attach tooltips, help text, and validation rules
-* **Results** – configure scoring, branching, and summaries
-
-**Core Capabilities**
-
-* Atomic components: text, number, checkbox, search selector
-* Live preview pane updates as you edit
-* Pluggable runtime engine for evaluating conditions and outputs
-* JSON-first configuration system (readable, exportable, versionable)
-* TypeScript, ESLint, and Vite for rapid iteration and safety
+1. [Features (Current)](#features-current)
+2. [Current Tech Stack (Implemented)](#current-tech-stack-implemented)
+3. [Future Additions (Planned)](#future-additions-planned)
+4. [Getting Started](#getting-started)
+5. [Current Scripts](#current-scripts)
+6. [Project Structure (Current)](#project-structure-current)
+7. [Roadmap (Planned)](#roadmap-planned)
+8. [Configuration Architecture](#configuration-architecture)
+9. [Calculogic-Style Concern System (CSCS)](#calculogic-style-concern-system-cscs)
+10. [Comment & Provenance Protocol (CCPP)](#comment--provenance-protocol-ccpp)
 
 ---
 
-## **Tech Stack**
+## Features (Current)
 
-* **React 18 + TypeScript**
-* **Vite** – dev server & optimized builds
-* **ESLint + Prettier** – code quality & formatting
-* **Jest + React Testing Library** – unit/integration tests
+- Global header shell with Build / Logic / Knowledge / Results tabs and mode controls.
+- Build tab layout with draggable/resizable panels and persisted dimensions.
+- Context-driven content drawer that resolves `docs:<id>` payloads.
+- Type-safe configuration-oriented structure following CSCS + CCPP conventions.
 
----
+## Current Tech Stack (Implemented)
 
-## **Getting Started**
+### Runtime
+- React 19
+- React DOM 19
+- React Router DOM 7
+- Zustand
+- react-resizable-panels
+- json-logic-js
+- mustache
 
-### **Prerequisites**
+### Tooling
+- TypeScript 5
+- Vite 6
+- ESLint 9 + typescript-eslint
+- Node.js built-in test runner (`node --test`) for unit tests
 
-* Node.js ≥ 16
-* npm (or Yarn)
+## Future Additions (Planned)
 
-### **Install**
+These are intentionally planned but not yet baseline in this repository:
+
+- Prettier formatting pipeline
+- Jest and/or React Testing Library integration for component-level testing
+- CI quality gates that enforce lint/build/test on every pull request
+- Expanded integration test coverage for builder interactions
+
+## Getting Started
+
+### Prerequisites
+- Node.js 22+
+- npm
+
+### Install
 
 ```bash
 git clone https://github.com/your-org/Calculogic_React_App.git
@@ -66,174 +66,70 @@ cd Calculogic_React_App
 npm install
 ```
 
----
-
-## **Development**
-
-Start a local development server with hot-reload:
+### Run locally
 
 ```bash
 npm run dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173) to view the builder.
-Changes to files in `src/` reload automatically.
+Open `http://localhost:5173`.
 
----
-
-## **Building for Production**
-
-Generate an optimized production build in `dist/`:
+## Current Scripts
 
 ```bash
-npm run build
+npm run dev      # Start Vite dev server
+npm run lint     # Run ESLint
+npm run build    # Type-check + production build
+npm test         # Run unit tests with node:test
+npm run preview  # Preview the built app locally
 ```
 
-You can serve the output with any static file host.
+## Project Structure (Current)
 
----
-
-## **Project Structure**
-
-```
+```text
 /
-├─ public/            
-│   └─ index.html          # HTML template
-├─ src/               
-│   ├─ builder/            # Builder UI & tab modules
-│   ├─ components/         # Shared React components
-│   ├─ engine/             # JSON runtime & logic evaluator
-│   └─ App.tsx             # Root component & routing
-├─ dist/                   # Production output
-├─ package.json            # Scripts & dependencies
-├─ eslint.config.js        # Linting rules
-├─ tsconfig.json           # TypeScript config
-└─ vite.config.ts          # Vite build/dev config
+├─ doc/                                # Architecture and NL-first workflow docs
+├─ public/                             # Static assets copied by Vite
+├─ src/
+│  ├─ assets/                          # App assets
+│  ├─ components/
+│  │  ├─ ContentDrawer/                # Drawer build/style and anchor utility
+│  │  └─ GlobalHeaderShell/            # Build/logic/knowledge/results concerns
+│  ├─ content/                         # Content context + provider registry/adapter
+│  ├─ content-drawer/                  # Shared content drawer domain types/providers
+│  ├─ tabs/
+│  │  ├─ BuildTab.tsx                  # Build tab entry
+│  │  └─ build/                        # BuildSurface build/style/logic + anchors
+│  ├─ App.tsx                          # Top-level app composition
+│  ├─ App.logic.ts                     # App-level logic wiring
+│  └─ main.tsx                         # React entrypoint
+├─ eslint.config.js
+├─ package.json
+├─ tsconfig*.json
+└─ vite.config.ts
 ```
 
----
+## Roadmap (Planned)
 
-## **Configuration Architecture**
+- Converge transitional content adapter usage onto the canonical provider registry API.
+- Break down larger logic modules (especially build surface interactions) into smaller focused utilities/hooks.
+- Expand unit + integration tests around resizing, content resolution, and state persistence.
+- Add CI automation for lint/build/test enforcement.
 
-All structural, logic, and scoring details for Calculogic live in the **Configuration Architecture** —
-a living specification describing how JSON configurations represent forms, quizzes, and templates.
+## Configuration Architecture
 
-📄 [View the external document](https://docs.google.com/document/d/1UNlEDQTqWKbuq2QIFNIhYWxzMzj_opopgXu4QIScZKA/edit)
-📚 [Read the local summary](doc/ConfigurationArchitectureSummary.md)
+- External architecture document: <https://docs.google.com/document/d/1UNlEDQTqWKbuq2QIFNIhYWxzMzj_opopgXu4QIScZKA/edit>
+- Local summary: `doc/ConfigurationArchitectureSummary.md`
 
-**Covers**
+## Calculogic-Style Concern System (CSCS)
 
-* Configuration schema: containers, fields, and sub-containers
-* How Build/View/Logic/Knowledge/Results map to JSON
-* Runtime evaluation, validation, and scoring
-* Export and shareable JSON formats
+The CSCS defines concern boundaries and dependency direction across Build / BuildStyle / Logic / Knowledge / Results.
 
----
+- Spec: `doc/CSCS.md`
+- Doc-engine mapping: `doc/DocEngine-CSCS-Mapping.md`
 
-## **Calculogic-Style Concern System (CSCS)**
+## Comment & Provenance Protocol (CCPP)
 
-The **CSCS** defines how every module is structured and reasoned about.
-It guarantees architectural purity and predictable diffs across the codebase.
+CCPP defines file headers, section/atomic comments, decision notes, and provenance annotations.
 
-**Canonical Order:**
-`Build → View → Logic → Knowledge → Results`
-
-**Core Principles**
-
-* **Ordering Source (BOS):** The highest present layer defines structure; all lower layers mirror its top-down order.
-* **Attachment-Only for Non-Sources:** Non-BOS layers attach to declared anchors only.
-* **Stable Anchors:** Public selectors (class/data-attr) are the sole references.
-* **Directional Dependencies:**
-
-  * Build feeds View & Logic
-  * Logic feeds Results
-  * Knowledge informs all
-    No upward or cyclic references.
-* **Purity per Layer:**
-
-  * Build = structure | View = appearance | Logic = interaction/state | Knowledge = guidance | Results = derived output
-* **Locality:** Co-locate code per concern; nested concerns follow the same rules.
-* **Monotonic Diffs:** Changes cascade top-down across sibling layers.
-* **Minimal Surface Area:** Expose anchors, events, and read-only signals only.
-
-**Decision Framework**
-
-1. **Concern Definition Protocol (CDP)** — one-page template for defining each concern’s scope, invariants, and acceptance.
-2. **Four Tests** — single reason to change, boundary of effects, ordering consistency, visible contract.
-3. **Change Management** — promotions, merges, renames, spec-drift guard.
-4. **Interfaces & Contracts** — anchors, scoped events, and signals; no hidden coupling.
-5. **Acceptance Checklist** — purity, mirroring, and consistent diffs enforced per PR.
-
-**Example Classifications**
-
-| Concern                    | Ordering Source | Description                                                        |
-| -------------------------- | --------------- | ------------------------------------------------------------------ |
-| Structure & Responsiveness | Build           | Frame, panes, sections; no DnD.                                    |
-| Atomic Components          | Build           | Atom list; Logic handles drag-and-drop.                            |
-| Configurations             | Build           | Config blocks + persistence; Logic handles DnD; Results summarize. |
-| Search/Browse              | Build           | Filter UI; Logic handles queries; Results handle counts.           |
-
-📘 See [`docs/CSCS.md`](docs/CSCS.md) for the full rubric.
-
-For doc-engine modules, use [`doc/DocEngine-CSCS-Mapping.md`](doc/DocEngine-CSCS-Mapping.md) as the concern mapping + naming checklist.
-
----
-
-## **Comment & Provenance Protocol (CCPP)**
-
-The **CCPP** is Calculogic’s standard for inline documentation, decision history, and provenance tracking.
-It ensures every file is self-describing and ethically transparent.
-
-**Principles**
-
-* **BOS Alignment:** Comment order mirrors the Build hierarchy.
-* **Five Comment Types:** File Header, Section Header, Inline Rationale, Decision Note, Provenance Block.
-* **Explain Why, Not What:** Comments describe reasoning, not narration.
-* **Traceability:** External logic or data must include URL, timestamp, hash, and license.
-* **Ephemeral Ethics:** No external data is retained; provenance only.
-* **Lint Integration:** CI verifies headers, order, TODO expiry, and provenance blocks.
-
-**Example**
-
-```tsx
-/**
- * Concern: BuilderShell
- * Layer: View
- * BuildIndex: 01.00
- * AttachesTo: .builder-shell
- * Responsibility: Responsive frame chrome (no behavior)
- * Invariants: No overflow; focus ring visible
- */
-export function BuilderShellView(){...}
-
-// [Section 01.10] Header
-// Purpose: Global header and tab chrome
-// Inputs: layoutMode
-// Outputs: none
-// Constraints: sticky; min-height 56px
-
-// DECISION: Keyboard navigation | 2025-10-20
-// Context: accessibility
-// Choice: Arrow keys preferred over mouse drag
-// Consequence: simpler pointer code, improved a11y
-
-// SOURCE: https://example.org/a11y/drag-guidance
-// Accessed: 2025-10-20T15:04:12Z
-// Hash: sha256:9b7c…3ad
-// License: CC-BY 4.0
-```
-
-📘 Full spec: [`docs/CCPP.md`](docs/CCPP.md)
-
----
-
-## **Contributing**
-
-1. Fork the repo
-2. Create a feature branch (`git checkout -b feature/name`)
-3. Commit changes (`git commit -m "feat: add xyz"`)
-4. Push to your branch (`git push origin feature/name`)
-5. Open a Pull Request with details and screenshots
-
-Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow.
-All new code must comply with **CSCS** and **CCPP** standards.
+- Spec: `doc/CCPP.md`

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -173,11 +173,11 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 
 ### 5.2 Atomic Components — Primitives (Logic)
 - **[5.2.1] Primitive – "Clamp Utility"**
-  - Helper ensuring panel sizes stay within min/max bounds.
+  - Helper ensuring panel sizes stay within min/max bounds and exported for boundary-value unit tests.
 - **[5.2.2] Primitive – "Keyboard Resize Handler"**
   - Responds to arrow keys on grips for accessible resizing.
 - **[5.2.3] Primitive – "Pointer Resize Handler"**
-  - Manages pointerdown/move/up events across grips.
+  - Manages pointerdown/move/up events across grips with typed listener registration to avoid `any` casts.
 - **[5.2.4] Primitive – "Persistence Effect"**
   - Syncs panel dimensions and collapse state to `localStorage`.
 - **[5.2.5] Primitive – "Bindings Memo"**

--- a/doc/nl-doc-engine/cfg-contentDrawer.md
+++ b/doc/nl-doc-engine/cfg-contentDrawer.md
@@ -11,7 +11,7 @@
 - Scrollable content region.
 
 ### §3.4 Primitive — "Anchor Jump Target"
-- Deterministic anchor alignment for `anchorId` navigation.
+- Deterministic anchor alignment for `anchorId` navigation; utility remains pure and exportable for edge-case tests.
 
 ## 4. BuildStyle
 ### §4.1 Container — "Drawer Visual Shell"

--- a/doc/nl-doc-engine/cfg-contentResolver.md
+++ b/doc/nl-doc-engine/cfg-contentResolver.md
@@ -50,6 +50,7 @@ Accepts provider adapters registered by `cfg-providerRegistry`, emits nodes conf
 ### 3.3 Atomic Components — Primitives (Build)
 - **[3.3.1] Primitive – "Request Guard"**
 - **[3.3.2] Primitive – "Scope Parser"**
+  - Split namespace parser is exported for contract tests covering valid/invalid `contentId` formats.
 - **[3.3.3] Primitive – "Adapter Lookup"**
 - **[3.3.4] Primitive – "Adapter Execute"**
 - **[3.3.5] Primitive – "Raw Node Mapper"**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test --experimental-strip-types test/**/*.test.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",

--- a/src/components/ContentDrawer/ContentDrawer.anchor.ts
+++ b/src/components/ContentDrawer/ContentDrawer.anchor.ts
@@ -1,0 +1,25 @@
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Build
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Provide deterministic heading-to-anchor normalization for drawer section ids.
+ * Invariants: Output is lowercase, punctuation-stripped, and whitespace-collapsed with hyphen separators.
+ */
+
+// ─────────────────────────────────────────────
+// 3. Build – cfg-contentDrawer (Content Drawer Configuration)
+// NL Sections: §3.4 in cfg-contentDrawer.md
+// Purpose: Share pure anchor-id normalization primitive between renderer and tests.
+// Constraints: Keep transformation deterministic and side-effect free.
+// ─────────────────────────────────────────────
+
+// [3.4] cfg-contentDrawer · Primitive · "Anchor Jump Target"
+// Concern: Build · Parent: "Drawer Body" · Catalog: navigation.anchor
+// Notes: Mirrors section headings into deterministic ids for hash-like in-drawer jumps.
+export function toAnchorId(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useMemo, useRef } from 'react';
 import { resolveContent } from '../../content/contentProviders';
+import { toAnchorId } from './ContentDrawer.anchor';
 import { useContentState } from '../../content/ContentContext';
 import './ContentDrawer.css';
 
@@ -18,17 +19,6 @@ import './ContentDrawer.css';
 // Purpose: Provide shell, header, body, and anchor-target structure for drawer content.
 // Constraints: Keep anchor identifiers deterministic and preserve right-side shell wrapper.
 // ─────────────────────────────────────────────
-
-// [3.4] cfg-contentDrawer · Primitive · "Anchor Jump Target"
-// Concern: Build · Parent: "Drawer Body" · Catalog: navigation.anchor
-// Notes: Mirrors section headings into deterministic ids for hash-like in-drawer jumps.
-function toAnchorId(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .trim()
-    .replace(/\s+/g, '-');
-}
 
 // ─────────────────────────────────────────────
 // 5. Logic – cfg-contentDrawer (Content Drawer Configuration)

--- a/src/components/ContentDrawer/index.tsx
+++ b/src/components/ContentDrawer/index.tsx
@@ -1,2 +1,2 @@
-export { ContentDrawer } from './ContentDrawer';
-export type { ContentDrawerProps, ContentNode } from './ContentDrawer';
+export { default as ContentDrawer } from './ContentDrawer';
+export { toAnchorId } from './ContentDrawer.anchor';

--- a/src/content/ContentProviderRegistry.ts
+++ b/src/content/ContentProviderRegistry.ts
@@ -6,7 +6,7 @@
  * Invariants: Content ids must include namespace prefix, registered providers are keyed by namespace, unresolved ids return NotFound.
  */
 
-import { HEADER_DOC_DEFINITIONS } from '../components/GlobalHeaderShell/GlobalHeaderShell.knowledge';
+import { HEADER_DOC_DEFINITIONS } from '../components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts';
 
 export interface ContentResolutionRequest<Context = unknown> {
   contentId: string;
@@ -121,7 +121,7 @@ contentProviderRegistry.registerProvider('docs', DOCS_PROVIDER);
 // [3.3.2] cfg-contentResolver · Primitive · "Scope Parser"
 // Concern: Build · Parent: "Request Intake" · Catalog: resolver.parse
 // Notes: Splits content id into namespace and provider-local identifier.
-function splitNamespace(contentId: string): { namespace: string | null; resolvedId: string | null } {
+export function splitNamespace(contentId: string): { namespace: string | null; resolvedId: string | null } {
   const [namespace, ...rest] = contentId.split(':');
   const resolvedId = rest.join(':');
 

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -7,7 +7,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent, MouseEvent, TouchEvent, RefObject } from 'react';
-import { BUILD_ANCHORS } from './anchors';
+import { BUILD_ANCHORS } from './anchors.ts';
 
 // ─────────────────────────────────────────────
 // 5. Logic – cfg-buildSurface (Build Surface Configuration)
@@ -107,7 +107,7 @@ const SECTION_ORDER: SectionId[] = [
   'search-configurations',
 ];
 
-function clamp(value: number, min: number, max: number) {
+export function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
 }
 
@@ -185,8 +185,8 @@ function useSectionLogic(
   }, []);
 
   const stopDrag = useCallback(() => {
-    window.removeEventListener('mousemove', onMove as any);
-    window.removeEventListener('touchmove', onMove as any);
+    window.removeEventListener('mousemove', onMove as unknown as EventListener);
+    window.removeEventListener('touchmove', onMove as unknown as EventListener);
     window.removeEventListener('mouseup', stopDrag);
     window.removeEventListener('touchend', stopDrag);
     lastY.current = null;
@@ -199,8 +199,8 @@ function useSectionLogic(
       lastY.current = clientY;
       setDragging(true);
       document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', onMove as any, { passive: true });
-      window.addEventListener('touchmove', onMove as any, { passive: true });
+      window.addEventListener('mousemove', onMove as unknown as EventListener, { passive: true });
+      window.addEventListener('touchmove', onMove as unknown as EventListener, { passive: true });
       window.addEventListener('mouseup', stopDrag);
       window.addEventListener('touchend', stopDrag);
     },
@@ -326,8 +326,8 @@ function useLeftPanelLogic(): LeftPanelLogic {
   }, []);
 
   const stopDrag = useCallback(() => {
-    window.removeEventListener('mousemove', onMove as any);
-    window.removeEventListener('touchmove', onMove as any);
+    window.removeEventListener('mousemove', onMove as unknown as EventListener);
+    window.removeEventListener('touchmove', onMove as unknown as EventListener);
     window.removeEventListener('mouseup', stopDrag);
     window.removeEventListener('touchend', stopDrag);
     lastX.current = null;
@@ -340,8 +340,8 @@ function useLeftPanelLogic(): LeftPanelLogic {
       lastX.current = clientX;
       setDragging(true);
       document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', onMove as any, { passive: true });
-      window.addEventListener('touchmove', onMove as any, { passive: true });
+      window.addEventListener('mousemove', onMove as unknown as EventListener, { passive: true });
+      window.addEventListener('touchmove', onMove as unknown as EventListener, { passive: true });
       window.addEventListener('mouseup', stopDrag);
       window.addEventListener('touchend', stopDrag);
     },
@@ -445,8 +445,8 @@ function useRightPanelLogic(): RightPanelLogic {
   }, []);
 
   const stopDrag = useCallback(() => {
-    window.removeEventListener('mousemove', onMove as any);
-    window.removeEventListener('touchmove', onMove as any);
+    window.removeEventListener('mousemove', onMove as unknown as EventListener);
+    window.removeEventListener('touchmove', onMove as unknown as EventListener);
     window.removeEventListener('mouseup', stopDrag);
     window.removeEventListener('touchend', stopDrag);
     lastX.current = null;
@@ -459,8 +459,8 @@ function useRightPanelLogic(): RightPanelLogic {
       lastX.current = clientX;
       setDragging(true);
       document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', onMove as any, { passive: true });
-      window.addEventListener('touchmove', onMove as any, { passive: true });
+      window.addEventListener('mousemove', onMove as unknown as EventListener, { passive: true });
+      window.addEventListener('touchmove', onMove as unknown as EventListener, { passive: true });
       window.addEventListener('mouseup', stopDrag);
       window.addEventListener('touchend', stopDrag);
     },

--- a/test/build-surface-utils.test.mjs
+++ b/test/build-surface-utils.test.mjs
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { clamp } from '../src/tabs/build/BuildSurface.logic.ts';
+
+test('clamp enforces lower and upper boundaries', () => {
+  assert.equal(clamp(100, 120, 240), 120);
+  assert.equal(clamp(180, 120, 240), 180);
+  assert.equal(clamp(260, 120, 240), 240);
+});

--- a/test/content-drawer-anchor.test.mjs
+++ b/test/content-drawer-anchor.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toAnchorId } from '../src/components/ContentDrawer/ContentDrawer.anchor.ts';
+
+test('toAnchorId normalizes heading punctuation and spacing', () => {
+  assert.equal(toAnchorId('  Build + Logic: Overview  '), 'build-logic-overview');
+});
+
+test('toAnchorId preserves existing hyphens while trimming output', () => {
+  assert.equal(toAnchorId('Results - Score Card'), 'results---score-card');
+});

--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { contentProviderRegistry, splitNamespace } from '../src/content/ContentProviderRegistry.ts';
+
+test('splitNamespace parses namespaced ids', () => {
+  assert.deepEqual(splitNamespace('docs:doc-build'), {
+    namespace: 'docs',
+    resolvedId: 'doc-build',
+  });
+});
+
+test('splitNamespace rejects ids without a namespace payload', () => {
+  assert.deepEqual(splitNamespace('docs:'), { namespace: null, resolvedId: null });
+  assert.deepEqual(splitNamespace('doc-build'), { namespace: null, resolvedId: null });
+});
+
+test('contentProviderRegistry resolves registered docs content', () => {
+  const resolved = contentProviderRegistry.resolveContent({ contentId: 'docs:doc-build' });
+  assert.equal(resolved.type, 'content');
+  if (resolved.type === 'content') {
+    assert.equal(resolved.namespace, 'docs');
+    assert.equal(resolved.contentId, 'doc-build');
+  }
+});
+
+test('contentProviderRegistry returns not_found for missing docs content', () => {
+  const missing = contentProviderRegistry.resolveContent({ contentId: 'docs:not-real' });
+  assert.deepEqual(missing, {
+    type: 'not_found',
+    namespace: 'docs',
+    contentId: 'not-real',
+    reason: 'Documentation entry was not found.',
+  });
+});


### PR DESCRIPTION
### Motivation
- The repo health review identified stale onboarding docs, missing test runner, and lint/build failures that block quality gates.
- The intent is to make README accurate about current implementation vs planned features and to add a minimal test harness with contract-style unit tests for high-priority utilities.

### Description
- Rewrote `README.md` to separate **Current Tech Stack (Implemented)** from **Future Additions (Planned)** and updated project structure and scripts to reflect working commands (added `npm test`).
- Added a baseline test harness using the Node.js built-in test runner and an `npm test` script (`node --test --experimental-strip-types test/**/*.test.mjs`).
- Added 3 test files covering 7 tests: `test/content-provider-registry.test.mjs` (namespace splitting + registry hit/miss), `test/content-drawer-anchor.test.mjs` (`toAnchorId` edge cases), and `test/build-surface-utils.test.mjs` (`clamp` boundary values).
- Stabilization fixes: corrected `ContentDrawer` barrel export, extracted `toAnchorId` into `src/components/ContentDrawer/ContentDrawer.anchor.ts` and exported it, exported `splitNamespace` from `ContentProviderRegistry.ts`, exported `clamp` from `BuildSurface.logic.ts`, and replaced `any` listener casts with safer `unknown as EventListener` assertions to satisfy linting/type checks.
- Updated NL-skeleton docs first (per NL-First workflow) to note testability/export of `toAnchorId`, `splitNamespace`, and `clamp` and to document typed listener intent.

### Testing
- Ran `npm run lint`; it passed with 2 existing `react-refresh` warnings and no errors.
- Ran `npm run build`; TypeScript type-check and `vite build` completed successfully.
- Ran `npm test`; all added tests passed (7 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd12bc4e08331889b991e5a9e8b03)