### PR TITLE
Refactor header doc IDs into pack-owned constants

### DIFF
--- a/doc/nl-doc-engine/cfg-contentResolver.md
+++ b/doc/nl-doc-engine/cfg-contentResolver.md
@@ -102,12 +102,15 @@ Promises, abortable operations, schema validation hooks.
 ## 6. Knowledge Concern (Reference Data)
 ### 6.1 Maps / Dictionaries
 - Provider-to-adapter map and node-type normalization map.
+- Header docs catalog keyed by pack-owned `HeaderDocId` constants from `header-doc.ids.ts`.
 
 ### 6.2 Constants
 - Cache TTL defaults, retry limits, resolver error codes.
+- Canonical header doc identifiers (`doc-build`, `doc-logic`, `doc-knowledge`, `doc-results`) exported from pack-owned ids module.
 
 ### 6.3 Shared / Global Reference
 - Shares schema version and provider capability constants with sibling configs.
+- Exposes docs namespace formatting helper (`toDocsContentId`) at the pack/provider boundary so shell components avoid inline id encoding details.
 
 ## 7. Results Concern (Outputs)
 ### 7.1 User-Facing Outputs
@@ -131,6 +134,7 @@ Promises, abortable operations, schema validation hooks.
 - `src/doc-engine/types.ts`
 - `src/doc-engine/registry.ts`
 - `src/content/providers/docs.provider.ts`
+- `src/content/packs/header-docs/header-doc.ids.ts`
 - `src/content/packs/header-docs/header-docs.catalog.ts`
 - `src/doc-engine/index.ts`
 

--- a/doc/nl-shell/shell-globalHeader.md
+++ b/doc/nl-shell/shell-globalHeader.md
@@ -182,6 +182,7 @@ Coordinates with cfg-appFrame to mount the active configuration, routes publish 
 ### 6.2 Constants
 - **[6.2.1] Primitive – "Header Tab Knowledge Base"**
   - Ordered array of concern tab definitions with hover summaries.
+  - Tab-to-doc bindings reference pack-owned doc ids (header-doc.ids) instead of inline literals.
 - **[6.2.2] Primitive – "Brand Wordmark Copy"**
   - Display string for Calculogic wordmark.
 - **[6.2.3] Primitive – "Brand Tagline Copy"**
@@ -195,6 +196,7 @@ Coordinates with cfg-appFrame to mount the active configuration, routes publish 
 
 ### 6.3 Shared / Global Reference
 - Exposes tab ordering and copy for cfg-appFrame to reference when rendering nested surfaces.
+- Defers doc-id semantics (identifier constants and optional `docs:` namespacing helper) to the header docs pack/provider boundary.
 
 ## 7. Results Concern (Outputs)
 ### 7.1 User-Facing Outputs

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -5,6 +5,7 @@
  * Responsibility: Compose semantic header frame with brand identity, tab navigation, and publish CTA anchors.
  * Invariants: Preserve tab order, retain ARIA roles, keep publish CTA as button element.
  */
+import { toDocsContentId } from '../../content/packs/header-docs/header-doc.ids.ts';
 import type { GlobalHeaderShellBuildBindings } from './GlobalHeaderShell.logic';
 
 type HeaderMode = GlobalHeaderShellBuildBindings['activeModeByTab']['build'];
@@ -342,7 +343,7 @@ export function GlobalHeaderShell({
                     docId={tab.docId}
                     onMouseEnter={() => hoverTab(tab.id)}
                     onFocus={() => hoverTab(tab.id)}
-                    onClick={() => openContent({ contentId: `docs:${tab.docId}` })}
+                    onClick={() => openContent({ contentId: toDocsContentId(tab.docId) })}
                     describedById={infoLabelId}
                   />
                 </div>

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
@@ -13,6 +13,8 @@
 // Constraints: Values must remain serializable and environment-agnostic.
 // ─────────────────────────────────────────────
 
+import { HEADER_DOC_IDS, type HeaderDocId } from '../../content/packs/header-docs/header-doc.ids.ts';
+
 // [6.1] shell-globalHeader · Primitive · "Header Tab Identifier Types"
 // Concern: Knowledge · Catalog: types.identifier
 // Notes: Enumerates supported tab and mode identifiers shared across concerns.
@@ -26,7 +28,7 @@ export interface HeaderTabDefinition {
   id: HeaderTabId;
   label: string;
   order: number;
-  docId: string;
+  docId: HeaderDocId;
   hoverSummary: string;
 }
 
@@ -42,7 +44,7 @@ export interface HeaderModeDefinition {
   id: HeaderModeId;
   label: string;
   description: string;
-  docId?: string;
+  docId?: HeaderDocId;
   hoverSummary?: string;
 }
 
@@ -58,25 +60,25 @@ export const HEADER_TAB_MAP: Record<HeaderTabId, HeaderTabMapEntry> = {
   build: {
     label: 'Build',
     order: 1,
-    docId: 'doc-build',
+    docId: HEADER_DOC_IDS.build,
     hoverSummary: 'Owns and arranges structure: containers, sub-containers, and atomic components.',
   },
   logic: {
     label: 'Logic',
     order: 2,
-    docId: 'doc-logic',
+    docId: HEADER_DOC_IDS.logic,
     hoverSummary: 'Defines calculations, conditions, validation rules, and interactions.',
   },
   knowledge: {
     label: 'Knowledge',
     order: 3,
-    docId: 'doc-knowledge',
+    docId: HEADER_DOC_IDS.knowledge,
     hoverSummary: 'Stores reusable traits, constants, and reference schemas.',
   },
   results: {
     label: 'Results',
     order: 4,
-    docId: 'doc-results',
+    docId: HEADER_DOC_IDS.results,
     hoverSummary: 'Derived outputs and summaries produced from structure + logic + knowledge.',
   },
 };
@@ -94,14 +96,14 @@ export const HEADER_MODE_DEFINITIONS: HeaderModeCatalog = {
       id: 'default',
       label: 'Build',
       description: 'Define and arrange containers, sub-containers, and atomic components.',
-      docId: 'doc-build',
+      docId: HEADER_DOC_IDS.build,
       hoverSummary: 'Build mode focuses on the structural hierarchy and anchor placement.',
     },
     style: {
       id: 'style',
       label: 'Style',
       description: 'Configure layout-affecting style for Build outputs (grouping, alignment, sizing).',
-      docId: 'doc-build',
+      docId: HEADER_DOC_IDS.build,
       hoverSummary: 'Style the structural outputs without mutating the canonical container tree.',
     },
   },
@@ -110,14 +112,14 @@ export const HEADER_MODE_DEFINITIONS: HeaderModeCatalog = {
       id: 'default',
       label: 'Results',
       description: 'Design and inspect derived outputs, scores, and summaries.',
-      docId: 'doc-results',
+      docId: HEADER_DOC_IDS.results,
       hoverSummary: 'Review the derived outputs before sharing or publishing.',
     },
     style: {
       id: 'style',
       label: 'Style',
       description: 'Configure layout-affecting style for Results outputs (cards, grouping, highlight rules).',
-      docId: 'doc-results',
+      docId: HEADER_DOC_IDS.results,
       hoverSummary: 'Adjust the presentation for results without redefining calculations.',
     },
   },

--- a/src/content/packs/header-docs/header-doc.ids.ts
+++ b/src/content/packs/header-docs/header-doc.ids.ts
@@ -1,0 +1,24 @@
+/**
+ * Configuration: cfg-contentResolver (Doc Engine Content Resolver Configuration)
+ * Concern File: Knowledge
+ * Source NL: doc/nl-doc-engine/cfg-contentResolver.md
+ * Responsibility: Define canonical doc identifiers and docs namespace formatting helpers for header content packs.
+ * Invariants: Doc ids remain stable across shell consumers; docs namespace prefixing is deterministic.
+ */
+
+export const HEADER_DOC_IDS = {
+  build: 'doc-build',
+  logic: 'doc-logic',
+  knowledge: 'doc-knowledge',
+  results: 'doc-results',
+} as const;
+
+export type HeaderDocId = (typeof HEADER_DOC_IDS)[keyof typeof HEADER_DOC_IDS];
+
+export function toDocsContentId(docId: string): string {
+  return `docs:${docId}`;
+}
+
+export function isHeaderDocId(docId: string): docId is HeaderDocId {
+  return Object.values(HEADER_DOC_IDS).includes(docId as HeaderDocId);
+}

--- a/src/content/packs/header-docs/header-docs.catalog.ts
+++ b/src/content/packs/header-docs/header-docs.catalog.ts
@@ -6,12 +6,14 @@
  * Invariants: Doc ids remain stable, default content metadata is deterministic, unknown doc ids resolve to null.
  */
 
+import { HEADER_DOC_IDS, isHeaderDocId, type HeaderDocId } from './header-doc.ids.ts';
+
 // [6.5.a] shell-globalHeader · Primitive · "Header Documentation Link Schema"
 // Concern: Knowledge · Catalog: schema.definition
 // Notes: Associates documentation links for cross-navigation inside modal output.
 export interface HeaderDocLink {
   label: string;
-  docId: string;
+  docId: HeaderDocId;
   description?: string;
 }
 
@@ -42,7 +44,7 @@ export interface ContentMeta {
 // Concern: Knowledge · Catalog: schema.definition
 // Notes: Source of truth for documentation payload consumed by results concern modal.
 export interface HeaderDocDefinition {
-  id: string;
+  id: HeaderDocId;
   concern: 'Build' | 'Logic' | 'Knowledge' | 'Results';
   title: string;
   summary: string;
@@ -77,9 +79,9 @@ function withDefaultContentMeta(definition: Omit<HeaderDocDefinition, 'contentMe
 // [6.5.d] shell-globalHeader · Primitive · "Header Documentation Definitions"
 // Concern: Knowledge · Catalog: data.collection
 // Notes: Encodes contextual documentation surfaced via info icon modal per concern.
-export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
-  'doc-build': withDefaultContentMeta({
-    id: 'doc-build',
+export const HEADER_DOC_DEFINITIONS: Record<HeaderDocId, HeaderDocDefinition> = {
+  [HEADER_DOC_IDS.build]: withDefaultContentMeta({
+    id: HEADER_DOC_IDS.build,
     concern: 'Build',
     title: 'Build Concern Overview',
     summary:
@@ -114,18 +116,18 @@ export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
     links: [
       {
         label: 'Jump to Logic guidance',
-        docId: 'doc-logic',
+        docId: HEADER_DOC_IDS.logic,
         description: 'Add state handling and conditional rules once structure is in place.',
       },
       {
         label: 'Review Results outputs',
-        docId: 'doc-results',
+        docId: HEADER_DOC_IDS.results,
         description: 'Confirm derived data and presentation targets before publishing.',
       },
     ],
   }),
-  'doc-logic': withDefaultContentMeta({
-    id: 'doc-logic',
+  [HEADER_DOC_IDS.logic]: withDefaultContentMeta({
+    id: HEADER_DOC_IDS.logic,
     concern: 'Logic',
     title: 'Logic Concern Overview',
     summary: 'Add calculations, conditions, and interaction rules. Keep heavy math in helpers and orchestrate workflows here.',
@@ -158,13 +160,13 @@ export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
     links: [
       {
         label: 'See Knowledge reference',
-        docId: 'doc-knowledge',
+        docId: HEADER_DOC_IDS.knowledge,
         description: 'Understand how shared schemas and traits feed your logic flows.',
       },
     ],
   }),
-  'doc-knowledge': withDefaultContentMeta({
-    id: 'doc-knowledge',
+  [HEADER_DOC_IDS.knowledge]: withDefaultContentMeta({
+    id: HEADER_DOC_IDS.knowledge,
     concern: 'Knowledge',
     title: 'Knowledge Concern Overview',
     summary: 'Store reusable traits, constants, and reference schemas to keep builds consistent.',
@@ -191,18 +193,18 @@ export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
     links: [
       {
         label: 'Review Build structure',
-        docId: 'doc-build',
+        docId: HEADER_DOC_IDS.build,
         description: 'See how Knowledge summaries surface within the structural concern.',
       },
       {
         label: 'Inspect Results outputs',
-        docId: 'doc-results',
+        docId: HEADER_DOC_IDS.results,
         description: 'Confirm how Knowledge data feeds final reporting.',
       },
     ],
   }),
-  'doc-results': withDefaultContentMeta({
-    id: 'doc-results',
+  [HEADER_DOC_IDS.results]: withDefaultContentMeta({
+    id: HEADER_DOC_IDS.results,
     concern: 'Results',
     title: 'Results Concern Overview',
     summary: 'Design and inspect derived outputs, scores, and summaries. Results/Style/ fine-tunes their presentation.',
@@ -236,12 +238,12 @@ export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
     links: [
       {
         label: 'Open Build guidance',
-        docId: 'doc-build',
+        docId: HEADER_DOC_IDS.build,
         description: 'Verify structural anchors before styling outcomes.',
       },
       {
         label: 'Reference Knowledge data',
-        docId: 'doc-knowledge',
+        docId: HEADER_DOC_IDS.knowledge,
         description: 'Ensure shared traits and constants align with your reporting.',
       },
     ],
@@ -252,5 +254,9 @@ export const HEADER_DOC_DEFINITIONS: Record<string, HeaderDocDefinition> = {
 // Concern: Knowledge · Catalog: data.accessor
 // Notes: Provides safe lookup for modal consumption with null fallback when docId is unknown.
 export function resolveHeaderDoc(docId: string): HeaderDocDefinition | null {
-  return HEADER_DOC_DEFINITIONS[docId] ?? null;
+  if (!isHeaderDocId(docId)) {
+    return null;
+  }
+
+  return HEADER_DOC_DEFINITIONS[docId];
 }

--- a/src/content/providers/docs.provider.ts
+++ b/src/content/providers/docs.provider.ts
@@ -7,11 +7,12 @@
  */
 
 import { HEADER_DOC_DEFINITIONS, type HeaderDocDefinition } from '../packs/header-docs/header-docs.catalog.ts';
+import { isHeaderDocId } from '../packs/header-docs/header-doc.ids.ts';
 import type { ContentProvider } from '../../doc-engine/types.ts';
 
 export const DOCS_PROVIDER: ContentProvider<unknown, HeaderDocDefinition> = {
   resolveContent: ({ contentId, anchorId }) => {
-    const doc = HEADER_DOC_DEFINITIONS[contentId];
+    const doc = isHeaderDocId(contentId) ? HEADER_DOC_DEFINITIONS[contentId] : null;
 
     if (!doc) {
       return {


### PR DESCRIPTION
### Motivation
- Decouple docs identifier semantics from the UI shell so the header shell no longer hardcodes doc IDs and the semantics live at the content pack/provider boundary for extraction and clearer boundaries. 
- Keep runtime behavior unchanged while making doc-id typing and namespacing explicit and reusable across the content/provider surface.

### Description
- Add `src/content/packs/header-docs/header-doc.ids.ts` exporting `HEADER_DOC_IDS`, `HeaderDocId` type, `toDocsContentId()` helper, and `isHeaderDocId()` type guard. 
- Update `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts` to import `HEADER_DOC_IDS` and use its constants and `HeaderDocId` typing for tab/mode `docId` values instead of inline string literals. 
- Update `src/content/packs/header-docs/header-docs.catalog.ts` to use `HeaderDocId` for types, key its `HEADER_DOC_DEFINITIONS` by `HEADER_DOC_IDS`, and guard lookups with `isHeaderDocId`. 
- Update `src/content/providers/docs.provider.ts` to validate incoming `contentId` with `isHeaderDocId` before indexing the catalog, and update `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx` to use `toDocsContentId(tab.docId)` instead of constructing ``docs:${tab.docId}`` inline. 
- Update NL skeleton docs (`doc/nl-shell/shell-globalHeader.md` and `doc/nl-doc-engine/cfg-contentResolver.md`) to record that doc-id semantics now live in the pack/provider boundary. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm test` and all tests passed (`9/9` tests OK). 
- Ran `npm run lint` and lint completed; two pre-existing `react-refresh` warnings remain in unrelated files and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992838b4654833183260b40212b91e6)