### PR TITLE
docs: refine Build Surface global-host inventory plan with incremental extraction workflow

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -112,6 +112,27 @@ This split is expected to reduce churn by keeping shell behavior stable while en
    - Repeated patterns around selectors/adapters may justify role promotion later.
    - This pass explicitly defers any role-registry expansion.
 
+## Incremental Refactor Migration Method (Draft)
+
+Implementation should execute as **semantic-slice extraction** rather than broad file rewrites.
+
+- Extract one semantic slice at a time from legacy source into its planned canonical target.
+- Prefer behavior-preserving moves first; do not combine extraction with broad behavior redesign in the same slice.
+- Drain legacy files incrementally as responsibilities move out.
+- A legacy file may remain temporarily as a thin delegator/wrapper ("legacy wrapper") only when needed for transition stability.
+- Legacy wrappers are transitional only and should be removed once repointing is stable.
+
+Recommended extraction rhythm per slice:
+
+1. **Extract**
+   - Move a bounded responsibility into the destination canonical file from this inventory.
+2. **Repoint**
+   - Update imports/references/call sites to consume the new destination.
+3. **Cleanup / Normalize**
+   - Align local names/comments/NL references, remove dead code, and normalize remaining seams.
+4. **Retire Legacy**
+   - Delete drained legacy files, or temporarily reduce to a thin wrapper until safe removal.
+
 ## Adoption / Implementation Guidance (Draft)
 
 1. Start with docs-first planning (this inventory + naming examples), then apply implementation in small PR slices.
@@ -121,7 +142,39 @@ This split is expected to reduce churn by keeping shell behavior stable while en
    - persistence extraction,
    - tab-provider wiring introduction,
    - optional follow-up tab-provider expansion.
-4. During implementation, keep NL and CCPP alignment for any changed shell/config concern files.
+4. Execute in semantic-slice order, extracting one bounded responsibility at a time and keeping host-shell vs tab-population boundaries explicit.
+5. Separate extraction churn from cleanup churn when practical (for example: extraction/repoint first, naming/comment normalization second).
+6. Avoid mixing refactor + optimization + behavior changes in one pass unless a safety fix requires coupling.
+7. Keep PRs boundary-focused and reviewable; each slice should state the boundary being migrated and the legacy surface being drained.
+8. During implementation, keep NL and CCPP alignment for any changed shell/config concern files.
+
+### Draft Inventory Status Tracking Guidance (Migration Lifecycle)
+
+The `Status` column may be used as a migration-lifecycle trace, not only planning intent.
+
+Recommended status progression vocabulary:
+
+- `draft`
+- `planned`
+- `in-progress`
+- `extracted`
+- `repointed`
+- `legacy-wrapper` *(optional, temporary transitional state)*
+- `retired`
+- `deferred`
+
+Guidance:
+
+- Not every inventory item must pass through every status.
+- `legacy-wrapper` is optional and should be short-lived.
+- Statuses are for migration traceability/reconciliation, not rigid process law.
+
+### Incremental Extraction Safety Notes
+
+- Avoid introducing circular imports while extracting slices from legacy files.
+- Keep ownership obvious after each extraction; do not leave misleading names/comments that imply old ownership.
+- Validate React hook/state boundary safety during logic extraction (hook order, closure capture, effects coupling).
+- Prefer behavior-preserving extraction before optimization.
 
 ## Repo-Reality Constraints (Observed in Current Tree)
 


### PR DESCRIPTION
### Motivation

- Provide actionable, implementation-focused guidance for incrementally refactoring Build Surface into a global host while preserving the existing architecture split and naming policy. 
- Make the migration process reviewable and low-churn by formalizing a semantic-slice extraction rhythm and a short-lived compatibility option when necessary. 
- Improve inventory traceability by adding a migration-lifecycle status vocabulary for reconciling planning with work-in-progress.

### Description

- Added a new `Incremental Refactor Migration Method (Draft)` section that mandates extracting one semantic slice at a time and documents the Extract → Repoint → Cleanup/Normalize → Retire Legacy rhythm. 
- Introduced the concept of a temporary `legacy wrapper` (thin delegator) and clarified it must be short-lived and removed once repointing stabilizes. 
- Expanded `Adoption / Implementation Guidance (Draft)` to require semantic-slice ordering, separation of extraction vs cleanup churn, caution against coupling refactor/optimization/behavior changes, and PR boundary-focused guidance. 
- Added `Draft Inventory Status Tracking Guidance (Migration Lifecycle)` with recommended status vocabulary and short `Incremental Extraction Safety Notes` (circular-imports, ownership clarity, React hook/state caution, behavior-preserving-first). 
- Preserved all existing architecture direction, responsibility buckets, and naming decisions and limited edits to only `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`.

### Testing

- Confirmed repo root and branch with `pwd && git rev-parse --abbrev-ref HEAD`, which ran successfully on branch `work`.
- Read and re-reviewed the target document with `sed -n '1,260p' doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` to verify additive changes and preservation of existing sections. 
- Verified presence of required convention files with the convention-file check command used earlier, which succeeded for `doc/ConventionRoutines/CCPP.md`, `CSCS.md`, `General-NL-Skeletons.md`, and `NL-First-Workflow.md`.
- Ensured only the intended doc file changed via `git diff --name-only` and `git status --short`, ran `git diff --check` to validate no whitespace errors, then committed the change with `git commit -m "docs: add semantic-slice migration method to Build Surface host inventory plan"`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d39d7ad8883318d2b468cfb0e7df8)