### PR TITLE
Use app-level content registry for ContentDrawer resolution

### DIFF
--- a/doc/nl-doc-engine/cfg-contentDrawer.md
+++ b/doc/nl-doc-engine/cfg-contentDrawer.md
@@ -25,7 +25,9 @@
 - Open/close state and focus return.
 
 ### §5.2 Subcontainer — "Resolver Pipeline"
-- Namespace routing and deterministic provider resolution.
+- Resolve through app-level content provider registry using request `{ contentId, anchorId }`.
+- Map normalized doc-engine resolver outputs into drawer-local render shapes via a thin adapter.
+- Keep unresolved namespace/invalid ids deterministic (`null` or existing missing fallback) so UI behavior remains stable.
 
 ### §5.3 Primitive — "Anchor Scroll Handler"
 - Scroll to anchor when content resolves.

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useMemo, useRef } from 'react';
-import { resolveContent } from '../../content/contentProviders';
+import { resolveDrawerContent } from '../../content/contentResolutionAdapter';
 import { toAnchorId } from './ContentDrawer.anchor';
 import { useContentState } from '../../content/ContentContext';
 import './ContentDrawer.css';
@@ -35,8 +35,11 @@ export default function ContentDrawer() {
   // Concern: Logic · Parent: "Drawer State Orchestrator" · Catalog: resolver.pipeline
   // Notes: Active content id is resolved lazily and memoized per id transition.
   const resolution = useMemo(
-    () => (activeContentId ? resolveContent(activeContentId) : null),
-    [activeContentId],
+    () =>
+      activeContentId
+        ? resolveDrawerContent(activeContentId, activeContentAnchorId ?? undefined)
+        : null,
+    [activeContentAnchorId, activeContentId],
   );
 
   // [5.3] cfg-contentDrawer · Primitive · "Anchor Scroll Handler"

--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -1,0 +1,73 @@
+/**
+ * Configuration: cfg-contentDrawer (Content Drawer Configuration)
+ * Concern File: Logic
+ * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
+ * Responsibility: Adapt app-level registry resolution into drawer-local render shapes.
+ * Invariants: Docs payloads map to drawer doc shape, docs not_found maps to drawer missing shape, invalid or unsupported ids map to null.
+ */
+
+import {
+  contentProviderRegistry,
+  type ContentNode,
+  type HeaderDocDefinition,
+  type NotFound,
+} from './index';
+
+export type DrawerContentResolution =
+  | {
+      kind: 'doc';
+      contentId: string;
+      doc: HeaderDocDefinition;
+    }
+  | {
+      kind: 'missing';
+      contentId: string;
+    };
+
+// [5.2] cfg-contentDrawer · Primitive · "Registry Resolution Adapter"
+// Concern: Logic · Parent: "Resolver Pipeline" · Catalog: resolver.adapter
+// Notes: Preserves legacy drawer contract while consuming normalized registry outputs.
+export function resolveDrawerContent(
+  contentId: string,
+  anchorId?: string,
+): DrawerContentResolution | null {
+  const resolved = contentProviderRegistry.resolveContent({
+    contentId,
+    anchorId,
+  });
+
+  if (resolved.type === 'content') {
+    return toDrawerDocResolution(contentId, resolved);
+  }
+
+  return toDrawerMissingResolution(contentId, resolved);
+}
+
+function toDrawerDocResolution(
+  requestContentId: string,
+  resolved: ContentNode,
+): DrawerContentResolution | null {
+  if (resolved.namespace !== 'docs') {
+    return null;
+  }
+
+  return {
+    kind: 'doc',
+    contentId: requestContentId,
+    doc: resolved.payload as HeaderDocDefinition,
+  };
+}
+
+function toDrawerMissingResolution(
+  requestContentId: string,
+  resolved: NotFound,
+): DrawerContentResolution | null {
+  if (resolved.namespace !== 'docs') {
+    return null;
+  }
+
+  return {
+    kind: 'missing',
+    contentId: requestContentId,
+  };
+}


### PR DESCRIPTION
### Motivation
- Move ContentDrawer resolution from the local `contentProviders` helper to the app-level `contentProviderRegistry` so provider selection is centralized and namespaced.
- Preserve the drawer UI contract by mapping normalized doc-engine outputs into the existing drawer resolution shapes so rendering/anchor behavior stays deterministic.
- Keep unsupported namespaces and invalid ids deterministic (return `null` / fallback) to maintain existing unavailable-content UX.

### Description
- Updated the NL skeleton first (`doc/nl-doc-engine/cfg-contentDrawer.md`) to require registry-based resolution and an adapter mapping before changing code.
- Added a thin app-layer adapter `src/content/contentResolutionAdapter.ts` that calls `contentProviderRegistry.resolveContent({ contentId, anchorId })` and maps `ContentNode` (`type: 'content'`) to `{ kind: 'doc', contentId, doc }`, `NotFound` to `{ kind: 'missing', contentId }`, and returns `null` for unsupported/invalid namespaces.
- Switched `src/components/ContentDrawer/ContentDrawer.tsx` to import and use `resolveDrawerContent(activeContentId, activeContentAnchorId ?? undefined)` (via `useMemo`) and adjusted memo dependencies; retained existing anchor scroll and UI rendering paths unchanged.

### Testing
- Ran the TypeScript build + production bundling via `npm run build`, which completed successfully (tsc + Vite build passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb5173f98833188f25ac4ec023e91)