### PR TITLE
docs(architecture): add temporary canonical draft semantic root rule for buildsurface

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -159,6 +159,12 @@ Notes:
 
 ## Deferred Decisions / Open Questions
 
+### Temporary Rule (Current React App Scope)
+
+For current React app inventory/refactor planning, `buildsurface` is the **canonical draft semantic root** unless superseded by an approved naming/architecture decision.
+
+Ambiguity note: final global semantic root naming remains intentionally deferred due to potential confusion between Build concern/tab naming and BuildSurface architectural surface/root naming.
+
 1. **Global root semantic target finalization**
    - Keep `buildsurface` for this draft.
    - Potential future rename to a broader semantic target is deferred.


### PR DESCRIPTION
### Motivation
- Reduce naming ambiguity during current React app planning by documenting a temporary, local canonical draft semantic root for `buildsurface` while explicitly deferring any final global rename decision.

### Description
- Added a `Temporary Rule (Current React App Scope)` subsection to `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` that states `buildsurface` is the canonical draft semantic root for current inventory/refactor planning unless superseded by an approved naming/architecture decision, and included a brief ambiguity note explaining the deferred rename rationale (potential confusion between Build concern/tab naming and BuildSurface architectural surface/root naming); this is a docs-only change with no code, renames, or tooling added.

### Testing
- Performed automated repository and doc validation commands to confirm the change and required conventions exist, including `pwd`/`git branch --show-current`, presence checks for the four convention files, `sed` to view the target doc, `rg` searches for key phrases, and a diff of the updated file, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e89b8dfe4833186a4af2fb597ea33)