### PR TITLE
Harden build-surface persistence parsing with diagnosable fallbacks

### DIFF
--- a/doc/audits/persistence-inventory.md
+++ b/doc/audits/persistence-inventory.md
@@ -1,0 +1,45 @@
+# Persistence Contract Stability Pass — Inventory and Targeted Hardening
+
+## Scope
+- Repo scan commands:
+  - `rg -n "localStorage|sessionStorage|persist|storage" src`
+  - `rg -n "localStorage|sessionStorage" src`
+- Storage APIs discovered: `localStorage` only (no `sessionStorage` usage in `src/`).
+
+## Repo-wide persistence inventory
+
+| Storage key | File paths / symbols | Owner | Purpose | Payload shape | Defaults / fallback | Validation/parsing | Bounds / clamping | Versioning | Risk notes |
+|---|---|---|---|---|---|---|---|---|---|
+| `section-configurations-state` | `src/tabs/build/BuildSurface.logic.ts` (`useBuildSurfaceLogic`, `useSectionLogic`) | Build tab logic | Persist Configurations section height/collapsed state | JSON object `{ version, height, collapsed }` | Fallback `{ version:1, height:180, collapsed:false }` | `parseSectionStatePayload` in `src/tabs/build/buildSurfacePersistence.contracts.ts` | Height clamped to `[32, parentHeight - 64]`; toggle restore min `120` | Versioned (`version:1`) with legacy unversioned upgrade | Read-on-init key; malformed/legacy/version drift risks; now includes explicit fallback reason codes. |
+| `section-atomic-components-state` | `src/tabs/build/BuildSurface.logic.ts` (`useBuildSurfaceLogic`, `useSectionLogic`) | Build tab logic | Persist Atomic Components section height/collapsed state | JSON object `{ version, height, collapsed }` | Fallback `{ version:1, height:260, collapsed:false }` | `parseSectionStatePayload` in `buildSurfacePersistence.contracts.ts` | Height clamped to `[32, parentHeight - 64]`; toggle restore min `120` | Versioned (`version:1`) with legacy unversioned upgrade | Same contract path as above; highest risk due to init-time usage and JSON shape. |
+| `section-search-configurations-state` | `src/tabs/build/BuildSurface.logic.ts` (`useBuildSurfaceLogic`, `useSectionLogic`) | Build tab logic | Persist Search Configurations section height/collapsed state | JSON object `{ version, height, collapsed }` | Fallback `{ version:1, height:180, collapsed:false }` | `parseSectionStatePayload` in `buildSurfacePersistence.contracts.ts` | Height clamped to `[32, parentHeight - 64]`; toggle restore min `120` | Versioned (`version:1`) with legacy unversioned upgrade | Same high-risk section contract family; now hardened centrally. |
+| `right-panel-state` | `src/tabs/build/BuildSurface.logic.ts` (`useRightPanelLogic`) | Build tab logic | Persist inspector width/collapsed state | JSON object `{ version, width, collapsed }` | Fallback `{ version:1, width:320, collapsed:false }` | `parseRightPanelStatePayload` in `buildSurfacePersistence.contracts.ts` | Width clamped to `[40, max(160, innerWidth - 320)]`; toggle collapsed width `40`; expanded restore min `200` | Versioned (`version:1`) with legacy unversioned upgrade | Read-on-init JSON contract; version drift can break init if not guarded. |
+| `left-panel-width` | `src/tabs/build/BuildSurface.logic.ts` (`useLeftPanelLogic`) | Build tab logic | Persist catalog width | Primitive numeric string (e.g. `"320"`) | Fallback `320` | Inline `Number(raw)` + finite guard in `useLeftPanelLogic` | Width clamped to `[160, max(160, innerWidth - 320)]` | Unversioned primitive by design | Lower-risk scalar contract; intentionally unchanged this pass. |
+
+## Risk ranking
+1. `right-panel-state` — JSON object, read on init, version-sensitive.
+2. `section-*-state` family — JSON object, read on init, shared parser path used by 3 keys.
+3. `left-panel-width` — scalar string with simple finite-number guard.
+
+## Selected targets in this PR
+- `right-panel-state` (`parseRightPanelStatePayload` path).
+- `section-*-state` family (`parseSectionStatePayload` path).
+
+### Rationale
+- Highest risk by prioritization rules: JSON object payloads + read-on-init contracts + shared parser logic.
+- Small-scope consolidation opportunity already existed (`parsePayloadContract`), so hardening could be done with low churn in owner module.
+
+## Hardening implemented
+- Added explicit fallback reason taxonomy: `malformed-json`, `unsupported-version`, `invalid-shape`.
+- Added `wasMigrated` metadata to parse result for explicit legacy-upgrade observability.
+- Added explicit unsupported-version detection with reset-to-default behavior.
+- Preserved legacy unversioned JSON upgrade behavior for backward compatibility.
+
+## Intentionally unchanged
+- `left-panel-width` remains primitive numeric string.
+- Why unchanged: it is a simple scalar with existing finite guard + clamp and does not currently need schema metadata; migrating to JSON in this pass would add churn without commensurate risk reduction.
+
+## Recommended next persistence targets
+1. Extract left-panel numeric parsing into `buildSurfacePersistence.contracts.ts` for uniform diagnostics (`reasonCode`) while keeping primitive storage shape.
+2. Add optional dev-only telemetry aggregation for persistence fallbacks across Build-surface keys to detect contract drift patterns.
+3. If future fields are required for left panel, migrate `left-panel-width` to versioned object with explicit legacy string upgrade path.

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -23,6 +23,7 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - Global context: Theme tokens inherited from cfg-appFrame; routing context determines active tab.
 - External data sources: `localStorage` for persistence of dimensions and collapse preferences.
 - Persistence payload contract: section/right-panel state uses versioned JSON payloads (`{ version: 1, ... }`) while readers continue to accept legacy unversioned JSON during migration.
+- Parser diagnostics contract: section/right-panel parsers emit explicit fallback reasons (`malformed-json`, `unsupported-version`, `invalid-shape`) so read wrappers can report non-fatal, diagnosable reset paths.
 - Left panel width intentionally remains the legacy primitive numeric string contract (`"<width>"`) to avoid unnecessary migration churn for a single scalar value; migrate to versioned JSON only when left-panel persistence needs additional fields/metadata.
 
 ### 2.3 Dependencies
@@ -191,7 +192,9 @@ Coordinates with shell-globalHeader for tab selection, exposes anchors to shell-
 - **[5.2.7] Primitive – "Versioned Payload Contract"**
   - Centralized in `src/tabs/build/buildSurfacePersistence.contracts.ts`.
   - Normalizes persisted section and right-panel payloads to `{ version: 1, ...state }` on writes while accepting prior unversioned JSON shapes on reads.
-  - Handles malformed JSON syntax in parser helpers by returning versioned fallback state with `{ wasFallback: true, reason }` so read-path wrappers can report non-fatal diagnostics consistently.
+  - Handles malformed JSON syntax in parser helpers by returning versioned fallback state with `{ wasFallback: true, reasonCode, reason }` so read-path wrappers can report non-fatal diagnostics consistently.
+  - Distinguishes unsupported version mismatches from malformed/invalid-shape payloads and resets to safe defaults for unsupported/malformed payloads.
+  - Marks successful legacy upgrades via `wasMigrated: true` so the persisted contract can be rewritten as versioned JSON by existing write effects.
   - Left-panel width intentionally remains a primitive numeric string contract until the payload requires additional structured fields.
 
 ### 5.2.3 Derived Values

--- a/src/tabs/build/buildSurfacePersistence.contracts.ts
+++ b/src/tabs/build/buildSurfacePersistence.contracts.ts
@@ -24,9 +24,16 @@ export interface VersionedRightPanelStatePayload {
   collapsed: boolean;
 }
 
+export type BuildSurfacePersistenceFallbackReasonCode =
+  | 'malformed-json'
+  | 'unsupported-version'
+  | 'invalid-shape';
+
 export interface BuildSurfacePersistenceParseResult<TPayload> {
   state: TPayload;
   wasFallback: boolean;
+  wasMigrated: boolean;
+  reasonCode?: BuildSurfacePersistenceFallbackReasonCode;
   reason?: string;
 }
 
@@ -34,10 +41,19 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function hasUnsupportedVersion(value: unknown): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const parsed = value as { version?: unknown };
+  return typeof parsed.version === 'number' && parsed.version !== BUILD_SURFACE_PERSISTENCE_VERSION;
+}
+
 function parsePayloadContract<TVersionedPayload, TLegacyPayload>(
   raw: string,
   fallback: TVersionedPayload,
-  reason: string,
+  fallbackLabel: string,
   isVersionedPayload: (value: unknown) => value is TVersionedPayload,
   isLegacyPayload: (value: unknown) => value is TLegacyPayload,
   upgradeLegacyPayload: (legacyPayload: TLegacyPayload) => TVersionedPayload,
@@ -47,18 +63,44 @@ function parsePayloadContract<TVersionedPayload, TLegacyPayload>(
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return { state: fallback, wasFallback: true, reason };
+    return {
+      state: fallback,
+      wasFallback: true,
+      wasMigrated: false,
+      reasonCode: 'malformed-json',
+      reason: `${fallbackLabel}: malformed-json`,
+    };
   }
 
   if (isVersionedPayload(parsed)) {
-    return { state: parsed, wasFallback: false };
+    return { state: parsed, wasFallback: false, wasMigrated: false };
   }
 
   if (isLegacyPayload(parsed)) {
-    return { state: upgradeLegacyPayload(parsed), wasFallback: false };
+    return {
+      state: upgradeLegacyPayload(parsed),
+      wasFallback: false,
+      wasMigrated: true,
+    };
   }
 
-  return { state: fallback, wasFallback: true, reason };
+  if (hasUnsupportedVersion(parsed)) {
+    return {
+      state: fallback,
+      wasFallback: true,
+      wasMigrated: false,
+      reasonCode: 'unsupported-version',
+      reason: `${fallbackLabel}: unsupported-version`,
+    };
+  }
+
+  return {
+    state: fallback,
+    wasFallback: true,
+    wasMigrated: false,
+    reasonCode: 'invalid-shape',
+    reason: `${fallbackLabel}: invalid-shape`,
+  };
 }
 
 export function serializeSectionStatePayload(

--- a/test/build-surface-utils.test.mjs
+++ b/test/build-surface-utils.test.mjs
@@ -72,7 +72,9 @@ test('parseSectionStatePayload falls back to versioned defaults on malformed pay
       collapsed: false,
     },
     wasFallback: true,
-    reason: 'Malformed persisted section state payload',
+    wasMigrated: false,
+    reasonCode: 'invalid-shape',
+    reason: 'Malformed persisted section state payload: invalid-shape',
   });
 });
 
@@ -91,7 +93,9 @@ test('parseSectionStatePayload handles malformed JSON syntax via non-fatal fallb
         collapsed: false,
       },
       wasFallback: true,
-      reason: 'Malformed persisted section state payload',
+      wasMigrated: false,
+      reasonCode: 'malformed-json',
+      reason: 'Malformed persisted section state payload: malformed-json',
     });
   });
 });
@@ -107,6 +111,26 @@ test('parseRightPanelStatePayload upgrades legacy payloads without version', () 
       collapsed: true,
     },
     wasFallback: false,
+    wasMigrated: true,
+  });
+});
+
+
+
+test('parseRightPanelStatePayload resets unsupported versions with diagnosable reason', () => {
+  const fallback = { width: 320, collapsed: false };
+  const parsed = parseRightPanelStatePayload('{"version":2,"width":500,"collapsed":false}', fallback);
+
+  assert.deepEqual(parsed, {
+    state: {
+      version: 1,
+      width: 320,
+      collapsed: false,
+    },
+    wasFallback: true,
+    wasMigrated: false,
+    reasonCode: 'unsupported-version',
+    reason: 'Malformed persisted right panel state payload: unsupported-version',
   });
 });
 
@@ -120,5 +144,6 @@ test('section payload round-trips through serializer and parser', () => {
   assert.deepEqual(parsed, {
     state: serialized,
     wasFallback: false,
+    wasMigrated: false,
   });
 });


### PR DESCRIPTION
### Motivation
- Improve stability of Build-surface persisted state by making JSON parse/migration outcomes explicit and diagnosable so malformed or version-drifted payloads reset safely and report a clear reason. 
- Keep the change small and owner-local by hardening the existing parser in the Build subsystem and producing an inventory + NL updates rather than introducing a global persistence framework.

### Description
- Added a fallback taxonomy and richer parse result metadata in `src/tabs/build/buildSurfacePersistence.contracts.ts` by introducing `BuildSurfacePersistenceFallbackReasonCode`, extending `BuildSurfacePersistenceParseResult` with `wasMigrated` and `reasonCode`, and updating `parsePayloadContract` to handle `malformed-json`, `unsupported-version`, and `invalid-shape` cases. 
- Preserved legacy upgrade paths by keeping the unversioned-to-versioned migration behavior while making migration explicit (`wasMigrated: true`) and resetting to safe defaults on unsupported versions. 
- Updated documentation and NL contract to reflect the diagnostics contract in `doc/nl-config/cfg-buildSurface.md` and added a repo-level persistence inventory at `doc/audits/persistence-inventory.md` listing all discovered `localStorage` keys, ownership, payload shapes, risk ranking, selected targets, and follow-ups. 
- Adjusted and added tests in `test/build-surface-utils.test.mjs` to cover malformed JSON fallback, invalid-shape fallback, legacy migration signaling, unsupported-version reset, and round-trip serializer/parser behavior.

### Testing
- Ran `npm test` which executed unit tests in `test/**/*.test.mjs` and all tests passed after updates (previously failing assertions were fixed to match the new parse-result contract). 
- Ran `npm run lint` which completed successfully but reports two unrelated pre-existing warnings (non-blocking). 
- Ran `npm run build` which completed successfully producing a production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998eb3620fc8331b9aa126455e7b3cf)