### PR TITLE
docs: micro-polish Build Surface Global Host slice playbook wording

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -22,6 +22,7 @@ This playbook operationalizes the Build Surface → Global Host migration as a *
 - The inventory plan remains the source of truth for draft targets, mapping direction, status vocabulary, and naming alignment.
 - This playbook defines **how** semantic slices are executed, verified, and reconciled as implementation lands.
 - This playbook does not replace task-specific engineering judgment; it provides guardrails and repeatable review shape.
+- In short: the inventory plan is the target/mapping ledger, while this playbook is the execution/verification routine.
 
 ## Scope Boundaries
 
@@ -270,6 +271,7 @@ Keep each PR reviewable and semantically scoped.
 - do not combine refactor + optimization + feature behavior change unless safety-coupled
 - state boundary being migrated and legacy source being drained in PR summary
 - include explicit verification notes in PR summary
+- verification notes should state both what was checked (manual and/or automated) and what was intentionally not checked in this slice (if any)
 
 ### Good PR Shapes (Examples)
 
@@ -283,7 +285,7 @@ The inventory plan remains the migration ledger; update it deliberately.
 
 ### When to Update `Status`
 
-Update status when slice materially changes lifecycle state, e.g.:
+Update status when slice materially changes lifecycle state (that is, changes status/ownership interpretation in a way that affects inventory tracking or migration decisions), e.g.:
 
 - `planned` → `in-progress`
 - `in-progress` → `extracted`
@@ -320,6 +322,8 @@ Do not mass-edit inventory rows for docs-only wording polish unrelated to landed
 
 ## Optional Starter Slice Backlog (Draft Guidance, Not Mandatory)
 
+These starter examples follow current draft inventory/repo-reality naming and are illustrative execution aids for slicing; they are not a naming-policy or role-registry expansion by this playbook.
+
 ### 1) Persistence Canonicalization + Repoint Prep
 - **Objective:** align persistence contracts/logic to canonical targets and prep clean repoint seam.
 - **Likely target file(s):** `src/tabs/build/buildsurface-persistence.logic.ts`, `src/tabs/build/buildsurface-persistence.contracts.ts`
@@ -353,7 +357,7 @@ Do not mass-edit inventory rows for docs-only wording polish unrelated to landed
 - **Likely target file(s):** `src/tabs/build/leftpanel-build-sources.wiring.ts`, `src/tabs/build/leftpanel-tab-provider.contracts.ts`
 - **Likely legacy source(s):** `src/tabs/build/BuildSurface.logic.ts`
 - **Risk:** Medium
-- **Notes:** keep provider contract thin and host-facing.
+- **Notes:** keep provider contracts thin and host-facing.
 
 ### 6) Build Entry Repoint Slice (Forwarder-Aware)
 - **Objective:** repoint Build entry/mount path toward new host wiring seam.


### PR DESCRIPTION
### Motivation

- Apply a focused clarity and alignment polish to the Build Surface → Global Host slice execution playbook without changing purpose, scope, naming policy, or the execution model.

### Description

- Edited only `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` to add a concise purpose-level cross-reference clarifying that the inventory plan is the target/mapping ledger while the playbook is the execution/verification routine. 
- Added a short PR verification-evidence guidance line instructing PR summaries to state what was checked (manual and/or automated) and what was intentionally not checked in the slice. 
- Clarified the phrase “materially changes lifecycle state” with a micro-definition tying it to changes in status/ownership interpretation that affect inventory tracking or migration decisions. 
- Added a draft-safe note that starter backlog example filenames (including `*.contracts.ts` examples) are illustrative of current repo reality and not a naming-policy or role-registry expansion, and made a small wording consistency tweak (`provider contract` → `provider contracts`).

### Testing

- Verified the target file exists and inspected the updated contents of `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md`, and the check completed successfully. 
- Confirmed the repository diff showed only the intended playbook file changed and the change was recorded as a docs-only update. 
- Created the PR metadata (title/body) and validated that the change is documentation-only with no `src/` files modified; all automation steps used for these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4aa42ba4833197ab22b3599b54e5)