### PR TITLE
docs: clarify intentional deferral of validator/tooling enforcement in structural addressing draft

### DIFF
--- a/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -316,4 +316,4 @@ This draft establishes grammar first. Later passes should synchronize wording/ex
    - new convention examples
    - new comment patterns where applicable
 4. Backfill legacy material incrementally during normal touchpoints.
-5. Validator/tooling enforcement is intentionally deferred to a later pass; this document does not define validator modes, parser APIs, or implementation behavior in this closure pass.
+5. Validator/tooling enforcement remains intentionally deferred until draft grammar decisions are closed and convention wording is stabilized; this document does not define validator modes, parser APIs, or implementation behavior in this closure pass.


### PR DESCRIPTION
### Motivation
- Tighten wording in the structural addressing draft so it explicitly states that validator/tooling enforcement is intentionally deferred while draft grammar decisions and convention wording are stabilized.

### Description
- Updated item 5 in §12 of `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` to read that validator/tooling enforcement "remains intentionally deferred until draft grammar decisions are closed and convention wording is stabilized," preserving the document's draft/living-spec posture and avoiding any validator design or implementation details.

### Testing
- Performed repo preflight and file inspections: confirmed repository path/branch, verified presence of the four Calculogic convention files and the target spec, displayed the target file around the edited lines, and produced a diff showing the single-line wording replacement, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7e3d7d88833189b7db5eb324b997)