### PR TITLE
Fix Node test module resolution in build surface logic imports

### DIFF
--- a/src/shared/interaction/usePointerDrag.ts
+++ b/src/shared/interaction/usePointerDrag.ts
@@ -6,7 +6,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
-import { disableDocumentUserSelect } from './pointerDrag';
+import { disableDocumentUserSelect } from './pointerDrag.ts';
 
 export type PointerDragAxis = 'x' | 'y' | 'both';
 

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -7,8 +7,8 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent, PointerEvent, RefObject } from 'react';
-import { clampNumber } from '../../shared/interaction/pointerDrag';
-import { usePointerDrag } from '../../shared/interaction/usePointerDrag';
+import { clampNumber } from '../../shared/interaction/pointerDrag.ts';
+import { usePointerDrag } from '../../shared/interaction/usePointerDrag.ts';
 import { BUILD_ANCHORS } from './anchors.ts';
 import {
   defaultBuildSurfacePersistenceReporter,


### PR DESCRIPTION
### Motivation
- `npm test` failed under Node's ESM test runner because extensionless relative imports in the build-surface logic path were not resolved by Node the same way the bundler does. 
- Tests under `node --test --experimental-strip-types` must be resolvable by Node to keep CI reliable without changing runtime app behavior. 
- Doc-engine tests must remain app-agnostic and import only the doc-engine barrel so the doc-engine package can be extracted later without pulling app providers.

### Description
- Added explicit `.ts` extensions to relative imports used by the BuildSurface logic path to satisfy Node ESM resolution without changing runtime behavior by editing `src/tabs/build/BuildSurface.logic.ts` and the transitive import in `src/shared/interaction/usePointerDrag.ts`. 
- Files changed: `src/tabs/build/BuildSurface.logic.ts` (changed imports to `.../pointerDrag.ts` and `.../usePointerDrag.ts`) and `src/shared/interaction/usePointerDrag.ts` (changed import to `./pointerDrag.ts`).
- Kept all other code and interfaces intact; this is a minimal, standards-aligned fix that preserves existing behavior and bundler compatibility. 
- Verified doc-engine tests already use an in-test mock provider and import only `src/doc-engine/index.ts`, preserving barrel-only imports required for extraction.

### Testing
- Ran `npm test -- --runInBand`, which completed with all tests passing (`ok 9`, `fail 0`).
- Ran repository scans (`rg`) to confirm there are no app-level deep imports of `doc-engine/registry` or `doc-engine/types`, and that tests import `src/doc-engine/index.ts` only, which succeeded. 
- The change was committed and validated locally; tests pass and doc-engine tests remain decoupled from app provider code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995018f93b08331bf94fb31533fee54)