### PR TITLE
test: harden content resolver contract coverage

### DIFF
--- a/test/content-provider-registry.test.mjs
+++ b/test/content-provider-registry.test.mjs
@@ -45,6 +45,15 @@ test('parseContentRef returns invalid_ref for abc', () => {
   });
 });
 
+test('parseContentRef treats additional colon segments as part of resolved payload id', () => {
+  // Contract: only the first colon splits namespace from provider-owned id payload.
+  assert.deepEqual(parseContentRef('docs:guides:getting-started'), {
+    type: 'valid',
+    namespace: 'docs',
+    resolvedId: 'guides:getting-started',
+  });
+});
+
 
 test('contentProviderRegistry resolves docs:doc-build to found payload', () => {
   const contentProviderRegistry = createRegistry();
@@ -77,6 +86,44 @@ test('contentProviderRegistry resolves otherns:x to no_provider when only docs p
     namespace: 'otherns',
     contentId: 'x',
     reason: 'No content provider registered for namespace: otherns.',
+  });
+});
+
+test('contentProviderRegistry forwards anchor and context to provider with namespace-stripped content id', () => {
+  const capturedRequests = [];
+  const contentProviderRegistry = new ContentProviderRegistry();
+
+  contentProviderRegistry.registerProvider('docs', {
+    resolveContent: request => {
+      capturedRequests.push(request);
+      return {
+        type: 'found',
+        namespace: 'docs',
+        contentId: request.contentId,
+        anchorId: request.anchorId,
+        payload: request.context,
+      };
+    },
+  });
+
+  const resolved = contentProviderRegistry.resolveContent({
+    contentId: 'docs:build:intro',
+    anchorId: 'overview',
+    context: { locale: 'en-US' },
+  });
+
+  assert.deepEqual(capturedRequests, [{
+    contentId: 'build:intro',
+    anchorId: 'overview',
+    context: { locale: 'en-US' },
+  }]);
+
+  assert.deepEqual(resolved, {
+    type: 'found',
+    namespace: 'docs',
+    contentId: 'build:intro',
+    anchorId: 'overview',
+    payload: { locale: 'en-US' },
   });
 });
 


### PR DESCRIPTION
### Motivation
- Audit revealed a small contract gap in content resolver intake: `parseContentRef` behavior for payload ids containing additional `:` segments was not explicitly tested. 
- The resolver-to-provider forwarding contract (namespace stripping plus passthrough of `anchorId` and `context`) was also unprotected and likely to regress during adapter refactors.

### Description
- Added a parsing contract test in `test/content-provider-registry.test.mjs` that verifies only the first `:` splits the namespace and that remaining segments are preserved in `resolvedId` (`docs:guides:getting-started`).
- Added a resolver forwarding contract test in `test/content-provider-registry.test.mjs` that asserts `ContentProviderRegistry.resolveContent` strips the namespace from the provider request and forwards `anchorId` and `context` unchanged, and that the provider response shape is preserved.
- No production code changes were required; this PR is test-only and keeps scope minimal (2 new tests, within the 3-test cap).

### Testing
- Ran `npm test` and all tests passed (18/18). 
- Ran `npm run lint` which completed successfully with two pre-existing Fast Refresh warnings (no new lint errors). 
- Ran `npm run build` which completed successfully and produced the production build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f4804a008331a80cabaae254bf11)