### PR TITLE
docs: micro-polish General-NL-Skeletons.md readability and assembly parallelism

### DIFF
--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -47,7 +47,8 @@ Passes: [0–7] (Multi-pass implementation)
   - Container – top-level encapsulation in a concern for this configuration; not nested inside other Containers in that concern; may contain Subcontainers and/or Primitives directly (flat or hierarchical).
   - Subcontainer – nested encapsulation; always inside a Container or another Subcontainer; never at the root of a concern.
   - Primitive – leaf unit; contains nothing else (single field, rule, style block, kb map, result line, etc.).
-- Concern vs hierarchy are orthogonal: any valid combination is allowed as long as the concern’s purity rules are respected.
+- Concern vs hierarchy are orthogonal.
+  - Any valid combination is allowed as long as the concern’s purity rules are respected.
 
 ### Draft Structural-Address Usage Notes (Supplementary)
 
@@ -332,7 +333,8 @@ Passes: [0–7] (Multi-pass implementation)
 #### 3.0 Dependencies & Hierarchy Notes
 
 - Parent App, routing, providers.
-- This shell has one or more Containers at the top level for Build; shell zones are modeled as Subcontainers and Primitives under those containers.
+- This shell has one or more Containers at the top level for Build.
+  - Shell zones are modeled as Subcontainers and Primitives under those containers.
 
 #### 3.1 Atomic Components — Containers (Build) – `"[Shell Container]"`
 
@@ -343,7 +345,7 @@ Passes: [0–7] (Multi-pass implementation)
 - Anchor: shell-level anchor if needed.
 - Structural Address (Draft, optional): `[A.1.2 / 3.1 / etc.]`
 
-#### 3.2 Atomic Components — Subcontainers (Build) – “Shell Zones”
+#### 3.2 Atomic Components — Subcontainers (Build) – `"Shell Zones"`
 
 - Zone A Subcontainer: [Brand / Nav / Tools]
 - Zone B Subcontainer: [Tabs / Modes / Breadcrumbs]
@@ -448,7 +450,9 @@ Passes: [0–7] (Multi-pass implementation)
 
 #### 9.2 Assembly Logic
 
-- Implementation pattern:
+- `index.ts` wires shell concerns together.
+- It exports a shell component that implements this project shell.
+- Implementation pattern typically includes:
   - Hook for logic.
   - Build component for structure.
   - Knowledge/constants.


### PR DESCRIPTION
### Motivation
- Improve scanability and formatting consistency in `doc/ConventionRoutines/General-NL-Skeletons.md` with a tiny, low-risk readability pass. 
- Make Shell-level `9.2 Assembly Logic` read more parallel to the Configuration-level guidance without changing semantics or contracts. 

### Description
- Split the long semantic line about concern vs hierarchy into a short lead bullet plus a sub-bullet to improve scanability while preserving meaning. 
- Split the long Shell `3.0 Dependencies & Hierarchy Notes` sentence into a parent bullet and a sub-bullet for clarity. 
- Normalize quote/placeholder style in the repeated shell template heading by changing the heading to use a consistent quoted template form: `"Shell Zones"`. 
- Tightened ProjectShell `9.2 Assembly Logic` wording to explicitly state that `index.ts` wires shell concerns and exports the shell component, and preserved the existing implementation-pattern framing. 
- Only `doc/ConventionRoutines/General-NL-Skeletons.md` was edited and no numbering, concern ordering, policy, or draft/deferred boundaries were changed. 

### Testing
- Confirmed repository context and that required convention files exist by reading `doc/ConventionRoutines/CCPP.md`, `doc/ConventionRoutines/CSCS.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md` using `sed`, which succeeded. 
- Verified the change via `git diff -- doc/ConventionRoutines/General-NL-Skeletons.md` and inspected relevant file regions with `nl -ba doc/ConventionRoutines/General-NL-Skeletons.md | sed -n ...`, both succeeded. 
- Staged and committed the change with `git add` and `git commit`, producing a commit titled "docs: micro-polish General NL skeleton readability and assembly parallelism", which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d04a29f7c83318f0107fc84340230)