### PR TITLE
Fix pointer-drag capture fallback and normalize TS imports

### DIFF
--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -177,7 +177,8 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - **[5.2.2] Primitive – "Keyboard Resize Handler"**
   - Responds to arrow keys on grips for accessible resizing.
 - **[5.2.3] Primitive – "Pointer Resize Handler"**
-  - Uses shared `usePointerDrag` with incremental deltas (`dx/dy` from last pointer position), pointer capture for section and side-panel grips, guarded capture release, and a shared cleanup path for `pointerup`/`pointercancel`/capture-loss; no window-level mouse/touch listener scaffolding remains in BuildSurface logic hooks.
+  - Uses shared `usePointerDrag` with incremental deltas (`dx/dy` from last pointer position), pointer capture for section and side-panel grips, guarded capture release, and a shared cleanup path for `pointerup`/`pointercancel`/capture-loss.
+  - When pointer capture is unavailable or fails to activate, `usePointerDrag` temporarily attaches move/up/cancel listeners to `window` so drag lifecycles stay active after the pointer exits the handle.
 - **[5.2.4] Primitive – "Persistence Effect"**
   - Syncs panel dimensions and collapse state to `localStorage`.
 - **[5.2.5] Primitive – "Bindings Memo"**

--- a/src/shared/interaction/usePointerDrag.ts
+++ b/src/shared/interaction/usePointerDrag.ts
@@ -19,14 +19,17 @@ export type UsePointerDragOptions = {
   setPointerCapture?: boolean;
 };
 
+type DragListenerHost = HTMLElement | Window;
+
 type DragState = {
   pointerId: number;
   lastX: number;
   lastY: number;
   target: HTMLElement;
-  moveListener: (event: PointerEvent) => void;
-  upListener: (event: PointerEvent) => void;
-  cancelListener: (event: PointerEvent) => void;
+  listenerHost: DragListenerHost;
+  moveListener: EventListener;
+  upListener: EventListener;
+  cancelListener: EventListener;
   lostCaptureListener: (event: PointerEvent) => void;
 };
 
@@ -66,9 +69,9 @@ export function usePointerDrag(opts: UsePointerDragOptions): {
       const dragState = dragStateRef.current;
       if (!dragState || dragState.pointerId !== pointerId) return;
 
-      dragState.target.removeEventListener('pointermove', dragState.moveListener);
-      dragState.target.removeEventListener('pointerup', dragState.upListener);
-      dragState.target.removeEventListener('pointercancel', dragState.cancelListener);
+      dragState.listenerHost.removeEventListener('pointermove', dragState.moveListener);
+      dragState.listenerHost.removeEventListener('pointerup', dragState.upListener);
+      dragState.listenerHost.removeEventListener('pointercancel', dragState.cancelListener);
       dragState.target.removeEventListener('lostpointercapture', dragState.lostCaptureListener);
 
       safeReleasePointerCapture(dragState.target, pointerId);
@@ -104,9 +107,11 @@ export function usePointerDrag(opts: UsePointerDragOptions): {
         finishDrag(dragStateRef.current.pointerId);
       }
 
+      let captureActive = false;
       if (setPointerCapture) {
         try {
           target.setPointerCapture(pointerId);
+          captureActive = target.hasPointerCapture(pointerId);
         } catch {
           // WHY: Fallback path keeps drag active even if capture is unavailable.
         }
@@ -122,7 +127,10 @@ export function usePointerDrag(opts: UsePointerDragOptions): {
         pointerId,
       });
 
-      const moveListener = (pointerMoveEvent: PointerEvent) => {
+      const moveListener: EventListener = event => {
+        if (!(event instanceof PointerEvent)) return;
+
+        const pointerMoveEvent = event;
         const activeDrag = dragStateRef.current;
         if (!activeDrag || pointerMoveEvent.pointerId !== activeDrag.pointerId) return;
 
@@ -144,12 +152,18 @@ export function usePointerDrag(opts: UsePointerDragOptions): {
         });
       };
 
-      const upListener = (pointerUpEvent: PointerEvent) => {
+      const upListener: EventListener = event => {
+        if (!(event instanceof PointerEvent)) return;
+
+        const pointerUpEvent = event;
         if (pointerUpEvent.pointerId !== pointerId) return;
         finishDrag(pointerId);
       };
 
-      const cancelListener = (pointerCancelEvent: PointerEvent) => {
+      const cancelListener: EventListener = event => {
+        if (!(event instanceof PointerEvent)) return;
+
+        const pointerCancelEvent = event;
         if (pointerCancelEvent.pointerId !== pointerId) return;
         finishDrag(pointerId);
       };
@@ -159,11 +173,14 @@ export function usePointerDrag(opts: UsePointerDragOptions): {
         finishDrag(pointerId);
       };
 
+      const listenerHost: DragListenerHost = captureActive ? target : window;
+
       dragStateRef.current = {
         pointerId,
         lastX: event.clientX,
         lastY: event.clientY,
         target,
+        listenerHost,
         moveListener,
         upListener,
         cancelListener,
@@ -171,9 +188,9 @@ export function usePointerDrag(opts: UsePointerDragOptions): {
       };
       setIsDragging(true);
 
-      target.addEventListener('pointermove', moveListener);
-      target.addEventListener('pointerup', upListener);
-      target.addEventListener('pointercancel', cancelListener);
+      listenerHost.addEventListener('pointermove', moveListener);
+      listenerHost.addEventListener('pointerup', upListener);
+      listenerHost.addEventListener('pointercancel', cancelListener);
       target.addEventListener('lostpointercapture', lostCaptureListener);
     },
     [axis, disableUserSelectDuringDrag, finishDrag, onMove, onStart, setPointerCapture]

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -7,8 +7,8 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent, PointerEvent, RefObject } from 'react';
-import { clampNumber } from '../../shared/interaction/pointerDrag.ts';
-import { usePointerDrag } from '../../shared/interaction/usePointerDrag.ts';
+import { clampNumber } from '../../shared/interaction/pointerDrag';
+import { usePointerDrag } from '../../shared/interaction/usePointerDrag';
 import { BUILD_ANCHORS } from './anchors.ts';
 import {
   defaultBuildSurfacePersistenceReporter,


### PR DESCRIPTION
### Motivation
- Remove brittle extensioned imports that can cause toolchain resolution issues and follow TypeScript import idioms. 
- Improve reliability of the shared `usePointerDrag` primitive so drags continue when pointer capture is unsupported or fails. 

### Description
- Replaced extensioned imports in Build Surface logic from `.../pointerDrag.ts` and `.../usePointerDrag.ts` to extensionless imports to avoid tooling friction and keep idiomatic TS imports. 
- Enhanced `usePointerDrag` to check whether capture actually became active after `setPointerCapture` and, when not active, attach `pointermove`/`pointerup`/`pointercancel` listeners to `window` for the drag duration so the pointer lifecycle stays alive when the pointer leaves the handle. 
- Introduced a `listenerHost` abstraction in the drag state to add/remove listeners from either the original `target` or `window`, and updated listener types and runtime `instanceof PointerEvent` guards to keep TypeScript happy and avoid incorrect event assumptions. 
- Updated the `cfg-buildSurface` NL skeleton (`doc/nl-config/cfg-buildSurface.md`) to document the capture-failure fallback behavior prior to implementation. 

### Testing
- Ran `npm run lint`, which completed successfully (existing unrelated ESLint warnings remain but no errors). 
- Ran `npm run build`, which completed successfully and produced a production build without type or runtime listener errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a14e4b148331a8c6da0ce4cfff75)