### PR TITLE
docs: centralize migration status vocabulary in v1 registry

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -12,6 +12,7 @@
   - `doc/ConventionRoutines/CSCS.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md`
+  - `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`
 
 ## Purpose
 
@@ -213,7 +214,7 @@ This inventory support is intended to surface numbering/provenance inconsistenci
 
 The `Status` column may be used as a migration-lifecycle trace, not only planning intent.
 
-Recommended status progression vocabulary:
+Recommended status progression vocabulary (from `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`):
 
 - `draft`
 - `planned`

--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -14,12 +14,14 @@
   - `doc/ConventionRoutines/CCPP.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `doc/ConventionRoutines/NL-First-Workflow.md`
+  - `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`
 
 ## Purpose
 
 This playbook operationalizes the Build Surface → Global Host migration as a **repeatable execution workflow**.
 
-- The inventory plan remains the source of truth for draft targets, mapping direction, status vocabulary, and naming alignment.
+- The inventory plan remains the source of truth for draft targets, mapping direction, and naming alignment.
+- Status token meanings are centralized in `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`.
 - This playbook defines **how** semantic slices are executed, verified, and reconciled as implementation lands.
 - This playbook does not replace task-specific engineering judgment; it provides guardrails and repeatable review shape.
 - In short: the inventory plan is the target/mapping ledger, while this playbook is the execution/verification routine.
@@ -268,6 +270,8 @@ Use only the checklists relevant to the touched boundary.
 Use temporary wrappers/forwarders only as transitional seams.
 
 ### Lifecycle Labels
+
+Use centralized token meanings from `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`.
 
 - **`extracted`**: responsibility moved to target, but consumers may still route through legacy path.
 - **`repointed`**: active consumers switched to target path.

--- a/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
+++ b/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
@@ -15,16 +15,20 @@ This policy defines lightweight conventions for NL-document split migrations dur
 
 ## Migration Lifecycle Statuses
 
-Use explicit statuses in migration indexes/mapping tables:
+Status token meanings are centralized in:
 
-1. **planned** – target and intent identified; no canonical repoint yet.
-2. **in-progress** – split target drafting/migration underway.
-3. **repointed** – canonical source moved for the mapped slice; provenance links recorded.
-4. **retired** – legacy slice/doc no longer canonical after complete verified migration.
+- `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`
+
+This policy keeps the core scaffold lifecycle statuses and relies on the registry for deterministic shared meanings:
+
+1. **planned**
+2. **in-progress**
+3. **repointed**
+4. **retired**
 
 ### Lifecycle Vocabulary Alignment Note
 
-The four statuses above are the **minimum/core scaffold** for this policy. Architecture/inventory docs may use additional transitional statuses (for example `extracted`, `legacy-wrapper`, `deferred`) for finer migration tracking, provided meanings are explicit and truthfully applied.
+The four statuses above are the **minimum/core scaffold** for this policy. Additional transitional statuses used in architecture/inventory/playbook tracking (for example `extracted`, `legacy-wrapper`, `deferred`) should use the same centralized meanings from the registry rather than ad-hoc redefinition.
 
 `legacy-wrapper` may apply to NL docs when a monolith or index/wrapper continues forwarding readers to repointed split-canonical slices. In code-oriented inventories, the same term may remain code-centric; NL docs may alternatively use equivalent explicit wording when that is clearer.
 
@@ -53,6 +57,7 @@ A slice is considered done when all of the following are true:
 
 ## Cross-References
 
+- `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`
 - `doc/ConventionRoutines/General-NL-Skeletons.md`
 - `doc/ConventionRoutines/NL-First-Workflow.md`
 - `doc/ConventionRoutines/CCPP.md`

--- a/doc/ConventionRoutines/StatusVocabularyRegistry-V1.md
+++ b/doc/ConventionRoutines/StatusVocabularyRegistry-V1.md
@@ -1,0 +1,36 @@
+# Status Vocabulary Registry (v1)
+
+## Purpose
+
+This registry centralizes migration/tracking status tokens used across migration policy, architecture inventory, execution playbook, reconciliation, and mapping/index docs.
+
+Status meanings are defined here to reduce cross-document drift. Documents should not invent ad-hoc statuses without explicit definition. If a one-off status is temporarily needed, define it locally with deterministic meaning and promote it into this registry in a follow-up conventions pass when it is reused.
+
+This v1 registry is intentionally minimal and does not define transition-graph enforcement.
+
+## Doc Classes
+
+- `policy`: migration/convention policy docs.
+- `inventory`: architecture inventory/planning docs with status columns.
+- `playbook`: execution-playbook docs that guide migration slices.
+- `reconciliation`: migration/reconciliation ledgers and progress notes.
+- `mapping-table`: explicit legacy-to-target mapping/index tables.
+
+## Token Registry (v1)
+
+| token | meaning | allowed doc classes | notes |
+|---|---|---|---|
+| `draft` | Item or row is early/provisional and not yet migration-committed. | `inventory`, `reconciliation` | Use only where draft-state tracking is explicitly needed. |
+| `planned` | Target and migration intent are identified; no active extraction/repoint has landed yet. | `policy`, `inventory`, `playbook`, `reconciliation`, `mapping-table` | Core scaffold status. |
+| `in-progress` | Migration work for the mapped slice/item is actively underway but not yet extracted/repointed complete. | `policy`, `inventory`, `playbook`, `reconciliation`, `mapping-table` | Core scaffold status. |
+| `extracted` | Responsibility has been moved to a target path/doc, but active consumers may still use a legacy path/doc until repoint is complete. | `inventory`, `playbook`, `reconciliation`, `mapping-table` | Transitional status used for partial migration completion. |
+| `repointed` | Active consumers/readers are switched to the canonical target; provenance/mapping links are recorded. | `policy`, `inventory`, `playbook`, `reconciliation`, `mapping-table` | Core scaffold status. |
+| `legacy-wrapper` | Legacy path/doc remains as a thin forwarding/delegator wrapper with no unique responsibility, pending retirement. | `policy`, `inventory`, `playbook`, `reconciliation`, `mapping-table` | Transitional status; should remain short-lived. |
+| `retired` | Legacy path/doc is no longer canonical and has been fully drained/removed from active use. | `policy`, `inventory`, `playbook`, `reconciliation`, `mapping-table` | Core scaffold status. |
+| `deferred` | Work is intentionally postponed for a later slice/pass and not currently active. | `policy`, `inventory`, `playbook`, `reconciliation`, `mapping-table` | Use with explicit blocker/dependency note when possible. |
+
+## Lightweight Add-New-Token Guidance
+
+1. Define the token locally with exact meaning and scope if immediately needed.
+2. Use it sparingly until cross-doc reuse is proven.
+3. Promote it into this registry in the next conventions pass before broad reuse.


### PR DESCRIPTION
### Motivation

- Prevent drift in migration/inventory/playbook/reconciliation docs by centralizing status token meanings in a minimal v1 registry. 
- Provide a compact, deterministic source of truth for the core NL-split scaffold statuses and commonly used transitional tokens without adding tooling or validators.

### Description

- Added `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md` which defines a small token set (`draft`, `planned`, `in-progress`, `extracted`, `repointed`, `legacy-wrapper`, `retired`, `deferred`) with precise meanings, allowed doc classes, and lightweight guidance for adding new tokens. 
- Updated `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md` to reference the new registry as the authoritative source for lifecycle vocabulary while preserving the policy's scaffold context. 
- Updated `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` to reference the registry in its related-docs list and to point the recommended status progression back to the centralized registry. 
- Updated `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` to reference the registry and to defer lifecycle label semantics to the centralized definitions; no workflow or enforcement rules were added. 
- This is a docs-only pass and does not introduce validators, transition graphs, or code changes outside documentation.

### Testing

- Ran repository preflight checks and existence checks for the touched docs (`pwd`, branch check, and file presence) which succeeded. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it returned clean. 
- Verified cross-doc references and token coverage with `rg` searches for `StatusVocabularyRegistry-V1.md` and the tokens (`planned`, `in-progress`, `extracted`, `legacy-wrapper`, `deferred`) across the updated docs which succeeded.
- Confirmed the new registry file and edits are staged/committed in the working branch and are ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e80be41ac83319bd06f551610c4ea)