### PR TITLE
Barrel & boundary sanity: expose docs-id contracts and route header imports via content barrel

### DIFF
--- a/doc/audits/Barrel-Boundary-Sanity-2026-02-20.md
+++ b/doc/audits/Barrel-Boundary-Sanity-2026-02-20.md
@@ -1,0 +1,85 @@
+# Barrel & Boundary Sanity Pass — 2026-02-20
+
+## Scope
+- Repo-wide audit of every `src/**/index.ts` and `src/**/index.tsx` barrel.
+- Minimal code fixes applied only for truthful exports and canonical boundary import usage.
+
+## 1) All barrels checked + classification
+
+- `src/content/index.ts`
+  - Classification: **boundary/public API barrel** for content-facing consumers.
+  - Notes: Exposes provider and docs catalog contracts; intentionally does not re-export `contentProviderRegistry`.
+- `src/doc-engine/index.ts`
+  - Classification: **boundary/public API barrel** for doc engine contracts/utilities.
+  - Notes: Re-exports registry/types only (content-agnostic).
+- `src/components/ContentDrawer/index.tsx`
+  - Classification: **feature-local convenience barrel**.
+  - Notes: Exposes component default and `toAnchorId` helper for nearby consumers.
+- `src/components/GlobalHeaderShell/index.tsx`
+  - Classification: **feature-local convenience barrel**.
+  - Notes: Composes build/results concerns + logic and re-exports header tab/mode types.
+- `src/tabs/build/index.tsx`
+  - Classification: **feature-local convenience barrel**.
+  - Notes: Default build tab composer only.
+
+## 2) Invalid/stale/misleading exports found
+
+### Issue A — Missing docs-id exports from content public surface
+- Problem: `src/content/index.ts` did not export docs-id helpers/types used by shell consumers.
+- Why boundary-relevant: Consumers used deep imports into `src/content/packs/...` bypassing content boundary surface.
+- Minimal fix:
+  - Added `HEADER_DOC_IDS`, `isHeaderDocId`, `toDocsContentId`, and `HeaderDocId` exports to `src/content/index.ts`.
+
+### Before/after API sketch (content barrel)
+- Before:
+  - `export { DOCS_PROVIDER, HEADER_DOC_DEFINITIONS, resolveHeaderDoc, ...types }`
+- After:
+  - `export { DOCS_PROVIDER, HEADER_DOC_DEFINITIONS, resolveHeaderDoc, HEADER_DOC_IDS, isHeaderDocId, toDocsContentId, ...types }`
+  - `export type { HeaderDocId }`
+
+## 3) Cross-boundary re-export issues
+
+- No boundary-violating re-exports found in barrels (e.g., no `doc-engine` barrel re-exporting app/UI internals).
+- Import chain observations (non-re-export):
+  - `src/components/GlobalHeaderShell/*` previously imported docs-id symbols via deep path under `src/content/packs/...`.
+  - This was a boundary-usage smell (not a hard ownership leak), corrected by routing imports through `src/content/index.ts`.
+
+## 4) Import-direction guardrail audit
+
+### Required guardrails
+- `src/doc-engine/**` importing from `src/content/**`: **none found**.
+- `src/doc-engine/**` importing from `src/components/**`: **none found**.
+
+### Additional layering observations
+- `src/content/**` imports from `src/doc-engine/index.ts` for engine contracts: expected direction.
+- `src/components/**` imports from `src/content` for UI content resolution and docs metadata: expected direction.
+
+## 5) Cycles (in-scope vs out-of-scope)
+
+- In-scope cycles caused by barrel misuse in touched scope: **none detected** via import inspection.
+- Out-of-scope: no broad cycle-elimination work attempted (per scope cap).
+
+## 6) Convergence notes for duplicate public paths
+
+- Canonical path selected for docs-id access from UI boundary:
+  - `src/content/index.ts`.
+- Transitional/deep path still present in repo:
+  - `src/content/packs/header-docs/header-doc.ids.ts` (direct imports remain valid for pack-internal modules).
+- Minimal convergence fix applied at UI boundary call sites:
+  - `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`
+  - `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`
+
+## 7) Intentionally left unchanged
+
+- `src/components/ContentDrawer/index.tsx` re-export of `toAnchorId` left unchanged.
+  - Reason: feature-local convenience barrel is currently used and not crossing ownership boundaries.
+- `src/tabs/build/index.tsx` left unchanged.
+  - Reason: already truthful and boundary-neutral.
+- No NL/CCPP doc updates.
+  - Reason: no public ownership/responsibility contract changed; only truthful exports/import path convergence.
+
+## 8) Recommended next cleanup targets
+
+1. Add lint rule(s) for restricted deep imports so UI layers must consume content contracts through `src/content/index.ts`.
+2. Evaluate whether `src/components/ContentDrawer/index.tsx` should split helper exports into a non-component module to silence fast-refresh warnings.
+3. Consider formalizing barrel classifications in a short repo note to distinguish public API barrels from convenience barrels.

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -5,7 +5,7 @@
  * Responsibility: Compose semantic header frame with brand identity, tab navigation, and publish CTA anchors.
  * Invariants: Preserve tab order, retain ARIA roles, keep publish CTA as button element.
  */
-import { toDocsContentId } from '../../content/packs/header-docs/header-doc.ids.ts';
+import { toDocsContentId } from '../../content';
 import type { GlobalHeaderShellBuildBindings } from './GlobalHeaderShell.logic';
 
 type HeaderMode = GlobalHeaderShellBuildBindings['activeModeByTab']['build'];

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
@@ -13,7 +13,7 @@
 // Constraints: Values must remain serializable and environment-agnostic.
 // ─────────────────────────────────────────────
 
-import { HEADER_DOC_IDS, type HeaderDocId } from '../../content/packs/header-docs/header-doc.ids.ts';
+import { HEADER_DOC_IDS, type HeaderDocId } from '../../content';
 
 // [6.1] shell-globalHeader · Primitive · "Header Tab Identifier Types"
 // Concern: Knowledge · Catalog: types.identifier

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -6,6 +6,8 @@ export type {
   HeaderDocSection,
 } from './packs/header-docs/header-docs.catalog.ts';
 export { HEADER_DOC_DEFINITIONS, resolveHeaderDoc } from './packs/header-docs/header-docs.catalog.ts';
+export { HEADER_DOC_IDS, isHeaderDocId, toDocsContentId } from './packs/header-docs/header-doc.ids.ts';
+export type { HeaderDocId } from './packs/header-docs/header-doc.ids.ts';
 
 // NOTE: contentProviderRegistry is intentionally not re-exported from this barrel.
 // Import it from ./contentEngine to keep a single canonical ownership path.


### PR DESCRIPTION
### Motivation

- Ensure barrel files are truthful public surfaces and prevent consumers using deep imports across boundaries by exposing required docs-id contracts from the content barrel. 
- Keep the change minimal and low-churn by only fixing misleading exports and a small number of boundary-facing call sites. 
- Preserve extraction guardrails and existing behavior while clarifying canonical import paths for header docs metadata.

### Description

- Exported `HEADER_DOC_IDS`, `isHeaderDocId`, `toDocsContentId` and the `HeaderDocId` type from `src/content/index.ts` so UI consumers can import docs-id helpers through the content public API (symbols added: `HEADER_DOC_IDS`, `isHeaderDocId`, `toDocsContentId`, `HeaderDocId`).
- Replaced deep imports at header UI call sites to use the canonical content barrel by updating `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx` and `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts` to import docs-id symbols from `../../content` instead of `../../content/packs/...`.
- Added an audit report documenting the barrel/boundary pass at `doc/audits/Barrel-Boundary-Sanity-2026-02-20.md` which lists barrels checked, classifications, issues found, and recommended next steps.
- Intentionally left `contentProviderRegistry` unexported from the content barrel to preserve a single canonical ownership path and kept all changes limited to export/import hygiene without changing runtime behavior.

### Testing

- Ran `npm test` and all tests passed (`16` tests, all ok). 
- Ran `npm run lint` which completed successfully but reported existing `react-refresh/only-export-components` warnings (no new lint errors). 
- Ran `npm run build` which completed successfully and produced a production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f085c9bc8331be3078c55a6fd4a6)