### PR TITLE
docs(conventions): align convention docs formatting and V1.2 labels, defer file renames

### DIFF
--- a/doc/ConventionRoutines/CCPP.md
+++ b/doc/ConventionRoutines/CCPP.md
@@ -1,5 +1,5 @@
-Calculogic Comment & Provenance Protocol (CCPP, NL-Aligned)
-1. Purpose
+# Calculogic Comment & Provenance Protocol (CCPP, NL-Aligned)
+## 1. Purpose
 Comments encode intent, structure, and provenance in a way that:
 Mirrors the NL skeleton order,
 
@@ -9,7 +9,7 @@ And keeps files navigable top-down.
 
 Comments are not narration of obvious code; they are a projection of the NL skeleton and decisions into the codebase.
 
-2. Comment Types (Use Only These)
+## 2. Comment Types (Use Only These)
 File Header – one per file.
 
 Section Header – top of each config section inside a file.
@@ -24,8 +24,8 @@ TODO with expiry – actionable, owner + date.
 
 Provenance Block – when external logic/content influences code (no payload).
 
-3. Required Fields & Format
-3.1 File Header (TS/TSX/TS, etc.)
+## 3. Required Fields & Format
+### 3.1 File Header (TS/TSX/TS, etc.)
 /**
  * ProjectShell/Config: Global Header Shell (shell-globalHeader)
  * Concern File: Build | BuildStyle | Logic | Knowledge | Results | ResultsStyle
@@ -35,7 +35,7 @@ Provenance Block – when external logic/content influences code (no payload).
  * Notes: <optional; ADR id, link, or short note>
  */
 For non-shell configs, replace ProjectShell/Config with Configuration: cfg-....
-3.2 Section Header (per configuration inside a concern file)
+### 3.2 Section Header (Per Configuration Inside a Concern File)
 // ─────────────────────────────────────────────
 // 3. Build – cfg-tabNavigation (Tab Navigation)
 // NL Sections: §3.0–3.3 in cfg-tabNavigation.md
@@ -44,7 +44,7 @@ For non-shell configs, replace ProjectShell/Config with Configuration: cfg-....
 // ─────────────────────────────────────────────
 The leading number (3. here) matches the NL skeleton’s concern index.
 
-3.3 Atomic Comment (Container / Subcontainer / Primitive)
+### 3.3 Atomic Comment (Container / Subcontainer / Primitive)
 // [3.2.2] cfg-tabNavigation · Subcontainer · "Center Zone – Tab Strip"
 // Concern: Build · Parent: "Global Header Shell" · Catalog: layout.group
 // Notes: hosts 4 tabs and info icons; no reordering; center-aligned
@@ -59,26 +59,26 @@ Second line: Concern, Parent (if any), Catalog id.
 Third line: short intent/constraint note.
 
 These should read like compressed NL bullets and are the main thing AI should preserve.
-3.4 Inline Rationale
+### 3.4 Inline Rationale
 // WHY: Avoids focus loss when switching tabs via keyboard
 Use sparingly, only when the reason is not obvious.
-3.5 Decision Note
+### 3.5 Decision Note
 // DECISION: Tab hover previews via CSS only | 2025-11-05
 // Context: Keep Logic lightweight for header interactions
 // Choice: Use CSS hover for previews instead of JS listeners
 // Consequence: Less JS complexity; no previews on touch devices
 // ADR: header-hover-001   // optional
 Promote a Decision note to a standalone ADR when the rationale spans multiple paragraphs, introduces cross-team dependencies, or affects more than one configuration. Longer decisions live alongside other records in doc/decisions/*.md; reference the ADR id from the inline note once it exists.
-3.6 TODO with expiry
+### 3.6 TODO with Expiry
 // TODO(@owner, 2025-12-01): Wire openDoc(docId) to docs modal shell
 Must always have owner and date.
-3.7 Provenance Block
+### 3.7 Provenance Block
 // SOURCE: https://example.org/a11y/tabs
 // Accessed: 2025-11-05T14:22:00Z
 // Note: Pattern used as reference for keyboard tab navigation; no content copied
 No payload; just reference.
 
-4. Language & Mapping
+## 4. Language & Mapping
 TS/TSX/JS: /** ... */ for file header; // ... for everything else.
 
 CSS: /* ... */ for file and atomic comments; still match NL numbers.
@@ -89,7 +89,7 @@ JSON: no comments; if needed, keep a .meta or .md doc instead.
 
 Markdown docs: NL skeletons themselves.
 
-5. NL Skeleton Alignment
+## 5. NL Skeleton Alignment
 Every concern file must have:
 
 A file header linking to its NL doc.
@@ -104,7 +104,7 @@ When a number changes in NL (e.g. 3.2.1 → 3.2.2), comments should be updated t
 
 When a new atomic is added to NL, a new atomic comment + code block is added in the same position.
 
-6. Strict Do / Don’t
+## 6. Strict Do / Don’t
 Do
 Use NL section numbers [3.2.1] consistently across files.
 
@@ -123,7 +123,7 @@ Use unlabeled TODO:.
 
 Copy external content into comments.
 
-7. Minimal Examples
+## 7. Minimal Examples
 Build file:
 /**
  * Configuration: cfg-tabNavigation (Tab Navigation)
@@ -159,7 +159,7 @@ BuildStyle file:
   /* ... */
 }
 
-Bad vs. good atomic comments
+### Bad vs. Good Atomic Comments
 
 - Bad:
   - `// handles tab click`
@@ -170,7 +170,7 @@ Bad vs. good atomic comments
   - `// Concern: Logic · Parent: "Tab Navigation Logic" · Notes: syncs active tab state`
   - `const handleTabSelect = (tabId: string) => setActiveTab(tabId);`
 
-8. Maintenance Rules
+## 8. Maintenance Rules
 On every structural change:
 Update the NL skeleton first.
 
@@ -185,7 +185,7 @@ Remove or update any Decision notes that no longer apply (add new ones instead o
 Clean up or close TODOs on each release cut.
 
 
-9. Pre-Merge CCPP Review Checklist
+## 9. Pre-Merge CCPP Review Checklist
 Before merging, confirm each touched concern file passes all checks:
 
 - [ ] File header uses `Configuration:` or `ProjectShell/Config:` (as applicable), includes `Concern File`, `Source NL`, `Responsibility`, and `Invariants`.

--- a/doc/ConventionRoutines/CSCS.md
+++ b/doc/ConventionRoutines/CSCS.md
@@ -1,5 +1,7 @@
-Calculogic Concern System (CCS, NL-Aligned, Codebase-Level)
-1. First Principles
+# Calculogic Concern System (CCS, NL-Aligned, Codebase-Level)
+
+> Note: This document filename remains `CSCS.md` for compatibility in this pass. In content, the canonical acronym is **CCS** (Calculogic Concern System).
+## 1. First Principles
 Configuration is semantic, not a file
 
 A Configuration is a semantic module (e.g. “Global Header Shell”, “Tab Navigation”).
@@ -8,7 +10,7 @@ It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, Resul
 
 Code lives in six concern files; the configuration is defined by its NL skeleton, not its file layout. The canonical section layout and numbering for NL skeletons is defined in General-NL-Skeletons.md and every configuration or shell document must follow it exactly.
 
-NL Skeleton as the ordering source
+### NL Skeleton as the Ordering Source
 
 Each configuration has an NL Configuration Skeleton (or ProjectShell skeleton).
 
@@ -16,7 +18,7 @@ The skeleton’s numbered sections (3 = Build, 4 = BuildStyle, 5 = Logic, 6 = Kn
 
 Code in all concern files must follow this order and mirror the same numbering in comments.
 
-Concerns vs. hierarchical types (orthogonal axes)
+### Concerns vs. Hierarchical Types (Orthogonal Axes)
 
 Every Atomic Component has:
 
@@ -26,7 +28,7 @@ A Hierarchical type: Container, Subcontainer, or Primitive.
 
 These axes are independent: you can have a Logic Container, a Build Primitive, a ResultsStyle Primitive, etc.
 
-Purity per concern
+### Purity per Concern
 
 Build – structure only (containers, subcontainers, primitives; no state, no visual design tokens).
 
@@ -40,7 +42,7 @@ Results – derived outputs / readouts; no structure creation beyond what Build 
 
 ResultsStyle – styling of results; no structure, no logic.
 
-Folder mapping
+### Folder Mapping
 
 - Build → files like src/configs/<configId>/<ConfigName>.build.tsx or src/shells/<shellId>/<ShellName>.build.tsx
 - BuildStyle → CSS or CSS-Module files like src/configs/<configId>/<ConfigName>.build.module.css or src/shells/<shellId>/<ShellName>.build.css
@@ -51,7 +53,7 @@ Folder mapping
 
 Shells follow the same pattern within src/shells/<shellId>/, sharing the same base name across all concern files. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files; the corresponding Build and Results `.tsx` components expose the class names and data attributes that those styles consume.
 
-Structure source and fallbacks
+### Structure Source and Fallbacks
 
 Build is the default structural source for any UI configuration or shell.
 
@@ -59,13 +61,13 @@ Non-structural concerns (BuildStyle, Logic, Knowledge, Results, ResultsStyle) ne
 
 Fallback (rare): if a configuration has no Build (e.g. a pure data concern), use the highest present non-style concern as the mental ordering source (Logic → Knowledge → Results), but it still must not invent DOM structure.
 
-Anchors are stable
+### Anchors Are Stable
 
 Every visible piece of structure exposes stable anchors (class, data-anchor, or id).
 
 All non-Build concerns refer to these anchors, never to incidental DOM or query patterns.
 
-Directional dependencies
+### Directional Dependencies
 
 Build → BuildStyle / Logic / ResultsStyle.
 
@@ -75,19 +77,19 @@ Knowledge informs all but depends on none.
 
 No upward or cyclic imports (e.g., Results cannot feed Logic, Logic cannot define anchors).
 
-Locality
+### Locality
 
 Code for one configuration’s concerns lives in its folder under builder/configs/ or builder/shells/.
 
 Nested configurations (e.g., a shell zone as its own config) live inside the parent’s folder but obey all the same rules independently.
 
-Monotonic diffs
+### Monotonic Diffs
 
 When you change structure in the NL skeleton for a configuration, corresponding changes in Build, BuildStyle, Logic, Knowledge, Results, and ResultsStyle must appear in the same top-down order when you read each file.
 
-2. Configuration Definition Template (Per Configuration or Shell)
+## 2. Configuration Definition Template (Per Configuration or Shell)
 Use this before writing code or asking AI to generate code.
-NL Skeleton:
+### NL Skeleton
 Create doc/nl-config/cfg-*.md or doc/nl-shell/shell-*.md using the General NL Skeleton – Configuration-Level or ProjectShell-Level.
 
 That document is the canonical contract for:
@@ -100,7 +102,7 @@ Containers/Subcontainers/Primitives and their order,
 
 Numbering (3.x.y, 4.x.y, 5.x.y, etc.).
 
-Concern entry (per configuration):
+### Concern Entry (Per Configuration)
 Name: Short, unambiguous; use cfg-* for configs, shell-* for shells.
 
 Purpose (1 sentence): What outcome this configuration achieves.
@@ -119,7 +121,7 @@ Invariants: Truths that must always hold (e.g. “Tabs never wrap; scroll instea
 
 Dependencies: Only on lower-level utilities, shared hooks, or Knowledge; no cross-concern cheating.
 
-3. Atomic Components (per concern)
+## 3. Atomic Components (Per Concern)
 For each concern in the NL skeleton, list:
 Containers – top-level roots for that concern in this configuration.
 
@@ -127,7 +129,7 @@ Subcontainers – nested encapsulations inside Containers.
 
 Primitives – leaves: individual fields, rules, styles, state atoms, maps, result lines.
 
-Rules:
+### Rules
 A concern can have one or more Containers at the top level.
 
 Subcontainers only appear inside Containers (never at the root of a concern).
@@ -139,9 +141,9 @@ Flat roots (contain only primitives), or
 
 Hierarchical roots (contain subcontainers and primitives).
 
-4. Decision Rules (What Belongs Where, NL-Aware)
+## 4. Decision Rules (What Belongs Where, NL-Aware)
 Use these to keep responsibilities clean:
-Structure vs interaction vs readout
+### Structure vs Interaction vs Readout
 
 Changes to regions, zones, section layout → Build.
 
@@ -153,24 +155,24 @@ Copy, labels, options, thresholds → Knowledge.
 
 Counters, scores, derived summaries → Results.
 
-No structure in non-structural concerns
+### No Structure in Non-Structural Concerns
 
 BuildStyle, Logic, Knowledge, Results, ResultsStyle must not introduce new DOM or change sibling ordering. They attach to anchors established in Build.
 
-Results is “where data ends”
+### Results Is “Where Data Ends”
 
 Once you are just showing derived information (e.g., state summaries, counts, debug), it belongs in Results / ResultsStyle; it cannot mutate structure or state.
 
-Knowledge is guidance, not behavior
+### Knowledge Is Guidance, Not Behavior
 
 Tooltips, doc text, label maps, thresholds live in Knowledge and do not contain side effects or layout code.
 
-Use the NL hierarchy to split or merge
+### Use the NL Hierarchy to Split or Merge
 
 If you can’t describe a section of behavior/structure in a single NL bullet under one concern, it’s a sign you have multiple concerns tangled together—split them.
 
-5. Nested vs Sibling Configurations
-Nested configuration if all are true:
+## 5. Nested vs Sibling Configurations
+### Nested Configuration (All Must Be True)
 
 It attaches to specific anchors owned by a parent configuration.
 
@@ -180,7 +182,7 @@ It never reorders or replaces the parent’s anchors.
 
 Example: The global header shell includes a nested tab-strip configuration that mounts directly into the header’s Build anchors.
 
-Sibling configuration otherwise:
+### Sibling Configuration (Otherwise)
 
 It uses the same frame (shell) but defines its own Build structure and anchors.
 
@@ -188,8 +190,8 @@ Promote from nested → sibling when a feature gains its own structure, reuse, o
 
 Example: cfg-intro, cfg-q-motivations, and cfg-buildSurface coexist as siblings that the spa host shell swaps within the same main-pane frame.
 
-6. Change Management
-When you change a configuration:
+## 6. Change Management
+### When You Change a Configuration
 Update its NL skeleton first:
 
 Adjust the numbering and text for any moved/added/removed Container/Subcontainer/Primitive.
@@ -204,7 +206,7 @@ Preserve anchors if possible:
 
 If anchors must change, treat that as a deliberate breaking change and update all attached concerns.
 
-Acceptance (per PR):
+### Acceptance (Per PR)
 
 NL skeleton updated and committed.
 

--- a/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -51,7 +51,7 @@ This spec is intentionally explicit and semantic (no guessing/inference required
 ## Table of Contents
 
 - [Purpose](#purpose)
-- [Scope and Adoption Policy (V1.1)](#scope-and-adoption-policy-v11)
+- [Scope and Adoption Policy (V1.2)](#scope-and-adoption-policy-v12)
   - [Scope (what this applies to)](#scope-what-this-applies-to)
   - [Legacy file reality (important)](#legacy-file-reality-important)
   - [Adoption rule](#adoption-rule)
@@ -86,7 +86,7 @@ This spec is intentionally explicit and semantic (no guessing/inference required
     - [`adapter` (optional future)](#adapter-optional-future)
     - [`registry` (optional future)](#registry-optional-future)
     - [`selector` (optional future, use carefully)](#selector-optional-future-use-carefully)
-- [Legacy Migration and Rename Policy (V1.1)](#legacy-migration-and-rename-policy-v11)
+- [Legacy Migration and Rename Policy (V1.2)](#legacy-migration-and-rename-policy-v12)
   - [Do not mass-rename by default](#do-not-mass-rename-by-default)
   - [Rename when it is justified](#rename-when-it-is-justified)
   - [Commit hygiene for renames](#commit-hygiene-for-renames)
@@ -109,26 +109,26 @@ This spec is intentionally explicit and semantic (no guessing/inference required
   - [Bad examples](#bad-examples)
 - [Validation Rules V1 (for future script/test)](#validation-rules-v1-for-future-scripttest)
 - [Change Policy V1](#change-policy-v1)
-- [Validator Rollout Guidance (V1.1)](#validator-rollout-guidance-v11)
+- [Validator Rollout Guidance (V1.2)](#validator-rollout-guidance-v12)
   - [Recommended validator modes](#recommended-validator-modes)
   - [Important](#important)
 - [Suggested Initial Active Role Set](#suggested-initial-active-role-set)
-- [Role to Extension Guidance (Recommended, Non-Binding) (V1.1)](#role-to-extension-guidance-recommended-non-binding-v11)
+- [Role to Extension Guidance (Recommended, Non-Binding) (V1.2)](#role-to-extension-guidance-recommended-non-binding-v12)
   - [Recommended patterns](#recommended-patterns)
   - [Notes](#notes)
-- [Allowed Special Cases and Reserved Filenames (V1.1)](#allowed-special-cases-and-reserved-filenames-v11)
+- [Allowed Special Cases and Reserved Filenames (V1.2)](#allowed-special-cases-and-reserved-filenames-v12)
   - [1) Barrel files](#1-barrel-files)
   - [2) Framework / tool required filenames](#2-framework--tool-required-filenames)
   - [3) Route / entrypoint convention files (if applicable)](#3-route--entrypoint-convention-files-if-applicable)
   - [4) Test files (if/when covered by separate test naming spec)](#4-test-files-ifwhen-covered-by-separate-test-naming-spec)
   - [5) Type declaration and ambient files](#5-type-declaration-and-ambient-files)
-- [Rename Impact Checklist (V1.1)](#rename-impact-checklist-v11)
+- [Rename Impact Checklist (V1.2)](#rename-impact-checklist-v12)
   - [Required checks](#required-checks)
   - [Sanity checks](#sanity-checks)
 
 ---
 
-## Scope and Adoption Policy (V1.1)
+## Scope and Adoption Policy (V1.2)
 
 This document defines the canonical naming contract for Calculogic code files.
 
@@ -423,7 +423,7 @@ Defines style concerns for results-layer presentation.
 
 ---
 
-## Legacy Migration and Rename Policy (V1.1)
+## Legacy Migration and Rename Policy (V1.2)
 
 This section prevents unnecessary churn while still moving the repo toward canonical naming.
 
@@ -735,7 +735,7 @@ When adding a new role, explicitly classify whether it is a concern-aligned role
 
 ---
 
-## Validator Rollout Guidance (V1.1)
+## Validator Rollout Guidance (V1.2)
 
 Validation should support incremental adoption.
 
@@ -797,7 +797,7 @@ This is already a usable foundation for:
 
 ---
 
-## Role to Extension Guidance (Recommended, Non-Binding) (V1.1)
+## Role to Extension Guidance (Recommended, Non-Binding) (V1.2)
 
 Role defines purpose. Extension/format defines implementation language/runtime surface.
 
@@ -826,7 +826,7 @@ This section is guidance only (not a hard validation rule unless explicitly prom
   - pure logic, state transforms, reducers, selectors, parsing, guards, behavioral helpers
   - avoid UI rendering concerns where possible
 
-  - `*.contracts.ts`
+- `*.contracts.ts`
   - contract definitions, parsers, guards, normalization boundaries, version/shape checks
   - use when contract responsibility is primary and should remain stable/testable
   - avoid turning `contracts` files into generic helper dumps
@@ -842,7 +842,6 @@ This section is guidance only (not a hard validation rule unless explicitly prom
 - `*.results-style.css` or `*.results-style.module.css`
   - default style formats for results-layer presentation
   - prefer CSS / CSS Modules unless a documented subsystem pattern requires otherwise
-
   - `.module.css` indicates CSS Modules format (tooling-scoped CSS), not a Calculogic role
 
 
@@ -855,7 +854,7 @@ This section is guidance only (not a hard validation rule unless explicitly prom
 
 ---
 
-## Allowed Special Cases and Reserved Filenames (V1.1)
+## Allowed Special Cases and Reserved Filenames (V1.2)
 
 Not every file in a repo can or should use `<semantic-name>.<role>.<ext>`.
 
@@ -921,7 +920,7 @@ Allowed as implementation-specific exceptions.
 
 ---
 
-## Rename Impact Checklist (V1.1)
+## Rename Impact Checklist (V1.2)
 
 When renaming a file to canonical format, verify all impacted references and contracts.
 

--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -1,19 +1,19 @@
-Purpose / Usage
+# Purpose / Usage
 
 This doc defines the canonical NL skeleton templates used by all configuration (doc/nl-config/*.md) and shell (doc/nl-shell/*.md) documents. Section numbers (1–10) and concern ordering are considered stable contracts.
 
-Changing this doc
+## Changing This Doc
 
 If you change top-level sections or numbering here, you must also update NL-First-Workflow.md, CSCS.md, and CCPP.md to keep the system consistent.
 
-1) General NL Skeleton – Configuration-Level
+## 1) General NL Skeleton – Configuration-Level
 Use this for things like “Motivations question,” individual sections, etc.
 Configuration: [Config Name] ([config-id])
 Project: [Project Name] ([project-id])
 Type: [Configuration type, e.g. Question Block / Section / Interaction]
 Scope: [Local to page / shared / referenced by others]
 Passes: [0–7] (Multi-pass implementation)
-Semantic notes
+### Semantic Notes
 A Configuration is a semantic module, not a file.
 
 
@@ -54,12 +54,12 @@ Concern vs hierarchy are orthogonal: any valid combination is allowed as long as
 
 
 
-1. Purpose and Scope
+### 1. Purpose and Scope
 1.1 This configuration is responsible for […]
 1.2 It appears in context of […]
 1.3 It interacts with other configurations by […]
 
-2. Configuration Contracts
+### 2. Configuration Contracts
 2.1 TypeScript Interfaces
 Define props/state models used by this configuration.
 
@@ -90,7 +90,7 @@ Shared hooks / utilities:
 
 
 
-3. Build Concern (Structure)
+### 3. Build Concern (Structure)
 3.0 Dependencies & Hierarchy Notes
 Requires parent layout: […]
 
@@ -181,7 +181,7 @@ Props (NL description): […]
 
 
 
-4. BuildStyle Concern (Visual Styling of Structure)
+### 4. BuildStyle Concern (Visual Styling of Structure)
 4.0 Dependencies
 Needs theme tokens: […]
 
@@ -212,7 +212,7 @@ Hover, focus, active, disabled.
 
 
 
-5. Logic Concern (Workflow)
+### 5. Logic Concern (Workflow)
 5.0 Dependencies
 Hooks / router / form libs used.
 
@@ -246,7 +246,7 @@ Validation, submission, navigation, etc. (expressed as sequences of logic atoms,
 
 
 
-6. Knowledge Concern (Reference Data)
+### 6. Knowledge Concern (Reference Data)
 6.1 Maps / Dictionaries (Primitives – Knowledge)
 e.g. option maps, type definitions (kb.map).
 
@@ -263,7 +263,7 @@ Note here if this configuration depends on project-global Knowledge atoms (e.g. 
 
 
 
-7. Results Concern (Outputs)
+### 7. Results Concern (Outputs)
 7.1 User-Facing Outputs (Primitives / Containers – Results)
 What this configuration renders as “results” (e.g. summary lines, scores, lists).
 
@@ -277,7 +277,7 @@ Announcements, ARIA live regions, etc.
 
 
 
-8. ResultsStyle Concern (Output Styling)
+### 8. ResultsStyle Concern (Output Styling)
 8.1 Results Layout Styles (Primitives – ResultsStyle)
 Layout/styling for result blocks.
 
@@ -287,7 +287,7 @@ Styling for debug overlays/panels.
 
 
 
-9. Assembly Pattern
+### 9. Assembly Pattern
 9.1 File Structure (implementation pattern; configuration still semantic)
 /src/configs/[config-id]/[ConfigName]/
   [ConfigName].build.tsx
@@ -306,7 +306,7 @@ How parent passes props/context and uses this configuration.
 
 
 
-10. Implementation Passes
+### 10. Implementation Passes
 10.1 Pass Mapping
 Pass 0: […]
 
@@ -334,14 +334,14 @@ Accessibility checks passed
 
 
 
-2) General NL Skeleton – ProjectShell-Level (Global Shells)
+## 2) General NL Skeleton – ProjectShell-Level (Global Shells)
 Use this for things like the Global Header, App Shell, persistent sidebars.
 ProjectShell Configuration: [Shell Name] ([shell-id])
 Project: [Project Name] ([project-id])
 Type: Persistent [Shell type, e.g. Navigation Shell / App Layout Shell]
 Scope: Global – wraps all Configuration views
 Passes: [0–7] (Multi-pass implementation)
-Semantic notes
+### Semantic Notes
 A ProjectShell is still a Configuration in the semantic sense, but it is global and persistent.
 
 
@@ -352,12 +352,12 @@ Many Knowledge atoms here will be project-global (tab definitions, routes, break
 
 
 
-1. Purpose and Scope
+### 1. Purpose and Scope
 1.1 This shell provides the global [header/sidebar/layout] that persists across all Configuration views.
 1.2 It manages [navigation state, modes, responsive layout, etc.].
 1.3 It coordinates with routing and configuration context.
 
-2. Configuration Contracts
+### 2. Configuration Contracts
 2.1 TypeScript Interfaces
 Shell-level state types (tabs, modes, viewport, etc.).
 
@@ -371,7 +371,7 @@ URL patterns, config ID context, etc.
 
 
 
-3. Build Concern (Structure)
+### 3. Build Concern (Structure)
 3.0 Dependencies & Hierarchy Notes
 Parent App, routing, providers.
 
@@ -410,7 +410,7 @@ Buttons, labels, icons, previews, etc., assigned to each zone as leaf-level prim
 
 
 
-4. BuildStyle Concern (Visual Styling of Structure)
+### 4. BuildStyle Concern (Visual Styling of Structure)
 4.0 Dependencies
 Theme tokens and global layout rules.
 
@@ -432,7 +432,7 @@ Active tab, hover preview, disabled states.
 
 
 
-5. Logic Concern (Workflow)
+### 5. Logic Concern (Workflow)
 5.0 Dependencies
 Router, viewport detection, config context.
 
@@ -454,7 +454,7 @@ e.g. Publish, open docs, open settings.
 
 
 
-6. Knowledge Concern (Reference Data)
+### 6. Knowledge Concern (Reference Data)
 6.1 Shell Metadata (often project-global Knowledge atoms)
 Tab definitions, routes, tooltips.
 
@@ -468,7 +468,7 @@ Wordmark, tagline, home tooltip.
 
 
 
-7. Results Concern (Outputs)
+### 7. Results Concern (Outputs)
 7.1 Navigation State Output
 Debug display / current route string.
 
@@ -478,11 +478,11 @@ Tab change messages, mode change messages.
 
 
 
-8. ResultsStyle Concern (Output Styling)
+### 8. ResultsStyle Concern (Output Styling)
 8.1 Debug Overlay Styles
 8.2 Any special shell-only result visuals.
 
-9. Assembly Pattern
+### 9. Assembly Pattern
 9.1 File Structure
 /src/shells/[shell-id]/[ShellName]/
   [ShellName].build.tsx
@@ -501,7 +501,7 @@ How the shell wraps child routes/configurations.
 
 
 
-10. Implementation Passes
+### 10. Implementation Passes
 10.1 Pass Mapping
 Pass 0: Shell container
 

--- a/doc/ConventionRoutines/NL-First-Workflow.md
+++ b/doc/ConventionRoutines/NL-First-Workflow.md
@@ -1,6 +1,6 @@
-NL-First Workflow (What the AI Does First)
+# NL-First Workflow (What the AI Does First)
 Golden rule: Before generating or editing any code for a configuration or shell, instantiate the appropriate NL skeleton template from General-NL-Skeletons.md (Configuration-Level or ProjectShell-Level) and create or update the NL skeleton text file for it.
-0. NL Skeleton Step (Mandatory First Step)
+## 0. NL Skeleton Step (Mandatory First Step)
 When starting work on a feature, configuration, or shell:
 Decide the type:
 
@@ -44,7 +44,7 @@ Never add new code that isn’t described in the NL skeleton first.
 
 If new behavior/structure is needed, AI must update the NL file first, then code.
 
-1. Code Generation Step (After NL)
+## 1. Code Generation Step (After NL)
 Once the NL skeleton file is in place:
 Read cfg-*.md or shell-*.md top to bottom.
 
@@ -61,7 +61,7 @@ Prepend each with an atomic comment:
 // [3.2.2] cfg-tabNavigation · Subcontainer · "Center Zone – Tab Strip"
 // Concern: Build · Parent: "Global Header Shell" · Catalog: layout.group
 
-2. Enforcement Checklist (For AI / You)
+## 2. Enforcement Checklist (For AI / You)
 Any time code is generated or changed for a config/shell:
 NL skeleton file exists in doc/nl-config or doc/nl-shell.
 
@@ -71,7 +71,7 @@ All new functions/components/blocks have the correct [sectionNumber] cfg-id · t
 
 No concern file contains “orphan” code that isn’t mentioned in the NL skeleton.
 
-Example alignment
+### Example Alignment
 
 - NL excerpt:
   - [3.2.1] Subcontainer “Center Zone – Tab Strip” (Build)


### PR DESCRIPTION
### Motivation
- Make the ConventionRoutines docs internally consistent with an incremental V1.2 update while keeping filenames unchanged for a later rename pass. 
- Correct markdown formatting issues and improve heading/subheading structure across the convention docs for readability without changing policy semantics. 
- Remove a small rendering/indentation bug in the Role-to-Extension guidance so role bullets (notably `*.contracts.ts`) are top-level peers.

### Description
- Updated internal version/section references in `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` to reflect V1.2 labels and synchronized TOC anchors and headings (file left unchanged). 
- Fixed bullet hierarchy and spacing in the "Role to Extension Guidance" so `*.contracts.ts` is a top-level peer alongside `*.logic.ts`, `*.knowledge.ts`, etc., and cleaned adjacent list spacing. 
- Normalized acronym usage in `doc/ConventionRoutines/CSCS.md` by making `CCS` the canonical in-document acronym and adding a compatibility note that the filename remains `CSCS.md` in this pass. 
- Performed a formatting/structure pass (heading levels and small capitalization fixes) in `doc/ConventionRoutines/CCPP.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md` to improve consistency and readability without changing semantics.
- No runtime or code changes; no files were renamed in this pass (renames intentionally deferred). The modified files are: `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, `doc/ConventionRoutines/CSCS.md`, `doc/ConventionRoutines/CCPP.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md`.

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues; result: success. 
- Verified there are no remaining `V1.1` labels in the master list with `rg -n 'V1\.1' doc/ConventionRoutines/FileNamingMasterList-V1_1.md`; result: no remaining V1.1 references in the edited sections. 
- Confirmed `*.contracts.ts` now appears as a top-level peer bullet in the Role-to-Extension section by inspecting the updated fragment (`nl`/manual spot-check); result: formatted correctly. 
- Ensured no file rename operations occurred by checking `git diff --name-status` for renames; result: no renames detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bea3d71288331a5f41d0bd3cfe443)