### PR TITLE
Unify doc-engine resolution union and drawer error handling

### DIFF
--- a/doc/nl-doc-engine/cfg-contentDrawer.md
+++ b/doc/nl-doc-engine/cfg-contentDrawer.md
@@ -26,9 +26,13 @@
 
 ### §5.2 Subcontainer — "Resolver Pipeline"
 - Resolve through app-level content provider registry using request `{ contentId, anchorId }`.
-- Keep doc-engine resolver outputs in their canonical discriminated union (`type: 'content' | 'not_found'`) for drawer rendering.
-- Use adapter narrowing only for docs namespace eligibility (unsupported namespaces still return `null`).
-- Keep unresolved namespace/invalid ids deterministic (`null` or existing missing fallback) so UI behavior remains stable.
+- Keep doc-engine resolver outputs in a single canonical discriminated union (`found | not_found | unsupported_namespace | invalid_ref`) for drawer rendering.
+- `resolveDrawerContent` must never return `null`; it maps/forwards resolver outcomes 1:1.
+- Drawer UI copy is explicit per outcome:
+  - `found` → render resolved docs content.
+  - `not_found` → show missing content message.
+  - `unsupported_namespace` → show namespace not yet supported in drawer.
+  - `invalid_ref` → show malformed/bad link message.
 
 ### §5.3 Primitive — "Anchor Scroll Handler"
 - Scroll to anchor when content resolves.

--- a/doc/nl-doc-engine/cfg-contentResolver.md
+++ b/doc/nl-doc-engine/cfg-contentResolver.md
@@ -18,9 +18,13 @@ Accepts provider adapters registered by `cfg-providerRegistry`, emits nodes conf
 
 ## 2. Configuration Contracts
 ### 2.1 TypeScript Interfaces
-- `ContentResolverRequest` – provider key, scope descriptor, optional query/filter options.
-- `ContentResolverResponse` – resolved node collection, diagnostics, and cursor data.
-- `ContentResolverState` – cache slots, in-flight status, and error envelope.
+- `ContentResolutionRequest` – namespaced content reference (`namespace:id`), optional anchor, optional context.
+- `ContentResolutionResult` – discriminated union with exactly four outcomes:
+  - `found`
+  - `not_found`
+  - `unsupported_namespace`
+  - `invalid_ref`
+- `ParsedContentRef` – namespace parser result (`valid` vs `invalid_ref`) used by resolver guards and contract tests.
 
 ### 2.2 Data & State Requirements
 - Local state: per-request lifecycle state and cache index.
@@ -97,6 +101,7 @@ Promises, abortable operations, schema validation hooks.
 - **[5.3.3] Primitive – "Normalization Execution"**
 - **[5.3.4] Primitive – "Validation Gate"**
 - **[5.3.5] Primitive – "Fallback Resolution"**
+  - Resolver preserves semantic failure causes: malformed IDs return `invalid_ref`, unknown namespaces return `unsupported_namespace`, known namespace misses return `not_found`.
 - **[5.3.6] Primitive – "Response Emit"**
 
 ## 6. Knowledge Concern (Reference Data)
@@ -155,4 +160,4 @@ Promises, abortable operations, schema validation hooks.
 
 ### 10.2 Export Checklist
 - Containers/subcontainers/primitives are explicitly enumerated for CCPP mapping.
-- All resolver outputs reference `ContentNode` schema contract.
+- Resolver exports a single `ContentResolutionResult` union so consumers never branch on `null` for resolution outcomes.

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -61,27 +61,36 @@ export default function ContentDrawer() {
     return null;
   }
 
-  if (!resolution || resolution.type === 'not_found') {
-    const missingLabel = resolution
-      ? `${resolution.namespace ? `${resolution.namespace}:` : ''}${resolution.contentId}`
-      : activeContentId;
+  if (resolution && resolution.type !== 'found') {
+    const fallback =
+      resolution.type === 'not_found'
+        ? {
+            title: 'Missing content',
+            summary: `The provider could not resolve ${resolution.namespace}:${resolution.contentId}.`,
+          }
+        : resolution.type === 'unsupported_namespace'
+          ? {
+              title: 'Not supported in this drawer yet',
+              summary: `Namespace ${resolution.namespace} is not supported in this drawer yet.`,
+            }
+          : {
+              title: 'Bad link / malformed id',
+              summary: `The requested content reference (${resolution.contentId}) is malformed.`,
+            };
 
     return (
       // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
       // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
-      // Notes: Missing-resolution shell mirrors standard framing for predictable UX.
+      // Notes: Error-resolution shell mirrors standard framing for predictable UX.
       <aside className="content-drawer" data-anchor="content-drawer">
         {/* [3.2] cfg-contentDrawer · Subcontainer · "Drawer Header"
             Concern: Build · Parent: "Content Drawer Shell" · Catalog: layout.header
-            Notes: Shows not-found summary and recovery control. */}
+            Notes: Shows typed resolution summary and recovery control. */}
         <div className="content-drawer__header">
           <div>
             <p className="content-drawer__eyebrow">Content</p>
-            <h2 className="content-drawer__title">Content not found</h2>
-            <p className="content-drawer__summary">
-              The provider could not resolve{' '}
-              <strong>{missingLabel}</strong>.
-            </p>
+            <h2 className="content-drawer__title">{fallback.title}</h2>
+            <p className="content-drawer__summary">{fallback.summary}</p>
           </div>
           <button type="button" className="content-drawer__close" onClick={closeContent}>
             Close
@@ -91,7 +100,7 @@ export default function ContentDrawer() {
     );
   }
 
-  if (resolution.type === 'content' && resolution.namespace === 'docs') {
+  if (resolution && resolution.type === 'found' && resolution.namespace === 'docs') {
     const doc = resolution.payload;
     return (
       // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"

--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -2,35 +2,32 @@
  * Configuration: cfg-contentDrawer (Content Drawer Configuration)
  * Concern File: Logic
  * Source NL: doc/nl-doc-engine/cfg-contentDrawer.md
- * Responsibility: Narrow app-level registry resolution to docs namespace while preserving doc-engine union discriminants.
- * Invariants: Resolver outputs preserve type tags, docs namespace is required, invalid or unsupported ids map to null.
+ * Responsibility: Narrow app-level registry resolution to drawer-supported payloads while preserving canonical resolver outcomes.
+ * Invariants: Resolver outputs preserve type tags, adapter never returns null.
  */
 
-import type { ContentNode, NotFound } from '../doc-engine/index.ts';
+import type {
+  ContentResolutionResult,
+  FoundContent,
+  InvalidRef,
+  NotFound,
+  UnsupportedNamespace,
+} from '../doc-engine/index.ts';
 import type { HeaderDocDefinition } from './packs/header-docs/header-docs.catalog.ts';
 import { contentProviderRegistry } from './contentEngine';
 
-export type DrawerContentResolution = ContentNode<HeaderDocDefinition> | NotFound;
+export type DrawerContentResolution =
+  | FoundContent<HeaderDocDefinition>
+  | NotFound
+  | UnsupportedNamespace
+  | InvalidRef;
 
 // [5.2] cfg-contentDrawer · Primitive · "Registry Resolution Adapter"
 // Concern: Logic · Parent: "Resolver Pipeline" · Catalog: resolver.adapter
-// Notes: Preserves canonical resolver discriminants while narrowing to docs namespace.
-export function resolveDrawerContent(
-  contentId: string,
-  anchorId?: string,
-): DrawerContentResolution | null {
-  const resolved = contentProviderRegistry.resolveContent({
+// Notes: Returns canonical doc-engine union unchanged so drawer callers handle outcomes consistently.
+export function resolveDrawerContent(contentId: string, anchorId?: string): DrawerContentResolution {
+  return contentProviderRegistry.resolveContent({
     contentId,
     anchorId,
-  });
-
-  if (resolved.namespace !== 'docs') {
-    return null;
-  }
-
-  if (resolved.type === 'content') {
-    return resolved as ContentNode<HeaderDocDefinition>;
-  }
-
-  return resolved;
+  }) as ContentResolutionResult<HeaderDocDefinition>;
 }

--- a/src/content/providers/docs.provider.ts
+++ b/src/content/providers/docs.provider.ts
@@ -24,7 +24,7 @@ export const DOCS_PROVIDER: ContentProvider<unknown, HeaderDocDefinition> = {
     }
 
     return {
-      type: 'content',
+      type: 'found',
       namespace: 'docs',
       contentId,
       anchorId,

--- a/src/doc-engine/index.ts
+++ b/src/doc-engine/index.ts
@@ -1,4 +1,13 @@
-import { ContentProviderRegistry, splitNamespace } from './registry.ts';
+import { ContentProviderRegistry, parseContentRef, splitNamespace } from './registry.ts';
 
-export { ContentProviderRegistry, splitNamespace };
-export type { ContentNode, ContentProvider, ContentResolutionRequest, NotFound } from './types.ts';
+export { ContentProviderRegistry, parseContentRef, splitNamespace };
+export type {
+  ContentProvider,
+  ContentResolutionRequest,
+  ContentResolutionResult,
+  FoundContent,
+  InvalidRef,
+  NotFound,
+  ParsedContentRef,
+  UnsupportedNamespace,
+} from './types.ts';

--- a/src/doc-engine/registry.ts
+++ b/src/doc-engine/registry.ts
@@ -2,11 +2,16 @@
  * Configuration: cfg-contentResolver (Doc Engine Content Resolver Configuration)
  * Concern File: Build
  * Source NL: doc/nl-doc-engine/cfg-contentResolver.md
- * Responsibility: Provide a namespaced provider registry and resolver pipeline for normalized content nodes.
- * Invariants: Content ids must include namespace prefix, registered providers are keyed by namespace, unresolved ids return NotFound.
+ * Responsibility: Provide a namespaced provider registry and resolver pipeline for normalized content outcomes.
+ * Invariants: Content ids must include namespace prefix, registered providers are keyed by namespace, resolver never returns null.
  */
 
-import type { ContentNode, ContentProvider, ContentResolutionRequest, NotFound } from './types.ts';
+import type {
+  ContentProvider,
+  ContentResolutionRequest,
+  ContentResolutionResult,
+  ParsedContentRef,
+} from './types.ts';
 
 export class ContentProviderRegistry {
   private providers = new Map<string, ContentProvider>();
@@ -19,22 +24,19 @@ export class ContentProviderRegistry {
     contentId,
     anchorId,
     context,
-  }: ContentResolutionRequest<Context>): ContentNode | NotFound {
-    const { namespace, resolvedId } = splitNamespace(contentId);
+  }: ContentResolutionRequest<Context>): ContentResolutionResult {
+    const parsedRef = parseContentRef(contentId);
 
-    if (!namespace || !resolvedId) {
-      return {
-        type: 'not_found',
-        contentId,
-        reason: 'Content id must include a namespace prefix.',
-      };
+    if (parsedRef.type === 'invalid_ref') {
+      return parsedRef;
     }
 
+    const { namespace, resolvedId } = parsedRef;
     const provider = this.providers.get(namespace);
 
     if (!provider) {
       return {
-        type: 'not_found',
+        type: 'unsupported_namespace',
         namespace,
         contentId: resolvedId,
         reason: `No content provider registered for namespace: ${namespace}.`,
@@ -45,13 +47,37 @@ export class ContentProviderRegistry {
   }
 }
 
-export function splitNamespace(contentId: string): { namespace: string | null; resolvedId: string | null } {
+// [3.3.2] cfg-contentResolver · Primitive · "Scope Parser"
+// Concern: Build · Parent: "Request Intake" · Catalog: resolver.parser
+// Notes: Produces valid parsed refs or canonical invalid_ref outcomes used by resolver contract tests.
+export function parseContentRef(contentId: string): ParsedContentRef {
   const [namespace, ...rest] = contentId.split(':');
   const resolvedId = rest.join(':');
 
   if (!namespace || !resolvedId) {
+    return {
+      type: 'invalid_ref',
+      contentId,
+      reason: 'Content id must include a namespace prefix and payload (namespace:id).',
+    };
+  }
+
+  return {
+    type: 'valid',
+    namespace,
+    resolvedId,
+  };
+}
+
+export function splitNamespace(contentId: string): { namespace: string | null; resolvedId: string | null } {
+  const parsedRef = parseContentRef(contentId);
+
+  if (parsedRef.type === 'invalid_ref') {
     return { namespace: null, resolvedId: null };
   }
 
-  return { namespace, resolvedId };
+  return {
+    namespace: parsedRef.namespace,
+    resolvedId: parsedRef.resolvedId,
+  };
 }

--- a/src/doc-engine/types.ts
+++ b/src/doc-engine/types.ts
@@ -2,7 +2,7 @@
  * Configuration: cfg-contentResolver (Doc Engine Content Resolver Configuration)
  * Concern File: Knowledge
  * Source NL: doc/nl-doc-engine/cfg-contentResolver.md
- * Responsibility: Define normalized contracts for content resolution requests, content payloads, and not-found responses.
+ * Responsibility: Define normalized contracts for content resolution requests and typed resolution outcomes.
  * Invariants: Types preserve namespace-prefixed content addressing and deterministic resolver response union.
  */
 
@@ -12,8 +12,8 @@ export interface ContentResolutionRequest<Context = unknown> {
   context?: Context;
 }
 
-export interface ContentNode<Payload = unknown> {
-  type: 'content';
+export interface FoundContent<Payload = unknown> {
+  type: 'found';
   namespace: string;
   contentId: string;
   anchorId?: string;
@@ -22,11 +22,46 @@ export interface ContentNode<Payload = unknown> {
 
 export interface NotFound {
   type: 'not_found';
-  namespace?: string;
+  namespace: string;
   contentId: string;
   reason: string;
 }
 
+export interface UnsupportedNamespace {
+  type: 'unsupported_namespace';
+  namespace: string;
+  contentId: string;
+  reason: string;
+}
+
+export interface InvalidRef {
+  type: 'invalid_ref';
+  contentId: string;
+  reason: string;
+}
+
+export type ContentResolutionResult<Payload = unknown> =
+  | FoundContent<Payload>
+  | NotFound
+  | UnsupportedNamespace
+  | InvalidRef;
+
+export interface ParsedContentRefValid {
+  type: 'valid';
+  namespace: string;
+  resolvedId: string;
+}
+
+export interface ParsedContentRefInvalid {
+  type: 'invalid_ref';
+  contentId: string;
+  reason: string;
+}
+
+export type ParsedContentRef = ParsedContentRefValid | ParsedContentRefInvalid;
+
 export interface ContentProvider<Context = unknown, Payload = unknown> {
-  resolveContent: (request: ContentResolutionRequest<Context>) => ContentNode<Payload> | NotFound;
+  resolveContent: (
+    request: ContentResolutionRequest<Context>,
+  ) => FoundContent<Payload> | NotFound;
 }

--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { ContentProviderRegistry, splitNamespace } from '../src/doc-engine/index.ts';
+import { ContentProviderRegistry, parseContentRef, splitNamespace } from '../src/doc-engine/index.ts';
+
 const createMockDocsProvider = () => ({
   resolveContent: ({ contentId, anchorId }) => {
     if (contentId !== 'doc-build') {
@@ -13,7 +14,7 @@ const createMockDocsProvider = () => ({
     }
 
     return {
-      type: 'content',
+      type: 'found',
       namespace: 'docs',
       contentId,
       anchorId,
@@ -28,29 +29,23 @@ const createRegistry = () => {
   return registry;
 };
 
-test('splitNamespace parses namespaced ids', () => {
-  assert.deepEqual(splitNamespace('docs:doc-build'), {
+test('parseContentRef parses docs:abc as valid', () => {
+  assert.deepEqual(parseContentRef('docs:abc'), {
+    type: 'valid',
     namespace: 'docs',
-    resolvedId: 'doc-build',
+    resolvedId: 'abc',
   });
 });
 
-test('splitNamespace rejects ids without a namespace payload', () => {
-  assert.deepEqual(splitNamespace('docs:'), { namespace: null, resolvedId: null });
-  assert.deepEqual(splitNamespace('doc-build'), { namespace: null, resolvedId: null });
+test('parseContentRef returns invalid_ref for abc', () => {
+  assert.deepEqual(parseContentRef('abc'), {
+    type: 'invalid_ref',
+    contentId: 'abc',
+    reason: 'Content id must include a namespace prefix and payload (namespace:id).',
+  });
 });
 
-test('contentProviderRegistry resolves registered docs content', () => {
-  const contentProviderRegistry = createRegistry();
-  const resolved = contentProviderRegistry.resolveContent({ contentId: 'docs:doc-build' });
-  assert.equal(resolved.type, 'content');
-  if (resolved.type === 'content') {
-    assert.equal(resolved.namespace, 'docs');
-    assert.equal(resolved.contentId, 'doc-build');
-  }
-});
-
-test('contentProviderRegistry returns not_found for missing docs content', () => {
+test('contentProviderRegistry resolves unknown id in docs to not_found', () => {
   const contentProviderRegistry = createRegistry();
   const missing = contentProviderRegistry.resolveContent({ contentId: 'docs:not-real' });
   assert.deepEqual(missing, {
@@ -59,4 +54,23 @@ test('contentProviderRegistry returns not_found for missing docs content', () =>
     contentId: 'not-real',
     reason: 'Documentation entry was not found.',
   });
+});
+
+test('contentProviderRegistry resolves otherns:x to unsupported_namespace when only docs provider exists', () => {
+  const contentProviderRegistry = createRegistry();
+  const unsupported = contentProviderRegistry.resolveContent({ contentId: 'otherns:x' });
+  assert.deepEqual(unsupported, {
+    type: 'unsupported_namespace',
+    namespace: 'otherns',
+    contentId: 'x',
+    reason: 'No content provider registered for namespace: otherns.',
+  });
+});
+
+test('splitNamespace preserves backward-compatible parsing shape', () => {
+  assert.deepEqual(splitNamespace('docs:doc-build'), {
+    namespace: 'docs',
+    resolvedId: 'doc-build',
+  });
+  assert.deepEqual(splitNamespace('docs:'), { namespace: null, resolvedId: null });
 });


### PR DESCRIPTION
### Motivation
- Make content resolution deterministic across the engine and UI so callers never receive `null` and can handle outcomes consistently. 
- Surface explicit failure reasons (`invalid_ref`, `unsupported_namespace`, `not_found`) at the registry level so adapters/providers only need to report `found` vs `not_found`.
- Update the drawer UI to render explicit messaging per typed outcome to remove mystery states and simplify future namespaces/providers.

### Description
- Introduced a single typed union `ContentResolutionResult` in `src/doc-engine/types.ts` with four variants: `found`, `not_found`, `unsupported_namespace`, and `invalid_ref` and added `ParsedContentRef` types for parser results.
- Reworked the provider registry in `src/doc-engine/registry.ts` to export `parseContentRef`, return `invalid_ref` for malformed ids, return `unsupported_namespace` when no provider is registered, and forward provider-level misses as `not_found`.
- Updated `src/content/providers/docs.provider.ts` to emit `type: 'found'` on success to match the new union.
- Replaced the old adapter behavior with `src/content/contentResolutionAdapter.ts` so `resolveDrawerContent` returns the canonical doc-engine union unchanged (never `null`) and uses the typed `FoundContent<HeaderDocDefinition>` for payload typing.
- Updated `src/components/ContentDrawer/ContentDrawer.tsx` to explicitly handle each non-`found` outcome with clear UI copy: `not_found` → missing content, `unsupported_namespace` → not supported here yet, `invalid_ref` → bad link / malformed id, and to continue rendering docs payloads for `found` + `docs` namespace.
- Updated NL skeletons in `doc/nl-doc-engine/cfg-contentResolver.md` and `doc/nl-doc-engine/cfg-contentDrawer.md` to reflect the new contract and drawer responsibilities, and updated `src/doc-engine/index.ts` exports to match the new types.
- Added/updated fast contract tests in `test/content-provider-registry.test.mjs` to cover: `parseContentRef('docs:abc')` (valid), `parseContentRef('abc')` (`invalid_ref`), unknown docs id → `not_found`, and unsupported namespace → `unsupported_namespace`.

### Testing
- Ran `npm test` (node test suite) and all new and existing tests passed.
- Ran `npm run lint` which completed successfully (there are two unrelated lint warnings in other files but no failures).
- Ran `npm run build` which completed successfully and produced the production build artifacts.
- Attempted a Playwright capture during validation but the browser process crashed in this environment (SIGSEGV); this does not affect the automated unit/CI tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960afb6a8c8331bcde84345f794529)