### PR TITLE
refactor(build-surface): extract persistence contracts module and simplify read paths

### DIFF
--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -22,7 +22,8 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - Local state: Panel widths/heights, collapse states per section, hover/focus state for grips.
 - Global context: Theme tokens inherited from cfg-appFrame; routing context determines active tab.
 - External data sources: `localStorage` for persistence of dimensions and collapse preferences.
-- Persistence payload contract: JSON payloads include a numeric `version` field (`v1`) while readers continue to accept legacy unversioned payloads during migration.
+- Persistence payload contract: section/right-panel state uses versioned JSON payloads (`{ version: 1, ... }`) while readers continue to accept legacy unversioned JSON during migration.
+- Left panel width intentionally remains the legacy primitive numeric string contract (`"<width>"`) to avoid unnecessary migration churn for a single scalar value; migrate to versioned JSON only when left-panel persistence needs additional fields/metadata.
 
 ### 2.3 Dependencies
 - UI libs: React, including `useState`, `useEffect`, and refs for DOM measurements.
@@ -159,7 +160,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 ### 5.0 Dependencies
 - Relies on browser pointer and keyboard events for resizing.
 - Uses `localStorage` to persist panel states.
-- Uses shared payload parser/serializer helpers so each storage key enforces a stable versioned schema.
+- Uses shared payload parser/serializer helpers from `buildSurfacePersistence.contracts.ts` so section/right-panel keys enforce a stable versioned schema while left-panel width stays primitive.
 
 ### 5.1 Atomic Components — Containers (Logic)
 - **[5.1.1] Container – "Section Contracts"**
@@ -188,7 +189,9 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - **[5.2.6] Primitive – "Persistence Failure Reporter"**
   - Shared non-fatal reporting hook used by persistence reads/writes to emit diagnosable storage operation failures.
 - **[5.2.7] Primitive – "Versioned Payload Contract"**
-  - Normalizes persisted section and side-panel payloads to `{ version: 1, ...state }` on writes while accepting prior unversioned shapes on reads.
+  - Centralized in `src/tabs/build/buildSurfacePersistence.contracts.ts`.
+  - Normalizes persisted section and right-panel payloads to `{ version: 1, ...state }` on writes while accepting prior unversioned JSON shapes on reads.
+  - Left-panel width intentionally remains a primitive numeric string contract until the payload requires additional structured fields.
 
 ### 5.2.3 Derived Values
 - Derived booleans for collapsed states, computed widths/heights.
@@ -240,6 +243,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - src/tabs/build/BuildSurface.build.module.css
 - src/tabs/build/BuildSurface.logic.ts
 - src/tabs/build/buildSurfacePersistence.ts
+- src/tabs/build/buildSurfacePersistence.contracts.ts
 - src/tabs/build/BuildSurface.knowledge.ts
 - (Results and ResultsStyle files will be added when outputs exist.)
 - src/tabs/build/index.ts

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -191,6 +191,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - **[5.2.7] Primitive – "Versioned Payload Contract"**
   - Centralized in `src/tabs/build/buildSurfacePersistence.contracts.ts`.
   - Normalizes persisted section and right-panel payloads to `{ version: 1, ...state }` on writes while accepting prior unversioned JSON shapes on reads.
+  - Handles malformed JSON syntax in parser helpers by returning versioned fallback state with `{ wasFallback: true, reason }` so read-path wrappers can report non-fatal diagnostics consistently.
   - Left-panel width intentionally remains a primitive numeric string contract until the payload requires additional structured fields.
 
 ### 5.2.3 Derived Values

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -11,6 +11,14 @@ import { clampNumber } from '../../shared/interaction/pointerDrag.ts';
 import { usePointerDrag } from '../../shared/interaction/usePointerDrag.ts';
 import { BUILD_ANCHORS } from './anchors.ts';
 import {
+  parseRightPanelStatePayload,
+  parseSectionStatePayload,
+  serializeRightPanelStatePayload,
+  serializeSectionStatePayload,
+  type VersionedRightPanelStatePayload,
+  type VersionedSectionStatePayload,
+} from './buildSurfacePersistence.contracts.ts';
+import {
   defaultBuildSurfacePersistenceReporter,
   readBuildSurfaceStorage,
   writeBuildSurfaceStorage,
@@ -28,11 +36,7 @@ import {
 // Notes: Declares section identifiers, binding shapes, order, and helpers shared with Build.
 export type SectionId = 'configurations' | 'atomic-components' | 'search-configurations';
 
-interface SectionState {
-  version: 1;
-  height: number;
-  collapsed: boolean;
-}
+type SectionState = VersionedSectionStatePayload;
 
 interface SectionLogicOptions {
   initialHeight: number;
@@ -77,11 +81,7 @@ interface LeftPanelLogic {
   };
 }
 
-interface RightPanelState {
-  version: 1;
-  width: number;
-  collapsed: boolean;
-}
+type RightPanelState = VersionedRightPanelStatePayload;
 
 interface RightPanelLogic {
   width: number;
@@ -117,78 +117,6 @@ export function clamp(value: number, min: number, max: number) {
   return clampNumber(value, min, max);
 }
 
-
-
-// [5.2.7] cfg-buildSurface · Primitive · "Versioned Payload Contract"
-// Concern: Logic · Parent: "Section Contracts" · Catalog: contract.persistence
-// Notes: Keeps localStorage payloads forward-compatible by writing versioned state and accepting legacy unversioned payloads.
-const BUILD_SURFACE_PERSISTENCE_VERSION = 1 as const;
-
-function toVersionedSectionState(state: Omit<SectionState, 'version'>): SectionState {
-  return {
-    version: BUILD_SURFACE_PERSISTENCE_VERSION,
-    height: state.height,
-    collapsed: state.collapsed,
-  };
-}
-
-export function parseSectionStatePayload(raw: string, fallback: Omit<SectionState, 'version'>): SectionState {
-  const parsed = JSON.parse(raw) as Partial<SectionState>;
-  if (
-    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION &&
-    typeof parsed.height === 'number' &&
-    Number.isFinite(parsed.height) &&
-    typeof parsed.collapsed === 'boolean'
-  ) {
-    return parsed as SectionState;
-  }
-
-  if (
-    parsed.version === undefined &&
-    typeof parsed.height === 'number' &&
-    Number.isFinite(parsed.height) &&
-    typeof parsed.collapsed === 'boolean'
-  ) {
-    return toVersionedSectionState({
-      height: parsed.height,
-      collapsed: parsed.collapsed,
-    });
-  }
-
-  return toVersionedSectionState(fallback);
-}
-
-export function parseRightPanelStatePayload(raw: string, fallback: Omit<RightPanelState, 'version'>): RightPanelState {
-  const parsed = JSON.parse(raw) as Partial<RightPanelState>;
-  if (
-    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION &&
-    typeof parsed.width === 'number' &&
-    Number.isFinite(parsed.width) &&
-    typeof parsed.collapsed === 'boolean'
-  ) {
-    return parsed as RightPanelState;
-  }
-
-  if (
-    parsed.version === undefined &&
-    typeof parsed.width === 'number' &&
-    Number.isFinite(parsed.width) &&
-    typeof parsed.collapsed === 'boolean'
-  ) {
-    return {
-      version: BUILD_SURFACE_PERSISTENCE_VERSION,
-      width: parsed.width,
-      collapsed: parsed.collapsed,
-    };
-  }
-
-  return {
-    version: BUILD_SURFACE_PERSISTENCE_VERSION,
-    width: fallback.width,
-    collapsed: fallback.collapsed,
-  };
-}
-
 export function sectionTitle(id: SectionId) {
   switch (id) {
     case 'configurations':
@@ -216,32 +144,24 @@ function useSectionLogic(
       storageKey,
       () => {
         const raw = localStorage.getItem(storageKey);
-        if (!raw) return toVersionedSectionState({ height: initialHeight, collapsed: false });
-        const parsed = JSON.parse(raw) as Partial<SectionState>;
-        if (
-          (parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION || parsed.version === undefined) &&
-          typeof parsed.height === 'number' &&
-          Number.isFinite(parsed.height) &&
-          typeof parsed.collapsed === 'boolean'
-        ) {
-          return parseSectionStatePayload(raw, { height: initialHeight, collapsed: false });
+        if (!raw) return serializeSectionStatePayload({ height: initialHeight, collapsed: false });
+        const parsed = parseSectionStatePayload(raw, { height: initialHeight, collapsed: false });
+        if (parsed.wasFallback && parsed.reason) {
+          defaultBuildSurfacePersistenceReporter({
+            operation: 'read',
+            storageKey,
+            error: new Error(parsed.reason),
+          });
         }
-
-        defaultBuildSurfacePersistenceReporter({
-          operation: 'read',
-          storageKey,
-          error: new Error('Malformed persisted section state payload'),
-        });
-
-        return toVersionedSectionState({ height: initialHeight, collapsed: false });
+        return parsed.state;
       },
-      toVersionedSectionState({ height: initialHeight, collapsed: false })
+      serializeSectionStatePayload({ height: initialHeight, collapsed: false })
     )
   );
 
   useEffect(() => {
     writeBuildSurfaceStorage(storageKey, () => {
-      localStorage.setItem(storageKey, JSON.stringify(toVersionedSectionState(state)));
+      localStorage.setItem(storageKey, JSON.stringify(serializeSectionStatePayload(state)));
     });
   }, [state, storageKey]);
 
@@ -398,38 +318,27 @@ function useRightPanelLogic(): RightPanelLogic {
       STORAGE_KEY,
       () => {
         const raw = localStorage.getItem(STORAGE_KEY);
-        if (raw) {
-          const parsed = JSON.parse(raw) as Partial<RightPanelState>;
-          if (
-            (parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION || parsed.version === undefined) &&
-            typeof parsed.width === 'number' &&
-            Number.isFinite(parsed.width) &&
-            typeof parsed.collapsed === 'boolean'
-          ) {
-            return parseRightPanelStatePayload(raw, { width: 320, collapsed: false });
-          }
+        if (!raw) {
+          return serializeRightPanelStatePayload({ width: 320, collapsed: false });
         }
-
-        defaultBuildSurfacePersistenceReporter({
-          operation: 'read',
-          storageKey: STORAGE_KEY,
-          error: new Error('Malformed persisted right panel state payload'),
-        });
-
-        return { version: BUILD_SURFACE_PERSISTENCE_VERSION, width: 320, collapsed: false };
+        const parsed = parseRightPanelStatePayload(raw, { width: 320, collapsed: false });
+        if (parsed.wasFallback && parsed.reason) {
+          defaultBuildSurfacePersistenceReporter({
+            operation: 'read',
+            storageKey: STORAGE_KEY,
+            error: new Error(parsed.reason),
+          });
+        }
+        return parsed.state;
       },
-      { version: BUILD_SURFACE_PERSISTENCE_VERSION, width: 320, collapsed: false }
+      serializeRightPanelStatePayload({ width: 320, collapsed: false })
     )
   );
   const previousWidth = useRef<number | null>(null);
 
   useEffect(() => {
     writeBuildSurfaceStorage(STORAGE_KEY, () => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({
-        version: BUILD_SURFACE_PERSISTENCE_VERSION,
-        width: state.width,
-        collapsed: state.collapsed,
-      }));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(serializeRightPanelStatePayload(state)));
     });
   }, [state]);
 
@@ -440,7 +349,7 @@ function useRightPanelLogic(): RightPanelLogic {
         const min = 40;
         const max = Math.max(160, window.innerWidth - 320);
         const width = clamp(Math.round(previousState.width - dx), min, max);
-        return { ...previousState, version: BUILD_SURFACE_PERSISTENCE_VERSION, width };
+        return { ...previousState, width };
       });
     },
   });
@@ -463,10 +372,10 @@ function useRightPanelLogic(): RightPanelLogic {
     setState(previous => {
       if (!previous.collapsed) {
         previousWidth.current = previous.width;
-        return { ...previous, version: BUILD_SURFACE_PERSISTENCE_VERSION, collapsed: true, width: 40 };
+        return { ...previous, collapsed: true, width: 40 };
       }
       const restored = Math.max(previousWidth.current ?? 320, 200);
-      return { ...previous, version: BUILD_SURFACE_PERSISTENCE_VERSION, collapsed: false, width: restored };
+      return { ...previous, collapsed: false, width: restored };
     });
   }, []);
 

--- a/src/tabs/build/buildSurfacePersistence.contracts.ts
+++ b/src/tabs/build/buildSurfacePersistence.contracts.ts
@@ -34,6 +34,33 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function parsePayloadContract<TVersionedPayload, TLegacyPayload>(
+  raw: string,
+  fallback: TVersionedPayload,
+  reason: string,
+  isVersionedPayload: (value: unknown) => value is TVersionedPayload,
+  isLegacyPayload: (value: unknown) => value is TLegacyPayload,
+  upgradeLegacyPayload: (legacyPayload: TLegacyPayload) => TVersionedPayload,
+): BuildSurfacePersistenceParseResult<TVersionedPayload> {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { state: fallback, wasFallback: true, reason };
+  }
+
+  if (isVersionedPayload(parsed)) {
+    return { state: parsed, wasFallback: false };
+  }
+
+  if (isLegacyPayload(parsed)) {
+    return { state: upgradeLegacyPayload(parsed), wasFallback: false };
+  }
+
+  return { state: fallback, wasFallback: true, reason };
+}
+
 export function serializeSectionStatePayload(
   state: Omit<VersionedSectionStatePayload, 'version'>,
 ): VersionedSectionStatePayload {
@@ -44,39 +71,36 @@ export function serializeSectionStatePayload(
   };
 }
 
+function isVersionedSectionStatePayload(value: unknown): value is VersionedSectionStatePayload {
+  const parsed = value as Partial<VersionedSectionStatePayload>;
+  return (
+    parsed?.version === BUILD_SURFACE_PERSISTENCE_VERSION
+    && isFiniteNumber(parsed.height)
+    && typeof parsed.collapsed === 'boolean'
+  );
+}
+
+function isLegacySectionStatePayload(value: unknown): value is Omit<VersionedSectionStatePayload, 'version'> {
+  const parsed = value as Partial<VersionedSectionStatePayload>;
+  return (
+    parsed?.version === undefined
+    && isFiniteNumber(parsed.height)
+    && typeof parsed.collapsed === 'boolean'
+  );
+}
+
 export function parseSectionStatePayload(
   raw: string,
   fallback: Omit<VersionedSectionStatePayload, 'version'>,
 ): BuildSurfacePersistenceParseResult<VersionedSectionStatePayload> {
-  const parsed = JSON.parse(raw) as Partial<VersionedSectionStatePayload>;
-
-  if (
-    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION
-    && isFiniteNumber(parsed.height)
-    && typeof parsed.collapsed === 'boolean'
-  ) {
-    return { state: parsed as VersionedSectionStatePayload, wasFallback: false };
-  }
-
-  if (
-    parsed.version === undefined
-    && isFiniteNumber(parsed.height)
-    && typeof parsed.collapsed === 'boolean'
-  ) {
-    return {
-      state: serializeSectionStatePayload({
-        height: parsed.height,
-        collapsed: parsed.collapsed,
-      }),
-      wasFallback: false,
-    };
-  }
-
-  return {
-    state: serializeSectionStatePayload(fallback),
-    wasFallback: true,
-    reason: 'Malformed persisted section state payload',
-  };
+  return parsePayloadContract(
+    raw,
+    serializeSectionStatePayload(fallback),
+    'Malformed persisted section state payload',
+    isVersionedSectionStatePayload,
+    isLegacySectionStatePayload,
+    serializeSectionStatePayload,
+  );
 }
 
 export function serializeRightPanelStatePayload(
@@ -89,37 +113,36 @@ export function serializeRightPanelStatePayload(
   };
 }
 
+function isVersionedRightPanelStatePayload(value: unknown): value is VersionedRightPanelStatePayload {
+  const parsed = value as Partial<VersionedRightPanelStatePayload>;
+  return (
+    parsed?.version === BUILD_SURFACE_PERSISTENCE_VERSION
+    && isFiniteNumber(parsed.width)
+    && typeof parsed.collapsed === 'boolean'
+  );
+}
+
+function isLegacyRightPanelStatePayload(
+  value: unknown,
+): value is Omit<VersionedRightPanelStatePayload, 'version'> {
+  const parsed = value as Partial<VersionedRightPanelStatePayload>;
+  return (
+    parsed?.version === undefined
+    && isFiniteNumber(parsed.width)
+    && typeof parsed.collapsed === 'boolean'
+  );
+}
+
 export function parseRightPanelStatePayload(
   raw: string,
   fallback: Omit<VersionedRightPanelStatePayload, 'version'>,
 ): BuildSurfacePersistenceParseResult<VersionedRightPanelStatePayload> {
-  const parsed = JSON.parse(raw) as Partial<VersionedRightPanelStatePayload>;
-
-  if (
-    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION
-    && isFiniteNumber(parsed.width)
-    && typeof parsed.collapsed === 'boolean'
-  ) {
-    return { state: parsed as VersionedRightPanelStatePayload, wasFallback: false };
-  }
-
-  if (
-    parsed.version === undefined
-    && isFiniteNumber(parsed.width)
-    && typeof parsed.collapsed === 'boolean'
-  ) {
-    return {
-      state: serializeRightPanelStatePayload({
-        width: parsed.width,
-        collapsed: parsed.collapsed,
-      }),
-      wasFallback: false,
-    };
-  }
-
-  return {
-    state: serializeRightPanelStatePayload(fallback),
-    wasFallback: true,
-    reason: 'Malformed persisted right panel state payload',
-  };
+  return parsePayloadContract(
+    raw,
+    serializeRightPanelStatePayload(fallback),
+    'Malformed persisted right panel state payload',
+    isVersionedRightPanelStatePayload,
+    isLegacyRightPanelStatePayload,
+    serializeRightPanelStatePayload,
+  );
 }

--- a/src/tabs/build/buildSurfacePersistence.contracts.ts
+++ b/src/tabs/build/buildSurfacePersistence.contracts.ts
@@ -1,0 +1,125 @@
+/**
+ * Configuration: cfg-buildSurface (Build Surface Configuration)
+ * Concern File: Logic
+ * Source NL: doc/nl-config/cfg-buildSurface.md
+ * Responsibility: Define Build-surface persistence payload contracts with backward-compatible parsing and versioned serialization.
+ * Invariants: Versioned payloads write with schema version 1; legacy unversioned section/right-panel payloads remain readable.
+ */
+
+export const BUILD_SURFACE_PERSISTENCE_VERSION = 1 as const;
+
+// [5.2.7] cfg-buildSurface · Primitive · "Versioned Payload Contract"
+// Concern: Logic · Parent: "Section Contracts" · Catalog: contract.persistence
+// Notes: Centralizes Build-surface payload parsing/serialization with backward-compatible legacy JSON upgrades.
+
+export interface VersionedSectionStatePayload {
+  version: typeof BUILD_SURFACE_PERSISTENCE_VERSION;
+  height: number;
+  collapsed: boolean;
+}
+
+export interface VersionedRightPanelStatePayload {
+  version: typeof BUILD_SURFACE_PERSISTENCE_VERSION;
+  width: number;
+  collapsed: boolean;
+}
+
+export interface BuildSurfacePersistenceParseResult<TPayload> {
+  state: TPayload;
+  wasFallback: boolean;
+  reason?: string;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function serializeSectionStatePayload(
+  state: Omit<VersionedSectionStatePayload, 'version'>,
+): VersionedSectionStatePayload {
+  return {
+    version: BUILD_SURFACE_PERSISTENCE_VERSION,
+    height: state.height,
+    collapsed: state.collapsed,
+  };
+}
+
+export function parseSectionStatePayload(
+  raw: string,
+  fallback: Omit<VersionedSectionStatePayload, 'version'>,
+): BuildSurfacePersistenceParseResult<VersionedSectionStatePayload> {
+  const parsed = JSON.parse(raw) as Partial<VersionedSectionStatePayload>;
+
+  if (
+    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION
+    && isFiniteNumber(parsed.height)
+    && typeof parsed.collapsed === 'boolean'
+  ) {
+    return { state: parsed as VersionedSectionStatePayload, wasFallback: false };
+  }
+
+  if (
+    parsed.version === undefined
+    && isFiniteNumber(parsed.height)
+    && typeof parsed.collapsed === 'boolean'
+  ) {
+    return {
+      state: serializeSectionStatePayload({
+        height: parsed.height,
+        collapsed: parsed.collapsed,
+      }),
+      wasFallback: false,
+    };
+  }
+
+  return {
+    state: serializeSectionStatePayload(fallback),
+    wasFallback: true,
+    reason: 'Malformed persisted section state payload',
+  };
+}
+
+export function serializeRightPanelStatePayload(
+  state: Omit<VersionedRightPanelStatePayload, 'version'>,
+): VersionedRightPanelStatePayload {
+  return {
+    version: BUILD_SURFACE_PERSISTENCE_VERSION,
+    width: state.width,
+    collapsed: state.collapsed,
+  };
+}
+
+export function parseRightPanelStatePayload(
+  raw: string,
+  fallback: Omit<VersionedRightPanelStatePayload, 'version'>,
+): BuildSurfacePersistenceParseResult<VersionedRightPanelStatePayload> {
+  const parsed = JSON.parse(raw) as Partial<VersionedRightPanelStatePayload>;
+
+  if (
+    parsed.version === BUILD_SURFACE_PERSISTENCE_VERSION
+    && isFiniteNumber(parsed.width)
+    && typeof parsed.collapsed === 'boolean'
+  ) {
+    return { state: parsed as VersionedRightPanelStatePayload, wasFallback: false };
+  }
+
+  if (
+    parsed.version === undefined
+    && isFiniteNumber(parsed.width)
+    && typeof parsed.collapsed === 'boolean'
+  ) {
+    return {
+      state: serializeRightPanelStatePayload({
+        width: parsed.width,
+        collapsed: parsed.collapsed,
+      }),
+      wasFallback: false,
+    };
+  }
+
+  return {
+    state: serializeRightPanelStatePayload(fallback),
+    wasFallback: true,
+    reason: 'Malformed persisted right panel state payload',
+  };
+}

--- a/test/build-surface-utils.test.mjs
+++ b/test/build-surface-utils.test.mjs
@@ -8,9 +8,12 @@ import {
 } from '../src/tabs/build/buildSurfacePersistence.ts';
 import {
   clamp,
+} from '../src/tabs/build/BuildSurface.logic.ts';
+import {
   parseRightPanelStatePayload,
   parseSectionStatePayload,
-} from '../src/tabs/build/BuildSurface.logic.ts';
+  serializeSectionStatePayload,
+} from '../src/tabs/build/buildSurfacePersistence.contracts.ts';
 
 test('clamp enforces lower and upper boundaries', () => {
   assert.equal(clamp(100, 120, 240), 120);
@@ -63,9 +66,13 @@ test('parseSectionStatePayload falls back to versioned defaults on malformed pay
   const parsed = parseSectionStatePayload('{"height":"bad","collapsed":false}', fallback);
 
   assert.deepEqual(parsed, {
-    version: 1,
-    height: 180,
-    collapsed: false,
+    state: {
+      version: 1,
+      height: 180,
+      collapsed: false,
+    },
+    wasFallback: true,
+    reason: 'Malformed persisted section state payload',
   });
 });
 
@@ -74,8 +81,24 @@ test('parseRightPanelStatePayload upgrades legacy payloads without version', () 
   const parsed = parseRightPanelStatePayload('{"width":280,"collapsed":true}', fallback);
 
   assert.deepEqual(parsed, {
-    version: 1,
-    width: 280,
-    collapsed: true,
+    state: {
+      version: 1,
+      width: 280,
+      collapsed: true,
+    },
+    wasFallback: false,
+  });
+});
+
+test('section payload round-trips through serializer and parser', () => {
+  const serialized = serializeSectionStatePayload({ height: 222, collapsed: true });
+  const parsed = parseSectionStatePayload(JSON.stringify(serialized), {
+    height: 180,
+    collapsed: false,
+  });
+
+  assert.deepEqual(parsed, {
+    state: serialized,
+    wasFallback: false,
   });
 });

--- a/test/build-surface-utils.test.mjs
+++ b/test/build-surface-utils.test.mjs
@@ -76,6 +76,26 @@ test('parseSectionStatePayload falls back to versioned defaults on malformed pay
   });
 });
 
+
+
+test('parseSectionStatePayload handles malformed JSON syntax via non-fatal fallback metadata', () => {
+  const fallback = { height: 180, collapsed: false };
+
+  assert.doesNotThrow(() => {
+    const parsed = parseSectionStatePayload('{"height":180,', fallback);
+
+    assert.deepEqual(parsed, {
+      state: {
+        version: 1,
+        height: 180,
+        collapsed: false,
+      },
+      wasFallback: true,
+      reason: 'Malformed persisted section state payload',
+    });
+  });
+});
+
 test('parseRightPanelStatePayload upgrades legacy payloads without version', () => {
   const fallback = { width: 320, collapsed: false };
   const parsed = parseRightPanelStatePayload('{"width":280,"collapsed":true}', fallback);


### PR DESCRIPTION
### Motivation
- Centralize Build-surface persistence parsing/serialization to reduce duplicated JSON parsing in read paths and make upgrade/fallback behavior easier to reason about.
- Preserve runtime behavior and backward compatibility for existing persisted values while tightening diagnostics for malformed payloads.
- Keep ownership boundaries clear so `BuildSurface.logic.ts` focuses on hook/behavior and a small contracts module owns payload validation/serialization.

### Description
- Added a focused contracts module at `src/tabs/build/buildSurfacePersistence.contracts.ts` that owns the version constant and the parse/serialize helpers, exporting `BUILD_SURFACE_PERSISTENCE_VERSION`, `serializeSectionStatePayload`, `parseSectionStatePayload`, `serializeRightPanelStatePayload`, `parseRightPanelStatePayload`, `VersionedSectionStatePayload`, `VersionedRightPanelStatePayload`, and `BuildSurfacePersistenceParseResult`.
- Updated `src/tabs/build/BuildSurface.logic.ts` to import and consume the new helpers (`parseSectionStatePayload`, `parseRightPanelStatePayload`, `serializeSectionStatePayload`, `serializeRightPanelStatePayload`, and the versioned types) and simplified read/write flows so each payload is parsed once and the parser centrally signals fallback metadata for diagnostics.
- Kept left-panel width persistence as the existing primitive numeric string contract (`'left-panel-width'`) and preserved its non-fatal malformed-payload reporting, documenting this decision in `doc/nl-config/cfg-buildSurface.md` with a short rationale and migration trigger guidance.
- Moved/adjusted tests in `test/build-surface-utils.test.mjs` to target the extracted module and added a serializer/parser round-trip test covering section payloads; also preserved existing persistence failure tests that validate non-fatal reporting.

Before/After API sketch for the extracted persistence contract module
- Before: `parseSectionStatePayload` and `parseRightPanelStatePayload` (and `BUILD_SURFACE_PERSISTENCE_VERSION`) were defined inside `src/tabs/build/BuildSurface.logic.ts` and used inline in multiple read branches.
- After: New module `src/tabs/build/buildSurfacePersistence.contracts.ts` exports a small API surface: `BUILD_SURFACE_PERSISTENCE_VERSION`, `serializeSectionStatePayload`, `parseSectionStatePayload`, `serializeRightPanelStatePayload`, `parseRightPanelStatePayload`, and the versioned payload types; `BuildSurface.logic.ts` now imports these symbols and uses them for single-pass parsing/serialization.

Files changed (high level)
- New: `src/tabs/build/buildSurfacePersistence.contracts.ts` (exports contract helpers and types).
- Modified: `src/tabs/build/BuildSurface.logic.ts` (imports contract helpers, simplified read/write paths, uses parse-result metadata for reporting).
- Modified: `test/build-surface-utils.test.mjs` (tests updated to import from the contracts module and added round-trip coverage).
- Modified: `doc/nl-config/cfg-buildSurface.md` (short note describing why left-panel width remains unversioned and where the contracts live).

### Testing
- Ran `npm test` and all tests passed (14/14), including updated `test/build-surface-utils.test.mjs` which validates malformed fallbacks, legacy upgrades, and round-trip serialization.
- Ran `npm run lint` which completed successfully with existing repo warnings only (no new errors).
- Ran `npm run build` which completed successfully and produced the production build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e010ad0883319421e9bc30e4cc5f)