### PR TITLE
docs: define placeholder `x` legality matrix and NL skeleton alignment

### DIFF
--- a/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -269,7 +269,7 @@ For the current React repository usage, the following parser/notation decisions 
 
 1. **Placeholder `x`**
    - `x` is **not canonical** in structural addresses.
-   - Placeholder markers may appear only in illustrative/template contexts and must not appear in canonical addresses.
+   - Placeholder markers may appear only in explicitly marked illustrative/template contexts and must not appear in canonical addresses.
 
 2. **Host token in CCPP atomic IDs**
    - Host token remains **externally bound/context-bound** for now.
@@ -296,6 +296,22 @@ For the current React repository usage, the following parser/notation decisions 
    - Canonical parsing for this React App Scope v1 draft does not accept leading-zero normalization.
 
 These closures resolve ambiguity for current React-repo draft usage while preserving future cross-repo/engine flexibility.
+
+### 10.2 Placeholder `x` Legality Matrix (Documentation Classification Rule)
+
+This subsection is the **authoritative source** for `x` placeholder legality in this React repository's documentation scope.
+It is a documentation classification rule only; parser/validator/tooling behavior remains deferred as described elsewhere in this draft.
+
+| Context | `x` Allowed? | Classification / Marking Requirement | Notes |
+| --- | --- | --- | --- |
+| Illustrative examples | Yes, conditionally | **MUST** be labeled `Illustrative` or `Placeholder` near the example block/line. | Allowed only to demonstrate structure shape (for example, unresolved depth/index examples). |
+| Template scaffolds | Yes, conditionally | **MUST** be labeled `Illustrative` or `Placeholder`. | Applies to reusable doc templates where concrete canonical addresses are not yet assigned. |
+| Canonical structural addresses | No | Not applicable; canonical values must be fully concrete and numeric per grammar. | `x` is non-canonical and invalid in canonical address values. |
+| Canonical NL docs/config entries (address metadata intended as real/canonical) | No | Not applicable; address metadata must use canonical concrete addresses. | If placeholder text is temporarily shown for drafting, it must be explicitly marked and treated as non-canonical. |
+| CCPP canonical IDs (when referenced from this spec) | No (current React App Scope v1) | Not applicable in canonical IDs. | CCPP atomic IDs remain NL-section authoritative; placeholder `x` is non-canonical unless a future policy explicitly changes this. |
+| Migration planning rows | Yes, conditionally | **MUST** be labeled `Placeholder` or `Illustrative` at row/table scope. | Permitted only for transitional planning artifacts that are explicitly non-canonical. |
+
+Marking requirement (normative for docs): examples/templates using placeholder marker `x` **MUST** be explicitly marked `Illustrative` or `Placeholder` to avoid ambiguous interpretation in future scanning/validation workflows.
 
 ## 11. Future Sync Targets (Required)
 

--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -8,7 +8,8 @@ This doc defines the canonical NL skeleton templates used by all configuration (
 - **Structural Address (Draft):** Deterministic structural positioning (host-present or no-host forms) is a supplementary addressing layer described in `DeterministicStructuralAddressingSpec-Draft.md`.
 - **Relationship between the two:** These systems are related but **not identical**. Structural addresses do not replace NL section numbering in this skeleton.
 - **Template usage:** Where useful, templates may record structural addresses as **draft, optional metadata** alongside NL content.
-- **Placeholder note (`x`):** Examples that use `x` (for example `3.2.x`) are illustrative draft placeholders in this doc; placeholder marker policy remains deferred to `DeterministicStructuralAddressingSpec-Draft.md`.
+- **Placeholder note (`x`):** This document follows the authoritative placeholder legality rule in `DeterministicStructuralAddressingSpec-Draft.md` (§10.2). Any `x` usage here is non-canonical and allowed only for illustrative/template contexts.
+- **Marking requirement:** Any example/template in this document that uses `x` MUST be explicitly marked `Illustrative` or `Placeholder`.
 - **Governance note:** Comment/provenance protocol conventions remain governed by `CCPP.md`; this doc remains the canonical NL skeleton structure source.
 
 ## Split-Canonical NL Migration Clarification (Policy)
@@ -364,12 +365,12 @@ Passes: [0–7] (Multi-pass implementation)
 - Zone A Subcontainer: [Brand / Nav / Tools]
 - Zone B Subcontainer: [Tabs / Modes / Breadcrumbs]
 - Zone C Subcontainer: [Actions / Profile / Publish]
-- Structural Address (Draft, optional): `[A.1.2.1 / 3.2.x / etc.]`
+- Structural Address (Draft, optional, **Placeholder** example): `[A.1.2.1 / 3.2.x / etc.]`
 
 #### 3.3 Atomic Components — Primitives (Build)
 
 - Buttons, labels, icons, previews, etc., assigned to each zone as leaf-level primitives.
-- Structural Address (Draft, optional): `[A.1.2.1.4 / 3.3.x / etc.]`
+- Structural Address (Draft, optional, **Placeholder** example): `[A.1.2.1.4 / 3.3.x / etc.]`
 
 ### 4. BuildStyle Concern (Visual Styling of Structure)
 


### PR DESCRIPTION
### Motivation

- Close ambiguity about the placeholder marker `x` by making its allowed contexts and mandatory marking explicit in repo docs, and designate a single authoritative doc for the rule.

### Description

- Add an authoritative subsection `§10.2 Placeholder x Legality Matrix` to `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` that classifies `x` usage across contexts (illustrative examples, template scaffolds, canonical structural addresses, canonical NL/config metadata, CCPP IDs, migration rows) and includes a normative marking requirement that examples/templates using `x` MUST be labeled `Illustrative` or `Placeholder`.
- Tighten the existing `x` note in `doc/ConventionRoutines/General-NL-Skeletons.md` to explicitly reference the new `§10.2` as the authoritative source and add a marking requirement there, and label in-document placeholder examples as `**Placeholder**` examples to remove ambiguity.
- This is a docs-only classification change limited to the two target convention files and preserves the draft/living-doc intent while avoiding any validator/parser/tooling design changes.

### Testing

- Verified repository context and branch with `pwd` and `git rev-parse --abbrev-ref HEAD`, which succeeded. 
- Opened and inspected the updated files with `sed -n` to confirm the new `§10.2` content in `DeterministicStructuralAddressingSpec-Draft.md` and the cross-reference/marking edits in `General-NL-Skeletons.md`, which succeeded. 
- Ran targeted searches (`rg`) for placeholder-related tokens and checked the repository diff (`git diff`) and working status (`git status --short`) to confirm only the intended files were changed, which succeeded. 
- Committed the documentation edits locally, with the commit recorded; no automated validators or tooling changes were introduced or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7eea325883318e798155acacb9d7)