### PR TITLE
docs: require NL co-migration in Build Surface semantic slice execution

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -74,6 +74,21 @@ This snapshot is an observational planning aid for reconciliation; it may lag re
 
 ## Draft File Inventory Table
 
+## NL Co-Migration Inventory Scaffold (Slice-Level Planning Aid)
+
+Use this scaffold alongside the draft file inventory so each semantic slice tracks both code targets and NL migration state.
+
+| Semantic Slice Target | Code Target(s) (Planned/Actual) | Canonical Split NL Target (Planned/Actual) | Legacy NL Source Section(s) in `cfg-buildSurface.md` | Naming Alignment Check | Numbering / Provenance Status | Lifecycle Status | Notes |
+|---|---|---|---|---|---|---|---|
+| Host shell extraction slice (example) | `buildsurface.host.tsx`, `buildsurface-host.wiring.ts` | `doc/nl-config/cfg-buildSurface.host-surface.md` *(placeholder example)* | `[3.x]` host shell structure + `[5.x]` host orchestration sections | planned | pre-validation pending | planned | Replace placeholder path with adopted canonical NL target when finalized. |
+| Persistence contract slice (example) | `buildsurface-persistence.logic.ts`, `buildsurface-persistence.contracts.ts` | `doc/nl-config/cfg-buildSurface.persistence.md` *(placeholder example)* | `[5.2.4]`, `[5.2.7]` and related persistence references | in-progress | in-review | in-progress | Keep legacy monolith references annotated until repointed. |
+| Tab population seam slice (example) | `leftpanel-build-sources.wiring.ts` | `doc/nl-config/cfg-buildSurface.tab-sources.md` *(placeholder example)* | Build-tab source composition sections in legacy monolith | planned | pre-validation pending | planned | Canonical NL split target should become authoritative once slice lands. |
+
+Notes:
+- The NL target filenames above are **illustrative placeholders** to support planning vocabulary; adopt concrete paths only when slice work is approved.
+- Lifecycle values can use the same migration vocabulary as code inventory tracking (`planned`, `in-progress`, `extracted`, `repointed`, `legacy-wrapper`, `retired`, `deferred`) with NL-aware interpretation.
+- This scaffold is intentionally additive and low-churn; expand per-slice rows as work is scheduled, not as a full up-front enumeration requirement.
+
 | Semantic Target | Proposed Filename | Role | Responsibility Summary | Bucket | Parent Host / Scope | Replaces / Extracted From (Draft) | Status | Notes / Naming Rationale |
 |---|---|---|---|---|---|---|---|---|
 | Build Surface global host root | `buildsurface.host.tsx` | host | Own global host shell composition, panel frame, and host-level orchestration boundaries. | Global Host | Root global host surface | Extract shell composition concerns from `src/tabs/build/BuildSurface.build.tsx`. | planned | Keeps existing `buildsurface` semantic target while role becomes explicit host.
@@ -181,6 +196,17 @@ Recommended extraction rhythm per slice:
 6. Avoid mixing refactor + optimization + behavior changes in one pass unless a safety fix requires coupling.
 7. Keep PRs boundary-focused and reviewable; each slice should state the boundary being migrated and the legacy surface being drained.
 8. During implementation, keep NL and CCPP alignment for any changed shell/config concern files.
+
+### NL Migration State + Pre-Validation Guidance
+
+Track NL migration state in parallel with code migration state for each active semantic slice:
+
+- record canonical split NL target status (planned/actual) when a slice is opened
+- record legacy monolith NL status as forwarded / partial / retained for touched sections
+- confirm naming alignment for touched code and NL filenames before marking slice done
+- perform numbering/provenance pre-validation for touched atoms/sections before slice closure
+
+This inventory support is intended to surface numbering/provenance inconsistencies early during migration, while keeping final numbering-policy authority in convention documents.
 
 ### Draft Inventory Status Tracking Guidance (Migration Lifecycle)
 

--- a/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
@@ -103,7 +103,7 @@ Address:
 
 ---
 
-### Phase 2 — Global Host Surface Refactor Prep
+### Phase 2 — Global Host Surface Refactor Prep (Code + NL Co-Migration)
 
 #### Goal
 Prepare the Build Surface to become a shared/global host surface while preserving existing Build functionality.
@@ -113,6 +113,8 @@ Refactor the current surface so generic host behavior can be reused while tab-sp
 
 #### Objectives
 - Separate host-generic surface concerns from Build-specific source composition
+- Execute semantic NL split/refinement alongside code slice extraction for touched responsibilities
+- Establish canonical split NL targets incrementally while maintaining a legacy monolith wrapper/forwarding strategy during transition
 - Preserve deterministic UI structure/order and stable panel behavior
 - Create clean seams for tab-driven plugin-provided atoms/configurations/primitives
 
@@ -140,12 +142,17 @@ Split toward:
 - Refactor changes and/or architecture prep changes
 - Boundary notes documenting host-generic vs Build-specific responsibilities
 - Updated NL documents to maintain deterministic 1:1 ordering where affected
+- Canonical split NL targets for touched slices, plus legacy monolith forwarding/wrapper annotations where still transitional
 
 #### Verification (minimum)
 - `npm run lint`
 - `npm run build`
 - Existing Build tab behavior still works
 - Panel resize/collapse/persistence behavior remains stable
+- NL split targets are updated for touched semantic slices
+- Canonical split NL targets and legacy monolith forwarding/wrapper notes are coherent for touched areas
+- Naming alignment is preserved for touched code files and NL target filenames
+- Numbering/provenance consistency is preserved for touched atoms/sections
 
 ---
 
@@ -288,5 +295,6 @@ This is the recommended first step before globalizing the surface or expanding D
 When implementing any phase in this plan:
 - maintain deterministic ordering between NL and code
 - update NL only where responsibility/order/ownership changes
+- in Phase 2 slices, co-migrate touched NL sections with code extraction rather than deferring as cleanup
 - preserve low-churn boundaries during stabilization work
 - record boundary decisions if refactors alter subsystem responsibilities

--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -45,6 +45,16 @@ This playbook operationalizes the Build Surface → Global Host migration as a *
 
 ## Execution Model (Semantic-Slice Method)
 
+### NL Co-Migration Principle (Required)
+
+Semantic-slice execution for Build Surface global-host refactor uses **code + NL co-migration**, not deferred NL cleanup.
+
+- each semantic code slice should migrate/update corresponding NL slice content in the same pass when feasible
+- canonical split NL targets should become authoritative incrementally as slices land
+- legacy monolith NL content in `doc/nl-config/cfg-buildSurface.md` should be progressively forwarded/annotated as ownership drains
+- naming and NL references for touched files should be aligned in-slice to avoid post-hoc drift
+- numbering/provenance for touched atoms/sections should be pre-validated for consistency before slice exit
+
 Each slice should follow the same rhythm from the draft inventory plan:
 
 1. **Extract**
@@ -161,10 +171,18 @@ This ordering is a **draft-safe starting strategy** and not immutable law.
 - [ ] Related inventory rows identified
 - [ ] Dependencies from prior slices met
 - [ ] NL/CCPP touch impact identified (if concern ownership moves)
+- [ ] Legacy NL source section(s) in `doc/nl-config/cfg-buildSurface.md` identified for this slice
 
 ### Extract Steps
 1. <bounded extraction step>
 2. <bounded extraction step>
+
+### NL Co-Migration Steps
+1. <identify matching legacy NL section(s) in `cfg-buildSurface.md`>
+2. <create/update canonical split NL target file(s) for this semantic slice>
+3. <repoint or annotate legacy monolith NL references to reflect forwarded/partial/retained status>
+4. <verify naming alignment for touched code paths + NL filenames>
+5. <verify numbering/provenance consistency for touched atoms/sections>
 
 ### Repoint Steps
 1. <import/call-site repoint step>
@@ -185,10 +203,17 @@ This ordering is a **draft-safe starting strategy** and not immutable law.
 - [ ] Persistence safety checklist run (if touched)
 - [ ] Interaction safety checklist run (if touched)
 - [ ] Docs/contract alignment checklist run (if touched)
+- [ ] NL co-migration checklist run for touched semantic slice
 
 ### Done Criteria
 - [ ] Bounded responsibility moved
 - [ ] Required call sites repointed
+- [ ] Code behavior unchanged for the slice unless an explicit planned behavior adjustment was declared
+- [ ] Canonical split NL target exists or is updated for touched responsibility
+- [ ] Legacy `cfg-buildSurface.md` status updated (forwarded/partial/retained) for touched sections
+- [ ] NL/code references are coherent after repoint/annotation updates
+- [ ] Naming alignment check completed for touched code + NL files
+- [ ] Numbering/provenance consistency check completed for touched atoms/sections
 - [ ] Legacy status classified (`extracted`/`repointed`/`legacy-wrapper`/`retired`)
 - [ ] Inventory reconciliation update recorded when material
 
@@ -233,6 +258,10 @@ Use only the checklists relevant to the touched boundary.
 - [ ] NL references updated where filename/path contract changed
 - [ ] CCPP/NL notes updated where concern ownership shifted
 - [ ] inventory status/mapping updated when slice materially landed
+- [ ] canonical split NL target file(s) updated for touched semantic slice
+- [ ] legacy monolith NL sections marked forwarded/partial/retained where applicable
+- [ ] touched naming alignment validated across code path + NL filename references
+- [ ] touched numbering/provenance consistency validated (without expanding convention policy in this playbook)
 
 ## Wrapper / Forwarder Retirement Rules
 


### PR DESCRIPTION
### Motivation
- Reduce post-hoc drift by making NL (natural-language) skeleton updates part of each semantic slice instead of deferring NL cleanup to later passes. 
- Ensure per-slice done criteria explicitly require NL canonical-target status, naming alignment, and numbering/provenance pre-validation. 
- Provide inventory and sequence guidance so NL migration state is tracked and verified in parallel with code migration to preserve a low-churn, slice-based workflow.

### Description
- `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md`: added an explicit **NL Co-Migration Principle** and an NL co-migration checklist integrated into the per-slice template (preconditions, NL Co-Migration Steps, verification, and expanded done criteria including canonical NL target existence, legacy-monolith status, naming alignment, and numbering/provenance checks). 
- `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`: inserted an additive **NL Co-Migration Inventory Scaffold** (slice-level table) that records `Code Target(s)`, `Canonical Split NL Target`, `Legacy NL Source Section(s)`, `Naming Alignment Check`, `Numbering / Provenance Status`, and lifecycle state, plus a short **NL Migration State + Pre-Validation Guidance** section. 
- `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`: updated Phase 2 wording to require **code + NL co-migration**, establish canonical split NL targets incrementally (with legacy-monolith forwarding/wrapper strategy), and added verification criteria for NL updates, naming alignment, and numbering/provenance consistency while preserving phase ordering. 
- Preserved constraints: this is docs-only, kept numbering policy language generic (deferred to convention docs), did not rename files or modify `src/` code, and preserved the low-churn, semantic-slice approach.

### Testing
- Confirmed repository root and current branch with `pwd` and `git rev-parse --abbrev-ref HEAD`, which succeeded. 
- Verified required docs exist and were read: `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md`, `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`, `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`, and `doc/nl-config/cfg-buildSurface.md`. 
- Searched the edited docs for the new NL co-migration terms with `rg` to validate insertion, and inspected diffs with `git diff` to confirm exactly three architecture docs were changed; all checks succeeded. 
- Committed the changes to the branch and created the PR; no code files were changed and all automated repo-check commands executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e407389508331b01cf36e71e1b479)