### PR TITLE
docs: normalize wrapper/forwarder wording in BuildSurfaceGlobalHostSliceExecutionPlaybook

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -31,7 +31,7 @@ This playbook operationalizes the Build Surface → Global Host migration as a *
 - semantic-slice sequencing guidance
 - per-slice execution template and done criteria
 - reusable verification and safety checklists
-- wrapper/forwarder transitional rules and retirement criteria
+- wrapper/forwarder transitional seam rules and retirement criteria
 - PR boundary guidance for reviewability
 - inventory reconciliation/status update guidance
 
@@ -75,7 +75,7 @@ After extraction, repoint imports/call sites to the new destination in the minim
 Repoint guidance:
 
 - prefer direct repoint where impact is small and observable
-- allow temporary wrapper/forwarder only when repoint cannot land safely in the same slice
+- allow a temporary wrapper/forwarder only when repoint cannot land safely in the same slice
 - keep repoint diffs explicit and limited to touched seam paths
 
 ### 3) Cleanup / Normalize
@@ -90,12 +90,12 @@ Do not turn cleanup into broad tree-wide churn.
 
 ### 4) Retire Legacy
 
-Retire fully drained legacy files or leave a short-lived wrapper when necessary.
+Retire fully drained legacy files or leave a short-lived wrapper/forwarder when necessary.
 
 Legacy retirement should happen as soon as:
 
 - all call sites are repointed
-- wrapper has no unique behavior
+- wrapper/forwarder has no unique behavior
 - verification is complete for touched path
 
 ## Slice Ordering Strategy (Draft v1, Non-Mandatory)
@@ -177,7 +177,7 @@ This ordering is a **draft-safe starting strategy** and not immutable law.
 ### Wrapper/Forwarder Use
 - Allowed: <yes/no>
 - Why needed: <short rationale>
-- Retirement trigger for this wrapper: <explicit condition>
+- Retirement trigger for this wrapper/forwarder: <explicit condition>
 
 ### Verification Checks
 - [ ] Import/module safety checklist run (applicable items)
@@ -250,14 +250,14 @@ Use temporary wrappers/forwarders only as transitional seams.
 A wrapper/forwarder can be retired when:
 
 - all known call sites are repointed to canonical target
-- wrapper adds no unique behavior/state/contract translation
+- wrapper/forwarder adds no unique behavior/state/contract translation
 - touched-path verification is complete
 - inventory status has been updated to reflect repointed/retired state
-- no lingering imports depend on the wrapper path
+- no lingering imports depend on the wrapper/forwarder path
 
 ### Drift Control
 
-Avoid long-lived wrappers; if a wrapper survives multiple slices, record explicit blocker and target retirement slice.
+Avoid long-lived wrappers/forwarders; if a wrapper/forwarder survives multiple slices, record explicit blocker and target retirement slice.
 
 ## PR Boundary Guidance
 


### PR DESCRIPTION
### Motivation
- Make the playbook's usage of the transitional-seam terminology more consistent by normalizing references to `wrapper` / `forwarder` without changing intent or lifecycle semantics.
- Keep wording surgical and limited to phrasing improvements in the one requested file.

### Description
- Normalized phrasing in `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` (kept path and structure unchanged) so transitional seams are described as `wrapper/forwarder` or `wrapper/forwarder`-style where applicable. 
- Specific wording changes include: scope boundaries ("transitional seam rules"), repoint guidance (allow a temporary `wrapper/forwarder`), retire-legacy wording ("leave a short-lived wrapper/forwarder"), per-slice template retirement trigger wording, retirement criteria bullets, and drift-control wording. 
- Preserved lifecycle label names and meanings (including `legacy-wrapper`) and made no policy, architecture, or execution-model changes; only local readability/terminology edits were made.
- Only the single file `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` was modified.

### Testing
- Verified repository root and branch with `git rev-parse --show-toplevel` and `git branch --show-current`, which succeeded. 
- Inspected the updated file with `sed -n` to confirm the intended wording changes were applied. 
- Reviewed the working diff using `git status --short` and `git diff -- doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` and committed the change with `git commit -m "docs: align wrapper/forwarder wording in host slice playbook"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4c49713c8331927c5ab72e40fc7e)