### PR TITLE
docs: add snapshot freshness metadata to BuildSurface draft inventory

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -64,6 +64,12 @@ This split is expected to reduce churn by keeping shell behavior stable while en
 
 This snapshot is an observational planning aid for reconciliation; it may lag repo reality if this section is not refreshed after major extraction slices land.
 
+- **Snapshot Basis Commit/PR:** Post-Phase-1 baseline (PR #108)
+- **Snapshot Freshness:** observational (stale-allowed)
+- **Use For:** planning/reconciliation, not canonical repo truth
+
+Repo reality may diverge after the snapshot basis and should be rechecked before using this inventory as current-state evidence.
+
 > Post-Phase-1 status note (PR #108): current repo reality includes preview breakpoint controls/header chrome in `BuildSurface.build.tsx`, preview breakpoint state/bindings in `BuildSurface.logic.ts`, and dark-theme parity selectors across host-surface regions in `BuildSurface.view.css`; this was a host-stability behavior pass, not a host/global extraction slice.
 
 | Current File / Surface | Current Role / Shape | Current Responsibility (Observed) | Likely Draft Inventory Target(s) | Notes |


### PR DESCRIPTION
### Motivation
- Prevent readers and downstream automation from mistaking the draft inventory snapshot for the canonical current repo state by adding minimal freshness metadata to the document.

### Description
- Added an explicit metadata block immediately before the snapshot table in `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` containing `Snapshot Basis Commit/PR`, `Snapshot Freshness: observational (stale-allowed)`, and `Use For: planning/reconciliation, not canonical repo truth`, plus a one-line note that repo reality may diverge after the basis.

### Testing
- Ran repository checks and validations (`git status --short`, `rg -n "Snapshot Basis|Snapshot Freshness|Use For|Repo reality may diverge" doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`) and committed the change, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e88d2aa2c8331824a503b099c9f57)