### PR TITLE
docs: add NL split migration scaffolding and naming guidance

### DIFF
--- a/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -55,6 +55,10 @@ This spec is intentionally explicit and semantic (no guessing/inference required
   - [Scope (what this applies to)](#scope-what-this-applies-to)
   - [Legacy file reality (important)](#legacy-file-reality-important)
   - [Adoption rule](#adoption-rule)
+- [NL Split Refactor Naming Guidance (Incremental, Semantic-First)](#nl-split-refactor-naming-guidance-incremental-semantic-first)
+  - [Where numbering should live for NL split workflows](#where-numbering-should-live-for-nl-split-workflows)
+  - [NL Split Examples and Non-Examples](#nl-split-examples-and-non-examples)
+  - [Visual pattern recognition without filename churn](#visual-pattern-recognition-without-filename-churn)
 - [Core Filename Grammar](#core-filename-grammar)
   - [Canonical pattern](#canonical-pattern)
   - [Examples](#examples)
@@ -160,6 +164,42 @@ Do not block progress solely because unrelated legacy filenames do not match thi
 Apply this spec incrementally and deliberately.
 
 ---
+
+## NL Split Refactor Naming Guidance (Incremental, Semantic-First)
+
+For NL documentation split migrations (for example, evolving `cfg-buildSurface.md` into semantic split docs):
+
+- Prefer **stable semantic filenames** that describe enduring responsibility/scope.
+- Avoid churn-prone positional filename numbering schemes that require renaming when slice order changes.
+- Keep migration ordering/continuity in NL content structures (headings, mapping tables, provenance tokens, and optional manifests/index docs).
+
+### Where numbering should live for NL split workflows
+
+Use numbering/provenance continuity in:
+
+- section headings and migrated atom references,
+- legacy-to-canonical mapping tables,
+- provenance tokens and migration status rows,
+- optional manifest/index views for scanability.
+
+Do **not** require positional filename prefixes solely to preserve order.
+
+### NL Split Examples and Non-Examples
+
+**Examples (preferred semantic stability):**
+
+- `cfg-buildSurface-layoutAndAnchors.md`
+- `cfg-buildSurface-panelStateAndPersistence.md`
+- `cfg-buildSurface-previewAndInspectorFlows.md`
+
+**Non-examples (positional churn risk):**
+
+- `01-cfg-buildSurface.md`, `02-cfg-buildSurface.md`, `03-cfg-buildSurface.md`
+- `cfg-buildSurface-part1.md`, `cfg-buildSurface-part2.md` when parts are expected to reorder over time
+
+### Visual pattern recognition without filename churn
+
+When visual ordering is needed, prefer a manifest/index document that lists semantic files in desired reading order instead of encoding order into filenames.
 
 ## Core Filename Grammar
 

--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -11,6 +11,18 @@ This doc defines the canonical NL skeleton templates used by all configuration (
 - **Placeholder note (`x`):** Examples that use `x` (for example `3.2.x`) are illustrative draft placeholders in this doc; placeholder marker policy remains deferred to `DeterministicStructuralAddressingSpec-Draft.md`.
 - **Governance note:** Comment/provenance protocol conventions remain governed by `CCPP.md`; this doc remains the canonical NL skeleton structure source.
 
+## Split-Canonical NL Migration Clarification (Policy)
+
+- Semantic refactors may introduce **split-canonical NL docs** for a configuration when one monolithic NL file becomes too broad for maintainable co-migration.
+- During transition, the legacy monolith may temporarily operate as a **wrapper/index/forwarding** document that points to split-canonical targets.
+- The stable **1–10 section contract remains unchanged per NL document**. Split docs still follow the same top-level contract; this policy does not redesign or renumber the skeleton template.
+
+### Numbering & Provenance Continuity for Split Migration
+
+- Preserve continuity in content via explicit provenance/mapping references (for example, legacy section ranges and migrated atom IDs).
+- Keep numbering continuity in headings, mapping tables, provenance tokens, and migration manifests/indexes rather than requiring filename position prefixes.
+- A lightweight manifest/index may be used to improve visual ordering and scanability across split docs; this is recommended guidance, not a hard requirement.
+
 ## Changing This Doc
 
 If you change top-level sections or numbering here, you must also update `NL-First-Workflow.md`, `CSCS.md`, and `CCPP.md` to keep the system consistent.

--- a/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
+++ b/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
@@ -1,0 +1,53 @@
+# NL Split Migration and Numbering Policy (Scaffold)
+
+## Purpose and Scope
+
+This policy defines lightweight conventions for NL-document split migrations during semantic refactors (for example, Build Surface decomposition) while preserving existing NL-first and skeleton-contract rules.
+
+- In scope: NL migration lifecycle, wrapper/index behavior, numbering/provenance continuity, and cross-reference expectations.
+- Out of scope: replacing the base 1–10 skeleton templates, imposing repo-wide filename validators, or mandating immediate mass renames.
+
+## Definitions
+
+- **Legacy monolith NL doc:** Existing single NL file that currently contains end-to-end configuration documentation.
+- **Split-canonical NL doc:** New semantic NL file intended to become canonical for a bounded responsibility slice.
+- **Wrapper/index doc:** Transitional legacy NL document that remains readable while forwarding/repointing migrated slices to split-canonical targets.
+
+## Migration Lifecycle Statuses
+
+Use explicit statuses in migration indexes/mapping tables:
+
+1. **planned** – target and intent identified; no canonical repoint yet.
+2. **in-progress** – split target drafting/migration underway.
+3. **repointed** – canonical source moved for the mapped slice; provenance links recorded.
+4. **retired** – legacy slice/doc no longer canonical after complete verified migration.
+
+## Numbering and Provenance Continuity Rules
+
+- Preserve stable NL section continuity inside content and provenance artifacts; do not break the per-document 1–10 skeleton contract.
+- For migrated slices, record traceability from legacy section ranges/atom references to split-canonical locations.
+- Keep continuity in mapping tables, headings, and provenance tokens; do not rely on positional filename numbering to carry migration meaning.
+- Mark migration state truthfully; avoid declaring repointed/retired status before actual content migration is complete.
+
+## Naming Guidance References
+
+- Use semantic, low-churn NL filenames aligned with the naming philosophy in:
+  - `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
+- Keep migration-order readability via index/manifest docs where needed, instead of churn-prone filename prefixes.
+
+## High-Level Slice Done Checklist (Code + NL Co-Migration)
+
+A slice is considered done when all of the following are true:
+
+- [ ] Split-canonical NL target exists and follows the stable skeleton contract.
+- [ ] Legacy wrapper/index mapping table is updated with accurate status and provenance links.
+- [ ] Section/atom traceability from legacy to split target is explicit.
+- [ ] Any co-migrated implementation/docs are synchronized under NL-first workflow expectations.
+- [ ] No stale placeholder claims remain for the completed slice.
+
+## Cross-References
+
+- `doc/ConventionRoutines/General-NL-Skeletons.md`
+- `doc/ConventionRoutines/NL-First-Workflow.md`
+- `doc/ConventionRoutines/CCPP.md`
+- `doc/ConventionRoutines/CSCS.md`

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -2,6 +2,38 @@
 
 This document is an instance of the Configuration-Level NL Skeleton defined in ../ConventionRoutines/General-NL-Skeletons.md.
 
+## Transition Migration Status (Build Surface NL Split)
+- **State:** Planned / transition-ready scaffolding active.
+- **Current canonical source:** This monolithic `cfg-buildSurface.md` document remains the authoritative NL reference until split migration slices are explicitly repointed.
+- **Planned direction:** Introduce semantic split-canonical NL documents for Build Surface concerns and interaction slices while preserving section/provenance continuity.
+- **Truthfulness rule:** Mapping rows and target statuses must reflect actual migration state; do not mark slices as migrated until corresponding split docs are written and validated.
+
+## Canonical Split NL Targets (Planned / In-Progress)
+> Placeholder index for semantic split targets. Entries remain non-canonical until explicitly marked repointed.
+
+| Target NL Doc (planned) | Scope Intent | Status | Notes |
+|---|---|---|---|
+| `doc/nl-config/cfg-buildSurface-layoutAndAnchors.md` | Build/BuildStyle layout anchors and panel topology | planned | Placeholder only in this pass |
+| `doc/nl-config/cfg-buildSurface-panelStateAndPersistence.md` | Logic + Knowledge for resize/collapse persistence | planned | Placeholder only in this pass |
+| `doc/nl-config/cfg-buildSurface-previewAndInspectorFlows.md` | Preview controls + inspector behavioral workflows | planned | Placeholder only in this pass |
+
+## Legacy-to-Canonical Mapping Scaffold
+> Slice-by-slice migration tracker. Use one row per migrated section group; keep provenance explicit.
+
+| Legacy section(s) in `cfg-buildSurface.md` | Canonical split target | Migration status (`planned`/`in-progress`/`repointed`/`retired`) | Provenance / continuity notes |
+|---|---|---|---|
+| `3.x` (Build concern) | `TBD semantic split doc` | planned | Preserve direct traceability to existing `[3.*]` atoms |
+| `4.x` (BuildStyle concern) | `TBD semantic split doc` | planned | Keep selector/anchor provenance tied to migrated Build slices |
+| `5.x–6.x` (Logic + Knowledge) | `TBD semantic split doc` | planned | Keep persistence parser/version history references intact |
+| `7.x–8.x` (Results + ResultsStyle) | `TBD semantic split doc` | planned | Repoint only when output contracts are fully documented |
+
+## Monolith Behavior During Migration
+- This document currently acts as both:
+  - the **temporary source of truth** for Build Surface NL content, and
+  - a **transition wrapper/index** for upcoming semantic split-canonical NL docs.
+- During migration, sections may be incrementally forwarded/repointed to split docs, but unchanged sections continue to be read directly from this monolith.
+- Retirement rule: this monolith should be retired only after all mapped slices are repointed with explicit provenance continuity and no unresolved placeholders remain.
+
 ## 1. Purpose and Scope
 ### 1.1 Purpose
 Present the Calculogic Build tab surface, including navigation chrome, the catalog of configuration panels, the preview canvas, and the inspector column.


### PR DESCRIPTION
### Motivation
- Provide transition scaffolding so the Build Surface NL can be split into semantic canonical docs without breaking the stable NL skeleton contract. 
- Ensure migration truthfulness, provenance continuity, and low-churn filename guidance to enable incremental co-migration of NL and code. 
- Offer a concise policy scaffold and naming guidance to standardize how split NL targets are planned, tracked, and repointed during refactors.

### Description
- Updated `doc/nl-config/cfg-buildSurface.md` to act as a transition-ready legacy wrapper/index by adding a `Transition Migration Status`, a `Canonical Split NL Targets` placeholder index, a `Legacy-to-Canonical Mapping Scaffold`, and a `Monolith Behavior During Migration` note while preserving all existing canonical NL content. 
- Augmented `doc/ConventionRoutines/General-NL-Skeletons.md` with a `Split-Canonical NL Migration Clarification (Policy)` section and `Numbering & Provenance Continuity for Split Migration` guidance that explicitly preserves the stable 1–10 skeleton contract. 
- Extended `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` with `NL Split Refactor Naming Guidance` including where numbering should live, examples and non-examples, and TOC entries that promote semantic, low-churn filenames for split NL docs. 
- Added new lightweight policy scaffold `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md` containing purpose/scope, definitions (legacy monolith / split-canonical / wrapper/index), migration lifecycle statuses (`planned`, `in-progress`, `repointed`, `retired`), numbering/provenance continuity rules, naming references, and a high-level slice done checklist for NL+code co-migration. 
- Preserved constraints in this pass: no code changed, no mass renames, the existing NL skeleton numbering templates remain untouched, and the existing `FileNamingMasterList-V1_1.md` filename/version mismatch was noted but left unchanged per scope.

### Testing
- Verified the updated `doc/nl-config/cfg-buildSurface.md` still contains the canonical NL body by confirming `## 1. Purpose and Scope` and related sections remain present. 
- Confirmed `doc/ConventionRoutines/General-NL-Skeletons.md` retains the canonical `### 1`–`### 10` skeleton headings while containing the new split-canonical migration policy text. 
- Confirmed `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` TOC and content include the new `NL Split Refactor Naming Guidance` and example filenames. 
- Validated that all changes were documentation-only and no code files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4618f04483319a9874ff15cb348f)