### PR TITLE
docs(ccpp): micro-polish heading typo and atomic comment example consistency

### DIFF
--- a/doc/ConventionRoutines/CCPP.md
+++ b/doc/ConventionRoutines/CCPP.md
@@ -26,7 +26,7 @@ CCPP currently requires NL section IDs/section numbers (for example `[3.2.2]`) a
 
 ## 3. Required Fields & Format
 
-### 3.1 File Header (TS/TSX/TS, etc.)
+### 3.1 File Header (TS/TSX/JS, etc.)
 
 ```ts
 /**
@@ -217,7 +217,7 @@ export function GlobalHeaderShell() { ... }
   - (Narrates the obvious and lacks NL reference.)
 - Good:
   - `// [5.2.2] cfg-tabNavigation · Primitive · "handleTabSelect"`
-  - `// Concern: Logic · Parent: "Tab Navigation Logic" · Notes: syncs active tab state`
+  - `// Concern: Logic · Parent: "Tab Navigation Logic" · Catalog: logic.handler · Notes: syncs active tab state`
   - `// Structural Address (Draft, optional): A.1.5.2`
   - `const handleTabSelect = (tabId: string) => setActiveTab(tabId);`
 


### PR DESCRIPTION
### Motivation
- Perform a small, surgical documentation polish to fix a heading typo and bring the atomic-comment example into strict alignment with the atomic-comment rule in Section 3.3 without changing scope or policy.

### Description
- Corrected the Section 3.1 heading from `### 3.1 File Header (TS/TSX/TS, etc.)` to `### 3.1 File Header (TS/TSX/JS, etc.)` in `doc/ConventionRoutines/CCPP.md`.
- Updated the “Good” example under "Bad vs. Good Atomic Comments" so the second line includes a `Catalog` id: `// Concern: Logic · Parent: "Tab Navigation Logic" · Catalog: logic.handler · Notes: syncs active tab state`.
- No other files were modified and no draft/deferred structural-address decisions or policy content were changed.

### Testing
- Verified file existence and repository context with `pwd` and branch check, and confirmed the target file `doc/ConventionRoutines/CCPP.md` was present.
- Read and inspected the updated file with `sed -n '1,220p' doc/ConventionRoutines/CCPP.md` and `sed -n '220,320p' doc/ConventionRoutines/CCPP.md` to confirm the heading and example lines were updated as intended.
- Ran quick content checks with `rg -n "File Header \(|Structural Address|Concern: Logic" doc/ConventionRoutines/CCPP.md`, `nl -ba doc/ConventionRoutines/CCPP.md | sed -n '20,40p'`, and `nl -ba doc/ConventionRoutines/CCPP.md | sed -n '210,230p'`, and all inspections returned the expected updated content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf12d916483319bde57d8433a6fd4)