### PR TITLE
docs(conventions): normalize ConventionRoutines formatting and heading structure (no renames)

### DIFF
--- a/doc/ConventionRoutines/CCPP.md
+++ b/doc/ConventionRoutines/CCPP.md
@@ -1,31 +1,30 @@
 # Calculogic Comment & Provenance Protocol (CCPP, NL-Aligned)
+
 ## 1. Purpose
+
 Comments encode intent, structure, and provenance in a way that:
-Mirrors the NL skeleton order,
 
-Helps AI reconstruct or extend code from NL,
-
-And keeps files navigable top-down.
+- Mirrors the NL skeleton order.
+- Helps AI reconstruct or extend code from NL.
+- Keeps files navigable top-down.
 
 Comments are not narration of obvious code; they are a projection of the NL skeleton and decisions into the codebase.
 
 ## 2. Comment Types (Use Only These)
-File Header – one per file.
 
-Section Header – top of each config section inside a file.
-
-Atomic Comment – immediately before a Container/Subcontainer/Primitive.
-
-Inline Rationale – rare; why a non-obvious line/block exists.
-
-Decision Note – tiny ADR embedded in code.
-
-TODO with expiry – actionable, owner + date.
-
-Provenance Block – when external logic/content influences code (no payload).
+- File Header – one per file.
+- Section Header – top of each config section inside a file.
+- Atomic Comment – immediately before a Container/Subcontainer/Primitive.
+- Inline Rationale – rare; why a non-obvious line/block exists.
+- Decision Note – tiny ADR embedded in code.
+- TODO with expiry – actionable, owner + date.
+- Provenance Block – when external logic/content influences code (no payload).
 
 ## 3. Required Fields & Format
+
 ### 3.1 File Header (TS/TSX/TS, etc.)
+
+```ts
 /**
  * ProjectShell/Config: Global Header Shell (shell-globalHeader)
  * Concern File: Build | BuildStyle | Logic | Knowledge | Results | ResultsStyle
@@ -34,97 +33,123 @@ Provenance Block – when external logic/content influences code (no payload).
  * Invariants: <comma-separated truths>
  * Notes: <optional; ADR id, link, or short note>
  */
-For non-shell configs, replace ProjectShell/Config with Configuration: cfg-....
+```
+
+For non-shell configs, replace `ProjectShell/Config` with `Configuration: cfg-....`.
+
 ### 3.2 Section Header (Per Configuration Inside a Concern File)
+
+```ts
 // ─────────────────────────────────────────────
 // 3. Build – cfg-tabNavigation (Tab Navigation)
 // NL Sections: §3.0–3.3 in cfg-tabNavigation.md
 // Purpose: <short purpose>
 // Constraints: <key constraints or perf/a11y notes>
 // ─────────────────────────────────────────────
-The leading number (3. here) matches the NL skeleton’s concern index.
+```
+
+The leading number (`3.` here) matches the NL skeleton’s concern index.
 
 ### 3.3 Atomic Comment (Container / Subcontainer / Primitive)
+
+```ts
 // [3.2.2] cfg-tabNavigation · Subcontainer · "Center Zone – Tab Strip"
 // Concern: Build · Parent: "Global Header Shell" · Catalog: layout.group
 // Notes: hosts 4 tabs and info icons; no reordering; center-aligned
 function GlobalHeaderTabStripZone() {
   ...
 }
+```
+
 Rules:
-First line: [NLSectionNumber] cfg-id · HierarchicalType · "Name".
 
-Second line: Concern, Parent (if any), Catalog id.
-
-Third line: short intent/constraint note.
+- First line: `[NLSectionNumber] cfg-id · HierarchicalType · "Name"`.
+- Second line: Concern, Parent (if any), Catalog id.
+- Third line: short intent/constraint note.
 
 These should read like compressed NL bullets and are the main thing AI should preserve.
+
 ### 3.4 Inline Rationale
+
+```ts
 // WHY: Avoids focus loss when switching tabs via keyboard
+```
+
 Use sparingly, only when the reason is not obvious.
+
 ### 3.5 Decision Note
+
+```ts
 // DECISION: Tab hover previews via CSS only | 2025-11-05
 // Context: Keep Logic lightweight for header interactions
 // Choice: Use CSS hover for previews instead of JS listeners
 // Consequence: Less JS complexity; no previews on touch devices
 // ADR: header-hover-001   // optional
-Promote a Decision note to a standalone ADR when the rationale spans multiple paragraphs, introduces cross-team dependencies, or affects more than one configuration. Longer decisions live alongside other records in doc/decisions/*.md; reference the ADR id from the inline note once it exists.
+```
+
+Promote a Decision note to a standalone ADR when the rationale spans multiple paragraphs, introduces cross-team dependencies, or affects more than one configuration. Longer decisions live alongside other records in `doc/decisions/*.md`; reference the ADR id from the inline note once it exists.
+
 ### 3.6 TODO with Expiry
+
+```ts
 // TODO(@owner, 2025-12-01): Wire openDoc(docId) to docs modal shell
+```
+
 Must always have owner and date.
+
 ### 3.7 Provenance Block
+
+```ts
 // SOURCE: https://example.org/a11y/tabs
 // Accessed: 2025-11-05T14:22:00Z
 // Note: Pattern used as reference for keyboard tab navigation; no content copied
+```
+
 No payload; just reference.
 
 ## 4. Language & Mapping
-TS/TSX/JS: /** ... */ for file header; // ... for everything else.
 
-CSS: /* ... */ for file and atomic comments; still match NL numbers.
+- `TS/TSX/JS`: `/** ... */` for file header; `// ...` for everything else.
+- `CSS`: `/* ... */` for file and atomic comments; still match NL numbers.
+- `JSON`: no comments; if needed, keep a `.meta` or `.md` doc instead.
+- `Markdown docs`: NL skeletons themselves.
 
 Remember the concern-to-file mapping: Build/Results use `.tsx` structure files, BuildStyle/ResultsStyle are CSS or CSS-Module files that consume the anchors emitted by those structures, Logic lives in `.ts`/`.tsx` modules, and Knowledge is `.ts` data. Comment styles must match the host language.
 
-JSON: no comments; if needed, keep a .meta or .md doc instead.
-
-Markdown docs: NL skeletons themselves.
-
 ## 5. NL Skeleton Alignment
+
 Every concern file must have:
 
-A file header linking to its NL doc.
-
-Section headers for each configuration in NL order.
-
-Atomic comments for each Container/Subcontainer/Primitive referenced in NL.
+- A file header linking to its NL doc.
+- Section headers for each configuration in NL order.
+- Atomic comments for each Container/Subcontainer/Primitive referenced in NL.
 
 The NL skeleton is the source:
 
-When a number changes in NL (e.g. 3.2.1 → 3.2.2), comments should be updated to match.
-
-When a new atomic is added to NL, a new atomic comment + code block is added in the same position.
+- When a number changes in NL (e.g. `3.2.1 → 3.2.2`), comments should be updated to match.
+- When a new atomic is added to NL, a new atomic comment + code block is added in the same position.
 
 ## 6. Strict Do / Don’t
-Do
-Use NL section numbers [3.2.1] consistently across files.
 
-Explain why something exists, not what it does.
+### Do
 
-Keep comments short and structured (good for humans and AI).
+- Use NL section numbers `[3.2.1]` consistently across files.
+- Explain why something exists, not what it does.
+- Keep comments short and structured (good for humans and AI).
+- Update NL + comments in the same change as code.
 
-Update NL + comments in the same change as code.
+### Don’t
 
-Don’t
-Narrate obvious code.
-
-Add code that doesn’t correspond to a skeleton section (unless you add it to NL first).
-
-Use unlabeled TODO:.
-
-Copy external content into comments.
+- Narrate obvious code.
+- Add code that doesn’t correspond to a skeleton section (unless you add it to NL first).
+- Use unlabeled `TODO:`.
+- Copy external content into comments.
 
 ## 7. Minimal Examples
-Build file:
+
+### Build file
+
+```ts
 /**
  * Configuration: cfg-tabNavigation (Tab Navigation)
  * Concern File: Build
@@ -143,7 +168,11 @@ Build file:
 // [3.1] cfg-tabNavigation · Container · "Global Header Shell"
 // Concern: Build · Catalog: layout.shell
 export function GlobalHeaderShell() { ... }
-BuildStyle file:
+```
+
+### BuildStyle file
+
+```css
 /*
  * Configuration: cfg-tabNavigation (Tab Navigation)
  * Concern File: BuildStyle
@@ -158,34 +187,32 @@ BuildStyle file:
 .globalHeader__tab {
   /* ... */
 }
+```
 
 ### Bad vs. Good Atomic Comments
 
 - Bad:
   - `// handles tab click`
   - `const handleClick = () => setActive(tabId);`
-  (Narrates the obvious and lacks NL reference.)
+  - (Narrates the obvious and lacks NL reference.)
 - Good:
   - `// [5.2.2] cfg-tabNavigation · Primitive · "handleTabSelect"`
   - `// Concern: Logic · Parent: "Tab Navigation Logic" · Notes: syncs active tab state`
   - `const handleTabSelect = (tabId: string) => setActiveTab(tabId);`
 
 ## 8. Maintenance Rules
+
 On every structural change:
-Update the NL skeleton first.
 
-Then update code and comments to match:
-
-Keep section headers in NL order.
-
-Keep atomic comments synchronized with NL numbers.
-
-Remove or update any Decision notes that no longer apply (add new ones instead of rewriting history).
-
-Clean up or close TODOs on each release cut.
-
+- Update the NL skeleton first.
+- Then update code and comments to match:
+  - Keep section headers in NL order.
+  - Keep atomic comments synchronized with NL numbers.
+- Remove or update any Decision notes that no longer apply (add new ones instead of rewriting history).
+- Clean up or close TODOs on each release cut.
 
 ## 9. Pre-Merge CCPP Review Checklist
+
 Before merging, confirm each touched concern file passes all checks:
 
 - [ ] File header uses `Configuration:` or `ProjectShell/Config:` (as applicable), includes `Concern File`, `Source NL`, `Responsibility`, and `Invariants`.

--- a/doc/ConventionRoutines/CSCS.md
+++ b/doc/ConventionRoutines/CSCS.md
@@ -1,159 +1,134 @@
 # Calculogic Concern System (CCS, NL-Aligned, Codebase-Level)
 
 > Note: This document filename remains `CSCS.md` for compatibility in this pass. In content, the canonical acronym is **CCS** (Calculogic Concern System).
+
 ## 1. First Principles
-Configuration is semantic, not a file
+
+### Configuration is semantic, not a file
 
 A Configuration is a semantic module (e.g. “Global Header Shell”, “Tab Navigation”).
 
 It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
 
-Code lives in six concern files; the configuration is defined by its NL skeleton, not its file layout. The canonical section layout and numbering for NL skeletons is defined in General-NL-Skeletons.md and every configuration or shell document must follow it exactly.
+Code lives in six concern files; the configuration is defined by its NL skeleton, not its file layout. The canonical section layout and numbering for NL skeletons is defined in `General-NL-Skeletons.md` and every configuration or shell document must follow it exactly.
 
 ### NL Skeleton as the Ordering Source
 
-Each configuration has an NL Configuration Skeleton (or ProjectShell skeleton).
-
-The skeleton’s numbered sections (3 = Build, 4 = BuildStyle, 5 = Logic, 6 = Knowledge, 7 = Results, 8 = ResultsStyle) define the canonical top-down order for all concerns.
-
-Code in all concern files must follow this order and mirror the same numbering in comments.
+- Each configuration has an NL Configuration Skeleton (or ProjectShell skeleton).
+- The skeleton’s numbered sections (3 = Build, 4 = BuildStyle, 5 = Logic, 6 = Knowledge, 7 = Results, 8 = ResultsStyle) define the canonical top-down order for all concerns.
+- Code in all concern files must follow this order and mirror the same numbering in comments.
 
 ### Concerns vs. Hierarchical Types (Orthogonal Axes)
 
 Every Atomic Component has:
 
-A Concern: Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle, and
-
-A Hierarchical type: Container, Subcontainer, or Primitive.
+- A Concern: Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle.
+- A Hierarchical type: Container, Subcontainer, or Primitive.
 
 These axes are independent: you can have a Logic Container, a Build Primitive, a ResultsStyle Primitive, etc.
 
 ### Purity per Concern
 
-Build – structure only (containers, subcontainers, primitives; no state, no visual design tokens).
-
-BuildStyle – styling of structure only (layout, spacing, responsive rules; no DOM creation, no state).
-
-Logic – interaction, workflows, state, derived flags; no DOM, no CSS.
-
-Knowledge – copy, constants, reference tables; no state mutation, no layout, no behavior.
-
-Results – derived outputs / readouts; no structure creation beyond what Build defines.
-
-ResultsStyle – styling of results; no structure, no logic.
+- Build – structure only (containers, subcontainers, primitives; no state, no visual design tokens).
+- BuildStyle – styling of structure only (layout, spacing, responsive rules; no DOM creation, no state).
+- Logic – interaction, workflows, state, derived flags; no DOM, no CSS.
+- Knowledge – copy, constants, reference tables; no state mutation, no layout, no behavior.
+- Results – derived outputs / readouts; no structure creation beyond what Build defines.
+- ResultsStyle – styling of results; no structure, no logic.
 
 ### Folder Mapping
 
-- Build → files like src/configs/<configId>/<ConfigName>.build.tsx or src/shells/<shellId>/<ShellName>.build.tsx
-- BuildStyle → CSS or CSS-Module files like src/configs/<configId>/<ConfigName>.build.module.css or src/shells/<shellId>/<ShellName>.build.css
-- Logic → files like src/configs/<configId>/<ConfigName>.logic.ts (or `.logic.tsx` when React hooks are required)
-- Knowledge → files like src/configs/<configId>/<ConfigName>.knowledge.ts
-- Results → files like src/configs/<configId>/<ConfigName>.results.ts (or `.results.tsx` when JSX is emitted)
-- ResultsStyle → CSS or CSS-Module files like src/configs/<configId>/<ConfigName>.results.module.css or src/shells/<shellId>/<ShellName>.results.css
+- Build → files like `src/configs/<configId>/<ConfigName>.build.tsx` or `src/shells/<shellId>/<ShellName>.build.tsx`
+- BuildStyle → CSS or CSS-Module files like `src/configs/<configId>/<ConfigName>.build.module.css` or `src/shells/<shellId>/<ShellName>.build.css`
+- Logic → files like `src/configs/<configId>/<ConfigName>.logic.ts` (or `.logic.tsx` when React hooks are required)
+- Knowledge → files like `src/configs/<configId>/<ConfigName>.knowledge.ts`
+- Results → files like `src/configs/<configId>/<ConfigName>.results.ts` (or `.results.tsx` when JSX is emitted)
+- ResultsStyle → CSS or CSS-Module files like `src/configs/<configId>/<ConfigName>.results.module.css` or `src/shells/<shellId>/<ShellName>.results.css`
 
-Shells follow the same pattern within src/shells/<shellId>/, sharing the same base name across all concern files. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files; the corresponding Build and Results `.tsx` components expose the class names and data attributes that those styles consume.
+Shells follow the same pattern within `src/shells/<shellId>/`, sharing the same base name across all concern files. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files; the corresponding Build and Results `.tsx` components expose the class names and data attributes that those styles consume.
 
 ### Structure Source and Fallbacks
 
-Build is the default structural source for any UI configuration or shell.
-
-Non-structural concerns (BuildStyle, Logic, Knowledge, Results, ResultsStyle) never create or reorder structure; they attach to anchors defined by Build.
-
-Fallback (rare): if a configuration has no Build (e.g. a pure data concern), use the highest present non-style concern as the mental ordering source (Logic → Knowledge → Results), but it still must not invent DOM structure.
+- Build is the default structural source for any UI configuration or shell.
+- Non-structural concerns (BuildStyle, Logic, Knowledge, Results, ResultsStyle) never create or reorder structure; they attach to anchors defined by Build.
+- Fallback (rare): if a configuration has no Build (e.g. a pure data concern), use the highest present non-style concern as the mental ordering source (Logic → Knowledge → Results), but it still must not invent DOM structure.
 
 ### Anchors Are Stable
 
-Every visible piece of structure exposes stable anchors (class, data-anchor, or id).
-
-All non-Build concerns refer to these anchors, never to incidental DOM or query patterns.
+- Every visible piece of structure exposes stable anchors (class, data-anchor, or id).
+- All non-Build concerns refer to these anchors, never to incidental DOM or query patterns.
 
 ### Directional Dependencies
 
-Build → BuildStyle / Logic / ResultsStyle.
-
-Logic → Results.
-
-Knowledge informs all but depends on none.
-
-No upward or cyclic imports (e.g., Results cannot feed Logic, Logic cannot define anchors).
+- Build → BuildStyle / Logic / ResultsStyle.
+- Logic → Results.
+- Knowledge informs all but depends on none.
+- No upward or cyclic imports (e.g., Results cannot feed Logic, Logic cannot define anchors).
 
 ### Locality
 
-Code for one configuration’s concerns lives in its folder under builder/configs/ or builder/shells/.
-
-Nested configurations (e.g., a shell zone as its own config) live inside the parent’s folder but obey all the same rules independently.
+- Code for one configuration’s concerns lives in its folder under `builder/configs/` or `builder/shells/`.
+- Nested configurations (e.g., a shell zone as its own config) live inside the parent’s folder but obey all the same rules independently.
 
 ### Monotonic Diffs
 
 When you change structure in the NL skeleton for a configuration, corresponding changes in Build, BuildStyle, Logic, Knowledge, Results, and ResultsStyle must appear in the same top-down order when you read each file.
 
 ## 2. Configuration Definition Template (Per Configuration or Shell)
+
 Use this before writing code or asking AI to generate code.
+
 ### NL Skeleton
-Create doc/nl-config/cfg-*.md or doc/nl-shell/shell-*.md using the General NL Skeleton – Configuration-Level or ProjectShell-Level.
+
+Create `doc/nl-config/cfg-*.md` or `doc/nl-shell/shell-*.md` using the General NL Skeleton – Configuration-Level or ProjectShell-Level.
 
 That document is the canonical contract for:
 
-Purpose and scope,
-
-Per-concern responsibilities,
-
-Containers/Subcontainers/Primitives and their order,
-
-Numbering (3.x.y, 4.x.y, 5.x.y, etc.).
+- Purpose and scope.
+- Per-concern responsibilities.
+- Containers/Subcontainers/Primitives and their order.
+- Numbering (3.x.y, 4.x.y, 5.x.y, etc.).
 
 ### Concern Entry (Per Configuration)
-Name: Short, unambiguous; use cfg-* for configs, shell-* for shells.
 
-Purpose (1 sentence): What outcome this configuration achieves.
-
-In-Scope / Out-of-Scope: Boundaries for behavior and structure.
-
-Concerns present: Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle (which apply).
-
-Anchors: The structural anchors owned by this configuration (Build).
-
-Inputs: Props/context/events it consumes.
-
-Outputs: Events, derived values, results, or debug UI it emits.
-
-Invariants: Truths that must always hold (e.g. “Tabs never wrap; scroll instead”).
-
-Dependencies: Only on lower-level utilities, shared hooks, or Knowledge; no cross-concern cheating.
+- Name: Short, unambiguous; use `cfg-*` for configs, `shell-*` for shells.
+- Purpose (1 sentence): What outcome this configuration achieves.
+- In-Scope / Out-of-Scope: Boundaries for behavior and structure.
+- Concerns present: Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle (which apply).
+- Anchors: The structural anchors owned by this configuration (Build).
+- Inputs: Props/context/events it consumes.
+- Outputs: Events, derived values, results, or debug UI it emits.
+- Invariants: Truths that must always hold (e.g. “Tabs never wrap; scroll instead”).
+- Dependencies: Only on lower-level utilities, shared hooks, or Knowledge; no cross-concern cheating.
 
 ## 3. Atomic Components (Per Concern)
+
 For each concern in the NL skeleton, list:
-Containers – top-level roots for that concern in this configuration.
 
-Subcontainers – nested encapsulations inside Containers.
-
-Primitives – leaves: individual fields, rules, styles, state atoms, maps, result lines.
+- Containers – top-level roots for that concern in this configuration.
+- Subcontainers – nested encapsulations inside Containers.
+- Primitives – leaves: individual fields, rules, styles, state atoms, maps, result lines.
 
 ### Rules
-A concern can have one or more Containers at the top level.
 
-Subcontainers only appear inside Containers (never at the root of a concern).
-
-Primitives never contain anything else.
-
-Containers may be:
-Flat roots (contain only primitives), or
-
-Hierarchical roots (contain subcontainers and primitives).
+- A concern can have one or more Containers at the top level.
+- Subcontainers only appear inside Containers (never at the root of a concern).
+- Primitives never contain anything else.
+- Containers may be:
+  - Flat roots (contain only primitives), or
+  - Hierarchical roots (contain subcontainers and primitives).
 
 ## 4. Decision Rules (What Belongs Where, NL-Aware)
-Use these to keep responsibilities clean:
+
+Use these to keep responsibilities clean.
+
 ### Structure vs Interaction vs Readout
 
-Changes to regions, zones, section layout → Build.
-
-Visual variants, responsiveness, spacing → BuildStyle / ResultsStyle.
-
-State, validation, transitions, routing → Logic.
-
-Copy, labels, options, thresholds → Knowledge.
-
-Counters, scores, derived summaries → Results.
+- Changes to regions, zones, section layout → Build.
+- Visual variants, responsiveness, spacing → BuildStyle / ResultsStyle.
+- State, validation, transitions, routing → Logic.
+- Copy, labels, options, thresholds → Knowledge.
+- Counters, scores, derived summaries → Results.
 
 ### No Structure in Non-Structural Concerns
 
@@ -172,48 +147,43 @@ Tooltips, doc text, label maps, thresholds live in Knowledge and do not contain 
 If you can’t describe a section of behavior/structure in a single NL bullet under one concern, it’s a sign you have multiple concerns tangled together—split them.
 
 ## 5. Nested vs Sibling Configurations
+
 ### Nested Configuration (All Must Be True)
 
-It attaches to specific anchors owned by a parent configuration.
-
-It cannot operate meaningfully without that parent structure.
-
-It never reorders or replaces the parent’s anchors.
+- It attaches to specific anchors owned by a parent configuration.
+- It cannot operate meaningfully without that parent structure.
+- It never reorders or replaces the parent’s anchors.
 
 Example: The global header shell includes a nested tab-strip configuration that mounts directly into the header’s Build anchors.
 
 ### Sibling Configuration (Otherwise)
 
-It uses the same frame (shell) but defines its own Build structure and anchors.
+- It uses the same frame (shell) but defines its own Build structure and anchors.
+- Promote from nested → sibling when a feature gains its own structure, reuse, or lifecycle.
 
-Promote from nested → sibling when a feature gains its own structure, reuse, or lifecycle.
-
-Example: cfg-intro, cfg-q-motivations, and cfg-buildSurface coexist as siblings that the spa host shell swaps within the same main-pane frame.
+Example: `cfg-intro`, `cfg-q-motivations`, and `cfg-buildSurface` coexist as siblings that the spa host shell swaps within the same main-pane frame.
 
 ## 6. Change Management
+
 ### When You Change a Configuration
+
 Update its NL skeleton first:
 
-Adjust the numbering and text for any moved/added/removed Container/Subcontainer/Primitive.
+- Adjust the numbering and text for any moved/added/removed Container/Subcontainer/Primitive.
 
 Then update code:
 
-Adjust Build to match the new NL order.
-
-Update BuildStyle, Logic, Knowledge, Results, ResultsStyle in the same pass, keeping the same ordering and comment numbers.
+- Adjust Build to match the new NL order.
+- Update BuildStyle, Logic, Knowledge, Results, ResultsStyle in the same pass, keeping the same ordering and comment numbers.
 
 Preserve anchors if possible:
 
-If anchors must change, treat that as a deliberate breaking change and update all attached concerns.
+- If anchors must change, treat that as a deliberate breaking change and update all attached concerns.
 
 ### Acceptance (Per PR)
 
-NL skeleton updated and committed.
-
-Build matches NL structure and order.
-
-All other concerns follow the same ordering via comments.
-
-Concerns respect purity and directional dependencies.
-
-Comments (file headers + section headers + atomic comments) present and consistent.
+- NL skeleton updated and committed.
+- Build matches NL structure and order.
+- All other concerns follow the same ordering via comments.
+- Concerns respect purity and directional dependencies.
+- Comments (file headers + section headers + atomic comments) present and consistent.

--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -1,294 +1,223 @@
-# Purpose / Usage
+# General NL Skeletons
 
-This doc defines the canonical NL skeleton templates used by all configuration (doc/nl-config/*.md) and shell (doc/nl-shell/*.md) documents. Section numbers (1–10) and concern ordering are considered stable contracts.
+This doc defines the canonical NL skeleton templates used by all configuration (`doc/nl-config/*.md`) and shell (`doc/nl-shell/*.md`) documents. Section numbers (1–10) and concern ordering are considered stable contracts.
 
 ## Changing This Doc
 
-If you change top-level sections or numbering here, you must also update NL-First-Workflow.md, CSCS.md, and CCPP.md to keep the system consistent.
+If you change top-level sections or numbering here, you must also update `NL-First-Workflow.md`, `CSCS.md`, and `CCPP.md` to keep the system consistent.
+
+---
 
 ## 1) General NL Skeleton – Configuration-Level
+
 Use this for things like “Motivations question,” individual sections, etc.
+
 Configuration: [Config Name] ([config-id])
 Project: [Project Name] ([project-id])
 Type: [Configuration type, e.g. Question Block / Section / Interaction]
 Scope: [Local to page / shared / referenced by others]
 Passes: [0–7] (Multi-pass implementation)
+
 ### Semantic Notes
-A Configuration is a semantic module, not a file.
 
-
-It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
-
-
-Per-configuration implementation files live under paths like src/configs/<configId>/<ConfigName>.build.tsx (structure), src/configs/<configId>/<ConfigName>.build.module.css (configuration styling), and the other concern files with matching base names. The engine or build step may merge those into project-level bundles such as src/projects/<projectId>/Project.build.tsx. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files that target the anchors emitted by the Build and Results `.tsx` concerns.
-
-
-All content of a configuration is expressed as Atomic Components.
-
-
-Each atomic component has:
-
-
-a concern (Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle), and
-
-
-a hierarchical type: Container, Subcontainer, or Primitive.
-
-
-Most atoms belong to exactly one configuration. Some Knowledge/System atoms may be project-global (e.g. breakpoints, brand tokens) and are documented separately.
-
-
-Hierarchical types:
-
-
-Container – top-level encapsulation in a concern for this configuration; not nested inside other Containers in that concern; may contain Subcontainers and/or Primitives directly (flat or hierarchical).
-
-
-Subcontainer – nested encapsulation; always inside a Container or another Subcontainer; never at the root of a concern.
-
-
-Primitive – leaf unit; contains nothing else (single field, rule, style block, kb map, result line, etc.).
-
-
-Concern vs hierarchy are orthogonal: any valid combination is allowed as long as the concern’s purity rules are respected.
-
-
+- A Configuration is a semantic module, not a file.
+- It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
+- Per-configuration implementation files live under paths like `src/configs/<configId>/<ConfigName>.build.tsx` (structure), `src/configs/<configId>/<ConfigName>.build.module.css` (configuration styling), and the other concern files with matching base names. The engine or build step may merge those into project-level bundles such as `src/projects/<projectId>/Project.build.tsx`. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files that target the anchors emitted by the Build and Results `.tsx` concerns.
+- All content of a configuration is expressed as Atomic Components.
+- Each atomic component has:
+  - a concern (Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle), and
+  - a hierarchical type: Container, Subcontainer, or Primitive.
+- Most atoms belong to exactly one configuration. Some Knowledge/System atoms may be project-global (e.g. breakpoints, brand tokens) and are documented separately.
+- Hierarchical types:
+  - Container – top-level encapsulation in a concern for this configuration; not nested inside other Containers in that concern; may contain Subcontainers and/or Primitives directly (flat or hierarchical).
+  - Subcontainer – nested encapsulation; always inside a Container or another Subcontainer; never at the root of a concern.
+  - Primitive – leaf unit; contains nothing else (single field, rule, style block, kb map, result line, etc.).
+- Concern vs hierarchy are orthogonal: any valid combination is allowed as long as the concern’s purity rules are respected.
 
 ### 1. Purpose and Scope
-1.1 This configuration is responsible for […]
-1.2 It appears in context of […]
-1.3 It interacts with other configurations by […]
+
+- 1.1 This configuration is responsible for […].
+- 1.2 It appears in context of […].
+- 1.3 It interacts with other configurations by […].
 
 ### 2. Configuration Contracts
-2.1 TypeScript Interfaces
-Define props/state models used by this configuration.
 
+#### 2.1 TypeScript Interfaces
+
+Define props/state models used by this configuration.
 
 Example (code hint only):
 
-
+```ts
 interface [ConfigName]Props { ... }
 interface [ConfigName]State { ... }
-2.2 Data & State Requirements
-Local state:
+```
 
+#### 2.2 Data & State Requirements
 
-Global context needed:
+- Local state:
+- Global context needed:
+- External data sources (if any):
 
+#### 2.3 Dependencies
 
-External data sources (if any):
-
-
-2.3 Dependencies
-UI libs:
-
-
-Routing:
-
-
-Shared hooks / utilities:
-
-
+- UI libs:
+- Routing:
+- Shared hooks / utilities:
 
 ### 3. Build Concern (Structure)
-3.0 Dependencies & Hierarchy Notes
-Requires parent layout: […]
 
+#### 3.0 Dependencies & Hierarchy Notes
 
-Requires context: […]
+- Requires parent layout: […].
+- Requires context: […].
+- This concern has one or more Containers at the top level for this configuration.
+- Subcontainers only appear inside Containers (never at the root).
+- Containers may be used as:
+  - flat roots (directly containing only Primitives), or
+  - hierarchical roots (containing Subcontainers and Primitives).
 
+#### 3.1 Atomic Components — Containers (Build)
 
-This concern has one or more Containers at the top level for this configuration.
+- Name: `"[Container name]"`
+- Hierarchical type: Container
+- Concern: Build
+- Catalog base: `[layout.group / layout.stack / section.*]`
+- Anchor: `data-anchor="..."`
+- Layout: `[vertical / horizontal / grid]`
+- Children: `[subcontainers and/or primitives in order]`
 
+#### 3.2 Atomic Components — Subcontainers (Build)
 
-Subcontainers only appear inside Containers (never at the root).
+##### 3.2.1 Subcontainer `"[Name]"`
 
+- Hierarchical type: Subcontainer
+- Concern: Build
+- Purpose: […].
+- Catalog base: […].
+- Parent container: […].
+- Children: […].
 
-Containers may be used as:
+##### 3.2.2 Subcontainer `"[Name]"`
 
+- […].
 
-flat roots (directly containing only Primitives), or
+#### 3.3 Atomic Components — Primitives (Build)
 
+##### 3.3.1 Primitive `"[Name]"`
 
-hierarchical roots (containing Subcontainers and Primitives).
+- Hierarchical type: Primitive
+- Concern: Build
+- Catalog base: `[ui.text / ui.input / ui.button / ui.checkbox / ui.select / ui.details / etc.]`
+- Content / label: […].
+- Props (NL description): […].
 
+##### 3.3.2 Primitive `"[Name]"`
 
-3.1 Atomic Components — Containers (Build)
-Name: “[Container name]”
-
-
-Hierarchical type: Container
-
-
-Concern: Build
-
-
-Catalog base: [layout.group / layout.stack / section.*]
-
-
-Anchor: data-anchor="..."
-
-
-Layout: [vertical / horizontal / grid]
-
-
-Children: [subcontainers and/or primitives in order]
-
-
-3.2 Atomic Components — Subcontainers (Build)
-3.2.1 Subcontainer “[Name]”
-Hierarchical type: Subcontainer
-
-
-Concern: Build
-
-
-Purpose: […]
-
-
-Catalog base: […]
-
-
-Parent container: […]
-
-
-Children: […]
-
-
-3.2.2 Subcontainer “[Name]”
-[…]
-
-
-3.3 Atomic Components — Primitives (Build)
-3.3.1 Primitive “[Name]”
-Hierarchical type: Primitive
-
-
-Concern: Build
-
-
-Catalog base: [ui.text / ui.input / ui.button / ui.checkbox / ui.select / ui.details / etc.]
-
-
-Content / label: […]
-
-
-Props (NL description): […]
-
-
-3.3.2 Primitive “[Name]”
-[…]
-
-
+- […].
 
 ### 4. BuildStyle Concern (Visual Styling of Structure)
-4.0 Dependencies
-Needs theme tokens: […]
 
+#### 4.0 Dependencies
 
-4.1 Atomic Components — Containers / Groups (BuildStyle)
-Optional named style group for this configuration (e.g. “[ConfigName] Layout Styles”).
+- Needs theme tokens: […].
 
+#### 4.1 Atomic Components — Containers / Groups (BuildStyle)
 
-4.2 Atomic Components — Primitives (BuildStyle)
-Base Layout Styles
+- Optional named style group for this configuration (e.g. `"[ConfigName] Layout Styles"`).
 
+#### 4.2 Atomic Components — Primitives (BuildStyle)
 
-Container selector, basic flex/grid, spacing.
+- Base Layout Styles
+  - Container selector, basic flex/grid, spacing.
+- Element Styles
+  - Primitive-specific styles, states, variants.
 
+#### 4.3 Responsive Rules
 
-Element Styles
+- Breakpoints and what changes at each (ideally referencing project-global breakpoint constants in Knowledge).
 
+#### 4.4 Interaction Styles
 
-Primitive-specific styles, states, variants.
-
-
-4.3 Responsive Rules
-Breakpoints and what changes at each (ideally referencing project-global breakpoint constants in Knowledge).
-
-
-4.4 Interaction Styles
-Hover, focus, active, disabled.
-
-
+- Hover, focus, active, disabled.
 
 ### 5. Logic Concern (Workflow)
-5.0 Dependencies
-Hooks / router / form libs used.
 
+#### 5.0 Dependencies
 
-5.1 Atomic Components — Containers (Logic)
-Root logic container for this configuration (e.g. “[ConfigName]Logic hook”).
+- Hooks / router / form libs used.
 
+#### 5.1 Atomic Components — Containers (Logic)
 
-5.2 Atomic Components — Primitives (Logic)
-5.2.1 State Management
-Local state shape + initialization (logic.state atoms).
+- Root logic container for this configuration (e.g. `"[ConfigName]Logic hook"`).
 
+#### 5.2 Atomic Components — Primitives (Logic)
 
-Global state it reads/writes.
+##### 5.2.1 State Management
 
+- Local state shape + initialization (`logic.state` atoms).
+- Global state it reads/writes.
 
-5.2.2 Event Handlers
-OnChange, OnClick, OnSubmit, etc. (logic.on or handler atoms).
+##### 5.2.2 Event Handlers
 
+- OnChange, OnClick, OnSubmit, etc. (`logic.on` or handler atoms).
 
-5.2.3 Derived Values
-useMemo/selectors/computed flags (logic.compute atoms).
+##### 5.2.3 Derived Values
 
+- `useMemo`/selectors/computed flags (`logic.compute` atoms).
 
-5.2.4 Side Effects
-useEffect usage, subscriptions, listeners (if any).
+##### 5.2.4 Side Effects
 
+- `useEffect` usage, subscriptions, listeners (if any).
 
-5.2.5 Workflows
-Validation, submission, navigation, etc. (expressed as sequences of logic atoms, possibly grouped inside Subcontainers if needed).
+##### 5.2.5 Workflows
 
-
+- Validation, submission, navigation, etc. (expressed as sequences of logic atoms, possibly grouped inside Subcontainers if needed).
 
 ### 6. Knowledge Concern (Reference Data)
-6.1 Maps / Dictionaries (Primitives – Knowledge)
-e.g. option maps, type definitions (kb.map).
 
+#### 6.1 Maps / Dictionaries (Primitives – Knowledge)
 
-6.2 Constants (Primitives – Knowledge)
-Labels, copy strings, thresholds (kb.const, kb.list).
+- e.g. option maps, type definitions (`kb.map`).
 
+#### 6.2 Constants (Primitives – Knowledge)
 
-6.3 Shared / Global Reference
-IDs / doc links / anchors used elsewhere.
+- Labels, copy strings, thresholds (`kb.const`, `kb.list`).
 
+#### 6.3 Shared / Global Reference
 
-Note here if this configuration depends on project-global Knowledge atoms (e.g. breakpoints, brand tokens) instead of defining them locally.
-
-
+- IDs / doc links / anchors used elsewhere.
+- Note here if this configuration depends on project-global Knowledge atoms (e.g. breakpoints, brand tokens) instead of defining them locally.
 
 ### 7. Results Concern (Outputs)
-7.1 User-Facing Outputs (Primitives / Containers – Results)
-What this configuration renders as “results” (e.g. summary lines, scores, lists).
 
+#### 7.1 User-Facing Outputs (Primitives / Containers – Results)
 
-7.2 Dev / Debug Outputs
-Optional debug text/blocks for builders.
+- What this configuration renders as “results” (e.g. summary lines, scores, lists).
 
+#### 7.2 Dev / Debug Outputs
 
-7.3 Accessibility Outputs
-Announcements, ARIA live regions, etc.
+- Optional debug text/blocks for builders.
 
+#### 7.3 Accessibility Outputs
 
+- Announcements, ARIA live regions, etc.
 
 ### 8. ResultsStyle Concern (Output Styling)
-8.1 Results Layout Styles (Primitives – ResultsStyle)
-Layout/styling for result blocks.
 
+#### 8.1 Results Layout Styles (Primitives – ResultsStyle)
 
-8.2 Debug Display Styles
-Styling for debug overlays/panels.
+- Layout/styling for result blocks.
 
+#### 8.2 Debug Display Styles
 
+- Styling for debug overlays/panels.
 
 ### 9. Assembly Pattern
-9.1 File Structure (implementation pattern; configuration still semantic)
+
+#### 9.1 File Structure (implementation pattern; configuration still semantic)
+
+```text
 /src/configs/[config-id]/[ConfigName]/
   [ConfigName].build.tsx
   [ConfigName].build.module.css
@@ -297,193 +226,174 @@ Styling for debug overlays/panels.
   [ConfigName].results.ts
   [ConfigName].results.module.css
   index.ts
-9.2 Assembly Logic
-index.tsx wires concerns together and exports a single component that implements this configuration.
+```
 
+#### 9.2 Assembly Logic
 
-9.3 Integration
-How parent passes props/context and uses this configuration.
+- `index.tsx` wires concerns together and exports a single component that implements this configuration.
 
+#### 9.3 Integration
 
+- How parent passes props/context and uses this configuration.
 
 ### 10. Implementation Passes
-10.1 Pass Mapping
-Pass 0: […]
 
+#### 10.1 Pass Mapping
 
-Pass 1: […]
+- Pass 0: […].
+- Pass 1: […].
+- …
 
+#### 10.2 Export Checklist
 
-…
+- All concern files exist.
+- Types line up.
+- Logic matches spec.
+- Styling matches breakpoints.
+- Accessibility checks passed.
 
-
-10.2 Export Checklist
-All concern files exist
-
-
-Types line up
-
-
-Logic matches spec
-
-
-Styling matches breakpoints
-
-
-Accessibility checks passed
-
-
+---
 
 ## 2) General NL Skeleton – ProjectShell-Level (Global Shells)
+
 Use this for things like the Global Header, App Shell, persistent sidebars.
+
 ProjectShell Configuration: [Shell Name] ([shell-id])
 Project: [Project Name] ([project-id])
 Type: Persistent [Shell type, e.g. Navigation Shell / App Layout Shell]
 Scope: Global – wraps all Configuration views
 Passes: [0–7] (Multi-pass implementation)
+
 ### Semantic Notes
-A ProjectShell is still a Configuration in the semantic sense, but it is global and persistent.
 
-
-It spans the same concerns (Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle), and is also expressed entirely through Atomic Components (Containers, Subcontainers, Primitives).
-
-
-Many Knowledge atoms here will be project-global (tab definitions, routes, breakpoints, brand content) and consumed by other configurations.
-
-
+- A ProjectShell is still a Configuration in the semantic sense, but it is global and persistent.
+- It spans the same concerns (Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle), and is also expressed entirely through Atomic Components (Containers, Subcontainers, Primitives).
+- Many Knowledge atoms here will be project-global (tab definitions, routes, breakpoints, brand content) and consumed by other configurations.
 
 ### 1. Purpose and Scope
-1.1 This shell provides the global [header/sidebar/layout] that persists across all Configuration views.
-1.2 It manages [navigation state, modes, responsive layout, etc.].
-1.3 It coordinates with routing and configuration context.
+
+- 1.1 This shell provides the global [header/sidebar/layout] that persists across all Configuration views.
+- 1.2 It manages [navigation state, modes, responsive layout, etc.].
+- 1.3 It coordinates with routing and configuration context.
 
 ### 2. Configuration Contracts
-2.1 TypeScript Interfaces
-Shell-level state types (tabs, modes, viewport, etc.).
 
+#### 2.1 TypeScript Interfaces
 
-2.2 Global State Requirements
-What global state this shell owns or consumes.
+- Shell-level state types (tabs, modes, viewport, etc.).
 
+#### 2.2 Global State Requirements
 
-2.3 Routing & Context
-URL patterns, config ID context, etc.
+- What global state this shell owns or consumes.
 
+#### 2.3 Routing & Context
 
+- URL patterns, config ID context, etc.
 
 ### 3. Build Concern (Structure)
-3.0 Dependencies & Hierarchy Notes
-Parent App, routing, providers.
 
+#### 3.0 Dependencies & Hierarchy Notes
 
-This shell has one or more Containers at the top level for Build; shell zones are modeled as Subcontainers and Primitives under those containers.
+- Parent App, routing, providers.
+- This shell has one or more Containers at the top level for Build; shell zones are modeled as Subcontainers and Primitives under those containers.
 
+#### 3.1 Atomic Components — Containers (Build) – `"[Shell Container]"`
 
-3.1 Atomic Components — Containers (Build) – “[Shell Container]”
-Hierarchical type: Container
+- Hierarchical type: Container
+- Concern: Build
+- Catalog base: `layout.group / layout.shell`
+- Zones: left/center/right, top/bottom, etc.
+- Anchor: shell-level anchor if needed.
 
+#### 3.2 Atomic Components — Subcontainers (Build) – “Shell Zones”
 
-Concern: Build
+- Zone A Subcontainer: [Brand / Nav / Tools]
+- Zone B Subcontainer: [Tabs / Modes / Breadcrumbs]
+- Zone C Subcontainer: [Actions / Profile / Publish]
 
+#### 3.3 Atomic Components — Primitives (Build)
 
-Catalog base: layout.group / layout.shell
-
-
-Zones: left/center/right, top/bottom, etc.
-
-
-Anchor: shell-level anchor if needed.
-
-
-3.2 Atomic Components — Subcontainers (Build) – “Shell Zones”
-Zone A Subcontainer: [Brand / Nav / Tools]
-
-
-Zone B Subcontainer: [Tabs / Modes / Breadcrumbs]
-
-
-Zone C Subcontainer: [Actions / Profile / Publish]
-
-
-3.3 Atomic Components — Primitives (Build)
-Buttons, labels, icons, previews, etc., assigned to each zone as leaf-level primitives.
-
-
+- Buttons, labels, icons, previews, etc., assigned to each zone as leaf-level primitives.
 
 ### 4. BuildStyle Concern (Visual Styling of Structure)
-4.0 Dependencies
-Theme tokens and global layout rules.
 
+#### 4.0 Dependencies
 
-4.1 Base Layout Styles
-Shell container (padding, background, borders).
+- Theme tokens and global layout rules.
 
+#### 4.1 Base Layout Styles
 
-4.2 Zone Styles
-Alignment, spacing, stacking of zones.
+- Shell container (padding, background, borders).
 
+#### 4.2 Zone Styles
 
-4.3 Responsive Layout Rules
-Desktop / tablet / mobile behavior.
+- Alignment, spacing, stacking of zones.
 
+#### 4.3 Responsive Layout Rules
 
-4.4 Interaction States
-Active tab, hover preview, disabled states.
+- Desktop / tablet / mobile behavior.
 
+#### 4.4 Interaction States
 
+- Active tab, hover preview, disabled states.
 
 ### 5. Logic Concern (Workflow)
-5.0 Dependencies
-Router, viewport detection, config context.
 
+#### 5.0 Dependencies
 
-5.1 Global State Management
-Navigation state, modes, hover previews, etc.
+- Router, viewport detection, config context.
 
+#### 5.1 Global State Management
 
-5.2 Navigation Logic
-Tab activation, mode toggles, sync with URL.
+- Navigation state, modes, hover previews, etc.
 
+#### 5.2 Navigation Logic
 
-5.3 Responsive Logic
-Breakpoint calculation, conditional rendering flags.
+- Tab activation, mode toggles, sync with URL.
 
+#### 5.3 Responsive Logic
 
-5.4 Shell-Specific Workflows
-e.g. Publish, open docs, open settings.
+- Breakpoint calculation, conditional rendering flags.
 
+#### 5.4 Shell-Specific Workflows
 
+- e.g. Publish, open docs, open settings.
 
 ### 6. Knowledge Concern (Reference Data)
-6.1 Shell Metadata (often project-global Knowledge atoms)
-Tab definitions, routes, tooltips.
 
+#### 6.1 Shell Metadata (often project-global Knowledge atoms)
 
-6.2 Breakpoints
-Thresholds + helper functions (often project-global).
+- Tab definitions, routes, tooltips.
 
+#### 6.2 Breakpoints
 
-6.3 Brand Content
-Wordmark, tagline, home tooltip.
+- Thresholds + helper functions (often project-global).
 
+#### 6.3 Brand Content
 
+- Wordmark, tagline, home tooltip.
 
 ### 7. Results Concern (Outputs)
-7.1 Navigation State Output
-Debug display / current route string.
 
+#### 7.1 Navigation State Output
 
-7.2 Accessibility Announcements
-Tab change messages, mode change messages.
+- Debug display / current route string.
 
+#### 7.2 Accessibility Announcements
 
+- Tab change messages, mode change messages.
 
 ### 8. ResultsStyle Concern (Output Styling)
-8.1 Debug Overlay Styles
-8.2 Any special shell-only result visuals.
+
+#### 8.1 Debug Overlay Styles
+
+#### 8.2 Any special shell-only result visuals
 
 ### 9. Assembly Pattern
-9.1 File Structure
+
+#### 9.1 File Structure
+
+```text
 /src/shells/[shell-id]/[ShellName]/
   [ShellName].build.tsx
   [ShellName].build.module.css
@@ -492,33 +402,26 @@ Tab change messages, mode change messages.
   [ShellName].results.tsx
   [ShellName].results.module.css
   index.ts
-9.2 Assembly Logic
-Hook for logic, build component for structure, knowledge/constants, optional results debug.
+```
 
+#### 9.2 Assembly Logic
 
-9.3 Integration
-How the shell wraps child routes/configurations.
+- Hook for logic, build component for structure, knowledge/constants, optional results debug.
 
+#### 9.3 Integration
 
+- How the shell wraps child routes/configurations.
 
 ### 10. Implementation Passes
-10.1 Pass Mapping
-Pass 0: Shell container
 
+#### 10.1 Pass Mapping
 
-Pass 1+: Zones, tabs, actions, etc.
+- Pass 0: Shell container.
+- Pass 1+: Zones, tabs, actions, etc.
 
+#### 10.2 Export Checklist
 
-10.2 Export Checklist
-Shell renders correctly at all breakpoints
-
-
-Global state + routing are in sync
-
-
-All zones behave as specified
-
-
-Debug + accessibility pieces wired up
-
-
+- Shell renders correctly at all breakpoints.
+- Global state + routing are in sync.
+- All zones behave as specified.
+- Debug + accessibility pieces wired up.

--- a/doc/ConventionRoutines/NL-First-Workflow.md
+++ b/doc/ConventionRoutines/NL-First-Workflow.md
@@ -1,81 +1,66 @@
 # NL-First Workflow (What the AI Does First)
-Golden rule: Before generating or editing any code for a configuration or shell, instantiate the appropriate NL skeleton template from General-NL-Skeletons.md (Configuration-Level or ProjectShell-Level) and create or update the NL skeleton text file for it.
+
+Golden rule: Before generating or editing any code for a configuration or shell, instantiate the appropriate NL skeleton template from `General-NL-Skeletons.md` (Configuration-Level or ProjectShell-Level) and create or update the NL skeleton text file for it.
+
 ## 0. NL Skeleton Step (Mandatory First Step)
+
 When starting work on a feature, configuration, or shell:
-Decide the type:
 
-If it’s a normal configuration (e.g. “Tab Navigation”, “Brand Block”), use:
-
-doc/nl-config/cfg-[name].md
-
-If it’s a global shell (e.g. “Global Header Shell”), use:
-
-doc/nl-shell/shell-[name].md
-
-Create (or update) the NL skeleton file using the correct template:
-
-- Skeleton templates:
-  - General-NL-Skeletons.md → Section 1.x–10.x under “General NL Skeleton – Configuration-Level” for configurations
-  - General-NL-Skeletons.md → Section 1.x–10.x under “General NL Skeleton – ProjectShell-Level” for shells
-
-Fill it out in prose:
-
-Sections 1–10, including:
-
-Purpose and scope
-
-Configuration contracts
-
-Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle
-
-Atomic Components (Containers, Subcontainers, Primitives) with numbering (3.1, 3.2.1, 3.3.1, etc.)
-
-Assembly pattern and implementation passes
+1. Decide the type:
+   - If it’s a normal configuration (e.g. “Tab Navigation”, “Brand Block”), use `doc/nl-config/cfg-[name].md`.
+   - If it’s a global shell (e.g. “Global Header Shell”), use `doc/nl-shell/shell-[name].md`.
+2. Create (or update) the NL skeleton file using the correct template:
+   - `General-NL-Skeletons.md` → Section `1.x–10.x` under “General NL Skeleton – Configuration-Level” for configurations.
+   - `General-NL-Skeletons.md` → Section `1.x–10.x` under “General NL Skeleton – ProjectShell-Level” for shells.
+3. Fill it out in prose:
+   - Sections `1–10`, including:
+     - Purpose and scope.
+     - Configuration contracts.
+     - Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle.
+     - Atomic Components (Containers, Subcontainers, Primitives) with numbering (`3.1`, `3.2.1`, `3.3.1`, etc.).
+     - Assembly pattern and implementation passes.
 
 Implementation reminder: Build and Results concerns are authored in `.tsx` structure files, BuildStyle and ResultsStyle live in CSS or CSS-Module files, Logic occupies `.ts`/`.tsx` logic modules, and Knowledge resides in `.ts` static data modules. BuildStyle and ResultsStyle rely on the class names and data attributes emitted by their paired structure concerns.
 
 Only after the NL file exists and is filled in may the AI:
 
-Create or edit any concern files under src/builder/...
-
-Add or update code comments referencing [3.x.y], [4.x.y], etc.
+- Create or edit any concern files under `src/builder/...`.
+- Add or update code comments referencing `[3.x.y]`, `[4.x.y]`, etc.
 
 Never add new code that isn’t described in the NL skeleton first.
 
 If new behavior/structure is needed, AI must update the NL file first, then code.
 
 ## 1. Code Generation Step (After NL)
+
 Once the NL skeleton file is in place:
-Read cfg-*.md or shell-*.md top to bottom.
 
-For each concern, in order:
+1. Read `cfg-*.md` or `shell-*.md` top to bottom.
+2. For each concern, in order:
+   - Add/adjust the file header (with link to the NL file).
+   - Add/adjust section headers (`3. Build – cfg-...`, `4. BuildStyle – cfg-...`, etc.).
+   - Implement Containers/Subcontainers/Primitives in the same numeric order as NL.
+   - Prepend each with an atomic comment:
 
-Add/adjust the file header (with link to the NL file).
-
-Add/adjust section headers (3. Build – cfg-..., 4. BuildStyle – cfg-..., etc.).
-
-Implement Containers/Subcontainers/Primitives in the same numeric order as NL.
-
-Prepend each with an atomic comment:
-
+```ts
 // [3.2.2] cfg-tabNavigation · Subcontainer · "Center Zone – Tab Strip"
 // Concern: Build · Parent: "Global Header Shell" · Catalog: layout.group
+```
 
 ## 2. Enforcement Checklist (For AI / You)
+
 Any time code is generated or changed for a config/shell:
-NL skeleton file exists in doc/nl-config or doc/nl-shell.
 
-The change to code is reflected in NL, and the numbering matches.
-
-All new functions/components/blocks have the correct [sectionNumber] cfg-id · type · name comments.
-
-No concern file contains “orphan” code that isn’t mentioned in the NL skeleton.
+- NL skeleton file exists in `doc/nl-config` or `doc/nl-shell`.
+- The change to code is reflected in NL, and the numbering matches.
+- All new functions/components/blocks have the correct `[sectionNumber] cfg-id · type · name` comments.
+- No concern file contains “orphan” code that isn’t mentioned in the NL skeleton.
 
 ### Example Alignment
 
 - NL excerpt:
-  - [3.2.1] Subcontainer “Center Zone – Tab Strip” (Build)
-  - [5.2.2] Handler “handleTabSelect” (Logic)
+  - `[3.2.1]` Subcontainer “Center Zone – Tab Strip” (Build)
+  - `[5.2.2]` Handler “handleTabSelect” (Logic)
 - Code comments:
   - `// [3.2.1] cfg-buildSurface · Subcontainer · "Center Zone – Tab Strip"`
   - `// [5.2.2] cfg-buildSurface · Primitive · "handleTabSelect"`


### PR DESCRIPTION
### Motivation
- Improve readability and scanability across the ConventionRoutines guidance by normalizing heading hierarchy, spacing, list formatting, and code/example rendering. 
- Prioritize `General-NL-Skeletons.md` so NL skeleton templates are clearer and easier to follow for downstream NL-first workflows. 
- Preserve all policy meaning, examples, and numbering while avoiding file renames or semantic changes.

### Description
- Normalized top-level titles and heading hierarchies (`##`, `###`, `####`) and added consistent blank lines around headings and paragraphs in `doc/ConventionRoutines/General-NL-Skeletons.md`, `CCPP.md`, `CSCS.md`, and `NL-First-Workflow.md`.
- Converted dense prose and run-on lists into clear bulleted lists and numbered steps where appropriate, and wrapped code/example snippets in fenced code blocks for better rendering and copy/paste clarity.
- Fixed malformed list indentation and normalized inline formatting (inline code/backticks) and minor punctuation/spacing to improve scanability while preserving original semantics and examples.
- Files changed: `doc/ConventionRoutines/General-NL-Skeletons.md`, `doc/ConventionRoutines/CCPP.md`, `doc/ConventionRoutines/CSCS.md`, `doc/ConventionRoutines/NL-First-Workflow.md`; `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` was intentionally left untouched to avoid semantic risk.

### Testing
- Confirmed only docs were modified by listing changed files and ensuring the edit set matches the intended scope (4 docs touched, no source code changes).
- Ran a whitespace/format sanity check across diffs and found no whitespace or formatting errors.
- Verified repository state and latest change metadata to ensure the normalization pass was recorded and no filenames were renamed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699beef97e9c8331a671a91528aa5e3f)