### PR TITLE
Align NL skeletons and concern comments for build surface & global header; add alignment audit

### DIFF
--- a/doc/ComplianceAudits/Alignment-Audit-2026-02-21.md
+++ b/doc/ComplianceAudits/Alignment-Audit-2026-02-21.md
@@ -1,0 +1,61 @@
+# Alignment Audit – 2026-02-21
+
+## Scope and method
+- Binding routines reviewed first: `doc/ConventionRoutines/CCPP.md`, `doc/ConventionRoutines/CSCS.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md`.
+- Recently changed configuration/shell surfaces were identified from git history focused on active config/shell paths.
+- Audited targets:
+  - `cfg-buildSurface`
+  - `shell-globalHeader`
+
+## 1) cfg-buildSurface
+
+### Violations found
+1. **Build concern numbering drift in comments**
+   - Concern files: `src/tabs/BuildTab.tsx`, `src/tabs/build/BuildSurface.build.tsx`
+   - Sections involved: Build `§3.1.x`, `§3.2.x`, `§3.3.x`
+   - Violation: Comment labels used coarse or mismatched IDs (`[3.1]`, `[3.2]`, `[3.6.x]`) that did not match NL skeleton numbering.
+   - Minimal fix: Renumber atomic comments to the NL identifiers in-order.
+
+2. **Logic concern numbering drift in comments**
+   - Concern file: `src/tabs/build/BuildSurface.logic.ts`
+   - Sections involved: Logic `§5.1.1`–`§5.1.5`
+   - Violation: Container comments used `[5.1]` … `[5.5]` instead of NL IDs.
+   - Minimal fix: Renumber to `[5.1.1]` … `[5.1.5]`.
+
+3. **Knowledge concern numbering drift in comments**
+   - Concern file: `src/tabs/build/anchors.ts`
+   - Sections involved: Knowledge `§6.1.1`, `§6.2.1`
+   - Violation: Comments used `[6.1]` and `[6.2]` instead of NL IDs.
+   - Minimal fix: Renumber to `[6.1.1]` and `[6.2.1]`.
+
+### Status
+- Fixed in this alignment change set.
+
+## 2) shell-globalHeader
+
+### Violations found
+1. **NL → Code + Code → NL mismatch for mode menu atoms**
+   - Concern files: `doc/nl-shell/shell-globalHeader.md`, `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`
+   - Sections involved: Build `§3.2.x`, `§3.3.x`
+   - Violation: Build code contained mode-menu atoms/subcontainers not explicitly represented in NL.
+   - Minimal fix: Update NL first to add Build/Results mode menu subcontainers and shared mode-menu primitive, then renumber Build comments to match.
+
+2. **Knowledge schema/constants mismatch against NL numbering**
+   - Concern files: `doc/nl-shell/shell-globalHeader.md`, `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`
+   - Sections involved: Knowledge `§6.1.x`, `§6.2.x`
+   - Violation: Knowledge file included additional schema/constants with ad-hoc numbering (`6.1.a`, `6.2.a`, etc.) and duplicates not reflected in NL numbering.
+   - Minimal fix: Expand NL knowledge entries for tab schema, mode schema/catalog/sequence, then renumber code comments to aligned numeric IDs.
+
+3. **ResultsStyle atom missing explicit NL section mapping**
+   - Concern files: `doc/nl-shell/shell-globalHeader.md`, `src/components/GlobalHeaderShell/GlobalHeaderShell.results.css`
+   - Sections involved: ResultsStyle `§8.2`
+   - Violation: Code included live-region anchor style atom without explicit NL atomic ID.
+   - Minimal fix: Add `[8.2.1] Live Region Anchor` to NL and align CSS comment to `[8.2.1]`.
+
+### Status
+- Fixed in this alignment change set.
+
+## Purity and dependency direction
+- No new cross-concern imports were introduced during alignment.
+- Changes are comment/metadata/NL alignment only and preserve existing concern boundaries.
+

--- a/doc/nl-shell/shell-globalHeader.md
+++ b/doc/nl-shell/shell-globalHeader.md
@@ -52,10 +52,16 @@ Coordinates with cfg-appFrame to mount the active configuration, routes publish 
   - Children: `[3.3.8] Publish Button`.
 - **[3.2.4] Subcontainer – "Tab Item Row"**
   - Anchor pattern: `data-anchor="global-header.tab-{id}"`
-  - Children: `[3.3.5] Primary Tab Button`, `[3.3.6] Tab Info Icon`.
+  - Children: `[3.3.5] Primary Tab Button`, `[3.3.6] Tab Info Icon`, optional mode menus `[3.2.6] Build Tab – Mode Menu` and `[3.2.7] Results Tab – Mode Menu`.
 - **[3.2.5] Subcontainer – "Debug Panel Container"**
   - Anchor: `data-anchor="global-header.debug"`
   - Purpose: Hosts Results concern output when enabled.
+- **[3.2.6] Subcontainer – "Build Tab – Mode Menu"**
+  - Anchor: `data-anchor="global-header.mode-menu-build"`
+  - Purpose: Inline mode picker rendered adjacent to the Build tab while active/hovered.
+- **[3.2.7] Subcontainer – "Results Tab – Mode Menu"**
+  - Anchor: `data-anchor="global-header.mode-menu-results"`
+  - Purpose: Inline mode picker rendered adjacent to the Results tab while active/hovered.
 
 ### 3.3 Atomic Components — Primitives (Build)
 - **[3.3.1] Primitive – "Brand Home Link"**
@@ -79,6 +85,9 @@ Coordinates with cfg-appFrame to mount the active configuration, routes publish 
 - **[3.3.8] Primitive – "Publish Button"**
   - Element: `<button>`
   - Attributes: `type="button"`, `data-anchor="global-header.publish-button"`.
+- **[3.3.9] Primitive – "Mode Menu Item Baseline"**
+  - Element: `<button>`
+  - Purpose: Shared mode-item renderer used by both Build and Results mode menus.
 
 ## 4. BuildStyle Concern (Visual Styling of Structure)
 ### 4.0 Dependencies
@@ -176,7 +185,13 @@ Coordinates with cfg-appFrame to mount the active configuration, routes publish 
 ### 6.1 Maps / Dictionaries
 - **[6.1.1] Primitive – "Header Tab Identifier Types"**
   - Type aliases enumerating valid tab ids (build, logic, knowledge, results, resultsStyle).
-- **[6.1.2] Primitive – "Breakpoint Definition Schema"**
+- **[6.1.2] Primitive – "Header Tab Definition Schema"**
+  - Interface describing tab metadata consumed by Build and Logic concerns.
+- **[6.1.2.a] Primitive – "Header Tab Map Entry"**
+  - Utility type that stores per-tab metadata without repeating identifier keys.
+- **[6.1.3] Primitive – "Header Mode Definition Schema"**
+  - Interface describing mode metadata consumed by Build mode menus.
+- **[6.1.4] Primitive – "Breakpoint Definition Schema"**
   - Interface describing breakpoint metadata for responsive logic.
 
 ### 6.2 Constants
@@ -191,7 +206,11 @@ Coordinates with cfg-appFrame to mount the active configuration, routes publish 
   - Tooltip text for brand home link.
 - **[6.2.5] Primitive – "Publish Label Copy"**
   - Label for publish button.
-- **[6.2.6] Primitive – "Breakpoint Catalog"**
+- **[6.2.6] Primitive – "Header Mode Metadata Catalog"**
+  - Build/results mode metadata including labels, descriptions, and documentation ids.
+- **[6.2.7] Primitive – "Header Mode Sequence"**
+  - Canonical mode-order arrays used by mode menu renderers.
+- **[6.2.8] Primitive – "Breakpoint Catalog"**
   - Array of desktop/tablet/mobile breakpoint definitions.
 
 ### 6.3 Shared / Global Reference
@@ -219,7 +238,8 @@ ResultsStyle styling lives in CSS or CSS-Module files that target the debug/resu
   - Visual treatment for debug panel: background tint, typography, spacing.
 
 ### 8.2 Debug Display Styles
-- Additional states not yet required.
+- **[8.2.1] Primitive – "Live Region Anchor"**
+  - Selector targets `data-anchor="global-header.aria-live"` to keep announcements visually hidden.
 
 ## 9. Assembly Pattern
 ### 9.1 File Structure

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx
@@ -18,7 +18,7 @@ type ModeDefinition = GlobalHeaderShellBuildBindings['modeMetadata']['build'][He
 // Constraints: No additional wrappers beyond enumerated atoms; maintain anchor consistency.
 // ─────────────────────────────────────────────
 
-// [3.11] shell-globalHeader · Primitive · "Tab Info Icon"
+// [3.3.6] shell-globalHeader · Primitive · "Tab Info Icon"
 // Concern: Build · Parent: "Tab Item Row" · Catalog: action.icon
 // Notes: Shares hover state with tab button while exposing hover summary.
 function InfoIcon({
@@ -61,7 +61,7 @@ function InfoIcon({
   );
 }
 
-// [3.10] shell-globalHeader · Primitive · "Primary Tab Button"
+// [3.3.5] shell-globalHeader · Primitive · "Primary Tab Button"
 // Concern: Build · Parent: "Tab Item Row" · Catalog: navigation.tab
 // Notes: Role `tab` exposes active state and click handler per concern.
 function TabButton({
@@ -106,7 +106,7 @@ function TabButton({
   );
 }
 
-// [3.14] shell-globalHeader · Primitive · "Mode Menu Item Baseline"
+// [3.3.9] shell-globalHeader · Primitive · "Mode Menu Item Baseline"
 // Concern: Build · Parent: "Build/Results Mode Menu" · Catalog: navigation.pill
 // Notes: Shared renderer for Build/Results mode selectors with active state styling.
 function ModeMenuItem({
@@ -139,7 +139,7 @@ function ModeMenuItem({
   );
 }
 
-// [3.10.a] shell-globalHeader · Subcontainer · "Build Tab – Mode Menu"
+// [3.2.6] shell-globalHeader · Subcontainer · "Build Tab – Mode Menu"
 // Concern: Build · Parent: "Tab Item Row" · Catalog: navigation.breadcrumb
 // Notes: Presents inline Build modes when tab active or hovered.
 function BuildModeMenu({
@@ -174,7 +174,7 @@ function BuildModeMenu({
   );
 }
 
-// [3.10.b] shell-globalHeader · Subcontainer · "Results Tab – Mode Menu"
+// [3.2.7] shell-globalHeader · Subcontainer · "Results Tab – Mode Menu"
 // Concern: Build · Parent: "Tab Item Row" · Catalog: navigation.breadcrumb
 // Notes: Presents inline Results modes when tab active or hovered.
 function ResultsModeMenu({
@@ -209,7 +209,7 @@ function ResultsModeMenu({
   );
 }
 
-// [3.1] shell-globalHeader · Container · "Global Header Shell Frame"
+// [3.1.1] shell-globalHeader · Container · "Global Header Shell Frame"
 // Concern: Build · Catalog: layout.shell
 // Notes: Header landmark orchestrating all header zones and anchors.
 export function GlobalHeaderShell({
@@ -229,7 +229,7 @@ export function GlobalHeaderShell({
   isMobile,
   openContent,
 }: GlobalHeaderShellBuildBindings) {
-  // [3.6] shell-globalHeader · Primitive · "Brand Tagline"
+  // [3.3.4] shell-globalHeader · Primitive · "Brand Tagline"
   // Concern: Build · Parent: "Brand Identity Zone" · Catalog: content.copy
   // Notes: Controlled here to suppress tagline on mobile breakpoints.
   const showTagline = !isMobile;
@@ -239,7 +239,7 @@ export function GlobalHeaderShell({
   );
 
   return (
-    // [3.1] shell-globalHeader · Container · "Global Header Shell Frame"
+    // [3.1.1] shell-globalHeader · Container · "Global Header Shell Frame"
     // Concern: Build · Catalog: layout.shell
     // Notes: Landmark wrapper distributing three primary header zones.
     <header data-anchor="global-header" className="global-header-shell">
@@ -307,7 +307,7 @@ export function GlobalHeaderShell({
               ? modeMetadata.results[activeModeId ?? 'default']
               : null;
             return (
-              // [3.9] shell-globalHeader · Subcontainer · "Tab Item Row"
+              // [3.2.4] shell-globalHeader · Subcontainer · "Tab Item Row"
               // Concern: Build · Parent: "Tab List Track" · Catalog: layout.row
               // Notes: Couples tab button, info icon, and mode menu per concern.
               <div

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts
@@ -15,13 +15,13 @@
 
 import { HEADER_DOC_IDS, type HeaderDocId } from '../../content';
 
-// [6.1] shell-globalHeader · Primitive · "Header Tab Identifier Types"
+// [6.1.1] shell-globalHeader · Primitive · "Header Tab Identifier Types"
 // Concern: Knowledge · Catalog: types.identifier
 // Notes: Enumerates supported tab and mode identifiers shared across concerns.
 export type HeaderTabId = 'build' | 'logic' | 'knowledge' | 'results';
 export type HeaderModeId = 'default' | 'style';
 
-// [6.2] shell-globalHeader · Primitive · "Header Tab Definition Schema"
+// [6.1.2] shell-globalHeader · Primitive · "Header Tab Definition Schema"
 // Concern: Knowledge · Catalog: schema.definition
 // Notes: Shapes tab configuration consumed by build concern.
 export interface HeaderTabDefinition {
@@ -32,12 +32,12 @@ export interface HeaderTabDefinition {
   hoverSummary: string;
 }
 
-// [6.1.a] shell-globalHeader · Primitive · "Header Tab Map Entry"
+// [6.1.2.a] shell-globalHeader · Primitive · "Header Tab Map Entry"
 // Concern: Knowledge · Catalog: schema.definition
 // Notes: Stores per-tab metadata without repeating the identifier key.
 export type HeaderTabMapEntry = Omit<HeaderTabDefinition, 'id'>;
 
-// [6.2] shell-globalHeader · Primitive · "Header Mode Definition Schema"
+// [6.1.3] shell-globalHeader · Primitive · "Header Mode Definition Schema"
 // Concern: Knowledge · Catalog: schema.definition
 // Notes: Encapsulates metadata for Build and Results mode selections.
 export interface HeaderModeDefinition {
@@ -53,7 +53,7 @@ export type HeaderModeGroupId = 'build' | 'results';
 export type HeaderModeGroup = Record<HeaderModeId, HeaderModeDefinition>;
 export type HeaderModeCatalog = Record<HeaderModeGroupId, HeaderModeGroup>;
 
-// [6.1.b] shell-globalHeader · Primitive · "Header Tab Knowledge Base"
+// [6.2.1] shell-globalHeader · Primitive · "Header Tab Knowledge Base"
 // Concern: Knowledge · Catalog: data.collection
 // Notes: Canonical list of header tabs sorted by `order`.
 export const HEADER_TAB_MAP: Record<HeaderTabId, HeaderTabMapEntry> = {
@@ -87,7 +87,7 @@ export const HEADER_TAB_DEFINITIONS: HeaderTabDefinition[] = Object.entries(HEAD
   .map(([id, entry]) => ({ id: id as HeaderTabId, ...entry }))
   .sort((a, b) => a.order - b.order);
 
-// [6.2.a] shell-globalHeader · Primitive · "Header Mode Metadata Catalog"
+// [6.2.6] shell-globalHeader · Primitive · "Header Mode Metadata Catalog"
 // Concern: Knowledge · Catalog: data.collection
 // Notes: Provides labels and descriptions for Build and Results mode selectors.
 export const HEADER_MODE_DEFINITIONS: HeaderModeCatalog = {
@@ -125,7 +125,7 @@ export const HEADER_MODE_DEFINITIONS: HeaderModeCatalog = {
   },
 };
 
-// [6.2.b] shell-globalHeader · Primitive · "Header Mode Sequence"
+// [6.2.7] shell-globalHeader · Primitive · "Header Mode Sequence"
 // Concern: Knowledge · Catalog: data.collection
 // Notes: Preserves canonical ordering when rendering mode options.
 export type HeaderModeSequence = Record<HeaderModeGroupId, HeaderModeId[]>;
@@ -135,7 +135,7 @@ export const HEADER_MODE_SEQUENCE: HeaderModeSequence = {
   results: ['default', 'style'],
 };
 
-// [6.3] shell-globalHeader · Primitive · "Breakpoint Definition Schema"
+// [6.1.4] shell-globalHeader · Primitive · "Breakpoint Definition Schema"
 // Concern: Knowledge · Catalog: schema.definition
 // Notes: Structure for responsive breakpoint metadata.
 export interface BreakpointDefinition {
@@ -143,7 +143,7 @@ export interface BreakpointDefinition {
   minWidth: number;
 }
 
-// [6.3.a] shell-globalHeader · Primitive · "Responsive Breakpoint Catalog"
+// [6.2.8] shell-globalHeader · Primitive · "Breakpoint Catalog"
 // Concern: Knowledge · Catalog: data.collection
 // Notes: Breakpoint ordering aligns with logic heuristic priority.
 export const BREAKPOINTS: BreakpointDefinition[] = [
@@ -152,22 +152,22 @@ export const BREAKPOINTS: BreakpointDefinition[] = [
   { name: 'mobile', minWidth: 0 },
 ];
 
-// [6.4] shell-globalHeader · Primitive · "Brand Wordmark Copy"
+// [6.2.2] shell-globalHeader · Primitive · "Brand Wordmark Copy"
 // Concern: Knowledge · Catalog: content.copy
 // Notes: Brand name presented inside header link.
 export const BRAND_WORDMARK = 'Calculogic';
 
-// [6.4.a] shell-globalHeader · Primitive · "Brand Tagline Copy"
+// [6.2.3] shell-globalHeader · Primitive · "Brand Tagline Copy"
 // Concern: Knowledge · Catalog: content.copy
 // Notes: Supportive phrase rendered conditionally in build concern.
 export const BRAND_TAGLINE = 'a system for creating systems';
 
-// [6.4.b] shell-globalHeader · Primitive · "Brand Tooltip Copy"
+// [6.2.4] shell-globalHeader · Primitive · "Brand Tooltip Copy"
 // Concern: Knowledge · Catalog: content.copy
 // Notes: Tooltip content reinforcing link destination.
 export const BRAND_TOOLTIP = 'Return to Calculogic home / dashboard.';
 
-// [6.4.c] shell-globalHeader · Primitive · "Publish Label Copy"
+// [6.2.5] shell-globalHeader · Primitive · "Publish Label Copy"
 // Concern: Knowledge · Catalog: content.copy
 // Notes: Publish CTA text consumed by build concern.
 export const PUBLISH_LABEL = 'Publish';

--- a/src/components/GlobalHeaderShell/GlobalHeaderShell.results.css
+++ b/src/components/GlobalHeaderShell/GlobalHeaderShell.results.css
@@ -26,7 +26,7 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-/* [8.2] shell-globalHeader · Primitive · "Live Region Anchor"
+/* [8.2.1] shell-globalHeader · Primitive · "Live Region Anchor"
    Concern: ResultsStyle · Catalog: accessibility.liveRegion
    Notes: Ensures live region does not disrupt layout when rendered inline. */
 [data-anchor='global-header.aria-live'] {

--- a/src/tabs/BuildTab.tsx
+++ b/src/tabs/BuildTab.tsx
@@ -13,7 +13,7 @@
 // Constraints: Barrel stays stateless and transparent.
 // ─────────────────────────────────────────────
 
-// [3.1] cfg-buildSurface · Container · "Build Tab Forwarder"
+// [3.1.1] cfg-buildSurface · Container · "Build Tab Forwarder"
 // Concern: Build · Catalog: composition.forwarder
 // Notes: Re-exports the build assembly to preserve the App router contract.
 export { default } from './build';

--- a/src/tabs/build/BuildSurface.build.tsx
+++ b/src/tabs/build/BuildSurface.build.tsx
@@ -17,7 +17,7 @@ import { sectionTitle } from './BuildSurface.logic';
 // Constraints: No styling or state mutations beyond structural composition.
 // ─────────────────────────────────────────────
 
-// [3.2] cfg-buildSurface · Primitive · "Chevron Left Icon"
+// [3.3.1] cfg-buildSurface · Primitive · "Chevron Left Icon"
 // Concern: Build · Parent: "Section Panel Template" · Catalog: chrome.icon
 // Notes: Points inward to signal an expanded panel state within catalog shells.
 function ChevronLeftIcon() {
@@ -35,7 +35,7 @@ function ChevronLeftIcon() {
   );
 }
 
-// [3.3] cfg-buildSurface · Primitive · "Chevron Right Icon"
+// [3.3.2] cfg-buildSurface · Primitive · "Chevron Right Icon"
 // Concern: Build · Parent: "Section Panel Template" · Catalog: chrome.icon
 // Notes: Points outward to communicate collapsed panel affordances.
 function ChevronRightIcon() {
@@ -58,7 +58,7 @@ interface SectionContentConfig {
   render: () => ReactNode;
 }
 
-// [3.4] cfg-buildSurface · Primitive · "Section Content Catalog"
+// [3.3.3] cfg-buildSurface · Primitive · "Section Content Catalog"
 // Concern: Build · Parent: "Section Panel Template" · Catalog: layout.catalog
 // Notes: Maps section identifiers to anchored placeholder content for catalog panels.
 const SECTION_CONTENT: SectionContentConfig[] = [
@@ -123,7 +123,7 @@ function renderSectionContent(id: SectionId) {
   return match ? match.render() : null;
 }
 
-// [3.5] cfg-buildSurface · Subcontainer · "Section Panel Template"
+// [3.2.6] cfg-buildSurface · Subcontainer · "Section Panel Template"
 // Concern: Build · Parent: "Catalog Column" · Catalog: layout.section
 // Notes: Wraps section headers, content, and grips with deterministic anchors and ARIA bindings.
 function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
@@ -162,7 +162,7 @@ function SectionPanel({ binding }: { binding: SectionLogicBinding }) {
   );
 }
 
-// [3.6] cfg-buildSurface · Container · "Build Surface Layout"
+// [3.1.2] cfg-buildSurface · Container · "Build Surface Layout"
 // Concern: Build · Parent: "Build Surface Composer" · Catalog: layout.shell
 // Notes: Coordinates header chrome, catalog panels, preview stage, and inspector anchors.
 export function BuildSurface({
@@ -172,7 +172,7 @@ export function BuildSurface({
   leftPanel,
   rightPanel,
 }: BuildSurfaceBindings) {
-  // [3.6.2] cfg-buildSurface · Subcontainer · "Catalog Column"
+  // [3.2.3] cfg-buildSurface · Subcontainer · "Catalog Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column
   // Notes: Lists section panels in logic-supplied order with live resize affordances.
   const catalogColumn = (
@@ -189,7 +189,7 @@ export function BuildSurface({
     </aside>
   );
 
-  // [3.6.3] cfg-buildSurface · Primitive · "Catalog Grip"
+  // [3.3.5] cfg-buildSurface · Primitive · "Catalog Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Exposes left panel resize separator connected to logic grip props.
   const catalogGrip = (
@@ -200,7 +200,7 @@ export function BuildSurface({
     />
   );
 
-  // [3.6.4] cfg-buildSurface · Subcontainer · "Preview Stage"
+  // [3.2.4] cfg-buildSurface · Subcontainer · "Preview Stage"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.region
   // Notes: Placeholder canvas for future form preview anchored to center panel IDs.
   const previewStage = (
@@ -211,7 +211,7 @@ export function BuildSurface({
     </main>
   );
 
-  // [3.6.5] cfg-buildSurface · Primitive · "Inspector Grip"
+  // [3.3.7] cfg-buildSurface · Primitive · "Inspector Grip"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: control.grip
   // Notes: Provides resize handle between preview stage and inspector column.
   const inspectorGrip = (
@@ -222,7 +222,7 @@ export function BuildSurface({
     />
   );
 
-  // [3.6.6] cfg-buildSurface · Subcontainer · "Inspector Column"
+  // [3.2.5] cfg-buildSurface · Subcontainer · "Inspector Column"
   // Concern: Build · Parent: "Build Surface Layout" · Catalog: layout.column
   // Notes: Collapsible inspector with settings placeholder anchored to logic-provided IDs.
   const inspectorColumn = (

--- a/src/tabs/build/BuildSurface.logic.ts
+++ b/src/tabs/build/BuildSurface.logic.ts
@@ -31,7 +31,7 @@ import {
 // Constraints: Hooks stay local to the Build tab and clean up global listeners.
 // ─────────────────────────────────────────────
 
-// [5.1] cfg-buildSurface · Container · "Section Contracts"
+// [5.1.1] cfg-buildSurface · Container · "Section Contracts"
 // Concern: Logic · Catalog: contract.section
 // Notes: Declares section identifiers, binding shapes, order, and helpers shared with Build.
 export type SectionId = 'configurations' | 'atomic-components' | 'search-configurations';
@@ -130,7 +130,7 @@ export function sectionTitle(id: SectionId) {
   }
 }
 
-// [5.2] cfg-buildSurface · Container · "Section Logic Hook"
+// [5.1.2] cfg-buildSurface · Container · "Section Logic Hook"
 // Concern: Logic · Parent: "Section Contracts" · Catalog: hook.section
 // Notes: Persists section height/collapse state and emits ARIA-aware bindings.
 function useSectionLogic(
@@ -237,7 +237,7 @@ function useSectionLogic(
   };
 }
 
-// [5.3] cfg-buildSurface · Container · "Left Panel Logic"
+// [5.1.3] cfg-buildSurface · Container · "Left Panel Logic"
 // Concern: Logic · Parent: "Section Logic Hook" · Catalog: hook.panel
 // Notes: Persists catalog column width and exposes accessible grip bindings.
 function useLeftPanelLogic(): LeftPanelLogic {
@@ -308,7 +308,7 @@ function useLeftPanelLogic(): LeftPanelLogic {
   };
 }
 
-// [5.4] cfg-buildSurface · Container · "Right Panel Logic"
+// [5.1.4] cfg-buildSurface · Container · "Right Panel Logic"
 // Concern: Logic · Parent: "Left Panel Logic" · Catalog: hook.panel
 // Notes: Manages inspector width persistence, collapse toggles, and grip bindings.
 function useRightPanelLogic(): RightPanelLogic {
@@ -396,7 +396,7 @@ function useRightPanelLogic(): RightPanelLogic {
   };
 }
 
-// [5.5] cfg-buildSurface · Container · "Surface Bindings"
+// [5.1.5] cfg-buildSurface · Container · "Surface Bindings"
 // Concern: Logic · Parent: "Right Panel Logic" · Catalog: hook.aggregator
 // Notes: Bundles anchor map, ordered sections, and panel bindings for the Build layout.
 export function useBuildSurfaceLogic(): BuildSurfaceBindings {

--- a/src/tabs/build/anchors.ts
+++ b/src/tabs/build/anchors.ts
@@ -13,7 +13,7 @@
 // Constraints: Anchor registry stays deterministic and pure.
 // ─────────────────────────────────────────────
 
-// [6.1] cfg-buildSurface · Primitive · "Anchor Registry"
+// [6.1.1] cfg-buildSurface · Primitive · "Anchor Registry"
 // Concern: Knowledge · Catalog: contract.anchor
 // Notes: Enumerates public anchor factories consumed by Build, BuildStyle, and Logic.
 export const BUILD_ANCHORS = {
@@ -37,7 +37,7 @@ export const BUILD_ANCHORS = {
   list: (id: string) => `builder-list-${id}`,
 } as const;
 
-// [6.2] cfg-buildSurface · Primitive · "Anchor Type Alias"
+// [6.2.1] cfg-buildSurface · Primitive · "Anchor Type Alias"
 // Concern: Knowledge · Parent: "Anchor Registry" · Catalog: contract.type
 // Notes: Provides union of anchor identifiers for compile-time validation.
 export type BuildAnchorId = typeof BUILD_ANCHORS[keyof typeof BUILD_ANCHORS];


### PR DESCRIPTION
### Motivation

- Restore Calculogic CCPP/CSCS + NL‑First alignment by fixing comment numbering and NL ↔ code mismatches observed in recently changed header and build-surface areas. 
- Ensure the code's atomic comment IDs mirror the authoritative NL skeleton so tooling and reviewers can rely on stable anchors and provenance. 
- Record the findings and fixes in a repeatable audit for future compliance reviews.

### Description

- Updated the NL skeleton first: modified `doc/nl-shell/shell-globalHeader.md` to declare the implemented mode‑menu subcontainers, mode metadata primitives, and an explicit ResultsStyle live‑region atom so NL represents current code structure. 
- Renumbered and aligned atomic/section comments to match the NL identifiers across Build/Logic/Knowledge/ResultsStyle concerns in these files: `src/components/GlobalHeaderShell/GlobalHeaderShell.build.tsx`, `src/components/GlobalHeaderShell/GlobalHeaderShell.knowledge.ts`, `src/components/GlobalHeaderShell/GlobalHeaderShell.results.css`, `src/tabs/BuildTab.tsx`, `src/tabs/build/BuildSurface.build.tsx`, `src/tabs/build/BuildSurface.logic.ts`, and `src/tabs/build/anchors.ts` (comments updated only; behavior preserved). 
- Added a compliance artifact `doc/ComplianceAudits/Alignment-Audit-2026-02-21.md` documenting violations found, exact section references, and the minimal fixes applied in this alignment change set.

### Testing

- Ran `npm run -s lint`, which completed with no errors (two pre-existing fast-refresh warnings reported in unrelated files). 
- Ran `npm run -s build` (Vite production build), which completed successfully and produced the distribution artifacts. 
- No runtime/behavioral changes were introduced; this change set is limited to NL documentation and comment/provenance numbering alignment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ea9413308331a87658f0e70f200d)