### PR TITLE
docs: micro-polish General-NL-Skeletons consistency fixes

### DIFF
--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -8,6 +8,7 @@ This doc defines the canonical NL skeleton templates used by all configuration (
 - **Structural Address (Draft):** Deterministic structural positioning (host-present or no-host forms) is a supplementary addressing layer described in `DeterministicStructuralAddressingSpec-Draft.md`.
 - These are related but **not identical** systems: structural addresses do not replace NL section numbering in this skeleton.
 - Where useful, templates may record structural addresses as **draft, optional metadata** alongside NL content.
+- Placeholder examples that use `x` (for example `3.2.x`) are illustrative draft placeholders in this doc; placeholder marker policy remains deferred to `DeterministicStructuralAddressingSpec-Draft.md`.
 - Comment/provenance protocol conventions remain governed by `CCPP.md`; this doc remains the canonical NL skeleton structure source.
 
 ## Changing This Doc
@@ -30,7 +31,7 @@ Passes: [0–7] (Multi-pass implementation)
 
 - A Configuration is a semantic module, not a file.
 - It spans up to six concerns: Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle.
-- Per-configuration implementation files live under paths like `src/configs/<configId>/<ConfigName>.build.tsx` (structure), `src/configs/<configId>/<ConfigName>.build.module.css` (configuration styling), and the other concern files with matching base names. The engine or build step may merge those into project-level bundles such as `src/projects/<projectId>/Project.build.tsx`. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files that target the anchors emitted by the Build and Results `.tsx` concerns.
+- Per-configuration implementation files live under paths like `src/configs/<configId>/<ConfigName>.build.tsx` (structure), `src/configs/<configId>/<ConfigName>.build-style.module.css` (configuration styling), and the other concern files with matching base names. The engine or build step may merge those into project-level bundles such as `src/projects/<projectId>/Project.build.tsx`. BuildStyle and ResultsStyle are implemented as CSS/CSS-Module files (for example `[ConfigName].build-style.module.css` and `[ConfigName].results-style.module.css`) that target the anchors emitted by the Build and Results `.tsx` concerns; actual repository naming should still follow the naming master and current repo conventions.
 - All content of a configuration is expressed as Atomic Components.
 - Each atomic component has:
   - a concern (Build / BuildStyle / Logic / Knowledge / Results / ResultsStyle), and
@@ -239,17 +240,17 @@ interface [ConfigName]State { ... }
 ```text
 /src/configs/[config-id]/[ConfigName]/
   [ConfigName].build.tsx
-  [ConfigName].build.module.css
+  [ConfigName].build-style.module.css
   [ConfigName].logic.ts
   [ConfigName].knowledge.ts
   [ConfigName].results.ts
-  [ConfigName].results.module.css
+  [ConfigName].results-style.module.css
   index.ts
 ```
 
 #### 9.2 Assembly Logic
 
-- `index.tsx` wires concerns together and exports a single component that implements this configuration.
+- `index.ts` wires concerns together and exports a single component that implements this configuration.
 
 #### 9.3 Integration
 
@@ -424,11 +425,11 @@ Passes: [0–7] (Multi-pass implementation)
 ```text
 /src/shells/[shell-id]/[ShellName]/
   [ShellName].build.tsx
-  [ShellName].build.module.css
+  [ShellName].build-style.module.css
   [ShellName].logic.ts
   [ShellName].knowledge.ts
   [ShellName].results.tsx
-  [ShellName].results.module.css
+  [ShellName].results-style.module.css
   index.ts
 ```
 


### PR DESCRIPTION
### Motivation
- Resolve small internal consistency issues in `General-NL-Skeletons.md` after a structural-address sync pass without changing document scope or finalizing deferred decisions. 
- Keep assembly/file-structure examples aligned with explicit concern-role naming and ensure the assembly-logic file reference matches the file-tree examples.
- Make placeholder usage explicit so readers understand `x` is an illustrative draft placeholder and that policy remains deferred.

### Description
- Added a concise placeholder-note in the Addressing & Numbering section clarifying that examples using `x` (e.g. `3.2.x`) are illustrative draft placeholders and that placeholder marker policy is deferred to `DeterministicStructuralAddressingSpec-Draft.md`.
- Replaced example filenames in the semantic notes and assembly file trees from `*.build.module.css` / `*.results.module.css` to explicit concern-role examples `*.build-style.module.css` and `*.results-style.module.css` for both configuration and shell templates, and added a short note that actual repo naming should follow the naming master/current repo conventions.
- Aligned assembly logic wording by changing the configuration assembly reference from ``index.tsx`` to ``index.ts`` so the prose matches the file-tree example.
- Kept all edits surgical and limited to `doc/ConventionRoutines/General-NL-Skeletons.md`, preserving top-level section numbering and deferring any structural-address or naming policy decisions.

### Testing
- Inspected the edited file with ``nl -ba doc/ConventionRoutines/General-NL-Skeletons.md`` and confirmed the new placeholder note and filename examples appear in the expected locations; the command completed successfully.
- Read surrounding convention docs with ``sed -n '1,220p' doc/ConventionRoutines/CCPP.md`` and ``sed -n '1,220p' doc/ConventionRoutines/CSCS.md`` to ensure consistency and the commands completed successfully.
- Verified only the target file changed using ``git status --short`` and reviewed the patch with ``git diff -- doc/ConventionRoutines/General-NL-Skeletons.md``, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cffbf440483319ccf674344a9ac30)