### PR TITLE
docs: polish Build Surface sequence + NL lifecycle/naming consistency

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -86,6 +86,7 @@ Use this scaffold alongside the draft file inventory so each semantic slice trac
 
 Notes:
 - The NL target filenames above are **illustrative placeholders** to support planning vocabulary; adopt concrete paths only when slice work is approved.
+- Final NL split filename/pattern authority for placeholders belongs to `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` and `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`; this inventory is guidance, not naming law.
 - Lifecycle values can use the same migration vocabulary as code inventory tracking (`planned`, `in-progress`, `extracted`, `repointed`, `legacy-wrapper`, `retired`, `deferred`) with NL-aware interpretation.
 - This scaffold is intentionally additive and low-churn; expand per-slice rows as work is scheduled, not as a full up-front enumeration requirement.
 

--- a/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
@@ -279,14 +279,14 @@ This phase is intentionally deferred to avoid coupling publish implementation to
 
 ---
 
-## Suggested Immediate Next Task
+## Suggested Current Next Task
 
-**Phase 1 — Build Surface Host Stability Pass**
-- breakpoint preview behavior correctness
-- light/dark theme parity
-- verification + low-churn fixes only
+**Phase 2 — Global Host Surface Refactor Prep (Code + NL Co-Migration)**
+- separate host-generic surface concerns from Build-specific source composition
+- execute semantic NL co-migration for touched slices while preserving wrapper/index traceability
+- establish tab-driven source injection seams without broad implementation expansion
 
-This is the recommended first step before globalizing the surface or expanding Doc Engine/publish integration.
+With Phase 1 already completed, this is the recommended next step before deeper Doc Engine extraction/publish implementation phases.
 
 ---
 

--- a/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
+++ b/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
@@ -22,6 +22,12 @@ Use explicit statuses in migration indexes/mapping tables:
 3. **repointed** – canonical source moved for the mapped slice; provenance links recorded.
 4. **retired** – legacy slice/doc no longer canonical after complete verified migration.
 
+### Lifecycle Vocabulary Alignment Note
+
+The four statuses above are the **minimum/core scaffold** for this policy. Architecture/inventory docs may use additional transitional statuses (for example `extracted`, `legacy-wrapper`, `deferred`) for finer migration tracking, provided meanings are explicit and truthfully applied.
+
+`legacy-wrapper` may apply to NL docs when a monolith or index/wrapper continues forwarding readers to repointed split-canonical slices. In code-oriented inventories, the same term may remain code-centric; NL docs may alternatively use equivalent explicit wording when that is clearer.
+
 ## Numbering and Provenance Continuity Rules
 
 - Preserve stable NL section continuity inside content and provenance artifacts; do not break the per-document 1–10 skeleton contract.

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -10,6 +10,7 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 
 ## Canonical Split NL Targets (Planned / In-Progress)
 > Placeholder index for semantic split targets. Entries remain non-canonical until explicitly marked repointed.
+> Naming note: placeholder filenames are illustrative and must be normalized to an approved semantic-first, low-churn pattern before the first repointed slice (`doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`). Provisional starting shape (example-only): `cfg-buildSurface-<semantic-slice>.md`.
 
 | Target NL Doc (planned) | Scope Intent | Status | Notes |
 |---|---|---|---|
@@ -19,6 +20,7 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 
 ## Legacy-to-Canonical Mapping Scaffold
 > Slice-by-slice migration tracker. Use one row per migrated section group; keep provenance explicit.
+> Placeholder target labels in this table are planning scaffolds only and should be finalized per convention/policy authority before repointed status is claimed.
 
 | Legacy section(s) in `cfg-buildSurface.md` | Canonical split target | Migration status (`planned`/`in-progress`/`repointed`/`retired`) | Provenance / continuity notes |
 |---|---|---|---|


### PR DESCRIPTION
### Motivation
- Clean up small consistency nits introduced during the Build Surface refactor-doc updates so downstream slices and first NL split work have clear, low-drift guidance.
- Specifically: remove stale Phase 1 next-task wording, align lifecycle vocabulary across policy vs inventory docs, and tighten placeholder NL target naming guidance to reduce ad-hoc first-slice filename drift.

### Description
- Updated the sequence plan `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md` by renaming the next-task section to `Suggested Current Next Task` and pointing the recommendation to Phase 2 (Global Host Surface Refactor Prep). 
- Added a concise lifecycle-vocabulary alignment note to `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md` clarifying that `planned/in-progress/repointed/retired` are the minimum/core scaffold while acknowledging optional transitional statuses (e.g., `extracted`, `legacy-wrapper`, `deferred`) for architecture/inventory docs. 
- Tightened placeholder naming guidance in `doc/nl-config/cfg-buildSurface.md` by adding an explicit normalization note, referencing the convention docs for final authority, and providing an example-only provisional pattern (`cfg-buildSurface-<semantic-slice>.md`) while keeping placeholders non-final. 
- Added an explicit cross-doc authority note to `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` that final NL split filename/pattern authority belongs to `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` and `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`. 
- No code changes were made and `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` required no edits.

### Testing
- Read and inspected the modified files with `sed`/`nl` and searched for key phrases with `rg` to confirm wording updates and cross-references; all searches returned the expected updated lines. 
- Verified repo state and committed changes via `git status`, `git diff` and `git commit`, with the commit message `docs: polish build-surface split migration consistency nits` recorded on branch `work`. 
- Created the PR record for this docs-only pass (title/body prepared). 
- Summary of exact nits fixed and decisions: changed next-task wording in `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`; added lifecycle vocabulary alignment in `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`; added placeholder normalization and provisional-pattern guidance plus mapping-scaffold caution in `doc/nl-config/cfg-buildSurface.md`; added cross-doc naming-authority note in `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`; `FileNamingMasterList-V1_1.md` required no edit; final exact Build Surface split NL filenames remain intentionally deferred to the first real slice under convention/policy authority.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4deceb7c833193f3ff37f486a044)