### PR TITLE
Harden pointer-drag cleanup and preserve incremental delta behavior

### DIFF
--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -26,7 +26,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 ### 2.3 Dependencies
 - UI libs: React, including `useState`, `useEffect`, and refs for DOM measurements.
 - Routing: shell-globalHeader tab state (read-only).
-- Shared hooks / utilities: Utility functions for clamp logic and keyboard handling.
+- Shared hooks / utilities: `src/shared/interaction/usePointerDrag.ts` for pointer drag lifecycle + capture and `src/shared/interaction/pointerDrag.ts` clamp helpers for panel bounds.
 
 ## 3. Build Concern (Structure)
 ### 3.0 Dependencies & Hierarchy Notes
@@ -151,7 +151,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - At max-width 960px collapse inspector column by default while keeping anchors present.
 
 ### 4.4 Interaction Styles
-- Hover/focus states for grips reuse `[4.2.15]` pseudo-elements.
+- Hover/focus states for grips reuse `[4.2.15]` pseudo-elements and include `touch-action: none` so touch drags do not scroll the page.
 - Tabs and buttons use focus outlines sourced from Knowledge-defined tokens.
 
 ## 5. Logic Concern (Workflow)
@@ -177,7 +177,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - **[5.2.2] Primitive – "Keyboard Resize Handler"**
   - Responds to arrow keys on grips for accessible resizing.
 - **[5.2.3] Primitive – "Pointer Resize Handler"**
-  - Manages pointerdown/move/up events across grips with typed listener registration to avoid `any` casts.
+  - Uses shared `usePointerDrag` with incremental deltas (`dx/dy` from last pointer position), pointer capture for section and side-panel grips, guarded capture release, and a shared cleanup path for `pointerup`/`pointercancel`/capture-loss; no window-level mouse/touch listener scaffolding remains in BuildSurface logic hooks.
 - **[5.2.4] Primitive – "Persistence Effect"**
   - Syncs panel dimensions and collapse state to `localStorage`.
 - **[5.2.5] Primitive – "Bindings Memo"**
@@ -189,11 +189,11 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - Derived booleans for collapsed states, computed widths/heights.
 
 ### 5.2.4 Side Effects
-- Global pointer event subscription for resizing, cleaned up on unmount.
+- Pointer capture lifecycle inside `usePointerDrag`, including unmount cleanup and temporary `document.body.style.userSelect` suppression during active drag.
 - `localStorage` updates triggered by state changes.
 
 ### 5.2.5 Workflows
-- Resize workflow: Grip interaction → `[5.2.3]` updates dimensions → `[5.2.4]` persists values → Build re-renders with new sizes.
+- Resize workflow: Grip `onPointerDown` (touch-action disabled on handle) → `[5.2.3]` computes deltas and updates dimensions → `[5.2.4]` persists values → Build re-renders with new sizes.
 - Collapse workflow: Toggle click → Section state updates → `[5.2.5]` memo recalculates bindings for Build.
 
 ## 6. Knowledge Concern (Reference Data)

--- a/src/shared/interaction/pointerDrag.ts
+++ b/src/shared/interaction/pointerDrag.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared Interaction Utility: pointerDrag
+ * Concern File: Logic
+ * Responsibility: Provide clamp and drag-time document selection helpers for pointer interactions.
+ * Invariants: Helpers are side-effect free except explicit document selection toggles.
+ */
+
+export function clampNumber(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function disableDocumentUserSelect() {
+  const previousUserSelect = document.body.style.userSelect;
+  document.body.style.userSelect = 'none';
+
+  return () => {
+    document.body.style.userSelect = previousUserSelect;
+  };
+}

--- a/src/shared/interaction/usePointerDrag.ts
+++ b/src/shared/interaction/usePointerDrag.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared Interaction Hook: usePointerDrag
+ * Concern File: Logic
+ * Responsibility: Encapsulate pointer drag lifecycle with optional pointer capture and user-select suppression.
+ * Invariants: Drag cleanup always detaches listeners and restores temporary document state.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { disableDocumentUserSelect } from './pointerDrag';
+
+export type PointerDragAxis = 'x' | 'y' | 'both';
+
+export type UsePointerDragOptions = {
+  axis: PointerDragAxis;
+  onStart?: (ctx: { startX: number; startY: number; pointerId: number }) => void;
+  onMove: (ctx: { dx: number; dy: number; x: number; y: number; pointerId: number }) => void;
+  onEnd?: (ctx: { pointerId: number }) => void;
+  disableUserSelectDuringDrag?: boolean;
+  setPointerCapture?: boolean;
+};
+
+type DragState = {
+  pointerId: number;
+  lastX: number;
+  lastY: number;
+  target: HTMLElement;
+  moveListener: (event: PointerEvent) => void;
+  upListener: (event: PointerEvent) => void;
+  cancelListener: (event: PointerEvent) => void;
+  lostCaptureListener: (event: PointerEvent) => void;
+};
+
+export function usePointerDrag(opts: UsePointerDragOptions): {
+  onPointerDown: (e: ReactPointerEvent) => void;
+  isDragging: boolean;
+} {
+  const {
+    axis,
+    onStart,
+    onMove,
+    onEnd,
+    disableUserSelectDuringDrag = true,
+    setPointerCapture = true,
+  } = opts;
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStateRef = useRef<DragState | null>(null);
+  const restoreUserSelectRef = useRef<(() => void) | null>(null);
+
+  const safeReleasePointerCapture = useCallback(
+    (target: HTMLElement, pointerId: number) => {
+      if (!setPointerCapture) return;
+
+      try {
+        if (target.hasPointerCapture(pointerId)) {
+          target.releasePointerCapture(pointerId);
+        }
+      } catch {
+        // WHY: Some browsers can throw if the capture was already lost/released.
+      }
+    },
+    [setPointerCapture]
+  );
+
+  const finishDrag = useCallback(
+    (pointerId: number) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== pointerId) return;
+
+      dragState.target.removeEventListener('pointermove', dragState.moveListener);
+      dragState.target.removeEventListener('pointerup', dragState.upListener);
+      dragState.target.removeEventListener('pointercancel', dragState.cancelListener);
+      dragState.target.removeEventListener('lostpointercapture', dragState.lostCaptureListener);
+
+      safeReleasePointerCapture(dragState.target, pointerId);
+
+      restoreUserSelectRef.current?.();
+      restoreUserSelectRef.current = null;
+
+      dragStateRef.current = null;
+      setIsDragging(false);
+      onEnd?.({ pointerId });
+    },
+    [onEnd, safeReleasePointerCapture]
+  );
+
+  useEffect(() => {
+    return () => {
+      const activeDrag = dragStateRef.current;
+      if (activeDrag) {
+        finishDrag(activeDrag.pointerId);
+      }
+    };
+  }, [finishDrag]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent) => {
+      if (!event.isPrimary) return;
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+
+      const target = event.currentTarget as HTMLElement;
+      const pointerId = event.pointerId;
+
+      if (dragStateRef.current) {
+        finishDrag(dragStateRef.current.pointerId);
+      }
+
+      if (setPointerCapture) {
+        try {
+          target.setPointerCapture(pointerId);
+        } catch {
+          // WHY: Fallback path keeps drag active even if capture is unavailable.
+        }
+      }
+
+      if (disableUserSelectDuringDrag) {
+        restoreUserSelectRef.current = disableDocumentUserSelect();
+      }
+
+      onStart?.({
+        startX: event.clientX,
+        startY: event.clientY,
+        pointerId,
+      });
+
+      const moveListener = (pointerMoveEvent: PointerEvent) => {
+        const activeDrag = dragStateRef.current;
+        if (!activeDrag || pointerMoveEvent.pointerId !== activeDrag.pointerId) return;
+
+        // WHY: Preserve previous behavior by applying incremental deltas from last move.
+        const rawDx = pointerMoveEvent.clientX - activeDrag.lastX;
+        const rawDy = pointerMoveEvent.clientY - activeDrag.lastY;
+        activeDrag.lastX = pointerMoveEvent.clientX;
+        activeDrag.lastY = pointerMoveEvent.clientY;
+
+        const dx = axis === 'y' ? 0 : rawDx;
+        const dy = axis === 'x' ? 0 : rawDy;
+
+        onMove({
+          dx,
+          dy,
+          x: pointerMoveEvent.clientX,
+          y: pointerMoveEvent.clientY,
+          pointerId: activeDrag.pointerId,
+        });
+      };
+
+      const upListener = (pointerUpEvent: PointerEvent) => {
+        if (pointerUpEvent.pointerId !== pointerId) return;
+        finishDrag(pointerId);
+      };
+
+      const cancelListener = (pointerCancelEvent: PointerEvent) => {
+        if (pointerCancelEvent.pointerId !== pointerId) return;
+        finishDrag(pointerId);
+      };
+
+      const lostCaptureListener = (lostCaptureEvent: PointerEvent) => {
+        if (lostCaptureEvent.pointerId !== pointerId) return;
+        finishDrag(pointerId);
+      };
+
+      dragStateRef.current = {
+        pointerId,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        target,
+        moveListener,
+        upListener,
+        cancelListener,
+        lostCaptureListener,
+      };
+      setIsDragging(true);
+
+      target.addEventListener('pointermove', moveListener);
+      target.addEventListener('pointerup', upListener);
+      target.addEventListener('pointercancel', cancelListener);
+      target.addEventListener('lostpointercapture', lostCaptureListener);
+    },
+    [axis, disableUserSelectDuringDrag, finishDrag, onMove, onStart, setPointerCapture]
+  );
+
+  return { onPointerDown, isDragging };
+}

--- a/src/tabs/build/BuildSurface.build.tsx
+++ b/src/tabs/build/BuildSurface.build.tsx
@@ -152,7 +152,11 @@ function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
         {renderSectionContent(binding.id)}
       </div>
       {binding.gripVisible && (
-        <div data-anchor={BUILD_ANCHORS.sectionGrip(binding.id)} {...binding.gripProps} />
+        <div
+          data-anchor={BUILD_ANCHORS.sectionGrip(binding.id)}
+          style={{ touchAction: 'none' }}
+          {...binding.gripProps}
+        />
       )}
     </section>
   );
@@ -188,7 +192,13 @@ export function BuildSurface({
   // [3.6.3] cfg-buildSurface · Primitive · "Catalog Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Exposes left panel resize separator connected to logic grip props.
-  const catalogGrip = <div data-anchor={anchors.leftGrip} {...leftPanel.gripProps} />;
+  const catalogGrip = (
+    <div
+      data-anchor={anchors.leftGrip}
+      style={{ touchAction: 'none' }}
+      {...leftPanel.gripProps}
+    />
+  );
 
   // [3.6.4] cfg-buildSurface · Subcontainer · "Preview Stage"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.region
@@ -204,7 +214,13 @@ export function BuildSurface({
   // [3.6.5] cfg-buildSurface · Primitive · "Inspector Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Provides resize handle between preview stage and inspector column.
-  const inspectorGrip = <div data-anchor={anchors.rightGrip} {...rightPanel.gripProps} />;
+  const inspectorGrip = (
+    <div
+      data-anchor={anchors.rightGrip}
+      style={{ touchAction: 'none' }}
+      {...rightPanel.gripProps}
+    />
+  );
 
   // [3.6.6] cfg-buildSurface · Subcontainer · "Inspector Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -6,7 +6,9 @@
  * Invariants: Anchor usage mirrors Build structure; persisted dimensions stay within safe bounds.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent, MouseEvent, TouchEvent, RefObject } from 'react';
+import type { KeyboardEvent, PointerEvent, RefObject } from 'react';
+import { clampNumber } from '../../shared/interaction/pointerDrag.ts';
+import { usePointerDrag } from '../../shared/interaction/usePointerDrag.ts';
 import { BUILD_ANCHORS } from './anchors.ts';
 import {
   defaultBuildSurfacePersistenceReporter,
@@ -56,8 +58,7 @@ export interface SectionLogicBinding {
     tabIndex: number;
     'aria-orientation': 'horizontal';
     'aria-label': string;
-    onMouseDown: (event: MouseEvent<HTMLDivElement>) => void;
-    onTouchStart: (event: TouchEvent<HTMLDivElement>) => void;
+    onPointerDown: (event: PointerEvent<HTMLDivElement>) => void;
     onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
   };
 }
@@ -70,8 +71,7 @@ interface LeftPanelLogic {
     tabIndex: number;
     'aria-orientation': 'vertical';
     'aria-label': string;
-    onMouseDown: (event: MouseEvent<HTMLDivElement>) => void;
-    onTouchStart: (event: TouchEvent<HTMLDivElement>) => void;
+    onPointerDown: (event: PointerEvent<HTMLDivElement>) => void;
     onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
   };
 }
@@ -92,8 +92,7 @@ interface RightPanelLogic {
     tabIndex: number;
     'aria-orientation': 'vertical';
     'aria-label': string;
-    onMouseDown: (event: MouseEvent<HTMLDivElement>) => void;
-    onTouchStart: (event: TouchEvent<HTMLDivElement>) => void;
+    onPointerDown: (event: PointerEvent<HTMLDivElement>) => void;
     onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
   };
 }
@@ -113,7 +112,7 @@ const SECTION_ORDER: SectionId[] = [
 ];
 
 export function clamp(value: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, value));
+  return clampNumber(value, min, max);
 }
 
 export function sectionTitle(id: SectionId) {
@@ -137,9 +136,7 @@ function useSectionLogic(
   { initialHeight, storageKey, gripVisible = true }: SectionLogicOptions
 ): SectionLogicBinding {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const lastY = useRef<number | null>(null);
   const previousHeight = useRef<number | null>(null);
-  const [isDragging, setDragging] = useState(false);
   const [state, setState] = useState<SectionState>(() =>
     readBuildSurfaceStorage(
       storageKey,
@@ -176,65 +173,21 @@ function useSectionLogic(
     });
   }, [state, storageKey]);
 
-  const onMove = useCallback((event: MouseEvent | TouchEvent) => {
-    const client =
-      'touches' in event && event.touches.length
-        ? event.touches[0].clientY
-        : (event as MouseEvent).clientY;
-    const previousClient = lastY.current ?? client;
-    const delta = client - previousClient;
-    lastY.current = client;
-    setState(previous => {
-      const min = 32;
-      const parent = containerRef.current?.parentElement;
-      const parentHeight = parent
-        ? parent.getBoundingClientRect().height
-        : window.innerHeight;
-      const max = Math.max(min, parentHeight - 2 * min);
-      const height = clamp(Math.round(previous.height + delta), min, max);
-      return { ...previous, height, collapsed: height <= min };
-    });
-  }, []);
-
-  const stopDrag = useCallback(() => {
-    window.removeEventListener('mousemove', onMove as unknown as EventListener);
-    window.removeEventListener('touchmove', onMove as unknown as EventListener);
-    window.removeEventListener('mouseup', stopDrag);
-    window.removeEventListener('touchend', stopDrag);
-    lastY.current = null;
-    setDragging(false);
-    document.body.style.userSelect = '';
-  }, [onMove]);
-
-  const startDrag = useCallback(
-    (clientY: number) => {
-      lastY.current = clientY;
-      setDragging(true);
-      document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', onMove as unknown as EventListener, { passive: true });
-      window.addEventListener('touchmove', onMove as unknown as EventListener, { passive: true });
-      window.addEventListener('mouseup', stopDrag);
-      window.addEventListener('touchend', stopDrag);
+  const sectionPointerDrag = usePointerDrag({
+    axis: 'y',
+    onMove: ({ dy }) => {
+      setState(previous => {
+        const min = 32;
+        const parent = containerRef.current?.parentElement;
+        const parentHeight = parent
+          ? parent.getBoundingClientRect().height
+          : window.innerHeight;
+        const max = Math.max(min, parentHeight - 2 * min);
+        const height = clamp(Math.round(previous.height + dy), min, max);
+        return { ...previous, height, collapsed: height <= min };
+      });
     },
-    [onMove, stopDrag]
-  );
-
-  useEffect(() => () => stopDrag(), [stopDrag]);
-
-  const onMouseDown = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      startDrag(event.clientY);
-    },
-    [startDrag]
-  );
-
-  const onTouchStart = useCallback(
-    (event: TouchEvent<HTMLDivElement>) => {
-      if (event.touches.length) startDrag(event.touches[0].clientY);
-    },
-    [startDrag]
-  );
+  });
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const step = event.shiftKey ? 24 : 8;
@@ -270,7 +223,7 @@ function useSectionLogic(
     containerRef,
     height: state.height,
     collapsed: state.collapsed,
-    isDragging,
+    isDragging: sectionPointerDrag.isDragging,
     gripVisible,
     headerButtonProps: {
       onClick: toggle,
@@ -286,8 +239,7 @@ function useSectionLogic(
       tabIndex: 0,
       'aria-orientation': 'horizontal',
       'aria-label': `Resize ${sectionTitle(id)}`,
-      onMouseDown,
-      onTouchStart,
+      onPointerDown: sectionPointerDrag.onPointerDown,
       onKeyDown,
     },
   };
@@ -320,69 +272,22 @@ function useLeftPanelLogic(): LeftPanelLogic {
       320
     )
   );
-  const [isDragging, setDragging] = useState(false);
-  const lastX = useRef<number | null>(null);
-
   useEffect(() => {
     writeBuildSurfaceStorage(STORAGE_KEY, () => {
       localStorage.setItem(STORAGE_KEY, String(width));
     });
   }, [width]);
 
-  const onMove = useCallback((event: MouseEvent | TouchEvent) => {
-    const client =
-      'touches' in event && event.touches.length
-        ? event.touches[0].clientX
-        : (event as MouseEvent).clientX;
-    const previous = lastX.current ?? client;
-    const delta = client - previous;
-    lastX.current = client;
-    setWidth(previousWidth => {
-      const min = 160;
-      const max = Math.max(min, window.innerWidth - 320);
-      return clamp(Math.round(previousWidth + delta), min, max);
-    });
-  }, []);
-
-  const stopDrag = useCallback(() => {
-    window.removeEventListener('mousemove', onMove as unknown as EventListener);
-    window.removeEventListener('touchmove', onMove as unknown as EventListener);
-    window.removeEventListener('mouseup', stopDrag);
-    window.removeEventListener('touchend', stopDrag);
-    lastX.current = null;
-    setDragging(false);
-    document.body.style.userSelect = '';
-  }, [onMove]);
-
-  const startDrag = useCallback(
-    (clientX: number) => {
-      lastX.current = clientX;
-      setDragging(true);
-      document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', onMove as unknown as EventListener, { passive: true });
-      window.addEventListener('touchmove', onMove as unknown as EventListener, { passive: true });
-      window.addEventListener('mouseup', stopDrag);
-      window.addEventListener('touchend', stopDrag);
+  const leftPointerDrag = usePointerDrag({
+    axis: 'x',
+    onMove: ({ dx }) => {
+      setWidth(previousWidth => {
+        const min = 160;
+        const max = Math.max(min, window.innerWidth - 320);
+        return clamp(Math.round(previousWidth + dx), min, max);
+      });
     },
-    [onMove, stopDrag]
-  );
-
-  useEffect(() => () => stopDrag(), [stopDrag]);
-
-  const onMouseDown = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      startDrag(event.clientX);
-    },
-    [startDrag]
-  );
-
-  const onTouchStart = useCallback(
-    (event: TouchEvent<HTMLDivElement>) => {
-      if (event.touches.length) startDrag(event.touches[0].clientX);
-    },
-    [startDrag]
-  );
+  });
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const step = event.shiftKey ? 32 : 8;
@@ -399,14 +304,13 @@ function useLeftPanelLogic(): LeftPanelLogic {
 
   return {
     width,
-    isDragging,
+    isDragging: leftPointerDrag.isDragging,
     gripProps: {
       role: 'separator',
       tabIndex: 0,
       'aria-orientation': 'vertical',
       'aria-label': 'Resize left panel',
-      onMouseDown,
-      onTouchStart,
+      onPointerDown: leftPointerDrag.onPointerDown,
       onKeyDown,
     },
   };
@@ -444,8 +348,6 @@ function useRightPanelLogic(): RightPanelLogic {
       { width: 320, collapsed: false }
     )
   );
-  const [isDragging, setDragging] = useState(false);
-  const lastX = useRef<number | null>(null);
   const previousWidth = useRef<number | null>(null);
 
   useEffect(() => {
@@ -454,61 +356,17 @@ function useRightPanelLogic(): RightPanelLogic {
     });
   }, [state]);
 
-  const onMove = useCallback((event: MouseEvent | TouchEvent) => {
-    const client =
-      'touches' in event && event.touches.length
-        ? event.touches[0].clientX
-        : (event as MouseEvent).clientX;
-    const previous = lastX.current ?? client;
-    const delta = previous - client;
-    lastX.current = client;
-    setState(previousState => {
-      const min = 40;
-      const max = Math.max(160, window.innerWidth - 320);
-      const width = clamp(Math.round(previousState.width + delta), min, max);
-      return { ...previousState, width };
-    });
-  }, []);
-
-  const stopDrag = useCallback(() => {
-    window.removeEventListener('mousemove', onMove as unknown as EventListener);
-    window.removeEventListener('touchmove', onMove as unknown as EventListener);
-    window.removeEventListener('mouseup', stopDrag);
-    window.removeEventListener('touchend', stopDrag);
-    lastX.current = null;
-    setDragging(false);
-    document.body.style.userSelect = '';
-  }, [onMove]);
-
-  const startDrag = useCallback(
-    (clientX: number) => {
-      lastX.current = clientX;
-      setDragging(true);
-      document.body.style.userSelect = 'none';
-      window.addEventListener('mousemove', onMove as unknown as EventListener, { passive: true });
-      window.addEventListener('touchmove', onMove as unknown as EventListener, { passive: true });
-      window.addEventListener('mouseup', stopDrag);
-      window.addEventListener('touchend', stopDrag);
+  const rightPointerDrag = usePointerDrag({
+    axis: 'x',
+    onMove: ({ dx }) => {
+      setState(previousState => {
+        const min = 40;
+        const max = Math.max(160, window.innerWidth - 320);
+        const width = clamp(Math.round(previousState.width - dx), min, max);
+        return { ...previousState, width };
+      });
     },
-    [onMove, stopDrag]
-  );
-
-  useEffect(() => () => stopDrag(), [stopDrag]);
-
-  const onMouseDown = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      startDrag(event.clientX);
-    },
-    [startDrag]
-  );
-
-  const onTouchStart = useCallback(
-    (event: TouchEvent<HTMLDivElement>) => {
-      if (event.touches.length) startDrag(event.touches[0].clientX);
-    },
-    [startDrag]
-  );
+  });
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const step = event.shiftKey ? 32 : 8;
@@ -538,7 +396,7 @@ function useRightPanelLogic(): RightPanelLogic {
   return {
     width: state.width,
     collapsed: state.collapsed,
-    isDragging,
+    isDragging: rightPointerDrag.isDragging,
     toggle,
     contentAnchor: BUILD_ANCHORS.rightContent,
     gripProps: {
@@ -546,8 +404,7 @@ function useRightPanelLogic(): RightPanelLogic {
       tabIndex: 0,
       'aria-orientation': 'vertical',
       'aria-label': 'Resize right panel',
-      onMouseDown,
-      onTouchStart,
+      onPointerDown: rightPointerDrag.onPointerDown,
       onKeyDown,
     },
   };


### PR DESCRIPTION
### Motivation
- Fix robustness issues in the shared pointer-drag primitive by ensuring pointer capture is released safely and capture-loss is handled by the same cleanup path as `pointerup`/`pointercancel` to avoid thrown errors and leaked state. 
- Preserve the original incremental-delta semantics used by resize handlers (compute `dx/dy` from the previous pointer position via `lastX/lastY`) to prevent direction/acceleration regressions when resizing side panels. 
- Keep repository NL-first conventions by updating the `cfg-buildSurface` skeleton to document the updated pointer semantics before changing implementation.

### Description
- Hardened `src/shared/interaction/usePointerDrag.ts` with a `safeReleasePointerCapture` helper, added a `lostpointercapture` listener routed to the same `finishDrag` cleanup, and kept `lastX/lastY`-based incremental delta computation in the `move` handler. 
- Replaced prior mouse/touch scaffolding with the new pointer hook in `src/tabs/build/BuildSurface.logic.ts` and switched grip handlers to `onPointerDown`, importing `usePointerDrag` and `clampNumber`. 
- Added `style={{ touchAction: 'none' }}` to resize grips in `src/tabs/build/BuildSurface.build.tsx` so touch drags do not scroll the page. 
- Updated `doc/nl-config/cfg-buildSurface.md` to explicitly document incremental delta semantics and the unified pointer-capture cleanup lifecycle for `[5.2.3] Pointer Resize Handler` so NL and code remain aligned.

### Testing
- Ran `npm run lint` which completed with no errors and two pre-existing `react-refresh/only-export-components` warnings. 
- Ran `npm run build` which completed successfully (`tsc -b` + `vite build`). 
- Launched the dev server and ran a Playwright script to capture a screenshot of the Build surface, which produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69929c223f1c833187a1b5462a84c035)