### PR TITLE
docs: micro-polish deterministic structural addressing draft wording

### DIFF
--- a/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -179,7 +179,7 @@ Within same host (or same no-host artifact), sort by numeric segment tuple.
 5. Concern numbering semantics are shared across codebase and future program/engine scopes (same foundation, different scope).
 6. This spec does not redefine concern purity or dependency rules; it only fixes concern-slot position in structural addresses.
 
-> Clarifying note: concern numbering may begin at a non-`1` slot because earlier segments represent structural scope (`HostLetter` + host-local structure in host-present mode, or artifact-local root structure in no-host mode). This preserves CSCS/CCS canonical concern ordering while keeping scope identity explicit.
+> Clarifying note: concern slots are `3`–`8` (not `1`-based) because earlier positions are reserved for structural scope/placement segments (`HostLetter` + host-local structure index in host-present mode, vs artifact-local root structure index in no-host mode). Canonical CSCS/CCS concern numbering is preserved across both layouts rather than renumbered per mode.
 
 ## 8. Deep Nesting Rules (Required)
 
@@ -207,8 +207,8 @@ Within same host (or same no-host artifact), sort by numeric segment tuple.
 
 #### Top-level host with local structures
 
-- `A.1.3` => Host `A`, local structure `1`, concern Build
-- `A.2.5` => Host `A`, local structure `2`, concern Logic
+- `A.1.3` => Host `A`, host-local structure `1`, concern Build
+- `A.2.5` => Host `A`, host-local structure `2`, concern Logic
 
 #### Nested host context
 
@@ -232,7 +232,7 @@ Within same host (or same no-host artifact), sort by numeric segment tuple.
 
 ### 9.2 Non-Examples / Invalid or Ambiguous
 
-- `A.3` (invalid: host-present mode missing required concern slot)
+- `A.3` (invalid: host-present mode requires at least 3 segments: `HostLetter.HostLocalIndex.ConcernIndex`)
 - `1` (invalid: no-host mode missing concern slot)
 - `A.1.9` (invalid concern slot under current canonical concern range)
 - `AA.1.3` (invalid under current draft grammar: multi-letter host tokens are deferred in §10)


### PR DESCRIPTION
### Motivation
- Improve precision and short-term readability of the deterministic structural addressing draft without changing scope, grammar shape, or any deferred decisions.

### Description
- Minor, surgical edits to `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md`: tightened the `A.3` non-example to state the required host-present segment shape as `HostLetter.HostLocalIndex.ConcernIndex`, added a brief clarifying rationale that concern slots are `3–8` because earlier segments are reserved for structural scope/placement (host vs artifact layouts) and that canonical concern numbering is preserved across modes, and tuned two example lines to use the phrasing `host-local structure` for consistency (changes located in §7 clarifying note, §9.1 examples, and §9.2 non-examples).

### Testing
- Ran `git diff --check` to validate the working tree (no issues) and committed the doc-only change; no code tests were required for this documentation-only micro-polish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cd1cfa9a883319a020cdedcb8462c)