### PR TITLE
docs(architecture): add temporary preferred draft naming policy for left-panel tab wiring

### DIFF
--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -170,8 +170,11 @@ Ambiguity note: final global semantic root naming remains intentionally deferred
    - Potential future rename to a broader semantic target is deferred.
 
 2. **Final tab-provider naming pattern**
-   - Current draft uses `leftpanel-<tab>-sources.wiring.ts`.
-   - Whether provider naming should converge on `leftpanel-<tab>-provider.*` is deferred.
+   - **Temporary naming policy (current migration/refactor phase):**
+     - Preferred draft pattern: `leftpanel-<tab>-sources.wiring.ts`
+     - Allowed alternate (draft): provider-based naming (for example `leftpanel-<tab>-provider.*`) where already present or explicitly documented for a slice
+     - Current expectation: new additions in this migration phase use the preferred draft pattern unless a document explicitly states otherwise
+   - Final long-term convergence of sources-vs-provider naming remains deferred.
 
 3. **Future role promotion evaluation**
    - Repeated patterns around selectors/adapters may justify role promotion later.


### PR DESCRIPTION
### Motivation
- Provide a deterministic, temporary naming preference for left-panel tab wiring files during the current migration/refactor phase while preserving deferral of the final long-term naming convergence.

### Description
- Updated `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md` to add a temporary naming policy that records the preferred draft pattern `leftpanel-<tab>-sources.wiring.ts`, an allowed alternate provider-based draft (for example `leftpanel-<tab>-provider.*`) where already present or explicitly documented, the current expectation that new additions use the preferred pattern unless a doc explicitly states otherwise, and an explicit note that final sources-vs-provider convergence remains deferred.

### Testing
- Confirmed the presence of the required convention files via the convention-file check command and it succeeded.
- Inspected the modified documentation with `sed -n '1,260p'` and `nl -ba doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md | sed -n '160,190p'` to verify the temporary policy text appears at the expected location, and reviewed the repo diff for the changed file using `git diff -- doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8a3b29808331822c27cc254eaeef)