### PR TITLE
Refactor doc-engine exports to remove side-effect registry singleton

### DIFF
--- a/doc/nl-doc-engine/cfg-providerRegistry.md
+++ b/doc/nl-doc-engine/cfg-providerRegistry.md
@@ -124,7 +124,8 @@ Map/set operations, validation guards, optional event emitter for registry chang
 - Factory initializes defaults, then merges extension providers with policy checks.
 
 ### 9.3 Integration
-- Instantiated before resolver boot so adapter lookup is available at runtime.
+- Instantiated at the application composition root before resolver boot so adapter lookup is available at runtime.
+- Module exports remain side-effect free; provider registration is performed explicitly by the consumer/composition layer.
 
 ## 10. Implementation Passes
 ### 10.1 Pass Mapping

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,6 +1,5 @@
 export {
   ContentProviderRegistry,
-  contentProviderRegistry,
   splitNamespace,
   DOCS_PROVIDER,
 } from '../doc-engine/index.ts';

--- a/src/doc-engine/index.ts
+++ b/src/doc-engine/index.ts
@@ -5,6 +5,3 @@ export { ContentProviderRegistry, splitNamespace, DOCS_PROVIDER };
 export type { ContentNode, ContentProvider, ContentResolutionRequest, NotFound } from './types.ts';
 export type { ContentMeta, HeaderDocDefinition, HeaderDocLink, HeaderDocSection } from './catalogs/header-docs.catalog.ts';
 export { HEADER_DOC_DEFINITIONS, resolveHeaderDoc } from './catalogs/header-docs.catalog.ts';
-
-export const contentProviderRegistry = new ContentProviderRegistry();
-contentProviderRegistry.registerProvider('docs', DOCS_PROVIDER);

--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -1,6 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { contentProviderRegistry, splitNamespace } from '../src/doc-engine/index.ts';
+import {
+  ContentProviderRegistry,
+  DOCS_PROVIDER,
+  splitNamespace,
+} from '../src/doc-engine/index.ts';
+
+const createRegistry = () => {
+  const registry = new ContentProviderRegistry();
+  registry.registerProvider('docs', DOCS_PROVIDER);
+  return registry;
+};
 
 test('splitNamespace parses namespaced ids', () => {
   assert.deepEqual(splitNamespace('docs:doc-build'), {
@@ -15,6 +25,7 @@ test('splitNamespace rejects ids without a namespace payload', () => {
 });
 
 test('contentProviderRegistry resolves registered docs content', () => {
+  const contentProviderRegistry = createRegistry();
   const resolved = contentProviderRegistry.resolveContent({ contentId: 'docs:doc-build' });
   assert.equal(resolved.type, 'content');
   if (resolved.type === 'content') {
@@ -24,6 +35,7 @@ test('contentProviderRegistry resolves registered docs content', () => {
 });
 
 test('contentProviderRegistry returns not_found for missing docs content', () => {
+  const contentProviderRegistry = createRegistry();
   const missing = contentProviderRegistry.resolveContent({ contentId: 'docs:not-real' });
   assert.deepEqual(missing, {
     type: 'not_found',


### PR DESCRIPTION
### Motivation
- Remove module-level side effects from the Doc Engine index so the module is side-effect free and provider registration is performed explicitly at application composition time.
- Align implementation with the doc-engine NL skeleton which states registration should happen at the composition root rather than during module import.

### Description
- Updated `src/doc-engine/index.ts` to export only core primitives/types and provider/catalog symbols and removed the module-level `contentProviderRegistry` singleton creation and registration lines.
- Updated `src/content/index.ts` to stop re-exporting the removed `contentProviderRegistry` and match the new side-effect-free exports from `src/doc-engine/index.ts`.
- Updated `test/content-provider-registry.test.mjs` to construct a `ContentProviderRegistry` and call `registerProvider('docs', DOCS_PROVIDER)` explicitly inside the test setup instead of relying on an implicit singleton.
- Updated documentation `doc/nl-doc-engine/cfg-providerRegistry.md` to state that provider registration occurs at the application composition root and that module exports are side-effect free.

### Testing
- Ran `npm test` and all tests passed (test suite completed successfully). 
- Ran `npm run build` and the TypeScript/Vite production build completed successfully. 
- Verified with `rg -n "registerProvider\(|new ContentProviderRegistry\(|contentProviderRegistry" src/doc-engine` that no remaining side-effect registration exists in `src/doc-engine` and the check returned only expected registry API references.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb488bcd48331a7e4153dae3232eb)