### PR TITLE
docs: micro polish for build-surface sequencing intro and placeholder naming notes

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
@@ -8,9 +8,11 @@ It exists to prevent scope creep and to avoid building deeper integrations on to
 
 The current Build Surface is evolving from a Build-tab-specific implementation into a future **global host surface** that can support multiple concern tabs (Build, BuildStyle, Logic, Knowledge, Results, ResultsStyle) and plugin-driven atom/config sources.
 
-Before that refactor, the Build Surface needs a correctness pass for:
+This sequencing plan defined an upfront correctness prerequisite for:
 - breakpoint preview behavior (mobile/tablet/desktop)
 - light/dark theme parity
+
+That prerequisite host-stability pass is now completed (see Phase 1 status), and remains the baseline for the remaining refactor/integration phases.
 
 This plan also defines when to:
 - prove Doc Engine integration in the host app

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -10,7 +10,8 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 
 ## Canonical Split NL Targets (Planned / In-Progress)
 > Placeholder index for semantic split targets. Entries remain non-canonical until explicitly marked repointed.
-> Naming note: placeholder filenames are illustrative and must be normalized to an approved semantic-first, low-churn pattern before the first repointed slice (`doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`). Provisional starting shape (example-only): `cfg-buildSurface-<semantic-slice>.md`.
+> Naming note: placeholder row filenames below are illustrative semantic examples only (planning vocabulary), not final segment-style commitments.
+> Provisional pattern note: `cfg-buildSurface-<semantic-slice>.md` is a shape-level placeholder (semantic-first, low-churn). Exact segment style remains subject to convention/policy authority before the first repointed slice (`doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`).
 
 | Target NL Doc (planned) | Scope Intent | Status | Notes |
 |---|---|---|---|
@@ -20,7 +21,7 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 
 ## Legacy-to-Canonical Mapping Scaffold
 > Slice-by-slice migration tracker. Use one row per migrated section group; keep provenance explicit.
-> Placeholder target labels in this table are planning scaffolds only and should be finalized per convention/policy authority before repointed status is claimed.
+> Placeholder target labels in this table are planning scaffolds only and should be finalized per convention/policy authority before repointed status is claimed; they follow the same temporary, non-authoritative guidance class as the canonical-target placeholder examples above.
 
 | Legacy section(s) in `cfg-buildSurface.md` | Canonical split target | Migration status (`planned`/`in-progress`/`repointed`/`retired`) | Provenance / continuity notes |
 |---|---|---|---|


### PR DESCRIPTION
### Motivation
- Make the Build Surface sequence-plan intro read as current/timeless now that the Phase 1 host-stability pass is complete.  
- Tighten placeholder example wording in the Build Surface NL split scaffolding so illustrative placeholder rows and the provisional pattern note are clearly compatible and non-authoritative.

### Description
- Reworded the Purpose/intro in `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md` to frame the correctness pass as an upfront prerequisite that is now completed and preserved as the baseline for remaining phases.  
- Clarified the `Canonical Split NL Targets` block and the `Legacy-to-Canonical Mapping Scaffold` in `doc/nl-config/cfg-buildSurface.md` to state that placeholder row filenames are illustrative semantic examples only and that the provisional `cfg-buildSurface-<semantic-slice>.md` pattern is a shape-level placeholder subject to convention/policy before repointing.  
- No other documents were changed; `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` was reviewed and left intact because it already contains consistent guidance.

### Testing
- Verified repository context and scanned convention docs with `rg` to confirm required convention files exist and no unexpected files were touched, and inspected the edited files with `git diff` to ensure only the intended docs were modified.  
- Committed the changes with a doc-only commit message; no code or build artifacts were modified so no `npm` build or lint runs were required for this micro polish.  
- Summary / verification notes: exact edited locations were the Purpose/intro paragraph in `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md` (rephrased to reflect Phase 1 completion) and the `Canonical Split NL Targets` plus `Legacy-to-Canonical Mapping Scaffold` explanatory lines in `doc/nl-config/cfg-buildSurface.md`; the inventory plan file did not need a matching edit and was not changed; final canonical NL split filenames remain intentionally deferred and no placeholder row was promoted to a canonical name.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e52fd165083319679e1e8e58acd9e)