### PR TITLE
Unify contentProviderRegistry import path to contentEngine

### DIFF
--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -7,11 +7,12 @@
  */
 
 import {
-  contentProviderRegistry,
   type ContentNode,
   type HeaderDocDefinition,
   type NotFound,
 } from './index';
+// Canonical source: contentProviderRegistry lives in contentEngine.ts (owner module).
+import { contentProviderRegistry } from './contentEngine';
 
 export type DrawerContentResolution =
   | {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -13,3 +13,6 @@ export type {
   HeaderDocLink,
   HeaderDocSection,
 } from '../doc-engine/index.ts';
+
+// NOTE: contentProviderRegistry is intentionally not re-exported from this barrel.
+// Import it from ./contentEngine to keep a single canonical ownership path.


### PR DESCRIPTION
### Motivation
- Prevent import/export drift by making `contentProviderRegistry` owned and imported from a single canonical module (`src/content/contentEngine.ts`) instead of via the barrel, so code sites always resolve the same singleton source.

### Description
- Replaced the registry import in `src/content/contentResolutionAdapter.ts` to import `contentProviderRegistry` from `./contentEngine`, added an inline canonical-source note, and updated `src/content/index.ts` to explicitly document that the registry is not re-exported while preserving all type exports from the barrel.

### Testing
- Ran a symbol search with `rg -n "contentProviderRegistry" src/content src/components src/tabs test` and an index-import pattern search to confirm the registry is only imported from the canonical path, and ran `npm run build` which failed due to unrelated TypeScript type errors in `src/components/ContentDrawer/ContentDrawer.tsx` not caused by this import-path change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff3c019988331811f7b79c8c33be5)