### PR TITLE
Convergence health check + persistence contract baseline hardening

### DIFF
--- a/doc/HealthChecks/ConvergenceHealthCheck-2026-02-20.md
+++ b/doc/HealthChecks/ConvergenceHealthCheck-2026-02-20.md
@@ -1,0 +1,64 @@
+# Convergence & Contracts Health Check — 2026-02-20
+
+## 1) Single canonical resolver path
+Command run: `rg "resolveContent\\(" src`
+
+Call sites and path:
+- `src/content/contentResolutionAdapter.ts` → calls `contentProviderRegistry.resolveContent(...)` and narrows outcomes for drawer usage.
+- `src/doc-engine/registry.ts` → internal provider dispatch (`provider.resolveContent(...)`) inside `ContentProviderRegistry.resolveContent`.
+
+Assessment:
+- UI boundary path is singular: `resolveDrawerContent` in `src/content/contentResolutionAdapter.ts` is the canonical app-facing resolver entrypoint.
+- No direct UI call sites to `ContentProviderRegistry.resolveContent` were found outside the adapter path.
+
+## 2) Import-direction audit (extraction guardrail)
+Commands run:
+- `rg "^import .*from" src/doc-engine -n`
+- `rg "from '../content|from './content|from '../components|from './components|from '../../content|from '../../components' src/doc-engine -n`
+
+Assessment:
+- `src/doc-engine/**` imports are internal-only (`./registry.ts`, `./types.ts`).
+- No imports from `src/content/**` or `src/components/**` were found.
+
+## 3) Barrel sanity
+Command run: `rg --files src | rg 'index\\.tsx?$'`
+
+Barrels reviewed:
+- `src/doc-engine/index.ts`
+- `src/content/index.ts`
+- `src/components/ContentDrawer/index.tsx`
+- `src/components/GlobalHeaderShell/index.tsx`
+- `src/tabs/build/index.tsx`
+
+Assessment:
+- Each barrel exports concrete local symbols from same-scope modules.
+- `src/content/index.ts` explicitly avoids re-exporting `contentProviderRegistry`, preserving ownership boundary through `contentEngine`.
+- No cross-boundary re-export violations were identified in the current index files.
+
+## 4) Persistence contract stability
+Storage keys and payloads:
+- `section-configurations-state` → JSON object `{ version: 1, height: number, collapsed: boolean }` (legacy unversioned shape accepted on read).
+- `section-atomic-components-state` → JSON object `{ version: 1, height: number, collapsed: boolean }` (legacy accepted).
+- `section-search-configurations-state` → JSON object `{ version: 1, height: number, collapsed: boolean }` (legacy accepted).
+- `left-panel-width` → numeric string (legacy contract retained as-is).
+- `right-panel-state` → JSON object `{ version: 1, width: number, collapsed: boolean }` (legacy unversioned shape accepted on read).
+
+Assessment:
+- Version field added to JSON object payloads written by section and right-panel state contracts.
+- Read paths are backward-compatible for pre-version payloads.
+
+## 5) Minimal tests baseline
+Commands run:
+- `npm test`
+
+Contract-lock tests in place:
+- Namespace/id parsing:
+  - `parseContentRef` valid + invalid ref tests.
+  - `splitNamespace` backward-compatible shape test.
+- Resolver hit/miss behavior:
+  - resolver `found` outcome (`docs:doc-build`), `missing_content`, and `no_provider` tests.
+- Malformed storage payload fallback:
+  - `parseSectionStatePayload` malformed payload fallback test.
+  - `readBuildSurfaceStorage` non-throwing fallback + reporter test.
+
+Status: baseline satisfied (>= 3 tests spanning required contract categories).

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -22,6 +22,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - Local state: Panel widths/heights, collapse states per section, hover/focus state for grips.
 - Global context: Theme tokens inherited from cfg-appFrame; routing context determines active tab.
 - External data sources: `localStorage` for persistence of dimensions and collapse preferences.
+- Persistence payload contract: JSON payloads include a numeric `version` field (`v1`) while readers continue to accept legacy unversioned payloads during migration.
 
 ### 2.3 Dependencies
 - UI libs: React, including `useState`, `useEffect`, and refs for DOM measurements.
@@ -158,6 +159,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 ### 5.0 Dependencies
 - Relies on browser pointer and keyboard events for resizing.
 - Uses `localStorage` to persist panel states.
+- Uses shared payload parser/serializer helpers so each storage key enforces a stable versioned schema.
 
 ### 5.1 Atomic Components — Containers (Logic)
 - **[5.1.1] Container – "Section Contracts"**
@@ -185,6 +187,8 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
   - Memoized object mapping anchors to handlers/aria attributes consumed by Build.
 - **[5.2.6] Primitive – "Persistence Failure Reporter"**
   - Shared non-fatal reporting hook used by persistence reads/writes to emit diagnosable storage operation failures.
+- **[5.2.7] Primitive – "Versioned Payload Contract"**
+  - Normalizes persisted section and side-panel payloads to `{ version: 1, ...state }` on writes while accepting prior unversioned shapes on reads.
 
 ### 5.2.3 Derived Values
 - Derived booleans for collapsed states, computed widths/heights.

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -29,6 +29,7 @@ import {
 export type SectionId = 'configurations' | 'atomic-components' | 'search-configurations';
 
 interface SectionState {
+  version: 1;
   height: number;
   collapsed: boolean;
 }
@@ -77,6 +78,7 @@ interface LeftPanelLogic {
 }
 
 interface RightPanelState {
+  version: 1;
   width: number;
   collapsed: boolean;
 }
@@ -115,6 +117,78 @@ export function clamp(value: number, min: number, max: number) {
   return clampNumber(value, min, max);
 }
 
+
+
+// [5.2.7] cfg-buildSurface · Primitive · "Versioned Payload Contract"
+// Concern: Logic · Parent: "Section Contracts" · Catalog: contract.persistence
+// Notes: Keeps localStorage payloads forward-compatible by writing versioned state and accepting legacy unversioned payloads.
+const BUILD_SURFACE_PERSISTENCE_VERSION = 1 as const;
+
+function toVersionedSectionState(state: Omit<SectionState, 'version'>): SectionState {
+  return {
+    version: BUILD_SURFACE_PERSISTENCE_VERSION,
+    height: state.height,
+    collapsed: state.collapsed,
+  };
+}
+
+export function parseSectionStatePayload(raw: string, fallback: Omit<SectionState, 'version'>): SectionState {
+  const parsed = JSON.parse(raw) as Partial<SectionState>;
+  if (
+    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION &&
+    typeof parsed.height === 'number' &&
+    Number.isFinite(parsed.height) &&
+    typeof parsed.collapsed === 'boolean'
+  ) {
+    return parsed as SectionState;
+  }
+
+  if (
+    parsed.version === undefined &&
+    typeof parsed.height === 'number' &&
+    Number.isFinite(parsed.height) &&
+    typeof parsed.collapsed === 'boolean'
+  ) {
+    return toVersionedSectionState({
+      height: parsed.height,
+      collapsed: parsed.collapsed,
+    });
+  }
+
+  return toVersionedSectionState(fallback);
+}
+
+export function parseRightPanelStatePayload(raw: string, fallback: Omit<RightPanelState, 'version'>): RightPanelState {
+  const parsed = JSON.parse(raw) as Partial<RightPanelState>;
+  if (
+    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION &&
+    typeof parsed.width === 'number' &&
+    Number.isFinite(parsed.width) &&
+    typeof parsed.collapsed === 'boolean'
+  ) {
+    return parsed as RightPanelState;
+  }
+
+  if (
+    parsed.version === undefined &&
+    typeof parsed.width === 'number' &&
+    Number.isFinite(parsed.width) &&
+    typeof parsed.collapsed === 'boolean'
+  ) {
+    return {
+      version: BUILD_SURFACE_PERSISTENCE_VERSION,
+      width: parsed.width,
+      collapsed: parsed.collapsed,
+    };
+  }
+
+  return {
+    version: BUILD_SURFACE_PERSISTENCE_VERSION,
+    width: fallback.width,
+    collapsed: fallback.collapsed,
+  };
+}
+
 export function sectionTitle(id: SectionId) {
   switch (id) {
     case 'configurations':
@@ -142,17 +216,15 @@ function useSectionLogic(
       storageKey,
       () => {
         const raw = localStorage.getItem(storageKey);
-        if (!raw) return { height: initialHeight, collapsed: false };
+        if (!raw) return toVersionedSectionState({ height: initialHeight, collapsed: false });
         const parsed = JSON.parse(raw) as Partial<SectionState>;
         if (
+          (parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION || parsed.version === undefined) &&
           typeof parsed.height === 'number' &&
           Number.isFinite(parsed.height) &&
           typeof parsed.collapsed === 'boolean'
         ) {
-          return {
-            height: parsed.height,
-            collapsed: parsed.collapsed,
-          };
+          return parseSectionStatePayload(raw, { height: initialHeight, collapsed: false });
         }
 
         defaultBuildSurfacePersistenceReporter({
@@ -161,15 +233,15 @@ function useSectionLogic(
           error: new Error('Malformed persisted section state payload'),
         });
 
-        return { height: initialHeight, collapsed: false };
+        return toVersionedSectionState({ height: initialHeight, collapsed: false });
       },
-      { height: initialHeight, collapsed: false }
+      toVersionedSectionState({ height: initialHeight, collapsed: false })
     )
   );
 
   useEffect(() => {
     writeBuildSurfaceStorage(storageKey, () => {
-      localStorage.setItem(storageKey, JSON.stringify(state));
+      localStorage.setItem(storageKey, JSON.stringify(toVersionedSectionState(state)));
     });
   }, [state, storageKey]);
 
@@ -329,11 +401,12 @@ function useRightPanelLogic(): RightPanelLogic {
         if (raw) {
           const parsed = JSON.parse(raw) as Partial<RightPanelState>;
           if (
+            (parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION || parsed.version === undefined) &&
             typeof parsed.width === 'number' &&
             Number.isFinite(parsed.width) &&
             typeof parsed.collapsed === 'boolean'
           ) {
-            return parsed as RightPanelState;
+            return parseRightPanelStatePayload(raw, { width: 320, collapsed: false });
           }
         }
 
@@ -343,16 +416,20 @@ function useRightPanelLogic(): RightPanelLogic {
           error: new Error('Malformed persisted right panel state payload'),
         });
 
-        return { width: 320, collapsed: false };
+        return { version: BUILD_SURFACE_PERSISTENCE_VERSION, width: 320, collapsed: false };
       },
-      { width: 320, collapsed: false }
+      { version: BUILD_SURFACE_PERSISTENCE_VERSION, width: 320, collapsed: false }
     )
   );
   const previousWidth = useRef<number | null>(null);
 
   useEffect(() => {
     writeBuildSurfaceStorage(STORAGE_KEY, () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        version: BUILD_SURFACE_PERSISTENCE_VERSION,
+        width: state.width,
+        collapsed: state.collapsed,
+      }));
     });
   }, [state]);
 
@@ -363,7 +440,7 @@ function useRightPanelLogic(): RightPanelLogic {
         const min = 40;
         const max = Math.max(160, window.innerWidth - 320);
         const width = clamp(Math.round(previousState.width - dx), min, max);
-        return { ...previousState, width };
+        return { ...previousState, version: BUILD_SURFACE_PERSISTENCE_VERSION, width };
       });
     },
   });
@@ -386,10 +463,10 @@ function useRightPanelLogic(): RightPanelLogic {
     setState(previous => {
       if (!previous.collapsed) {
         previousWidth.current = previous.width;
-        return { ...previous, collapsed: true, width: 40 };
+        return { ...previous, version: BUILD_SURFACE_PERSISTENCE_VERSION, collapsed: true, width: 40 };
       }
       const restored = Math.max(previousWidth.current ?? 320, 200);
-      return { ...previous, collapsed: false, width: restored };
+      return { ...previous, version: BUILD_SURFACE_PERSISTENCE_VERSION, collapsed: false, width: restored };
     });
   }, []);
 

--- a/test/build-surface-utils.test.mjs
+++ b/test/build-surface-utils.test.mjs
@@ -6,7 +6,11 @@ import {
   readBuildSurfaceStorage,
   writeBuildSurfaceStorage,
 } from '../src/tabs/build/buildSurfacePersistence.ts';
-import { clamp } from '../src/tabs/build/BuildSurface.logic.ts';
+import {
+  clamp,
+  parseRightPanelStatePayload,
+  parseSectionStatePayload,
+} from '../src/tabs/build/BuildSurface.logic.ts';
 
 test('clamp enforces lower and upper boundaries', () => {
   assert.equal(clamp(100, 120, 240), 120);
@@ -51,4 +55,27 @@ test('writeBuildSurfaceStorage reports on write failure without throwing', () =>
   assert.equal(reports[0].operation, 'write');
   assert.equal(reports[0].storageKey, 'left-panel-width');
   assert.match(String(reports[0].error), /quota exceeded/);
+});
+
+
+test('parseSectionStatePayload falls back to versioned defaults on malformed payload', () => {
+  const fallback = { height: 180, collapsed: false };
+  const parsed = parseSectionStatePayload('{"height":"bad","collapsed":false}', fallback);
+
+  assert.deepEqual(parsed, {
+    version: 1,
+    height: 180,
+    collapsed: false,
+  });
+});
+
+test('parseRightPanelStatePayload upgrades legacy payloads without version', () => {
+  const fallback = { width: 320, collapsed: false };
+  const parsed = parseRightPanelStatePayload('{"width":280,"collapsed":true}', fallback);
+
+  assert.deepEqual(parsed, {
+    version: 1,
+    width: 280,
+    collapsed: true,
+  });
 });

--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -45,6 +45,19 @@ test('parseContentRef returns invalid_ref for abc', () => {
   });
 });
 
+
+test('contentProviderRegistry resolves docs:doc-build to found payload', () => {
+  const contentProviderRegistry = createRegistry();
+  const found = contentProviderRegistry.resolveContent({ contentId: 'docs:doc-build', anchorId: 'intro' });
+  assert.deepEqual(found, {
+    type: 'found',
+    namespace: 'docs',
+    contentId: 'doc-build',
+    anchorId: 'intro',
+    payload: { title: 'Build Docs' },
+  });
+});
+
 test('contentProviderRegistry resolves unknown id in docs to missing_content', () => {
   const contentProviderRegistry = createRegistry();
   const missing = contentProviderRegistry.resolveContent({ contentId: 'docs:not-real' });


### PR DESCRIPTION
### Motivation
- Provide a short actionable convergence & contracts health check for the app surface and lock down fragile persistence contracts before a refactor. 
- Establish a single canonical UI resolver path and confirm doc-engine import-direction guardrails to avoid cross-concern leaks. 
- Stabilize localStorage payload shapes for Build surface panels by introducing a versioned JSON contract while remaining backward-compatible. 
- Add minimal unit tests that lock the parsing/resolver/persistence behaviors needed for future refactors.

### Description
- Added `doc/HealthChecks/ConvergenceHealthCheck-2026-02-20.md` with the checklist output covering resolver call-sites, import-direction audit, barrel sanity, persistence key/payload inventory, and test baseline. 
- Updated the NL skeleton `doc/nl-config/cfg-buildSurface.md` first to document the versioned persistence contract and dependency on parser/serializer helpers per the NL-first workflow. 
- Implemented versioned persistence helpers in `src/tabs/build/BuildSurface.logic.ts`: introduced `BUILD_SURFACE_PERSISTENCE_VERSION`, `toVersionedSectionState`, `parseSectionStatePayload`, and `parseRightPanelStatePayload`, and changed read/write paths to accept legacy unversioned payloads and write `{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998db4a8c948331a87569b5a26486c0)