### PR TITLE
Harden resolver outcomes and make drawer resolution always return a typed result

### DIFF
--- a/doc/nl-doc-engine/cfg-contentDrawer.md
+++ b/doc/nl-doc-engine/cfg-contentDrawer.md
@@ -26,13 +26,14 @@
 
 ### §5.2 Subcontainer — "Resolver Pipeline"
 - Resolve through app-level content provider registry using request `{ contentId, anchorId }`.
-- Keep doc-engine resolver outputs in a single canonical discriminated union (`found | not_found | unsupported_namespace | invalid_ref`) for drawer rendering.
-- `resolveDrawerContent` must never return `null`; it maps/forwards resolver outcomes 1:1.
+- Keep resolver outputs explicit for drawer rendering (`found | invalid_ref | no_provider | missing_content | unsupported_namespace`).
+- `resolveDrawerContent` never returns `null`; it always emits a typed outcome.
+- Drawer adapter maps non-doc namespaces to `unsupported_namespace` while preserving doc-engine outcomes for docs refs.
 - Drawer UI copy is explicit per outcome:
   - `found` → render resolved docs content.
-  - `not_found` → show missing content message.
-  - `unsupported_namespace` → show namespace not yet supported in drawer.
   - `invalid_ref` → show malformed/bad link message.
+  - `unsupported_namespace` / `no_provider` → show not supported here yet message.
+  - `missing_content` → show content not found message.
 
 ### §5.3 Primitive — "Anchor Scroll Handler"
 - Scroll to anchor when content resolves.

--- a/doc/nl-doc-engine/cfg-contentResolver.md
+++ b/doc/nl-doc-engine/cfg-contentResolver.md
@@ -19,11 +19,9 @@ Accepts provider adapters registered by `cfg-providerRegistry`, emits nodes conf
 ## 2. Configuration Contracts
 ### 2.1 TypeScript Interfaces
 - `ContentResolutionRequest` – namespaced content reference (`namespace:id`), optional anchor, optional context.
-- `ContentResolutionResult` – discriminated union with exactly four outcomes:
+- `ContentResolutionResult` – discriminated union with exactly two top-level branches:
   - `found`
-  - `not_found`
-  - `unsupported_namespace`
-  - `invalid_ref`
+  - `NotFound` (`invalid_ref | no_provider | missing_content`)
 - `ParsedContentRef` – namespace parser result (`valid` vs `invalid_ref`) used by resolver guards and contract tests.
 
 ### 2.2 Data & State Requirements
@@ -101,7 +99,7 @@ Promises, abortable operations, schema validation hooks.
 - **[5.3.3] Primitive – "Normalization Execution"**
 - **[5.3.4] Primitive – "Validation Gate"**
 - **[5.3.5] Primitive – "Fallback Resolution"**
-  - Resolver preserves semantic failure causes: malformed IDs return `invalid_ref`, unknown namespaces return `unsupported_namespace`, known namespace misses return `not_found`.
+  - Resolver preserves semantic failure causes as explicit discriminants: malformed IDs return `invalid_ref`, unknown namespaces return `no_provider`, known namespace misses return `missing_content`.
 - **[5.3.6] Primitive – "Response Emit"**
 
 ## 6. Knowledge Concern (Reference Data)
@@ -161,3 +159,4 @@ Promises, abortable operations, schema validation hooks.
 ### 10.2 Export Checklist
 - Containers/subcontainers/primitives are explicitly enumerated for CCPP mapping.
 - Resolver exports a single `ContentResolutionResult` union so consumers never branch on `null` for resolution outcomes.
+- `NotFound` remains the failure branch but carries explicit discriminants (`invalid_ref | no_provider | missing_content`) to scale namespace/provider composition without ambiguous reason strings.

--- a/src/components/ContentDrawer/ContentDrawer.tsx
+++ b/src/components/ContentDrawer/ContentDrawer.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useMemo, useRef } from 'react';
 import { resolveDrawerContent } from '../../content/contentResolutionAdapter';
+import type { HeaderDocDefinition } from '../../content';
 import { toAnchorId } from './ContentDrawer.anchor';
 import { useContentState } from '../../content/ContentContext';
 import './ContentDrawer.css';
@@ -34,6 +35,7 @@ export default function ContentDrawer() {
   // [5.2] cfg-contentDrawer · Subcontainer · "Resolver Pipeline"
   // Concern: Logic · Parent: "Drawer State Orchestrator" · Catalog: resolver.pipeline
   // Notes: Active content id is resolved lazily and memoized per id transition.
+
   const resolution = useMemo(
     () =>
       activeContentId
@@ -57,27 +59,12 @@ export default function ContentDrawer() {
     }
   }, [activeContentAnchorId, activeContentId]);
 
-  if (!activeContentId) {
+  if (!activeContentId || !resolution) {
     return null;
   }
 
-  if (resolution && resolution.type !== 'found') {
-    const fallback =
-      resolution.type === 'not_found'
-        ? {
-            title: 'Missing content',
-            summary: `The provider could not resolve ${resolution.namespace}:${resolution.contentId}.`,
-          }
-        : resolution.type === 'unsupported_namespace'
-          ? {
-              title: 'Not supported in this drawer yet',
-              summary: `Namespace ${resolution.namespace} is not supported in this drawer yet.`,
-            }
-          : {
-              title: 'Bad link / malformed id',
-              summary: `The requested content reference (${resolution.contentId}) is malformed.`,
-            };
 
+  if (resolution.type === 'invalid_ref') {
     return (
       // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
       // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
@@ -89,8 +76,8 @@ export default function ContentDrawer() {
         <div className="content-drawer__header">
           <div>
             <p className="content-drawer__eyebrow">Content</p>
-            <h2 className="content-drawer__title">{fallback.title}</h2>
-            <p className="content-drawer__summary">{fallback.summary}</p>
+            <h2 className="content-drawer__title">Bad link / malformed id</h2>
+            <p className="content-drawer__summary">The requested content reference ({resolution.contentId}) is malformed.</p>
           </div>
           <button type="button" className="content-drawer__close" onClick={closeContent}>
             Close
@@ -100,8 +87,42 @@ export default function ContentDrawer() {
     );
   }
 
-  if (resolution && resolution.type === 'found' && resolution.namespace === 'docs') {
-    const doc = resolution.payload;
+  if (resolution.type === 'unsupported_namespace' || resolution.type === 'no_provider') {
+    return (
+      <aside className="content-drawer" data-anchor="content-drawer">
+        <div className="content-drawer__header">
+          <div>
+            <p className="content-drawer__eyebrow">Content</p>
+            <h2 className="content-drawer__title">Not supported in this drawer yet</h2>
+            <p className="content-drawer__summary">Namespace {resolution.namespace} is not supported in this drawer yet.</p>
+          </div>
+          <button type="button" className="content-drawer__close" onClick={closeContent}>
+            Close
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  if (resolution.type === 'missing_content') {
+    return (
+      <aside className="content-drawer" data-anchor="content-drawer">
+        <div className="content-drawer__header">
+          <div>
+            <p className="content-drawer__eyebrow">Content</p>
+            <h2 className="content-drawer__title">Content not found</h2>
+            <p className="content-drawer__summary">The provider could not resolve {resolution.namespace}:{resolution.contentId}.</p>
+          </div>
+          <button type="button" className="content-drawer__close" onClick={closeContent}>
+            Close
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  if (resolution.type === 'found' && resolution.namespace === 'docs') {
+    const doc = resolution.payload as HeaderDocDefinition;
     return (
       // [3.1] cfg-contentDrawer · Container · "Content Drawer Shell"
       // Concern: Build · Parent: "Content Drawer Configuration" · Catalog: layout.shell
@@ -181,5 +202,18 @@ export default function ContentDrawer() {
     );
   }
 
-  return null;
+  return (
+    <aside className="content-drawer" data-anchor="content-drawer">
+      <div className="content-drawer__header">
+        <div>
+          <p className="content-drawer__eyebrow">Content</p>
+          <h2 className="content-drawer__title">Not supported in this drawer yet</h2>
+          <p className="content-drawer__summary">Namespace {resolution.namespace} is not supported in this drawer yet.</p>
+        </div>
+        <button type="button" className="content-drawer__close" onClick={closeContent}>
+          Close
+        </button>
+      </div>
+    </aside>
+  );
 }

--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -10,24 +10,49 @@ import type {
   ContentResolutionResult,
   FoundContent,
   InvalidRef,
-  NotFound,
-  UnsupportedNamespace,
+  MissingContent,
+  NoProvider,
 } from '../doc-engine/index.ts';
-import type { HeaderDocDefinition } from './packs/header-docs/header-docs.catalog.ts';
 import { contentProviderRegistry } from './contentEngine';
 
 export type DrawerContentResolution =
-  | FoundContent<HeaderDocDefinition>
-  | NotFound
-  | UnsupportedNamespace
-  | InvalidRef;
+  | FoundContent
+  | MissingContent
+  | NoProvider
+  | InvalidRef
+  | {
+      type: 'unsupported_namespace';
+      namespace: string;
+      contentId: string;
+      reason: string;
+    };
 
 // [5.2] cfg-contentDrawer · Primitive · "Registry Resolution Adapter"
 // Concern: Logic · Parent: "Resolver Pipeline" · Catalog: resolver.adapter
-// Notes: Returns canonical doc-engine union unchanged so drawer callers handle outcomes consistently.
+// Notes: Returns canonical doc-engine union for docs and explicit unsupported_namespace for non-doc namespaces.
 export function resolveDrawerContent(contentId: string, anchorId?: string): DrawerContentResolution {
-  return contentProviderRegistry.resolveContent({
+  const resolution = contentProviderRegistry.resolveContent({
     contentId,
     anchorId,
-  }) as ContentResolutionResult<HeaderDocDefinition>;
+  }) as ContentResolutionResult;
+
+  if (resolution.type === 'found' && resolution.namespace !== 'docs') {
+    return {
+      type: 'unsupported_namespace',
+      namespace: resolution.namespace,
+      contentId: resolution.contentId,
+      reason: `Namespace ${resolution.namespace} is not supported in this drawer yet.`,
+    };
+  }
+
+  if (resolution.type === 'no_provider') {
+    return {
+      type: 'unsupported_namespace',
+      namespace: resolution.namespace,
+      contentId: resolution.contentId,
+      reason: `Namespace ${resolution.namespace} is not supported in this drawer yet.`,
+    };
+  }
+
+  return resolution;
 }

--- a/src/content/providers/docs.provider.ts
+++ b/src/content/providers/docs.provider.ts
@@ -3,7 +3,7 @@
  * Concern File: Logic
  * Source NL: doc/nl-doc-engine/cfg-contentResolver.md
  * Responsibility: Resolve docs namespace requests from the header docs catalog.
- * Invariants: Missing docs return deterministic not_found payloads matching existing runtime behavior.
+ * Invariants: Missing docs return deterministic missing_content payloads matching existing runtime behavior.
  */
 
 import { HEADER_DOC_DEFINITIONS, type HeaderDocDefinition } from '../packs/header-docs/header-docs.catalog.ts';
@@ -16,7 +16,7 @@ export const DOCS_PROVIDER: ContentProvider<unknown, HeaderDocDefinition> = {
 
     if (!doc) {
       return {
-        type: 'not_found',
+        type: 'missing_content',
         namespace: 'docs',
         contentId,
         reason: 'Documentation entry was not found.',

--- a/src/doc-engine/index.ts
+++ b/src/doc-engine/index.ts
@@ -7,7 +7,8 @@ export type {
   ContentResolutionResult,
   FoundContent,
   InvalidRef,
+  MissingContent,
+  NoProvider,
   NotFound,
   ParsedContentRef,
-  UnsupportedNamespace,
 } from './types.ts';

--- a/src/doc-engine/registry.ts
+++ b/src/doc-engine/registry.ts
@@ -36,7 +36,7 @@ export class ContentProviderRegistry {
 
     if (!provider) {
       return {
-        type: 'unsupported_namespace',
+        type: 'no_provider',
         namespace,
         contentId: resolvedId,
         reason: `No content provider registered for namespace: ${namespace}.`,

--- a/src/doc-engine/types.ts
+++ b/src/doc-engine/types.ts
@@ -20,12 +20,27 @@ export interface FoundContent<Payload = unknown> {
   payload: Payload;
 }
 
-export interface NotFound {
-  type: 'not_found';
+export interface InvalidRef {
+  type: 'invalid_ref';
+  contentId: string;
+  reason: string;
+}
+
+export interface NoProvider {
+  type: 'no_provider';
   namespace: string;
   contentId: string;
   reason: string;
 }
+
+export interface MissingContent {
+  type: 'missing_content';
+  namespace: string;
+  contentId: string;
+  reason: string;
+}
+
+export type NotFound = InvalidRef | NoProvider | MissingContent;
 
 export interface UnsupportedNamespace {
   type: 'unsupported_namespace';
@@ -34,17 +49,7 @@ export interface UnsupportedNamespace {
   reason: string;
 }
 
-export interface InvalidRef {
-  type: 'invalid_ref';
-  contentId: string;
-  reason: string;
-}
-
-export type ContentResolutionResult<Payload = unknown> =
-  | FoundContent<Payload>
-  | NotFound
-  | UnsupportedNamespace
-  | InvalidRef;
+export type ContentResolutionResult<Payload = unknown> = FoundContent<Payload> | NotFound;
 
 export interface ParsedContentRefValid {
   type: 'valid';
@@ -63,5 +68,5 @@ export type ParsedContentRef = ParsedContentRefValid | ParsedContentRefInvalid;
 export interface ContentProvider<Context = unknown, Payload = unknown> {
   resolveContent: (
     request: ContentResolutionRequest<Context>,
-  ) => FoundContent<Payload> | NotFound;
+  ) => FoundContent<Payload> | MissingContent;
 }

--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -6,7 +6,7 @@ const createMockDocsProvider = () => ({
   resolveContent: ({ contentId, anchorId }) => {
     if (contentId !== 'doc-build') {
       return {
-        type: 'not_found',
+        type: 'missing_content',
         namespace: 'docs',
         contentId,
         reason: 'Documentation entry was not found.',
@@ -45,22 +45,22 @@ test('parseContentRef returns invalid_ref for abc', () => {
   });
 });
 
-test('contentProviderRegistry resolves unknown id in docs to not_found', () => {
+test('contentProviderRegistry resolves unknown id in docs to missing_content', () => {
   const contentProviderRegistry = createRegistry();
   const missing = contentProviderRegistry.resolveContent({ contentId: 'docs:not-real' });
   assert.deepEqual(missing, {
-    type: 'not_found',
+    type: 'missing_content',
     namespace: 'docs',
     contentId: 'not-real',
     reason: 'Documentation entry was not found.',
   });
 });
 
-test('contentProviderRegistry resolves otherns:x to unsupported_namespace when only docs provider exists', () => {
+test('contentProviderRegistry resolves otherns:x to no_provider when only docs provider exists', () => {
   const contentProviderRegistry = createRegistry();
   const unsupported = contentProviderRegistry.resolveContent({ contentId: 'otherns:x' });
   assert.deepEqual(unsupported, {
-    type: 'unsupported_namespace',
+    type: 'no_provider',
     namespace: 'otherns',
     contentId: 'x',
     reason: 'No content provider registered for namespace: otherns.',


### PR DESCRIPTION
### Motivation
- Remove the ambiguous `null`/reason-string collapse in content resolution so callers can reliably branch on explicit discriminants rather than ad-hoc strings. 
- Split the prior `not_found`/`unsupported_namespace` semantics into explicit discriminants `invalid_ref`, `no_provider`, and `missing_content` so provider/namespace reasoning scales without ambiguity. 
- Ensure the drawer adapter never returns `null` so UI code cannot silently ignore unresolved references and receives a predictable typed outcome. 

### Description
- Replace the doc-engine contract types in `src/doc-engine/types.ts` to expose `InvalidRef`, `NoProvider`, and `MissingContent` and model `NotFound = InvalidRef | NoProvider | MissingContent`, keeping `FoundContent` as the success branch. 
- Update the provider registry in `src/doc-engine/registry.ts` to return `no_provider` when a namespace is not registered, and update the docs provider in `src/content/providers/docs.provider.ts` to return `missing_content` on misses. 
- Replace the drawer adapter in `src/content/contentResolutionAdapter.ts` so `resolveDrawerContent` always returns a typed outcome, maps non-doc/unsupported namespaces to `unsupported_namespace`, and remove the unused `HeaderDocDefinition` import. 
- Update `src/components/ContentDrawer/ContentDrawer.tsx` to handle `invalid_ref`, `unsupported_namespace`/`no_provider`, and `missing_content` with explicit UI messages and keep the `found` (docs) rendering path intact while preserving proper hook ordering. 
- Update NL skeletons (`doc/nl-doc-engine/cfg-contentResolver.md`, `doc/nl-doc-engine/cfg-contentDrawer.md`) and the registry unit tests (`test/content-provider-registry.test.mjs`) to reflect the new typed outcomes. 

### Testing
- Ran lint with `npm run lint` and the code passed with no ESLint errors (warnings only). 
- Ran unit tests with `npm test` and all tests passed (`10/10` tests). 
- Built the app with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69961021ea008331b23043e3a1776b26)