### PR TITLE
docs(ccpp): canonicalize Notes as final line in Good atomic comment example

### DIFF
--- a/doc/ConventionRoutines/CCPP.md
+++ b/doc/ConventionRoutines/CCPP.md
@@ -71,7 +71,7 @@ Rules:
 - First line: `[NLSectionNumber] cfg-id · HierarchicalType · "Name"`.
 - Second line: Concern, Parent (if any), Catalog id.
 - Optional line: `Structural Address (Draft, optional): <address>` when needed for draft-aligned structural tracing.
-- Final line: short intent/constraint note.
+- Final line: `Notes: ...` short intent/constraint note (keep Notes separate from the metadata line for deterministic readability).
 
 Atomic-comment requirement remains NL-section-based. Do not replace the bracket token with structural-address grammar in this pass.
 
@@ -217,8 +217,9 @@ export function GlobalHeaderShell() { ... }
   - (Narrates the obvious and lacks NL reference.)
 - Good:
   - `// [5.2.2] cfg-tabNavigation · Primitive · "handleTabSelect"`
-  - `// Concern: Logic · Parent: "Tab Navigation Logic" · Catalog: logic.handler · Notes: syncs active tab state`
+  - `// Concern: Logic · Parent: "Tab Navigation Logic" · Catalog: logic.handler`
   - `// Structural Address (Draft, optional): A.1.5.2`
+  - `// Notes: syncs active tab state`
   - `const handleTabSelect = (tabId: string) => setActiveTab(tabId);`
 
 ## 8. Maintenance Rules


### PR DESCRIPTION
### Motivation
- Align the “Good Atomic Comments” example with the canonical atomic-comment shape by keeping `Notes` on its own final line and make the Section 3.3 wording unambiguous about that rule.

### Description
- Edited `doc/ConventionRoutines/CCPP.md` to remove inline `Notes` from the metadata line in the Good example and add a separate final `// Notes: ...` line, and tightened the Section 3.3 rule text to state the final line should be `Notes: ...` (no other files changed).

### Testing
- Ran automated checks to confirm the target file exists (`test -f doc/ConventionRoutines/CCPP.md`), validated the example with `rg -n "Bad|Good|3\.3|Notes"`, and inspected the diff to ensure only the intended lines in `doc/ConventionRoutines/CCPP.md` were modified; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cfa918b108331b5645146e4ce5bfb)