### PR TITLE
Move content provider registry singleton into content layer

### DIFF
--- a/doc/nl-doc-engine/cfg-providerRegistry.md
+++ b/doc/nl-doc-engine/cfg-providerRegistry.md
@@ -92,6 +92,7 @@ Map/set operations, validation guards, optional event emitter for registry chang
 
 ### 6.2 Constants
 - Registry event names, default provider list, compatibility policy version.
+- App-level singleton registry initialized in `src/content/contentEngine.ts` with explicit `docs` namespace registration.
 
 ### 6.3 Shared / Global Reference
 - Exports provider metadata used by resolver and drawer.
@@ -119,12 +120,14 @@ Map/set operations, validation guards, optional event emitter for registry chang
 - `src/docEngine/providerRegistry/ProviderRegistry.logic.ts`
 - `src/docEngine/providerRegistry/ProviderRegistry.knowledge.ts`
 - `src/docEngine/providerRegistry/ProviderRegistry.results.ts`
+- `src/content/contentEngine.ts`
 
 ### 9.2 Assembly Logic
 - Factory initializes defaults, then merges extension providers with policy checks.
 
 ### 9.3 Integration
 - Instantiated before resolver boot so adapter lookup is available at runtime.
+- Content layer re-exports the singleton so app code consumes provider registration from `src/content/index.ts`.
 
 ## 10. Implementation Passes
 ### 10.1 Pass Mapping

--- a/src/content/contentEngine.ts
+++ b/src/content/contentEngine.ts
@@ -1,0 +1,22 @@
+/**
+ * Configuration: cfg-providerRegistry – Doc Engine Provider Registry Configuration
+ * Concern File: Logic
+ * Source NL: doc/nl-doc-engine/cfg-providerRegistry.md
+ * Responsibility: Compose the app-level content provider registry singleton and register built-in providers.
+ * Invariants: Singleton instance is created once per module load, docs provider is registered under the `docs` namespace.
+ */
+
+import { ContentProviderRegistry, DOCS_PROVIDER } from '../doc-engine';
+
+// ─────────────────────────────────────────────
+// 5. Logic – cfg-providerRegistry (Doc Engine Provider Registry Configuration)
+// NL Sections: §5.1–§5.3 in cfg-providerRegistry.md
+// Purpose: Instantiate and wire deterministic provider registration for application-level content resolution.
+// Constraints: Registration must be explicit and namespace-stable.
+// ─────────────────────────────────────────────
+
+// [5.3.2] cfg-providerRegistry · Primitive · "Registry Mutation"
+// Concern: Logic · Parent: "ProviderRegistryLogic" · Catalog: resolver.provider
+// Notes: Singleton registry receives explicit docs namespace registration for deterministic lookup.
+export const contentProviderRegistry = new ContentProviderRegistry();
+contentProviderRegistry.registerProvider('docs', DOCS_PROVIDER);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,9 +1,6 @@
-export {
-  ContentProviderRegistry,
-  contentProviderRegistry,
-  splitNamespace,
-  DOCS_PROVIDER,
-} from '../doc-engine/index.ts';
+export { contentProviderRegistry } from './contentEngine.ts';
+
+export { ContentProviderRegistry, splitNamespace, DOCS_PROVIDER } from '../doc-engine/index.ts';
 export type {
   ContentNode,
   ContentProvider,


### PR DESCRIPTION
### Motivation
- Ensure the application-level content provider registry lives in the content layer so app code imports a single, app-scoped singleton instead of relying on the doc-engine module to host it. 
- Follow the NL-first workflow by updating the provider-registry NL skeleton before code changes so comments and documentation remain authoritative.

### Description
- Add `src/content/contentEngine.ts` which imports `ContentProviderRegistry` and `DOCS_PROVIDER` from `src/doc-engine`, creates a `contentProviderRegistry` singleton, and registers the docs provider via `registerProvider('docs', DOCS_PROVIDER)`. 
- Update `src/content/index.ts` to export `contentProviderRegistry` from `./contentEngine.ts` and keep the utility/type exports forwarded from `src/doc-engine/index.ts`. 
- Update the NL skeleton `doc/nl-doc-engine/cfg-providerRegistry.md` to document the new content-layer singleton and the content-layer re-export integration.

### Testing
- Ran `npm test` and all tests passed successfully. 
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb503230c83318094e4d2a2ff9be8)