### PR TITLE
Unify ContentDrawer adapter and UI on doc-engine `type` union

### DIFF
--- a/doc/nl-doc-engine/cfg-contentDrawer.md
+++ b/doc/nl-doc-engine/cfg-contentDrawer.md
@@ -26,7 +26,8 @@
 
 ### §5.2 Subcontainer — "Resolver Pipeline"
 - Resolve through app-level content provider registry using request `{ contentId, anchorId }`.
-- Map normalized doc-engine resolver outputs into drawer-local render shapes via a thin adapter.
+- Keep doc-engine resolver outputs in their canonical discriminated union (`type: 'content' | 'not_found'`) for drawer rendering.
+- Use adapter narrowing only for docs namespace eligibility (unsupported namespaces still return `null`).
 - Keep unresolved namespace/invalid ids deterministic (`null` or existing missing fallback) so UI behavior remains stable.
 
 ### §5.3 Primitive — "Anchor Scroll Handler"

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -62,6 +62,10 @@ export default function ContentDrawer() {
   }
 
   if (!resolution || resolution.type === 'not_found') {
+    const missingLabel = resolution
+      ? `${resolution.namespace ? `${resolution.namespace}:` : ''}${resolution.contentId}`
+      : activeContentId;
+
     return (
       // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
       // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
@@ -76,7 +80,7 @@ export default function ContentDrawer() {
             <h2 className="content-drawer__title">Content not found</h2>
             <p className="content-drawer__summary">
               The provider could not resolve{' '}
-              <strong>{resolution?.contentId ? `${resolution.namespace ? `${resolution.namespace}:` : ''}${resolution.contentId}` : activeContentId}</strong>.
+              <strong>{missingLabel}</strong>.
             </p>
           </div>
           <button type="button" className="content-drawer__close" onClick={closeContent}>
@@ -88,7 +92,7 @@ export default function ContentDrawer() {
   }
 
   if (resolution.type === 'content' && resolution.namespace === 'docs') {
-    const doc = resolution.payload as HeaderDocDefinition;
+    const doc = resolution.payload;
     return (
       // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
       // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell

--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -2,31 +2,18 @@
  * Configuration: cfg-contentDrawer (Content Drawer Configuration)
  * Concern File: Logic
  * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
- * Responsibility: Adapt app-level registry resolution into drawer-local render shapes.
- * Invariants: Docs payloads map to drawer doc shape, docs not_found maps to drawer missing shape, invalid or unsupported ids map to null.
+ * Responsibility: Narrow app-level registry resolution to docs namespace while preserving doc-engine union discriminants.
+ * Invariants: Resolver outputs preserve type tags, docs namespace is required, invalid or unsupported ids map to null.
  */
 
-import {
-  contentProviderRegistry,
-  type ContentNode,
-  type HeaderDocDefinition,
-  type NotFound,
-} from './index';
+import type { ContentNode, HeaderDocDefinition, NotFound } from './index';
+import { contentProviderRegistry } from './contentEngine';
 
-export type DrawerContentResolution =
-  | {
-      kind: 'doc';
-      contentId: string;
-      doc: HeaderDocDefinition;
-    }
-  | {
-      kind: 'missing';
-      contentId: string;
-    };
+export type DrawerContentResolution = ContentNode<HeaderDocDefinition> | NotFound;
 
 // [5.2] cfg-contentDrawer · Primitive · "Registry Resolution Adapter"
 // Concern: Logic · Parent: "Resolver Pipeline" · Catalog: resolver.adapter
-// Notes: Preserves legacy drawer contract while consuming normalized registry outputs.
+// Notes: Preserves canonical resolver discriminants while narrowing to docs namespace.
 export function resolveDrawerContent(
   contentId: string,
   anchorId?: string,
@@ -36,38 +23,13 @@ export function resolveDrawerContent(
     anchorId,
   });
 
+  if (resolved.namespace !== 'docs') {
+    return null;
+  }
+
   if (resolved.type === 'content') {
-    return toDrawerDocResolution(contentId, resolved);
+    return resolved as ContentNode<HeaderDocDefinition>;
   }
 
-  return toDrawerMissingResolution(contentId, resolved);
-}
-
-function toDrawerDocResolution(
-  requestContentId: string,
-  resolved: ContentNode,
-): DrawerContentResolution | null {
-  if (resolved.namespace !== 'docs') {
-    return null;
-  }
-
-  return {
-    kind: 'doc',
-    contentId: requestContentId,
-    doc: resolved.payload as HeaderDocDefinition,
-  };
-}
-
-function toDrawerMissingResolution(
-  requestContentId: string,
-  resolved: NotFound,
-): DrawerContentResolution | null {
-  if (resolved.namespace !== 'docs') {
-    return null;
-  }
-
-  return {
-    kind: 'missing',
-    contentId: requestContentId,
-  };
+  return resolved;
 }


### PR DESCRIPTION
### Motivation
- The drawer resolution flow used an adapter-local discriminant (`kind`) that duplicated the doc-engine union and forced local mapping logic. This change aligns the adapter and UI to the canonical doc-engine discriminated union (`type: 'content' | 'not_found'`).
- Keep user-visible behavior identical for docs rendering, missing-content messaging, and anchor scrolling while removing redundant mappings and improving type-safety.

### Description
- Refactored the resolver adapter in `src/content/contentResolutionAdapter.ts` to return `ContentNode<HeaderDocDefinition> | NotFound` (preserving `type: 'content' | 'not_found'`) and to return `null` for non-`docs` namespaces. 
- Updated `src/components/ContentDrawer/ContentDrawer.tsx` to narrow on the canonical `resolution.type` and `resolution.namespace` only, removed any `kind`-based branches, and added a `missingLabel` local to satisfy TypeScript null-safety while preserving the original missing-message behavior. 
- Updated NL skeleton `doc/nl-doc-engine/cfg-contentDrawer.md` to describe the resolver pipeline using the canonical doc-engine discriminant and namespace-only narrowing.

### Testing
- Ran the repository build with `npm run build`, which completed successfully (TypeScript transpile and Vite build passed). 
- Ran focused tests `npm test -- content-provider-registry content-drawer-anchor`, and all related tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff3beb39c8331818c6a0429b21c7d)