### PR TITLE
docs(architecture): add BuildSurface Global Host slice execution playbook

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -1,0 +1,371 @@
+# Build Surface Global Host Slice Execution Playbook
+
+## Document Status
+
+- **Document Type:** Architecture Execution Playbook
+- **Status:** Draft (Docs-First Refactor Execution Guidance)
+- **Purpose:** Convert the Build Surface global-host draft inventory into a repeatable semantic-slice execution and verification workflow.
+- **Scope:** Execution sequencing guidance, per-slice template, safety checks, PR boundaries, and inventory reconciliation rules for Build Surface → Global Host migration.
+- **Related Docs:**
+  - `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`
+  - `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`
+  - `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
+  - `doc/ConventionRoutines/CSCS.md`
+  - `doc/ConventionRoutines/CCPP.md`
+  - `doc/ConventionRoutines/General-NL-Skeletons.md`
+  - `doc/ConventionRoutines/NL-First-Workflow.md`
+
+## Purpose
+
+This playbook operationalizes the Build Surface → Global Host migration as a **repeatable execution workflow**.
+
+- The inventory plan remains the source of truth for draft targets, mapping direction, status vocabulary, and naming alignment.
+- This playbook defines **how** semantic slices are executed, verified, and reconciled as implementation lands.
+- This playbook does not replace task-specific engineering judgment; it provides guardrails and repeatable review shape.
+
+## Scope Boundaries
+
+### In Scope (Required)
+
+- semantic-slice sequencing guidance
+- per-slice execution template and done criteria
+- reusable verification and safety checklists
+- wrapper/forwarder transitional rules and retirement criteria
+- PR boundary guidance for reviewability
+- inventory reconciliation/status update guidance
+
+### Out of Scope (Required)
+
+- architecture redesign beyond approved inventory direction
+- naming-policy expansion or role-registry changes
+- broad optimization passes bundled into slice execution
+- unrelated cleanup/renames outside the active slice boundary
+- changes that silently redesign behavior under an extraction label
+
+## Execution Model (Semantic-Slice Method)
+
+Each slice should follow the same rhythm from the draft inventory plan:
+
+1. **Extract**
+2. **Repoint**
+3. **Cleanup / Normalize**
+4. **Retire Legacy**
+
+### 1) Extract
+
+Define a bounded slice around one migration boundary (host shell, logic seam, persistence seam, contract seam, or tab-provider seam).
+
+A bounded slice should:
+
+- map to specific inventory row(s) and target file(s)
+- move one coherent responsibility cluster (not multiple unrelated concerns)
+- preserve behavior-first extraction before redesign
+
+Defer from this step:
+
+- broad stylistic cleanup
+- feature changes not required for migration safety
+- speculative naming shifts outside current inventory direction
+
+### 2) Repoint
+
+After extraction, repoint imports/call sites to the new destination in the minimum required scope.
+
+Repoint guidance:
+
+- prefer direct repoint where impact is small and observable
+- allow temporary wrapper/forwarder only when repoint cannot land safely in the same slice
+- keep repoint diffs explicit and limited to touched seam paths
+
+### 3) Cleanup / Normalize
+
+Normalize only the area touched by the slice:
+
+- remove dead imports and drained code paths
+- align local comments/NL references where ownership changed
+- apply naming normalization only for actively migrated files
+
+Do not turn cleanup into broad tree-wide churn.
+
+### 4) Retire Legacy
+
+Retire fully drained legacy files or leave a short-lived wrapper when necessary.
+
+Legacy retirement should happen as soon as:
+
+- all call sites are repointed
+- wrapper has no unique behavior
+- verification is complete for touched path
+
+## Slice Ordering Strategy (Draft v1, Non-Mandatory)
+
+This ordering is a **draft-safe starting strategy** and not immutable law.
+
+### Slice Group A — Canonicalization + Persistence Support Alignment (Low Risk)
+
+- **Why first:** tight blast radius; improves contract clarity before host/wiring extraction.
+- **Typical dependencies:** none beyond existing persistence call sites.
+- **Do not mix:** host shell extraction, tab-provider introduction, or app-level mount repoint.
+
+### Slice Group B — Host Shell Boundary Extraction Scaffolding
+
+- **Why now:** creates stable composition seams that later wiring slices can target.
+- **Typical dependencies:** Group A contract/persistence clarity is preferred.
+- **Do not mix:** behavior redesign of panel interactions or theme/breakpoint policy changes.
+
+### Slice Group C — Shared Host Wiring Seam Introduction
+
+- **Why now:** separates host-level orchestration from tab-specific population paths.
+- **Typical dependencies:** baseline host shell targets established in prior group.
+- **Do not mix:** broad tab-provider expansion or unrelated build/app frame edits.
+
+### Slice Group D — Tab-Provider Contract/Wiring Introduction
+
+- **Why now:** formalizes variable tab population seams after host shell is stable.
+- **Typical dependencies:** shared host wiring seam available.
+- **Do not mix:** final wrapper deletion unless all affected call sites are already repointed.
+
+### Slice Group E — Repoint Slices Across BuildTab/App Mount Path
+
+- **Why now:** repoint entry flow once host/tab seams are already explicit and testable.
+- **Typical dependencies:** wiring seams in place and verified.
+- **Do not mix:** large cosmetic cleanup or additional architecture experiments.
+
+### Slice Group F — Legacy Wrapper Retirement / Final Drain
+
+- **Why last:** avoids churn from deleting transitional seams too early.
+- **Typical dependencies:** all consumer imports switched and behavior checks complete.
+- **Do not mix:** fresh extraction scope in same PR; this should be drain/retire focused.
+
+## Per-Slice Execution Template (Copy/Use Per Task)
+
+```md
+### Slice Name
+- <short descriptive name>
+
+### Boundary Being Migrated
+- <host shell / persistence / wiring / contracts / repoint seam>
+
+### Inventory Row(s) / Target File(s)
+- Inventory rows: <list>
+- Target files: <list>
+
+### Legacy Source(s) Being Drained
+- <legacy files/paths and responsibility being drained>
+
+### Slice Type
+- <host | logic | wiring | contracts | persistence | repoint>
+
+### Preconditions
+- [ ] Related inventory rows identified
+- [ ] Dependencies from prior slices met
+- [ ] NL/CCPP touch impact identified (if concern ownership moves)
+
+### Extract Steps
+1. <bounded extraction step>
+2. <bounded extraction step>
+
+### Repoint Steps
+1. <import/call-site repoint step>
+2. <integration seam repoint step>
+
+### Cleanup / Normalize Steps
+1. <dead code cleanup>
+2. <local naming/comment/NL normalization>
+
+### Wrapper/Forwarder Use
+- Allowed: <yes/no>
+- Why needed: <short rationale>
+- Retirement trigger for this wrapper: <explicit condition>
+
+### Verification Checks
+- [ ] Import/module safety checklist run (applicable items)
+- [ ] Behavior parity checklist run (applicable items)
+- [ ] Persistence safety checklist run (if touched)
+- [ ] Interaction safety checklist run (if touched)
+- [ ] Docs/contract alignment checklist run (if touched)
+
+### Done Criteria
+- [ ] Bounded responsibility moved
+- [ ] Required call sites repointed
+- [ ] Legacy status classified (`extracted`/`repointed`/`legacy-wrapper`/`retired`)
+- [ ] Inventory reconciliation update recorded when material
+
+### Deferred Follow-Ups (Explicit)
+- <item intentionally not completed in this slice>
+```
+
+## Verification & Safety Checklists
+
+Use only the checklists relevant to the touched boundary.
+
+### A) Import / Module Safety
+
+- [ ] imports updated (relative + aliases)
+- [ ] exports/barrels updated where required
+- [ ] no circular import introduced in migrated path
+- [ ] dynamic/lazy import paths verified (if applicable)
+
+### B) Behavior Parity / Runtime Safety
+
+- [ ] shell layout still renders
+- [ ] left/canvas/right zones still mount correctly
+- [ ] tab switching behavior still works in touched paths
+- [ ] state/hook behavior preserved in touched modules
+- [ ] no obvious effect/closure regression introduced
+
+### C) Persistence Safety (When Touched)
+
+- [ ] parse/serialize behavior preserved
+- [ ] version constants/contracts remain aligned
+- [ ] fallback/default behavior preserved
+- [ ] no accidental persisted payload shape drift
+
+### D) Interaction Safety (When Touched)
+
+- [ ] panel resize/collapse behavior remains correct
+- [ ] inspector/right panel behavior remains intact
+- [ ] breakpoint/theme behavior remains intact (if touched)
+
+### E) Docs / Contract Alignment (When Touched)
+
+- [ ] NL references updated where filename/path contract changed
+- [ ] CCPP/NL notes updated where concern ownership shifted
+- [ ] inventory status/mapping updated when slice materially landed
+
+## Wrapper / Forwarder Retirement Rules
+
+Use temporary wrappers/forwarders only as transitional seams.
+
+### Lifecycle Labels
+
+- **`extracted`**: responsibility moved to target, but consumers may still route through legacy path.
+- **`repointed`**: active consumers switched to target path.
+- **`legacy-wrapper`**: legacy file remains as thin delegator only (no unique logic).
+- **`retired`**: legacy file removed after full drain.
+
+### Retirement Criteria (Required)
+
+A wrapper/forwarder can be retired when:
+
+- all known call sites are repointed to canonical target
+- wrapper adds no unique behavior/state/contract translation
+- touched-path verification is complete
+- inventory status has been updated to reflect repointed/retired state
+- no lingering imports depend on the wrapper path
+
+### Drift Control
+
+Avoid long-lived wrappers; if a wrapper survives multiple slices, record explicit blocker and target retirement slice.
+
+## PR Boundary Guidance
+
+Keep each PR reviewable and semantically scoped.
+
+### Required PR Shape Principles
+
+- one primary migration boundary per PR when practical
+- separate extraction work from broad cleanup work where possible
+- do not combine unrelated semantic slices
+- do not combine refactor + optimization + feature behavior change unless safety-coupled
+- state boundary being migrated and legacy source being drained in PR summary
+- include explicit verification notes in PR summary
+
+### Good PR Shapes (Examples)
+
+- **Extraction-only PR:** move persistence contracts/logic to canonical target + minimal repoints.
+- **Repoint-only PR:** switch BuildTab/App mount seam imports to established host wiring target.
+- **Retirement PR:** remove now-empty wrappers after confirmed repoint completion.
+
+## Inventory Reconciliation / Status Update Rules
+
+The inventory plan remains the migration ledger; update it deliberately.
+
+### When to Update `Status`
+
+Update status when slice materially changes lifecycle state, e.g.:
+
+- `planned` → `in-progress`
+- `in-progress` → `extracted`
+- `extracted` → `repointed`
+- `repointed` → `retired`
+- optional transitional `legacy-wrapper` when temporary delegator is intentionally retained
+
+### Snapshot/Mapping Update Rules
+
+- update snapshot/mapping sections when extracted/repointed ownership materially changes interpretation
+- preserve one-to-many drain visibility (one legacy source to multiple canonical targets)
+- avoid rewriting unaffected rows during narrow-scope slices
+- for partial completion, annotate precisely rather than over-claiming completion
+
+### Partial Slice Handling
+
+If slice is partially complete:
+
+- keep status conservative (`in-progress`, `extracted`, or `legacy-wrapper`)
+- record blockers/deferred follow-ups explicitly
+- avoid marking `retired` until wrapper/path drain is complete
+
+### Anti-Churn Rule
+
+Do not mass-edit inventory rows for docs-only wording polish unrelated to landed migration state.
+
+## Risk / Anti-Churn Guardrails
+
+- no mass renames during unrelated slices
+- no hidden role/responsibility changes without explicit boundary notes
+- no silent behavior redesign under “extraction” label
+- avoid mixing tab-provider expansion with shell extraction unless required by dependency
+- preserve small, auditable slice boundaries and explicit deferred lists
+
+## Optional Starter Slice Backlog (Draft Guidance, Not Mandatory)
+
+### 1) Persistence Canonicalization + Repoint Prep
+- **Objective:** align persistence contracts/logic to canonical targets and prep clean repoint seam.
+- **Likely target file(s):** `src/tabs/build/buildsurface-persistence.logic.ts`, `src/tabs/build/buildsurface-persistence.contracts.ts`
+- **Likely legacy source(s):** `src/tabs/build/buildSurfacePersistence.ts`, `src/tabs/build/buildSurfacePersistence.contracts.ts`
+- **Risk:** Low
+- **Notes:** keep behavior identical; no shell extraction mixed in.
+
+### 2) Host Root Shell Extraction Scaffold
+- **Objective:** establish global host root composition target.
+- **Likely target file(s):** `src/tabs/build/buildsurface.host.tsx`
+- **Likely legacy source(s):** `src/tabs/build/BuildSurface.build.tsx`
+- **Risk:** Medium
+- **Notes:** extraction scaffold only; avoid tab-provider redesign in same slice.
+
+### 3) Left Panel Host Extraction (Shell-Only)
+- **Objective:** isolate left panel shell frame from mixed BuildSurface composition.
+- **Likely target file(s):** `src/tabs/build/leftpanel.host.tsx`
+- **Likely legacy source(s):** `src/tabs/build/BuildSurface.build.tsx`, `src/tabs/build/BuildSurface.logic.ts`
+- **Risk:** Medium
+- **Notes:** keep section population semantics unchanged.
+
+### 4) Shared Host Wiring Seam Introduction
+- **Objective:** introduce host-level wiring seam for cross-zone orchestration.
+- **Likely target file(s):** `src/tabs/build/buildsurface-host.wiring.ts`
+- **Likely legacy source(s):** `src/tabs/build/BuildSurface.logic.ts`, `src/tabs/build/index.tsx`
+- **Risk:** Medium
+- **Notes:** do not repoint app mount path until seam is stable.
+
+### 5) Build-Tab Provider Wiring Extraction
+- **Objective:** isolate Build-tab-specific source feed seam.
+- **Likely target file(s):** `src/tabs/build/leftpanel-build-sources.wiring.ts`, `src/tabs/build/leftpanel-tab-provider.contracts.ts`
+- **Likely legacy source(s):** `src/tabs/build/BuildSurface.logic.ts`
+- **Risk:** Medium
+- **Notes:** keep provider contract thin and host-facing.
+
+### 6) Build Entry Repoint Slice (Forwarder-Aware)
+- **Objective:** repoint Build entry/mount path toward new host wiring seam.
+- **Likely target file(s):** `src/tabs/build/index.tsx`, `src/tabs/BuildTab.tsx`, `src/App.tsx`
+- **Likely legacy source(s):** forwarding paths currently anchored on BuildSurface legacy entry.
+- **Risk:** High
+- **Notes:** isolate repoint from new extraction; allow temporary forwarder if needed.
+
+---
+
+## Deferred Decisions (Intentional)
+
+- final immutable slice order is deferred; this playbook provides draft-safe guidance only
+- final global semantic root rename decisions remain deferred to future architecture control
+- any role-registry expansion remains deferred and out of scope for this playbook


### PR DESCRIPTION
### Motivation
- Provide a repeatable, reviewable execution playbook that operationalizes the draft inventory in `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` into a safe semantic-slice migration workflow. 
- Reduce migration churn and reviewer friction by prescribing a docs-first, behavior-preserving extraction rhythm and clear retirement rules for transitional wrappers/forwarders. 
- Keep naming/target inventory authority in the inventory plan while supplying practical per-slice templates, verification checklists, and reconciliation rules for implementers. 

### Description
- Add new playbook file `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` containing: document status, purpose, and explicit in-scope / out-of-scope boundaries. 
- Define the semantic-slice execution model (`Extract → Repoint → Cleanup / Normalize → Retire Legacy`), a draft v1 slice ordering strategy (Groups A–F), and an optional starter slice backlog with objectives/targets/risks. 
- Provide a reusable per-slice execution template (preconditions, extract/repoint/cleanup steps, verification, done criteria, deferred follow-ups), modular verification & safety checklists (import/module, runtime parity, persistence, interaction, docs/contract alignment), and explicit wrapper/forwarder lifecycle & retirement criteria (`extracted`, `repointed`, `legacy-wrapper`, `retired`). 
- Add PR boundary guidance for reviewable migration PRs and inventory reconciliation/status update rules to keep the draft inventory synchronized without causing mass churn; confirm this is a docs-first pass and makes no `src/` changes. 

### Testing
- Ran `git diff --check` to validate there are no whitespace/format issues; the check passed. 
- Inspected repository status with `git status --short` to confirm only `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` was added and no `src/` files were modified. 
- Confirmed the new playbook complements (does not duplicate) the existing inventory and sequence plan documents referenced in the header.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d46342d608331b426426cd685c911)