### PR TITLE
docs(architecture): reconcile Build Surface host-refactor docs after Phase 1 stability pass

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -61,6 +61,8 @@ This split is expected to reduce churn by keeping shell behavior stable while en
 
 This snapshot is an observational planning aid for reconciliation; it may lag repo reality if this section is not refreshed after major extraction slices land.
 
+> Post-Phase-1 status note (PR #108): current repo reality includes preview breakpoint controls/header chrome in `BuildSurface.build.tsx`, preview breakpoint state/bindings in `BuildSurface.logic.ts`, and dark-theme parity selectors across host-surface regions in `BuildSurface.view.css`; this was a host-stability behavior pass, not a host/global extraction slice.
+
 | Current File / Surface | Current Role / Shape | Current Responsibility (Observed) | Likely Draft Inventory Target(s) | Notes |
 |---|---|---|---|---|
 | `src/tabs/build/BuildSurface.build.tsx` | Legacy-heavy / mixed host+tab composition | Owns structural shell composition for left catalog, canvas, and right inspector zones plus section panel framing. | `buildsurface.host.tsx`, `leftpanel.host.tsx`, `canvas.host.tsx`, `rightpanel.host.tsx` | Currently overloaded as a single Build-tab composition surface; expected to drain into global host shell + seams. |

--- a/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
@@ -56,6 +56,17 @@ The Build Surface will evolve into a **global host surface** where:
 
 ## Work Order (Required Sequence)
 
+### Status Update (Post-Phase-1 Reconciliation)
+
+- **Phase 1 host stability pass is completed** via PR **#108**.
+- Landed scope (high level):
+  - preview-only breakpoint controls/state now drive deterministic preview sizing behavior in the Build Surface host UI
+  - dark-theme parity styling was expanded across Build Surface host regions (header/panels/canvas chrome)
+- Explicitly not included in PR #108:
+  - no Build Surface → Global Host refactor extraction/splitting
+  - no tab-provider seam extraction or inventory lifecycle progression work
+- Verification summary for that pass was captured in the PR (manual breakpoint/theme checks plus automated lint/build checks).
+
 ### Phase 1 — Build Surface Host Stability Pass
 
 #### Goal


### PR DESCRIPTION
### Motivation

- Reconcile architecture planning docs to reflect the merged Phase 1 host stability pass (PR #108) so readers see current repo reality without changing plan direction or migration lifecycle expectations.

### Description

- Added a concise post-Phase-1 status note to `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md` that records Phase 1 completion (PR #108), what landed (preview-only breakpoint behavior and dark-theme parity), and what did not (no host/global extraction). 
- Added a small repo-reality note to `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` identifying that `src/tabs/build/BuildSurface.build.tsx`, `BuildSurface.logic.ts`, and `BuildSurface.view.css` reflect the Phase 1 breakpoint and theme work; the note clarifies this was a stabilization pass, not an extraction slice. 
- Left `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` unchanged because the playbook and execution model remain aligned with the status-only reconciliation.

### Testing

- Confirmed the required architecture docs exist (`doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`, `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`, `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md`) and inspected the merged Phase 1 changes and current Build Surface files (`src/tabs/build/BuildSurface.build.tsx`, `src/tabs/build/BuildSurface.logic.ts`, `src/tabs/build/BuildSurface.view.css`).
- Ran repository checks and textual searches (`rg`/file reads) to verify preview breakpoint controls/state and dark-theme selectors are present in the listed `src/tabs/build/*` files and that the docs-only changes map to those observations.
- Verified low-churn diffs and formatting sanity via `git diff --check` and confirmed the diff is limited to the two documentation files listed above; no `src/` files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2e02647883319116ec58c5fa94e3)