### PR TITLE
docs: label slice ordering as heuristic non-normative guidance

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -130,7 +130,10 @@ Legacy retirement should happen when:
 
 ## Slice Ordering Strategy (Draft v1, Non-Mandatory)
 
+**Classification:** Heuristic Planning Guidance (Non-Normative)
+
 This ordering is a **draft-safe starting strategy** and not immutable law.
+It is not intended to be strict compliance criteria and may be adjusted based on repo reality, dependencies, and migration risk.
 
 ### Slice Group A — Canonicalization + Persistence Support Alignment (Low Risk)
 


### PR DESCRIPTION
### Motivation
- Make the slice ordering guidance in `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` explicitly non-normative by classifying it as heuristic planning guidance so readers and automation do not treat the suggested ordering as a strict requirement.

### Description
- Add the label `Classification: Heuristic Planning Guidance (Non-Normative)` under the "Slice Ordering Strategy" heading and a one-line clarification that the ordering "is not intended to be strict compliance criteria and may be adjusted based on repo reality, dependencies, and migration risk," while preserving the existing ordering guidance.

### Testing
- Performed repo preflight and file checks (`pwd`, branch check, confirmed convention files exist), inspected `doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md` with `sed`, applied the patch, and verified the diff shows the new classification line and clarification as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e87d5f0b48331946fa8d7bc4df8a9)