### PR TITLE
Decouple doc-engine seams for extraction readiness

### DIFF
--- a/doc/nl-doc-engine/cfg-providerRegistry.md
+++ b/doc/nl-doc-engine/cfg-providerRegistry.md
@@ -93,6 +93,7 @@ Map/set operations, validation guards, optional event emitter for registry chang
 ### 6.2 Constants
 - Registry event names, default provider list, compatibility policy version.
 - App-level singleton registry initialized in `src/content/contentEngine.ts` with explicit `docs` namespace registration.
+- Public API boundary for host consumers is `src/doc-engine/index.ts` only; host files should not deep-import `registry.ts` or `types.ts`.
 
 ### 6.3 Shared / Global Reference
 - Exports provider metadata used by resolver and drawer.
@@ -128,6 +129,7 @@ Map/set operations, validation guards, optional event emitter for registry chang
 ### 9.3 Integration
 - Instantiated at the application composition root before resolver boot so adapter lookup is available at runtime.
 - Module exports remain side-effect free; provider registration is performed explicitly by the consumer/composition layer.
+- Registry behavior tests use local mock providers and depend only on `src/doc-engine/*` so package extraction does not pull app providers.
 
 ## 10. Implementation Passes
 ### 10.1 Pass Mapping
@@ -139,3 +141,4 @@ Map/set operations, validation guards, optional event emitter for registry chang
 ### 10.2 Export Checklist
 - Atomic hierarchy is explicit for CCPP annotation mapping.
 - Provider definitions include schema compatibility metadata.
+- Extraction checklist is documented next to `src/doc-engine` to guide repointing host imports to `@calculogic/doc-engine`.

--- a/src/content/providers/docs.provider.ts
+++ b/src/content/providers/docs.provider.ts
@@ -8,7 +8,7 @@
 
 import { HEADER_DOC_DEFINITIONS, type HeaderDocDefinition } from '../packs/header-docs/header-docs.catalog.ts';
 import { isHeaderDocId } from '../packs/header-docs/header-doc.ids.ts';
-import type { ContentProvider } from '../../doc-engine/types.ts';
+import type { ContentProvider } from '../../doc-engine/index.ts';
 
 export const DOCS_PROVIDER: ContentProvider<unknown, HeaderDocDefinition> = {
   resolveContent: ({ contentId, anchorId }) => {

--- a/src/doc-engine/EXTRACTION-CHECKLIST.md
+++ b/src/doc-engine/EXTRACTION-CHECKLIST.md
@@ -1,0 +1,47 @@
+# Doc Engine Extraction + Repoint Imports Checklist
+
+Use this checklist when moving doc-engine into an external package (planned name: `@calculogic/doc-engine`).
+
+## 1) Public API surface to preserve
+
+The package should export the same API currently provided by `src/doc-engine/index.ts`:
+
+- `ContentProviderRegistry`
+- `splitNamespace`
+- `ContentNode`
+- `ContentProvider`
+- `ContentResolutionRequest`
+- `NotFound`
+
+## 2) Interface import rule after extraction
+
+In the interface app, import doc-engine APIs from the package root only:
+
+- ✅ `import { ContentProviderRegistry } from '@calculogic/doc-engine';`
+- ❌ `import { ContentProviderRegistry } from '@calculogic/doc-engine/registry';`
+- ❌ `import type { ContentProvider } from '@calculogic/doc-engine/types';`
+
+Until extraction is complete, keep using the same discipline with the local barrel:
+
+- ✅ `from '../doc-engine/index.ts'`
+- ❌ `from '../doc-engine/registry.ts'`
+- ❌ `from '../doc-engine/types.ts'`
+
+## 3) Explicitly not part of doc-engine package
+
+Do **not** move these into `@calculogic/doc-engine`:
+
+- App content providers under `src/content/providers/*`
+- App content packs under `src/content/packs/*`
+- UI adapters/composition under `src/content/*`
+- UI drawer components under `src/components/ContentDrawer/*`
+
+These are host-app responsibilities that consume doc-engine contracts.
+
+## 4) Repointing steps
+
+1. Create `@calculogic/doc-engine` with the `src/doc-engine/*` module contents.
+2. Publish/consume package in the interface repository.
+3. Replace local imports from `src/doc-engine/index.ts` with `@calculogic/doc-engine`.
+4. Keep provider registration in app composition (for example, `src/content/contentEngine.ts`).
+5. Run tests to ensure registry behavior (`namespaced ids`, provider resolution, and `not_found`) still passes.

--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -1,11 +1,30 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ContentProviderRegistry, splitNamespace } from '../src/doc-engine/index.ts';
-import { DOCS_PROVIDER } from '../src/content/providers/docs.provider.ts';
+const createMockDocsProvider = () => ({
+  resolveContent: ({ contentId, anchorId }) => {
+    if (contentId !== 'doc-build') {
+      return {
+        type: 'not_found',
+        namespace: 'docs',
+        contentId,
+        reason: 'Documentation entry was not found.',
+      };
+    }
+
+    return {
+      type: 'content',
+      namespace: 'docs',
+      contentId,
+      anchorId,
+      payload: { title: 'Build Docs' },
+    };
+  },
+});
 
 const createRegistry = () => {
   const registry = new ContentProviderRegistry();
-  registry.registerProvider('docs', DOCS_PROVIDER);
+  registry.registerProvider('docs', createMockDocsProvider());
   return registry;
 };
 


### PR DESCRIPTION
### Motivation
- Make the doc-engine boundary real so the engine can be extracted without dragging app-specific providers or UI code. 
- Remove test and type-import couplings to host application code so `src/doc-engine/*` becomes a standalone public surface.
- Record the repointing checklist next to the engine to guide future extraction and enforce import discipline.

### Description
- Replace the registry test dependency on the app `DOCS_PROVIDER` with a tiny in-test mock provider so the test imports only `src/doc-engine/*` and `node:test` (`test/content-provider-registry.test.mjs`).
- Change the app provider typing import to use the doc-engine barrel (`src/doc-engine/index.ts`) instead of deep-importing `types.ts` (`src/content/providers/docs.provider.ts`).
- Add `src/doc-engine/EXTRACTION-CHECKLIST.md` documenting the public API surface, future package repointing (`@calculogic/doc-engine`), and what must remain in the host app (providers, packs, UI adapters).
- Update the doc-engine NL skeleton (`doc/nl-doc-engine/cfg-providerRegistry.md`) to record the barrel-only import discipline and to note that registry tests must be app-agnostic.

### Testing
- Ran the doc-engine registry unit test with `node --test --experimental-strip-types test/content-provider-registry.test.mjs` and it passed (all assertions for `splitNamespace`, registered-provider resolution, and `not_found` succeeded).
- Performed a repository scan for deep imports and confirmed no host files import `doc-engine/registry.ts` or `doc-engine/types.ts` (imports now go through `src/doc-engine/index.ts`).
- Ran the full test script `npm test` which surfaced an unrelated module-resolution failure in `test/build-surface-utils.test.mjs` (existing host test requiring a path-extension fix) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fe9dc8d48331b954d263e7347da7)