### PR TITLE
docs(nl): add explicit hybrid-forwarding NL Migration Mode to cfg-buildSurface

### DIFF
--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -3,10 +3,12 @@
 This document is an instance of the Configuration-Level NL Skeleton defined in ../ConventionRoutines/General-NL-Skeletons.md.
 
 ## Transition Migration Status (Build Surface NL Split)
+- **NL Migration Mode:** `hybrid-forwarding`
 - **State:** Planned / transition-ready scaffolding active.
 - **Current canonical source:** This monolithic `cfg-buildSurface.md` document remains the authoritative NL reference until split migration slices are explicitly repointed.
 - **Planned direction:** Introduce semantic split-canonical NL documents for Build Surface concerns and interaction slices while preserving section/provenance continuity.
 - **Truthfulness rule:** Mapping rows and target statuses must reflect actual migration state; do not mark slices as migrated until corresponding split docs are written and validated.
+- **Mode meaning:** `hybrid-forwarding` means this monolith remains canonical for current content while also serving as a transition wrapper/index for planned split-canonical targets.
 
 ## Canonical Split NL Targets (Planned / In-Progress)
 > Placeholder index for semantic split targets. Entries remain non-canonical until explicitly marked repointed.


### PR DESCRIPTION
### Motivation
- Make the document’s dual role (authoritative monolith + migration wrapper/index) explicit and machine-readable by adding a top-level NL migration mode label to `doc/nl-config/cfg-buildSurface.md` so future validators/scanners and humans can detect the state without relying solely on prose.

### Description
- Added a top-level field under `## Transition Migration Status (Build Surface NL Split)`: `NL Migration Mode: hybrid-forwarding` and a one-line `Mode meaning` clarification that preserves existing transition semantics and truthfulness rules without changing migration behavior.

### Testing
- Opened and reviewed the four Calculogic convention files and the updated `doc/nl-config/cfg-buildSurface.md`, and verified the change is a single, docs-only insertion and that surrounding prose remains consistent and truthful.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e823436948331a219f945306a67dd)