### PR TITLE
Polish naming validator report metadata for V0.1.1

### DIFF
--- a/doc/ComplianceAudits/NamingValidatorBaseline-2026-02-25-V0_1_1.md
+++ b/doc/ComplianceAudits/NamingValidatorBaseline-2026-02-25-V0_1_1.md
@@ -1,0 +1,57 @@
+# Naming Validator Baseline (V0.1.1 Report Mode)
+
+## Scope
+
+- Validator: filename naming validator V0.1.1 polish pass
+- Mode: `report` only (no enforcement)
+- Source authority: `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
+
+## Baseline Summary
+
+- Total files scanned: **114**
+
+### Classification counts
+
+- `canonical`: **1**
+- `allowed-special-case`: **22**
+- `legacy-exception`: **76**
+- `invalid-ambiguous`: **15**
+
+### Warning code breakdown
+
+- `NAMING_BAD_SEMANTIC_CASE`: **10**
+- `NAMING_DEPRECATED_ROLE`: **1**
+- `NAMING_UNKNOWN_ROLE`: **4**
+
+### Special-case subtype breakdown
+
+- `ambient-declaration`: **1**
+- `barrel`: **5**
+- `conventional-doc`: **5**
+- `ecosystem-required`: **7**
+- `test-convention`: **4**
+
+### Warning role metadata breakdown
+
+- Role status:
+  - `active`: **10**
+  - `deprecated`: **1**
+- Role category:
+  - `architecture-support`: **1**
+  - `concern-core`: **9**
+  - `deprecated`: **1**
+
+## V0.1.1 Notes
+
+1. Deprecated role awareness is explicit in V0.1.1: files using role segment `view` in canonical position now emit `NAMING_DEPRECATED_ROLE` and include deprecation metadata for manual migration planning.
+2. README policy in V0.1.1 is explicit: `README.md` is treated as `allowed-special-case` with `specialCaseType: conventional-doc`.
+3. Ecosystem/tooling/test/barrel/ambient files remain report-mode special cases and now include deterministic subtype metadata.
+4. Report mode remains informational only (`exit 0`) with no soft-fail/hard-fail enforcement in this slice.
+
+## Determinism Note
+
+Repeated runs produced identical ordered output and identical summary counts.
+
+## Enforcement Note
+
+This baseline is informational only. V0.1.1 does **not** fail CI or block merges for naming findings.

--- a/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -1,16 +1,17 @@
-# Naming Validator Spec (V0.1)
+# Naming Validator Spec (V0.1.1)
 
 ## Purpose and Scope
 
-This document defines the V0.1 filename naming validator slice for deterministic automation.
+This document defines the V0.1.1 filename naming validator slice for deterministic automation.
 
-V0.1 scope is intentionally narrow:
+V0.1.1 scope is intentionally narrow:
 - filename validation only
 - report mode only
 - deterministic findings output
+- richer diagnostics for migration planning
 - no rename enforcement
 
-Out of scope for V0.1:
+Out of scope for V0.1.1:
 - structural addressing validation
 - NL↔Code numbering/parity validation
 - provenance token consistency checks
@@ -27,24 +28,37 @@ Supporting workflow alignment:
 - `doc/ConventionRoutines/CSCS.md`
 - `doc/ConventionRoutines/CCPP.md`
 
-## Canonical Filename Contract (V0.1)
+## Canonical Filename Contract (V0.1.1)
 
 Canonical grammar:
 - `<semantic-name>.<role>.<ext>`
 
-Recognized compound format suffixes in V0.1:
+Recognized compound format suffixes in V0.1.1:
 - `module.css`
 
-V0.1 active role registry:
-- `host`
-- `wiring`
-- `contracts`
-- `build`
-- `build-style`
-- `logic`
-- `knowledge`
-- `results`
-- `results-style`
+Filename grammar is unchanged from V0.1.
+
+## Role Registry Metadata (V0.1.1)
+
+V0.1.1 uses a structured role registry with metadata:
+- `role`
+- `category` (`concern-core` | `architecture-support` | `deprecated`)
+- `status` (`active` | `deprecated`)
+- `notes` (optional)
+
+Active roles:
+- `host` (`architecture-support`, `active`)
+- `wiring` (`architecture-support`, `active`)
+- `contracts` (`architecture-support`, `active`)
+- `build` (`concern-core`, `active`)
+- `build-style` (`concern-core`, `active`)
+- `logic` (`concern-core`, `active`)
+- `knowledge` (`concern-core`, `active`)
+- `results` (`concern-core`, `active`)
+- `results-style` (`concern-core`, `active`)
+
+Deprecated historical roles:
+- `view` (`deprecated`, `deprecated`) — historical pre-current concern split term.
 
 Semantic-name rules:
 - kebab-case only for canonical filenames
@@ -57,7 +71,7 @@ Parsing assumptions:
 
 ## Input Scope Modes
 
-V0.1 defines these modes:
+V0.1.1 defines these modes:
 
 1. `all-files` (implemented)
    - scans repository files with deterministic sorting
@@ -68,7 +82,7 @@ V0.1 defines these modes:
 
 ## Classification Outputs
 
-Stable classifications used by V0.1:
+Stable classifications used by V0.1.1:
 - `canonical`
 - `allowed-special-case`
 - `legacy-exception`
@@ -86,21 +100,45 @@ Each finding uses a stable object shape:
 - `suggestedFix` (optional)
 - `details` (optional object)
 
-## Finding / Error Codes (V0.1)
+### Special-case subtype metadata
+
+V0.1.1 keeps top-level classification `allowed-special-case` and adds deterministic subtype metadata in `details.specialCaseType`:
+- `ecosystem-required`: `package.json`, `package-lock.json`, `tsconfig*.json`, `vite.config.*`, `eslint.config.*`
+- `barrel`: `index.ts`, `index.tsx`
+- `test-convention`: `*.test.*`, `*.spec.*`
+- `ambient-declaration`: `*.d.ts`
+- `conventional-doc`: `README.md`
+
+README policy in V0.1.1: `README.md` is treated as `allowed-special-case` with subtype `conventional-doc`.
+
+### Deprecated role metadata
+
+When a canonical-like parse resolves to a known deprecated role (currently `view`):
+- classification remains `invalid-ambiguous`
+- code is `NAMING_DEPRECATED_ROLE`
+- `details` includes parsed filename metadata plus:
+  - `roleStatus: "deprecated"`
+  - `roleCategory: "deprecated"`
+  - optional `deprecationNote`
+- validator does not auto-map deprecated role to modern roles (manual migration required)
+
+## Finding / Error Codes (V0.1.1)
 
 - `NAMING_CANONICAL`
 - `NAMING_ALLOWED_SPECIAL_CASE`
 - `NAMING_LEGACY_EXCEPTION`
-- `NAMING_INVALID_PATTERN`
 - `NAMING_UNKNOWN_ROLE`
+- `NAMING_DEPRECATED_ROLE`
 - `NAMING_BAD_SEMANTIC_CASE`
 - `NAMING_ROLE_HYPHEN_AMBIGUITY`
 
+Code alignment note: `NAMING_INVALID_PATTERN` is deferred/removed from active V0.1.1 emission because unmatched filenames are intentionally classified as `NAMING_LEGACY_EXCEPTION` in report mode.
+
 ## Rollout Modes
 
-- `report` (V0.1 behavior)
+- `report` (V0.1.1 behavior)
   - always emits findings and summary
-  - never fails build in V0.1
+  - never fails build in V0.1.1
 - `soft-fail` (deferred)
   - planned targeted enforcement by folders or changed files
 - `hard-fail` (deferred)
@@ -108,13 +146,13 @@ Each finding uses a stable object shape:
 
 ## Exit Code Behavior
 
-V0.1 report mode exit behavior:
+V0.1.1 report mode exit behavior:
 - process exits `0`
 - invalid findings are reported but do not fail command
 
 ## Allowed Special-Case Handling Rules
 
-V0.1 recognizes these special cases:
+V0.1.1 recognizes these special cases:
 - barrel files: `index.ts`, `index.tsx`
 - framework/tool required names (root/tooling config patterns):
   - `package.json`
@@ -124,15 +162,17 @@ V0.1 recognizes these special cases:
   - `eslint.config.*`
 - test files: `*.test.*`, `*.spec.*`
 - ambient declarations: `*.d.ts`
+- conventional docs: `README.md`
 
-Special-case list is explicit and intentionally narrow in V0.1.
+Special-case list is explicit and intentionally narrow in V0.1.1.
 
 ## Legacy Exception Handling Rules
 
-For incremental adoption, V0.1 classifies non-canonical in-scope files as `legacy-exception` when they do not clearly claim canonical syntax.
+For incremental adoption, V0.1.1 classifies non-canonical in-scope files as `legacy-exception` when they do not clearly claim canonical syntax.
 
 A file is `invalid-ambiguous` instead of `legacy-exception` when it presents canonical intent but violates contract deterministically, including:
 - unknown role segment in canonical position
+- deprecated role segment in canonical position
 - semantic-name casing violation in canonical position
 - hyphen-appended role ambiguity (e.g., `leftpanel-selector-wiring.ts`)
 
@@ -141,8 +181,9 @@ A file is `invalid-ambiguous` instead of `legacy-exception` when it presents can
 - normalize path separators to `/`
 - sort findings by normalized path ascending
 - stable classification and code assignment per filename
+- deterministic summary breakdown ordering
 
-## Non-Goals (V0.1)
+## Non-Goals (V0.1.1)
 
 - no automatic rename suggestions beyond optional textual hints
 - no repository-wide rename migration

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,5 +1,8 @@
 # cfg-namingValidator
 
+## 0.0 Version
+Current implementation target: **V0.1.1** (report-mode polish pass).
+
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
 
@@ -10,8 +13,14 @@ The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1
 ### 2.2 Scope mode (V0.1)
 V0.1 scans repository files in all-files mode with deterministic path ordering.
 
-### 2.3 Active roles (V0.1)
-The validator uses the suggested initial active role set:
+### 2.3 Role registry metadata (V0.1.1)
+The validator uses a structured role registry with metadata fields:
+- `role`
+- `category` (`concern-core`, `architecture-support`, `deprecated`)
+- `status` (`active`, `deprecated`)
+- optional `notes`
+
+Active roles:
 - host
 - wiring
 - contracts
@@ -22,18 +31,28 @@ The validator uses the suggested initial active role set:
 - results
 - results-style
 
+Deprecated historical roles:
+- view
+
 ## 3.0 Classification Contract
 ### 3.1 Canonical
 Classify as canonical when filename parses as `<semantic-name>.<role>.<ext>` (including `.module.css`) with kebab-case semantic name and known role.
 
 ### 3.2 Allowed special case
-Classify as allowed special case for reserved filenames and patterns including barrel files, framework-required names, test files, and ambient declaration files.
+Classify as allowed special case for reserved filenames and patterns including barrel files, framework-required names, test files, ambient declaration files, and README convention docs.
+
+Allowed special-case findings include `details.specialCaseType` values:
+- `ecosystem-required`
+- `barrel`
+- `test-convention`
+- `ambient-declaration`
+- `conventional-doc`
 
 ### 3.3 Legacy exception
 Classify as legacy exception when file is in-scope but does not claim canonical structure and is tolerated by incremental adoption.
 
 ### 3.4 Invalid or ambiguous
-Classify as invalid or ambiguous when filename appears to claim canonical intent but violates deterministic parse rules (unknown role, bad semantic casing, or hyphen-appended role ambiguity).
+Classify as invalid or ambiguous when filename appears to claim canonical intent but violates deterministic parse rules (unknown role, deprecated role, bad semantic casing, or hyphen-appended role ambiguity).
 
 ## 4.0 Findings and Reporting
 ### 4.1 Stable finding schema
@@ -42,7 +61,14 @@ Each finding includes code, severity, path, classification, message, ruleRef, an
 ### 4.2 Deterministic ordering
 Findings and summary output sort by normalized relative path.
 
-### 4.3 Exit behavior (report mode)
+### 4.3 Summary breakdowns (V0.1.1)
+Report output includes deterministic summary breakdowns for:
+- classification counts
+- finding code counts
+- special-case subtype counts
+- warning role status/category counts (when metadata is present)
+
+### 4.4 Exit behavior (report mode)
 Report mode always exits with status code 0 and prints counts by classification.
 
 ## 5.0 Deferred Behavior

--- a/scripts/validate-naming.mjs
+++ b/scripts/validate-naming.mjs
@@ -7,12 +7,16 @@ const __dirname = path.dirname(__filename);
 const repositoryRoot = path.resolve(__dirname, '..');
 
 const { findings, totalFilesScanned } = runNamingValidator(repositoryRoot);
-const counts = summarizeFindings(findings);
+const summary = summarizeFindings(findings);
 
 const report = {
   mode: 'report',
   totalFilesScanned,
-  counts,
+  counts: summary.counts,
+  codeCounts: summary.codeCounts,
+  specialCaseTypeCounts: summary.specialCaseTypeCounts,
+  warningRoleStatusCounts: summary.warningRoleStatusCounts,
+  warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
   findings,
 };
 

--- a/src/validators/naming-validator.logic.mjs
+++ b/src/validators/naming-validator.logic.mjs
@@ -1,19 +1,27 @@
 import path from 'node:path';
 import fs from 'node:fs';
 
-const ACTIVE_ROLES = new Set([
-  'host',
-  'wiring',
-  'contracts',
-  'build',
-  'build-style',
-  'logic',
-  'knowledge',
-  'results',
-  'results-style',
-]);
+const ROLE_REGISTRY = [
+  { role: 'host', category: 'architecture-support', status: 'active' },
+  { role: 'wiring', category: 'architecture-support', status: 'active' },
+  { role: 'contracts', category: 'architecture-support', status: 'active' },
+  { role: 'build', category: 'concern-core', status: 'active' },
+  { role: 'build-style', category: 'concern-core', status: 'active' },
+  { role: 'logic', category: 'concern-core', status: 'active' },
+  { role: 'knowledge', category: 'concern-core', status: 'active' },
+  { role: 'results', category: 'concern-core', status: 'active' },
+  { role: 'results-style', category: 'concern-core', status: 'active' },
+  {
+    role: 'view',
+    category: 'deprecated',
+    status: 'deprecated',
+    notes: 'Historical role from pre-current concern split; manual migration required.',
+  },
+];
 
-const ROLE_SUFFIXES = [...ACTIVE_ROLES].sort((a, b) => b.length - a.length);
+const ROLE_METADATA = new Map(ROLE_REGISTRY.map(entry => [entry.role, entry]));
+const ACTIVE_ROLES = new Set(ROLE_REGISTRY.filter(entry => entry.status === 'active').map(entry => entry.role));
+const ROLE_SUFFIXES = ROLE_REGISTRY.map(entry => entry.role).sort((a, b) => b.length - a.length);
 const CANONICAL_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const REPORTABLE_EXTENSIONS = new Set([
   '.ts',
@@ -31,36 +39,42 @@ const EXCLUDED_DIRECTORIES = new Set(['.git', 'node_modules', 'dist', 'coverage'
 
 export const normalizePath = relativePath => relativePath.split(path.sep).join('/');
 
-export const isAllowedSpecialCase = filePath => {
+const getSpecialCaseType = filePath => {
   const normalizedPath = normalizePath(filePath);
   const basename = path.posix.basename(normalizedPath);
 
+  if (basename === 'README.md') {
+    return 'conventional-doc';
+  }
+
   if (basename === 'index.ts' || basename === 'index.tsx') {
-    return true;
+    return 'barrel';
   }
 
   if (/\.test\.[^.]+$/u.test(basename) || /\.spec\.[^.]+$/u.test(basename)) {
-    return true;
+    return 'test-convention';
   }
 
   if (/\.d\.ts$/u.test(basename)) {
-    return true;
+    return 'ambient-declaration';
   }
 
   if (normalizedPath === 'package.json' || normalizedPath === 'package-lock.json') {
-    return true;
+    return 'ecosystem-required';
   }
 
   if (/^tsconfig(\..+)?\.json$/u.test(basename)) {
-    return true;
+    return 'ecosystem-required';
   }
 
   if (/^vite\.config\.[^.]+$/u.test(basename) || /^eslint\.config\.[^.]+$/u.test(basename)) {
-    return true;
+    return 'ecosystem-required';
   }
 
-  return false;
+  return null;
 };
+
+export const isAllowedSpecialCase = filePath => getSpecialCaseType(filePath) !== null;
 
 export const parseCanonicalName = basename => {
   const parts = basename.split('.');
@@ -110,7 +124,8 @@ export const classifyPath = relativePath => {
   const normalizedPath = normalizePath(relativePath);
   const basename = path.posix.basename(normalizedPath);
 
-  if (isAllowedSpecialCase(normalizedPath)) {
+  const specialCaseType = getSpecialCaseType(normalizedPath);
+  if (specialCaseType) {
     return {
       code: 'NAMING_ALLOWED_SPECIAL_CASE',
       severity: 'info',
@@ -118,11 +133,45 @@ export const classifyPath = relativePath => {
       classification: 'allowed-special-case',
       message: 'Filename matches an allowed reserved/special-case pattern.',
       ruleRef: 'FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12',
+      details: { specialCaseType },
     };
   }
 
   const parsed = parseCanonicalName(basename);
   if (parsed) {
+    const roleMetadata = ROLE_METADATA.get(parsed.role);
+
+    if (!roleMetadata) {
+      return {
+        code: 'NAMING_UNKNOWN_ROLE',
+        severity: 'warn',
+        path: normalizedPath,
+        classification: 'invalid-ambiguous',
+        message: `Unknown role segment "${parsed.role}" in canonical position.`,
+        ruleRef: 'FileNamingMasterList-V1_1.md#role-registry-master-list-v1',
+        suggestedFix: 'Use a role from the active role registry.',
+        details: parsed,
+      };
+    }
+
+    if (roleMetadata.status === 'deprecated') {
+      return {
+        code: 'NAMING_DEPRECATED_ROLE',
+        severity: 'warn',
+        path: normalizedPath,
+        classification: 'invalid-ambiguous',
+        message: `Role segment "${parsed.role}" is deprecated and requires manual migration planning.`,
+        ruleRef: 'FileNamingMasterList-V1_1.md#role-registry-master-list-v1',
+        suggestedFix: 'Replace deprecated roles manually using current active role taxonomy.',
+        details: {
+          ...parsed,
+          roleStatus: roleMetadata.status,
+          roleCategory: roleMetadata.category,
+          deprecationNote: roleMetadata.notes,
+        },
+      };
+    }
+
     if (!ACTIVE_ROLES.has(parsed.role)) {
       return {
         code: 'NAMING_UNKNOWN_ROLE',
@@ -145,7 +194,11 @@ export const classifyPath = relativePath => {
         message: 'Semantic name must use kebab-case for canonical filenames.',
         ruleRef: 'FileNamingMasterList-V1_1.md#semantic-name',
         suggestedFix: `Rename semantic name "${parsed.semanticName}" to kebab-case.`,
-        details: parsed,
+        details: {
+          ...parsed,
+          roleStatus: roleMetadata.status,
+          roleCategory: roleMetadata.category,
+        },
       };
     }
 
@@ -156,7 +209,11 @@ export const classifyPath = relativePath => {
       classification: 'canonical',
       message: 'Filename is canonical.',
       ruleRef: 'FileNamingMasterList-V1_1.md#core-filename-grammar',
-      details: parsed,
+      details: {
+        ...parsed,
+        roleStatus: roleMetadata.status,
+        roleCategory: roleMetadata.category,
+      },
     };
   }
 
@@ -228,6 +285,15 @@ export const runNamingValidator = rootDirectory => {
   };
 };
 
+const incrementCounter = (counts, key) => {
+  counts[key] = (counts[key] ?? 0) + 1;
+};
+
+const sortCountObject = counts =>
+  Object.fromEntries(
+    Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)),
+  );
+
 export const summarizeFindings = findings => {
   const counts = {
     canonical: 0,
@@ -235,10 +301,33 @@ export const summarizeFindings = findings => {
     'legacy-exception': 0,
     'invalid-ambiguous': 0,
   };
+  const codeCounts = {};
+  const specialCaseTypeCounts = {};
+  const warningRoleStatusCounts = {};
+  const warningRoleCategoryCounts = {};
 
   for (const finding of findings) {
-    counts[finding.classification] += 1;
+    incrementCounter(counts, finding.classification);
+    incrementCounter(codeCounts, finding.code);
+
+    if (finding.details?.specialCaseType) {
+      incrementCounter(specialCaseTypeCounts, finding.details.specialCaseType);
+    }
+
+    if (finding.severity === 'warn' && finding.details?.roleStatus) {
+      incrementCounter(warningRoleStatusCounts, finding.details.roleStatus);
+    }
+
+    if (finding.severity === 'warn' && finding.details?.roleCategory) {
+      incrementCounter(warningRoleCategoryCounts, finding.details.roleCategory);
+    }
   }
 
-  return counts;
+  return {
+    counts,
+    codeCounts: sortCountObject(codeCounts),
+    specialCaseTypeCounts: sortCountObject(specialCaseTypeCounts),
+    warningRoleStatusCounts: sortCountObject(warningRoleStatusCounts),
+    warningRoleCategoryCounts: sortCountObject(warningRoleCategoryCounts),
+  };
 };

--- a/test/naming-validator.test.mjs
+++ b/test/naming-validator.test.mjs
@@ -46,10 +46,40 @@ test('classifies hyphen-appended role ambiguity as invalid-ambiguous', () => {
   assert.equal(finding.code, 'NAMING_ROLE_HYPHEN_AMBIGUITY');
 });
 
-test('classifies allowed special case for test files', () => {
+test('classifies ecosystem-required special case with subtype', () => {
+  const finding = classifyPath('vite.config.ts');
+  assert.equal(finding.classification, 'allowed-special-case');
+  assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
+  assert.equal(finding.details?.specialCaseType, 'ecosystem-required');
+});
+
+test('classifies barrel special case with subtype', () => {
+  const finding = classifyPath('src/tabs/build/index.ts');
+  assert.equal(finding.classification, 'allowed-special-case');
+  assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
+  assert.equal(finding.details?.specialCaseType, 'barrel');
+});
+
+test('classifies test convention special case with subtype', () => {
   const finding = classifyPath('test/content-provider-registry.test.mjs');
   assert.equal(finding.classification, 'allowed-special-case');
   assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
+  assert.equal(finding.details?.specialCaseType, 'test-convention');
+});
+
+test('classifies deprecated role usage as invalid-ambiguous with metadata', () => {
+  const finding = classifyPath('src/tabs/build/BuildSurface.view.css');
+  assert.equal(finding.classification, 'invalid-ambiguous');
+  assert.equal(finding.code, 'NAMING_DEPRECATED_ROLE');
+  assert.equal(finding.details?.roleStatus, 'deprecated');
+  assert.equal(finding.details?.roleCategory, 'deprecated');
+});
+
+test('classifies README as conventional-doc special case', () => {
+  const finding = classifyPath('README.md');
+  assert.equal(finding.classification, 'allowed-special-case');
+  assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
+  assert.equal(finding.details?.specialCaseType, 'conventional-doc');
 });
 
 test('classifies legacy exceptions for non-canonical legacy names', () => {


### PR DESCRIPTION
### Motivation
- Improve the naming validator’s report usefulness and reduce noise by adding deterministic special-case subtypes and richer role metadata without changing the canonical filename grammar (`<semantic-name>.<role>.<ext>`). 
- Make deprecated historical roles explicit for migration planning (start with `view`) and align spec/codes so emitted findings are predictable. 
- Preserve V0.1 constraints: report-mode only, deterministic output, no auto-fixes, and no filename grammar changes. 

### Description
- Spec update: elevate `NamingValidatorSpec` to V0.1.1 and document `details.specialCaseType` subtypes (`ecosystem-required`, `barrel`, `test-convention`, `ambient-declaration`, `conventional-doc`), structured role registry metadata (`role`, `category`, `status`, `notes`), README policy, and the explicit deprecation handling for `view` (emit `NAMING_DEPRECATED_ROLE`). (`doc/ConventionRoutines/NamingValidatorSpec.md`, `doc/nl-config/cfg-namingValidator.md`).
- Implementation: replace flat role set with a structured `ROLE_REGISTRY` and `ROLE_METADATA`, emit `details.specialCaseType` for allowed special cases, detect deprecated roles and emit `NAMING_DEPRECATED_ROLE` with `roleStatus`/`roleCategory`/`deprecationNote`, and keep canonical parsing unchanged. (`src/validators/naming-validator.logic.mjs`).
- Reporting: extend `scripts/validate-naming.mjs` and summarizer to include deterministic breakdowns: `codeCounts`, `specialCaseTypeCounts`, and warning role `status`/`category` counts in addition to classification counts. (`scripts/validate-naming.mjs`).
- Tests & baseline: add/update focused tests for subtype tagging, barrel/test/README handling, and deprecated-role detection, and add a V0.1.1 baseline audit doc summarizing counts and breakdowns. (`test/naming-validator.test.mjs`, `doc/ComplianceAudits/NamingValidatorBaseline-2026-02-25-V0_1_1.md`).
- Non-functional: preserved determinism (normalized paths, stable sorting), preserved report-only behavior and exit code `0`, and no auto-fix or enforcement changes.

### Testing
- Ran the test suite with `npm test`; all naming-validator tests and repository tests passed (31 tests related to naming behavior; overall test run succeeded). (Result: ✅ passed).
- Executed `npm run validate:naming` repeatedly and compared outputs for determinism; repeated runs produced identical ordering and counts (report summary: `totalFilesScanned: 114`, `canonical: 1`, `allowed-special-case: 22`, `legacy-exception: 76`, `invalid-ambiguous: 15`). (Result: ✅ deterministic).
- Ran `npm run lint`; linter completed with existing warnings but no errors. (Result: ✅ lint pass with warnings).
- Summary: automated tests and validation script runs succeeded and the new summary breakdowns and deprecated-role findings are present in the generated report. (No enforcement changes introduced.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ea68fc308833197ebbc6af993da64)