### PR TITLE
Align doc-engine extraction docs and tighten content/doc-engine boundary

### DIFF
--- a/doc/Architecture/DocEngineExtractionPlan.md
+++ b/doc/Architecture/DocEngineExtractionPlan.md
@@ -4,26 +4,27 @@ This document maps the current documentation engine signals in the builder UI an
 
 ## Inventory: Current Doc Engine Touchpoints
 
-### Knowledge layer (content model + source of truth)
-- `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`
+### Packs layer (source of truth for docs payload)
+- `src/content/packs/header-docs/header-docs.catalog.ts`
   - Structured doc content model (`HeaderDocDefinition`, sections, links).
   - Tab definitions include `docId` and `hoverSummary`.
   - `resolveHeaderDoc` provides a lookup accessor.
 
-### Logic layer (state + orchestration)
-- `src/components/GlobalHeaderShell/GlobalHeaderShell.logic.ts`
-  - `activeDocId` tracked in state.
-  - `openDoc` and `closeDoc` handlers exposed via bindings.
-  - Doc state is already decoupled from rendering.
+### Provider layer (docs namespace adapter)
+- `src/content/providers/docs.provider.ts`
+  - Owns `docs` namespace resolution.
+  - Resolves ids against pack content and returns canonical engine unions (`content` / `not_found`).
 
-### Build layer (UI entry points)
-- `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`
-  - `InfoIcon` triggers `openDoc(tab.docId)`.
-  - Tab metadata surfaces `hoverSummary`.
+### Composition root (registry singleton + registration)
+- `src/content/contentEngine.ts`
+  - Creates the app-level `ContentProviderRegistry` singleton.
+  - Registers the docs provider under namespace `docs`.
 
-### Results layer (diagnostics)
-- `src/components/GlobalHeaderShell/GlobalHeaderShell.results.tsx`
-  - Debug panel + live region uses the same shell state; can optionally surface doc state later.
+### UI triggers + rendering remain app-side
+- `src/components/GlobalHeaderShell/*`
+  - Header interactions trigger drawer open/close and pass doc ids.
+- `src/components/ContentDrawer/*`
+  - Drawer resolves and renders payload returned by registry/provider pipeline.
 
 ## Extraction Boundary (Proposed)
 

--- a/doc/HealthChecks/FolderOrganizationHealthCheck-2026-02-14.md
+++ b/doc/HealthChecks/FolderOrganizationHealthCheck-2026-02-14.md
@@ -1,14 +1,20 @@
 # Folder Organization Health Check (Doc-Engine Extraction Prep)
 
 ## Scope
+## Status (2026-02-16 update)
+- ✅ Change 1 completed (catalog moved to `src/content/packs/header-docs/header-docs.catalog.ts`).
+- ✅ Change 2 completed (provider moved to `src/content/providers/docs.provider.ts`).
+- ✅ Change 3 completed (engine barrel narrowed to core contracts/orchestrator).
+- ✅ Barrel boundary tightening completed (`src/content/index.ts` no longer re-exports engine types/registry).
+
 Repository: `HCAToolkit/Calculogic_React_App`
 Goal: assess folder boundaries for future doc-engine split with minimal churn.
 
 ## A) Current structure map (short)
 
 ### `src/` major folders
-- `src/doc-engine/` — staged doc-engine runtime boundary (types, registry, providers, catalogs, package-style exports).
-- `src/content/` — app composition + adapter layer (registry singleton wiring, drawer-specific resolver adapter, context provider/barrel).
+- `src/doc-engine/` — staged doc-engine runtime boundary (types, registry, package-style exports).
+- `src/content/` — app composition + adapter layer (packs, provider wiring, drawer-specific resolver adapter, context provider/barrel).
 - `src/components/GlobalHeaderShell/` — app shell UI and shell knowledge/logic/results composition.
 - `src/components/ContentDrawer/` — drawer UI adapter/presenter + anchor helper + styles.
 - `src/tabs/` — tab-level app UI features (currently Build tab).
@@ -30,8 +36,8 @@ Goal: assess folder boundaries for future doc-engine split with minimal churn.
 | `src/doc-engine/types.ts` | Engine Core | Canonical content contracts should be package-owned. |
 | `src/doc-engine/registry.ts` | Engine Core | Namespace parsing + provider registry orchestration are reusable core runtime primitives. |
 | `src/doc-engine/index.ts` | Engine Core (boundary candidate) | Public API surface for future package extraction. |
-| `src/doc-engine/providers/docs.provider.ts` | Provider (app-specific today) | Provider implementations are not required to live in engine core; this one is tied to header docs content and is a candidate to move app-side. |
-| `src/doc-engine/catalogs/header-docs.catalog.ts` | Content Pack (currently coupled) | App/header-specific docs payload; should not remain in long-term engine core. |
+| `src/content/providers/docs.provider.ts` | Provider (app-specific) | Docs namespace adapter is app-owned and intentionally outside engine core for extraction readiness. |
+| `src/content/packs/header-docs/header-docs.catalog.ts` | Content Pack (app-owned) | Header docs payload source of truth, owned by app content layer. |
 | `src/content/contentEngine.ts` | App Composition | Correct host-owned provider registration singleton location. |
 | `src/content/contentResolutionAdapter.ts` | UI Adapter (app layer) | Drawer-specific narrowing and mapping to docs payload should remain app-side. |
 | `src/content/ContentContext.tsx` | App Composition | UI state orchestration for drawer open/close belongs to app shell. |
@@ -41,13 +47,13 @@ Goal: assess folder boundaries for future doc-engine split with minimal churn.
 
 ## C) Top folder-organization issues (ranked)
 
-1. **High — content pack co-located in `src/doc-engine/catalogs/`**  
-   - Paths: `src/doc-engine/catalogs/header-docs.catalog.ts`, `src/doc-engine/providers/docs.provider.ts`  
-   - Risk: app/header-specific docs are packaged with core boundary, encouraging accidental coupling and making core extraction include content payloads by default.
+1. **Resolved — content pack/provider moved out of `src/doc-engine/`**  
+   - Paths: `src/content/packs/header-docs/header-docs.catalog.ts`, `src/content/providers/docs.provider.ts`  
+   - Outcome: app/header-specific docs payload and provider now live in app content layer, keeping core extractable.
 
-2. **Medium — app barrel re-exports engine internals under `src/content/`**  
+2. **Resolved — app barrel no longer re-exports engine internals**  
    - Path: `src/content/index.ts`  
-   - Risk: mixed import entrypoints (`../doc-engine` vs `../content`) can blur ownership over time and increase import churn during package cutover.
+   - Outcome: entrypoint ownership is explicit (`src/doc-engine` for engine runtime, `src/content` for app content).
 
 3. **Medium — shell knowledge still leaks doc/content identifiers into UI feature layer**  
    - Paths: `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`, `src/components/GlobalHeaderShell/index.tsx`  

--- a/src/content/contentEngine.ts
+++ b/src/content/contentEngine.ts
@@ -6,7 +6,7 @@
  * Invariants: Singleton instance is created once per module load, docs provider is registered under the `docs` namespace.
  */
 
-import { ContentProviderRegistry } from '../doc-engine';
+import { ContentProviderRegistry } from '../doc-engine/index.ts';
 import { DOCS_PROVIDER } from './providers/docs.provider.ts';
 
 // ─────────────────────────────────────────────

--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -6,7 +6,8 @@
  * Invariants: Resolver outputs preserve type tags, docs namespace is required, invalid or unsupported ids map to null.
  */
 
-import type { ContentNode, HeaderDocDefinition, NotFound } from './index';
+import type { ContentNode, NotFound } from '../doc-engine/index.ts';
+import type { HeaderDocDefinition } from './packs/header-docs/header-docs.catalog.ts';
 import { contentProviderRegistry } from './contentEngine';
 
 export type DrawerContentResolution = ContentNode<HeaderDocDefinition> | NotFound;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -7,8 +7,5 @@ export type {
 } from './packs/header-docs/header-docs.catalog.ts';
 export { HEADER_DOC_DEFINITIONS, resolveHeaderDoc } from './packs/header-docs/header-docs.catalog.ts';
 
-export { ContentProviderRegistry, splitNamespace } from '../doc-engine/index.ts';
-export type { ContentNode, ContentProvider, ContentResolutionRequest, NotFound } from '../doc-engine/index.ts';
-
 // NOTE: contentProviderRegistry is intentionally not re-exported from this barrel.
 // Import it from ./contentEngine to keep a single canonical ownership path.


### PR DESCRIPTION
### Motivation
- Keep documentation accurate after the catalog/provider moves so the extraction plan reflects the current code layout and prevents future drift. 
- Harden the extraction boundary by ensuring the app content barrel does not re-export engine runtime contracts, reducing churn when extracting `@calculogic/doc-engine`. 
- Make imports explicit so ownership (engine vs app content) is clear and future package repointing is mechanical. 

### Description
- Updated `doc/Architecture/DocEngineExtractionPlan.md` so the "Inventory: Current Doc Engine Touchpoints" lists packs, provider, composition root, and UI touchpoints at their new locations (`src/content/packs/...`, `src/content/providers/...`, `src/content/contentEngine.ts`, `src/components/GlobalHeaderShell/*`, `src/components/ContentDrawer/*`).
- Removed doc-engine runtime/type re-exports from `src/content/index.ts` so the content barrel now exposes only app-side artifacts (packs/providers) and no longer re-exports `ContentProviderRegistry`, `splitNamespace`, or engine types. 
- Codemodded imports in the content layer so engine contracts are imported from `src/doc-engine` and pack/payload types are imported from `src/content/packs`, specifically updating `src/content/contentResolutionAdapter.ts` and `src/content/contentEngine.ts` to be explicit. 
- Updated `doc/HealthChecks/FolderOrganizationHealthCheck-2026-02-14.md` with a short status block and refreshed path/ownership notes to mark the catalog/provider moves and barrel boundary tightening as completed. 

### Testing
- Ran `npm test -- --runInBand` and all tests passed (9/9 tests OK). 
- Ran `npm run build` and the build completed successfully. 
- Ran the import-sweep check for engine symbols imported via `src/*/content` and found no matches after the changes (verification command used in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925facac888331abdf08f555c0db04)