### PR TITLE
docs: add terminology scoping v1 for canonical usage

### DIFF
--- a/doc/ConventionRoutines/CCPP.md
+++ b/doc/ConventionRoutines/CCPP.md
@@ -14,6 +14,8 @@ Comments are not narration of obvious code; they are a projection of the NL skel
 
 CCPP currently requires NL section IDs/section numbers (for example `[3.2.2]`) as the primary comment anchor. Structural addresses are a separate draft concept and may be included as supplementary metadata where helpful.
 
+> Terminology scoping reference: when prose could confuse source-of-truth vs destination planning vs syntax/order meanings of "canonical", prefer scoped terms from `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md` (for example `canonical_source`, `canonical_target`, `canonical_order`, `canonical_grammar`).
+
 ## 2. Comment Types (Use Only These)
 
 - File Header – one per file.

--- a/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -29,6 +29,8 @@ This layer **complements and does not replace**:
 Addressing answers: “Where is this structural node in a deterministic sequence?”
 It does **not** redefine concern semantics, file naming, or provenance policy.
 
+> Terminology scoping note (V1): within this draft, address syntax/notation rules are treated as `canonical_grammar` concerns, while sequence/slot stability is treated as `canonical_order` concerns (see `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md`).
+
 ## 3. Core Concepts / Terminology
 
 ### 3.1 Structural Address
@@ -146,7 +148,7 @@ Examples: `1.3`, `3.5.1`, `2.3.1.1.4`
 For deterministic ordering, numeric segments are compared **numerically**, not lexically.
 
 - Correct numeric order: `...2` before `...10`
-- Not allowed as canonical sort: lexical string order where `...10` precedes `...2`
+- Not allowed as `canonical_order`: lexical string order where `...10` precedes `...2`
 
 Host letters sort alphabetically when comparing across host roots.
 Within same host (or same no-host artifact), sort by numeric segment tuple.
@@ -236,8 +238,8 @@ Within same host (or same no-host artifact), sort by numeric segment tuple.
 - `1` (invalid: no-host mode missing concern slot)
 - `A.1.9` (invalid concern slot under current canonical concern range)
 - `AA.1.3` (invalid under current draft grammar: multi-letter host tokens are deferred in §10)
-- `A.01.3` (invalid: canonical numeric segments must not include leading zeros in this React App Scope v1 draft)
-- `A.1.x.2` (invalid: placeholder markers such as `x` are non-canonical and not accepted in canonical addresses)
+- `A.01.3` (invalid: `canonical_grammar` numeric segments must not include leading zeros in this React App Scope v1 draft)
+- `A.1.x.2` (invalid: placeholder markers such as `x` are non-`canonical_grammar` and not accepted in canonical addresses)
 
 ## 10. Open Decisions / Deferred Decisions (Required)
 

--- a/doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md
+++ b/doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md
@@ -1,0 +1,48 @@
+# Terminology Scoping Conventions (V1)
+
+## 1. Purpose
+
+This document introduces a compact scoped-terminology convention for overloaded uses of the word `canonical`.
+
+This is a **docs-only terminology scoping pass**. It is intended to reduce ambiguity in validator-facing and convention-heavy documentation without performing a repo-wide prose rewrite.
+
+## 2. Scoped Canonical Terms (V1)
+
+Use the following scoped forms when determinism depends on exact meaning.
+
+### 2.1 `canonical_source`
+- Refers to: the current authoritative source of truth for content.
+- Does **not** refer to: a planned destination, filename shape, ordering rule, or syntax grammar.
+- Example: a migration wrapper doc that remains the active NL authority until repointing.
+
+### 2.2 `canonical_target`
+- Refers to: the intended destination artifact/path for migrated or repointed content.
+- Does **not** refer to: current authority before repointing.
+- Example: a planned split NL doc path listed in a migration scaffold.
+
+### 2.3 `canonical_filename`
+- Refers to: approved filename tokenization/pattern for an artifact class.
+- Does **not** refer to: which document currently owns semantic authority.
+- Example: a policy-approved segment style for `cfg-*.md` naming.
+
+### 2.4 `canonical_order`
+- Refers to: required stable ordering (for concerns, slots, sequence-sensitive tables, etc.).
+- Does **not** refer to: syntax/notation grammar or source-of-truth ownership.
+- Example: fixed CSCS concern slot ordering.
+
+### 2.5 `canonical_grammar`
+- Refers to: authoritative syntax/format rules for a notation.
+- Does **not** refer to: sort order, source authority, or destination planning.
+- Example: deterministic structural address token/segment grammar.
+
+## 3. Usage Guidance
+
+- Prefer scoped terms in tables, manifests, validator-facing notes, migration metadata, and other determinism-sensitive contexts.
+- Plain-language prose may still use unscoped "canonical" where context is obvious and ambiguity risk is low.
+- Do not force awkward prose rewrites solely to insert scoped terminology.
+
+## 4. Scope Boundary for This Pass
+
+This V1 pass is **not** a repo-wide terminology normalization rewrite.
+
+Deferred follow-up: a separate **Terminology Normalization Pass** can broaden normalization across overloaded terms, including `canonical` and `host` (and optionally `root`/`source`).

--- a/doc/nl-config/cfg-buildSurface.md
+++ b/doc/nl-config/cfg-buildSurface.md
@@ -5,13 +5,13 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 ## Transition Migration Status (Build Surface NL Split)
 - **NL Migration Mode:** `hybrid-forwarding`
 - **State:** Planned / transition-ready scaffolding active.
-- **Current canonical source:** This monolithic `cfg-buildSurface.md` document remains the authoritative NL reference until split migration slices are explicitly repointed.
-- **Planned direction:** Introduce semantic split-canonical NL documents for Build Surface concerns and interaction slices while preserving section/provenance continuity.
+- **Current canonical_source:** This monolithic `cfg-buildSurface.md` document remains the authoritative NL reference until split migration slices are explicitly repointed.
+- **Planned direction:** Introduce semantic split `canonical_target` NL documents for Build Surface concerns and interaction slices while preserving section/provenance continuity.
 - **Truthfulness rule:** Mapping rows and target statuses must reflect actual migration state; do not mark slices as migrated until corresponding split docs are written and validated.
-- **Mode meaning:** `hybrid-forwarding` means this monolith remains canonical for current content while also serving as a transition wrapper/index for planned split-canonical targets.
+- **Mode meaning:** `hybrid-forwarding` means this monolith remains the `canonical_source` for current content while also serving as a transition wrapper/index for planned `canonical_target` entries.
 
 ## Canonical Split NL Targets (Planned / In-Progress)
-> Placeholder index for semantic split targets. Entries remain non-canonical until explicitly marked repointed.
+> Placeholder index for semantic split targets. Entries remain non-`canonical_source` until explicitly marked repointed.
 > Naming note: placeholder row filenames below are illustrative semantic examples only (planning vocabulary), not final segment-style commitments.
 > Provisional pattern note: `cfg-buildSurface-<semantic-slice>.md` is a shape-level placeholder (semantic-first, low-churn). Exact segment style remains subject to convention/policy authority before the first repointed slice (`doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, `doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md`).
 > Binding-level note: **Binding Level** classifies row authoritativeness (`placeholder`/`planned`/`provisional`/`canonical`/`retired`) and is separate from migration lifecycle status.
@@ -23,8 +23,10 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 | `doc/nl-config/cfg-buildSurface-previewAndInspectorFlows.md` | Preview controls + inspector behavioral workflows | planned | placeholder | Placeholder only in this pass |
 
 ## Legacy-to-Canonical Mapping Scaffold
+
+> Terminology scoping note (V1): where determinism matters, this doc uses scoped labels from `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md` (for example `canonical_source` vs `canonical_target`) instead of overloaded plain "canonical".
 > Slice-by-slice migration tracker. Use one row per migrated section group; keep provenance explicit.
-> Placeholder target labels in this table are planning scaffolds only and should be finalized per convention/policy authority before repointed status is claimed; they follow the same temporary, non-authoritative guidance class as the canonical-target placeholder examples above.
+> Placeholder target labels in this table are planning scaffolds only and should be finalized per convention/policy authority before repointed status is claimed; they follow the same temporary, non-authoritative guidance class as the `canonical_target` placeholder examples above.
 > Migration lifecycle status and binding level are intentionally tracked as separate dimensions in this scaffold.
 
 | Legacy section(s) in `cfg-buildSurface.md` | Canonical split target | Migration status (`planned`/`in-progress`/`repointed`/`retired`) | Binding Level | Provenance / continuity notes |
@@ -37,7 +39,7 @@ This document is an instance of the Configuration-Level NL Skeleton defined in .
 ## Monolith Behavior During Migration
 - This document currently acts as both:
   - the **temporary source of truth** for Build Surface NL content, and
-  - a **transition wrapper/index** for upcoming semantic split-canonical NL docs.
+  - a **transition wrapper/index** for upcoming semantic split `canonical_target` NL docs.
 - During migration, sections may be incrementally forwarded/repointed to split docs, but unchanged sections continue to be read directly from this monolith.
 - Retirement rule: this monolith should be retired only after all mapped slices are repointed with explicit provenance continuity and no unresolved placeholders remain.
 


### PR DESCRIPTION
### Motivation
- The word "canonical" is used in multiple senses across convention-heavy docs and this can create ambiguity for validators and migration metadata. 
- Introduce a small, deterministic scoped terminology set to allow precise references in validator-facing notes and tables without a repo-wide rewrite. 
- Keep this change strictly docs-only and narrowly targeted to high-value touchpoints where ambiguity materially affects determinism. 

### Description
- Add `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md` which defines `canonical_source`, `canonical_target`, `canonical_filename`, `canonical_order`, and `canonical_grammar` with clear in/out meanings and usage guidance. 
- Apply scoped labels and a brief scoping note in `doc/nl-config/cfg-buildSurface.md` to mark the monolith as the `canonical_source` and planned split docs as `canonical_target` where migration determinism matters. 
- Add a terminology scoping note and replace a few validator-facing terms in `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` to distinguish `canonical_grammar` vs `canonical_order` in grammar/sorting rules. 
- Add a cross-reference note in `doc/ConventionRoutines/CCPP.md` advising authors to prefer scoped terms where plain "canonical" could be ambiguous. 
- No code, validator, tooling, or repo-wide search-and-replace changes were made and an explicit future-pass boundary for broader normalization was documented. 

### Testing
- Confirmed repository root and branch with `pwd` and `git rev-parse --abbrev-ref HEAD` (branch `work`) and proceeded from the repository root. 
- Searched validator/convention docs for occurrences of "canonical" with `rg -n "canonical"` to target minimal edits and verified expected replacements. 
- Ran commit and formatting checks via `git diff --check` and `git status --short`, both completed cleanly. 
- Changes were staged and committed (`git commit`) to branch `work` and a PR entry was prepared summarizing the docs-only, scoped adoption; automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e846dd8008331a6dbdefc3a90bf33)