### PR TITLE
docs: scope overloaded 'host' terminology and add targeted clarifications

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -1,6 +1,8 @@
 # Build Surface Global Host Draft Inventory Plan
 
 ## Document Status
+> Terminology note: in this architecture/playbook context, `host` refers to the `ui_host_surface` concept (UI composition shell) and `host_owner` boundary assignments where stated, not the `address_host` namespace token semantics used by structural addressing grammar. See `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md`.
+
 
 - **Document Type:** Architecture Planning + Draft Inventory
 - **Status:** Draft (Docs-First Refactor Prep)

--- a/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md
@@ -1,6 +1,8 @@
 # Build Surface Global Host Sequence Plan
 
 This document defines the recommended sequencing for stabilizing the Build Surface before converting it into a global host surface, integrating Doc Engine entry points, and preparing publish-flow integration seams.
+> Terminology note: in this architecture/playbook context, `host` refers to the `ui_host_surface` concept (UI composition shell) and `host_owner` boundary assignments where stated, not the `address_host` namespace token semantics used by structural addressing grammar. See `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md`.
+
 
 It exists to prevent scope creep and to avoid building deeper integrations on top of an unreliable host surface baseline.
 

--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -1,6 +1,8 @@
 # Build Surface Global Host Slice Execution Playbook
 
 ## Document Status
+> Terminology note: in this architecture/playbook context, `host` refers to the `ui_host_surface` concept (UI composition shell) and `host_owner` boundary assignments where stated, not the `address_host` namespace token semantics used by structural addressing grammar. See `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md`.
+
 
 - **Document Type:** Architecture Execution Playbook
 - **Status:** Draft (Docs-First Refactor Execution Guidance)

--- a/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -14,6 +14,8 @@
   - `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md` (global host sequencing context)
 - **Last reviewed:** 2026-02-23
 
+> Terminology note: in this document, unscoped `host` references for address grammar/namespace semantics should be interpreted as `address_host` (see `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md`). UI composition-shell meanings belong to `ui_host_surface` terminology in architecture docs.
+
 ## 2. Purpose
 
 This document defines the **deterministic structural addressing layer** used to identify structural units (containers/subcontainers/primitives or equivalent nodes) in a way that is parseable and stable.

--- a/doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md
+++ b/doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md
@@ -2,7 +2,7 @@
 
 ## 1. Purpose
 
-This document introduces a compact scoped-terminology convention for overloaded uses of the word `canonical`.
+This document introduces a compact scoped-terminology convention for overloaded uses of key terms including `canonical` and `host`.
 
 This is a **docs-only terminology scoping pass**. It is intended to reduce ambiguity in validator-facing and convention-heavy documentation without performing a repo-wide prose rewrite.
 
@@ -35,14 +35,39 @@ Use the following scoped forms when determinism depends on exact meaning.
 - Does **not** refer to: sort order, source authority, or destination planning.
 - Example: deterministic structural address token/segment grammar.
 
-## 3. Usage Guidance
+## 3. Scoped Host Terms (V1)
+
+Use the following scoped forms when `host` meaning must be deterministic across architecture and convention documents.
+
+### 3.1 `address_host`
+- Refers to: the structural-addressing namespace token/root concept used by deterministic address grammar (for example host-letter namespace roots in address strings).
+- Does **not** refer to: UI shell composition surfaces, app mount shells, or ownership assignments in refactor planning docs.
+- Example context: structural addressing/convention specs and validator-facing address grammar notes.
+
+### 3.2 `ui_host_surface`
+- Refers to: the UI composition shell/surface role (for example the Build Surface evolving into a global host surface).
+- Does **not** refer to: structural address namespace tokens/roots.
+- Example context: architecture plans, sequencing docs, and slice playbooks describing host UI composition/refactor boundaries.
+
+### 3.3 `host_owner`
+- Refers to: ownership/composition boundary assignment for host responsibilities (which module/surface owns specific host behavior/contracts).
+- Does **not** refer to: ticket/people ownership metadata or structural address namespace token semantics.
+- Example context: migration inventories/playbooks tracking responsibility drains and ownership shifts across host slices.
+
+## 4. Usage Guidance
 
 - Prefer scoped terms in tables, manifests, validator-facing notes, migration metadata, and other determinism-sensitive contexts.
-- Plain-language prose may still use unscoped "canonical" where context is obvious and ambiguity risk is low.
+- Plain-language prose may still use unscoped terms (for example `canonical` or `host`) where context is obvious and ambiguity risk is low.
+- In definition/rule statements where ambiguity is plausible, prefer scoped forms (for example `address_host` and `ui_host_surface`).
 - Do not force awkward prose rewrites solely to insert scoped terminology.
 
-## 4. Scope Boundary for This Pass
+## 5. Scope Boundary for This Pass
 
 This V1 pass is **not** a repo-wide terminology normalization rewrite.
 
-Deferred follow-up: a separate **Terminology Normalization Pass** can broaden normalization across overloaded terms, including `canonical` and `host` (and optionally `root`/`source`).
+Deferred follow-up: a separate **Terminology Normalization Pass (future)** should handle broader prose normalization across overloaded terms.
+
+High-risk normalization targets for that future pass:
+- Structural Addressing spec
+- Build Surface global host architecture docs
+- playbooks/inventories where both structural addressing and UI-host meanings appear


### PR DESCRIPTION
### Motivation
- Reduce ambiguity from overloaded uses of the word "host" by introducing scoped glossary terms and making only minimal, high-risk clarifications in architecture and addressing docs. 
- Preserve existing intent and avoid broad prose normalization or code changes while making deterministic definitions available for validator-facing and migration contexts.

### Description
- Added scoped glossary entries `address_host`, `ui_host_surface`, and `host_owner` with deterministic "refers to / does not refer to / example context" wording in `doc/ConventionRoutines/TerminologyScoping-Conventions-V1.md`.
- Inserted a brief terminology note into `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` clarifying that address-grammar `host` should be interpreted as `address_host`.
- Added minimal first-use/intro terminology notes to the Build Surface architecture docs to clarify that `host` in those docs refers to the `ui_host_surface` and `host_owner` meanings, not structural address tokens, in `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`, `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`, and `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md`.
- Explicitly documented that a broader Terminology Normalization Pass (future) is deferred for larger prose normalization and listed high-risk targets for that future pass.

### Testing
- Ran `git diff --check` to ensure there were no whitespace or diff-check issues and it returned clean results. 
- Verified the modifications by printing and inspecting the updated files (`sed`/`nl` checks) to confirm the new glossary entries and terminology notes are present. 
- Confirmed the docs-only pass was committed successfully and that no code or architecture files were modified beyond the targeted doc notes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8539c8ec8331928cee7abe5e8699)