### PR TITLE
Docs: align DocEngineExtractionPlan with provider + pack architecture

### DIFF
--- a/doc/Architecture/DocEngineExtractionPlan.md
+++ b/doc/Architecture/DocEngineExtractionPlan.md
@@ -31,50 +31,118 @@ This document maps the current documentation engine signals in the builder UI an
 - `src/doc-engine/*` is now the in-repo staging area for future package extraction.
 - Runtime rule: doc-engine runtime modules must not import UI feature code from `src/components/*` or `src/tabs/*`.
 
-### 1) New doc-engine package responsibilities
-Create a dedicated package/repo that owns the following:
-- Doc content model and types (definitions, sections, links).
-- Doc catalogs (the actual content data).
-- Accessors/resolvers (e.g., `resolveHeaderDoc`).
-- Optional helpers for search, indexing, and content normalization.
+## Target Architecture (Platform-aligned)
 
-**Suggested module boundary (future package):**
-```
-@calculogic/doc-engine
-├─ src
-│  ├─ types.ts              // HeaderDocDefinition, Section, Link
-│  ├─ catalog.ts            // HEADER_DOC_DEFINITIONS (or equivalent registry)
-│  ├─ resolvers.ts          // resolveHeaderDoc
-│  └─ index.ts              // public exports
-```
+This plan assumes a **provider + pack** model so the doc engine can be reused across multiple UIs (web/native) and can evolve toward multi-provider search without rewriting core contracts.
 
-### 2) Builder UI responsibilities (this repo)
-Keep UI wiring and interactions here:
-- Doc entry points (icons, buttons, hover summaries).
-- `openDoc/closeDoc` state management (or delegate to a hook that consumes the doc-engine).
-- Modal or panel rendering (when added).
+### A) `@calculogic/doc-engine` (core runtime)
+**Scope:** stable, reusable, UI-agnostic library.
 
-## Transitional Refactor Steps (Low-risk)
+Responsibilities:
+- Define canonical types and invariants:
+  - `ContentId` (namespaced IDs like `docs:doc-build`)
+  - canonical result union discriminant: `type: 'content' | 'not_found'`
+  - `ContentNode` / `NotFound` shapes
+- Provider contracts (plugins/adapters implement these):
+  - `resolveContent({ contentId, anchorId?, context? })`
+  - optional `search({ query, filters?, limit? })` (future)
+- `ContentProviderRegistry` orchestration:
+  - routes by namespace
+  - merges/normalizes provider results
+  - guarantees deterministic `not_found` semantics
+- Pure helpers (no side effects):
+  - namespacing utilities (e.g. `splitNamespace`)
+  - ID parsing and validation helpers
 
-1. **Extract types + catalog**
-   - Move doc-related types and data from `GlobalHeaderShell.knowledge.ts` into a dedicated module (even inside this repo first, e.g., `src/doc-engine/`).
-2. **Replace inline imports**
-   - Swap local `resolveHeaderDoc` and doc definitions with imports from the new module.
-3. **Promote to standalone repo**
-   - Lift `src/doc-engine/` into the separate repo and repoint imports to the package.
+Non-responsibilities (explicit):
+- No UI components, no React, no app state
+- No side-effect provider registration
+- No assumption that docs “live in the app repo”
+- No required ownership of catalog/content data (content comes from providers)
+
+### B) Providers (adapters / plugins)
+Providers define *where content comes from* and how it is loaded.
+
+Examples (not required for MVP):
+- In-memory catalog provider (dev/demo content)
+- Filesystem / Git provider (docs in a separate repo or local workspace)
+- Database provider (published user content, knowledge bases, etc.)
+- Search-index provider (Meilisearch/Elastic/etc.) for multi-provider search
+
+Providers may be shipped by plugins.
+
+### C) Content packs (docs content)
+“Packs” are content sources that providers read from:
+- official docs repo/package
+- plugin docs packs (namespaced)
+- user-generated docs stored in DB (published)
+- curated knowledge base docs
+
+Core doc-engine does not own packs; it only resolves IDs through providers.
+
+## Composition ownership (App layer)
+
+The **host application owns composition**:
+- It chooses which providers are enabled.
+- It registers providers in an app-level composition root (e.g. `src/content/contentEngine.ts`).
+- It may ship a small adapter layer for UI view models, but the doc-engine contract (`type: 'content' | 'not_found'`) remains canonical at the engine boundary.
+
+This ensures the same `@calculogic/doc-engine` package can be reused by:
+- the current web UI
+- a future native mobile UI
+- other clients (CLI tools, admin panels, plugin UIs)
+without re-implementing the engine.
+
+## Updated Extraction Steps (Provider + Pack aligned)
+
+### Step 0 — Core must be side-effect free (precondition)
+- `@calculogic/doc-engine` exports types, registry, helpers, and provider contracts.
+- It does not create singletons or register providers on import.
+
+### Step 1 — App owns provider wiring (precondition)
+- The app creates a registry singleton in an app composition root.
+- The app registers providers there (e.g. `docs` provider).
+
+### Step 2 — Decide where catalogs live (temporary vs long-term)
+Choose one:
+- **Temporary:** keep current in-repo catalogs while extracting the engine.
+- **Long-term:** move docs content into a separate “docs pack” repo/package and load via a provider.
+
+Do NOT bake app-specific catalogs into core as a permanent requirement.
+
+### Step 3 — Create the doc-engine repo/package
+- Create a new repo (e.g. `HCAToolkit/calculogic-doc-engine`).
+- Copy `src/doc-engine/**` into the package with a narrow public API (`src/index.ts`).
+- Add package build output (ESM + types).
+
+### Step 4 — Repoint app imports
+- Replace `src/doc-engine/*` imports with the package import (e.g. `@calculogic/doc-engine`).
+
+### Step 5 — Keep one integration test in the host app
+- Verify a known `docs:*` id resolves to `type: 'content'`.
+- Verify an unknown id resolves to `type: 'not_found'`.
+This guards the engine/app boundary during future refactors.
 
 ## Why this boundary is clean
 
-- The doc content is already isolated in a single knowledge file.
-- The UI only needs `docId` and `hoverSummary` metadata plus a lookup resolver.
-- Logic is already expressed via `openDoc/closeDoc`, so the rendering surface can evolve independently.
+- The doc engine is reusable across multiple UI surfaces because composition remains in the host app.
+- Provider contracts separate engine behavior from content storage choices.
+- Canonical `type: 'content' | 'not_found'` semantics keep integrations deterministic.
 
-## Notes for plugin architecture alignment
+## Plugin alignment (Providers + Packs)
 
-If the builder tabs become plugin-defined later, the doc-engine can support:
-- Plugin-supplied doc catalogs merged at runtime.
-- Namespace or owner fields in doc IDs.
-- Registration APIs to append docs without modifying core UI code.
+Plugins may ship:
+- **Providers** (new namespaces or new storage backends)
+- **Content packs** (docs content owned by the plugin)
+
+Namespacing guidance:
+- Keep IDs namespaced and collision-safe (examples):
+  - `docs:official:getting-started`
+  - `docs:plugin-x:overview`
+  - `kb:community:enneagram:type-5`
+  - `forms:published:abc123:docs`
+
+The doc engine remains the stable contract; plugins extend the ecosystem via providers/packs.
 
 ## CCPP Alignment Checklist for Doc Engine Work
 
@@ -91,12 +159,12 @@ Reference: `doc/ConventionRoutines/CCPP.md`.
 
 To validate the doc engine inside this repo, implement a minimal modal flow:
 1. **Trigger**: reuse `openDoc(docId)` from the header shell logic.
-2. **Resolve**: call the doc resolver for a `HeaderDocDefinition` payload.
-3. **Render**: show title, summary, and sections (heading + body list).
+2. **Resolve**: resolve by content ID and branch on `type: 'content' | 'not_found'`.
+3. **Render**: show title, summary, and sections (heading + body list) when content exists.
 4. **Close**: add `closeDoc()` handler, escape key support, and focus return.
 5. **Accessibility**: apply `role="dialog"`, `aria-modal="true"`, and focus trap.
 
-This keeps the UI and doc engine behavior stable before extracting the catalog into a separate package/repo.
+This keeps the UI and doc engine behavior stable before extracting catalogs into separate packs/providers.
 
 ## Doc-Engine Standards and Documentation Hub
 


### PR DESCRIPTION
### Motivation
- Update the extraction plan to reflect a provider + pack platform direction so the doc engine is reusable across UIs (web/native/other). 
- Make the engine contract canonical and deterministic by specifying the union discriminant `type: 'content' | 'not_found'` and moving content ownership to providers/packs. 
- Clarify that the host application owns provider registration/composition and that core remains side-effect free and UI-agnostic.

### Description
- Replace the extraction responsibilities with a `Target Architecture (Platform-aligned)` section that defines `@calculogic/doc-engine` responsibilities, provider contracts, and content pack semantics. 
- Add a `Composition ownership (App layer)` section that states the host app chooses and registers providers and preserves the engine boundary (`type: 'content' | 'not_found'`). 
- Replace the extraction/promotion steps with `Updated Extraction Steps (Provider + Pack aligned)` that require a side-effect-free core, app-owned wiring, a temporary vs long-term catalog decision, package extraction and repointing, and a single host-app integration test. 
- Update plugin guidance to `Plugin alignment (Providers + Packs)` with namespace-safe ID examples and a clear separation between providers and content packs; limit changes to the single doc file `doc/Architecture/DocEngineExtractionPlan.md`.

### Testing
- Ran `git diff -- doc/Architecture/DocEngineExtractionPlan.md` to verify the planned changes were present and the diff matched expectations, and it succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it returned no problems. 
- Committed the single-file documentation update with the message `Docs: align DocEngineExtractionPlan with provider + pack architecture` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900477d8f4833188d832c2d6bb091b)