### PR TITLE
Add deterministic naming validator scope profiles (repo|app|docs)

### DIFF
--- a/doc/ComplianceAudits/NamingValidatorBaseline-App-2026-02-25.md
+++ b/doc/ComplianceAudits/NamingValidatorBaseline-App-2026-02-25.md
@@ -1,0 +1,44 @@
+# Naming Validator Baseline (V0.1.2 Report Mode, App Scope)
+
+## Scope
+
+- Validator: filename naming validator V0.1.2
+- Mode: `report` only (no enforcement)
+- Scope profile: `app`
+- Command: `npm run validate:naming -- --scope=app`
+- Source authority: `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
+
+## Baseline Summary
+
+- Total files scanned: **52**
+
+### Classification counts
+
+- `canonical`: **1**
+- `allowed-special-case`: **17**
+- `legacy-exception`: **19**
+- `invalid-ambiguous`: **15**
+
+### Counts by finding code
+
+- `NAMING_ALLOWED_SPECIAL_CASE`: **17**
+- `NAMING_BAD_SEMANTIC_CASE`: **10**
+- `NAMING_CANONICAL`: **1**
+- `NAMING_DEPRECATED_ROLE`: **1**
+- `NAMING_LEGACY_EXCEPTION`: **19**
+- `NAMING_UNKNOWN_ROLE`: **4**
+
+### Counts by specialCaseType
+
+- `ambient-declaration`: **1**
+- `barrel`: **5**
+- `ecosystem-required`: **7**
+- `test-convention`: **4**
+
+## Interpretation Note
+
+App scope significantly reduces docs-driven legacy-exception noise while preserving app/tooling migration visibility.
+
+## Determinism Note
+
+Repeated runs for the same scope/repo state produced identical ordering and counts.

--- a/doc/ComplianceAudits/NamingValidatorBaseline-Docs-2026-02-25.md
+++ b/doc/ComplianceAudits/NamingValidatorBaseline-Docs-2026-02-25.md
@@ -1,0 +1,37 @@
+# Naming Validator Baseline (V0.1.2 Report Mode, Docs Scope)
+
+## Scope
+
+- Validator: filename naming validator V0.1.2
+- Mode: `report` only (no enforcement)
+- Scope profile: `docs`
+- Command: `npm run validate:naming -- --scope=docs`
+- Source authority: `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
+
+## Baseline Summary
+
+- Total files scanned: **66**
+
+### Classification counts
+
+- `canonical`: **0**
+- `allowed-special-case`: **5**
+- `legacy-exception`: **61**
+- `invalid-ambiguous`: **0**
+
+### Counts by finding code
+
+- `NAMING_ALLOWED_SPECIAL_CASE`: **5**
+- `NAMING_LEGACY_EXCEPTION`: **61**
+
+### Counts by specialCaseType
+
+- `conventional-doc`: **5**
+
+## Interpretation Note
+
+Docs scope is expected to show many legacy exceptions due to historical document naming patterns; this provides a targeted docs-only baseline.
+
+## Determinism Note
+
+Repeated runs for the same scope/repo state produced identical ordering and counts.

--- a/doc/ComplianceAudits/NamingValidatorBaseline-Repo-2026-02-25.md
+++ b/doc/ComplianceAudits/NamingValidatorBaseline-Repo-2026-02-25.md
@@ -1,0 +1,45 @@
+# Naming Validator Baseline (V0.1.2 Report Mode, Repo Scope)
+
+## Scope
+
+- Validator: filename naming validator V0.1.2
+- Mode: `report` only (no enforcement)
+- Scope profile: `repo`
+- Command: `npm run validate:naming -- --scope=repo`
+- Source authority: `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
+
+## Baseline Summary
+
+- Total files scanned: **118**
+
+### Classification counts
+
+- `canonical`: **1**
+- `allowed-special-case`: **22**
+- `legacy-exception`: **80**
+- `invalid-ambiguous`: **15**
+
+### Counts by finding code
+
+- `NAMING_ALLOWED_SPECIAL_CASE`: **22**
+- `NAMING_BAD_SEMANTIC_CASE`: **10**
+- `NAMING_CANONICAL`: **1**
+- `NAMING_DEPRECATED_ROLE`: **1**
+- `NAMING_LEGACY_EXCEPTION`: **80**
+- `NAMING_UNKNOWN_ROLE`: **4**
+
+### Counts by specialCaseType
+
+- `ambient-declaration`: **1**
+- `barrel`: **5**
+- `conventional-doc`: **5**
+- `ecosystem-required`: **7**
+- `test-convention`: **4**
+
+## Interpretation Note
+
+Repo scope remains the full migration baseline and intentionally includes docs-heavy legacy exceptions.
+
+## Determinism Note
+
+Repeated runs for the same scope/repo state produced identical ordering and counts.

--- a/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -1,17 +1,17 @@
-# Naming Validator Spec (V0.1.1)
+# Naming Validator Spec (V0.1.2)
 
 ## Purpose and Scope
 
-This document defines the V0.1.1 filename naming validator slice for deterministic automation.
+This document defines the V0.1.2 filename naming validator slice for deterministic automation.
 
-V0.1.1 scope is intentionally narrow:
+V0.1.2 scope is intentionally narrow:
 - filename validation only
 - report mode only
 - deterministic findings output
-- richer diagnostics for migration planning
+- deterministic scope profiles for migration planning
 - no rename enforcement
 
-Out of scope for V0.1.1:
+Out of scope for V0.1.2:
 - structural addressing validation
 - NL↔Code numbering/parity validation
 - provenance token consistency checks
@@ -28,19 +28,19 @@ Supporting workflow alignment:
 - `doc/ConventionRoutines/CSCS.md`
 - `doc/ConventionRoutines/CCPP.md`
 
-## Canonical Filename Contract (V0.1.1)
+## Canonical Filename Contract (V0.1.2)
 
 Canonical grammar:
 - `<semantic-name>.<role>.<ext>`
 
-Recognized compound format suffixes in V0.1.1:
+Recognized compound format suffixes in V0.1.2:
 - `module.css`
 
-Filename grammar is unchanged from V0.1.
+Filename grammar is unchanged from V0.1.1.
 
-## Role Registry Metadata (V0.1.1)
+## Role Registry Metadata (V0.1.2)
 
-V0.1.1 uses a structured role registry with metadata:
+V0.1.2 uses a structured role registry with metadata:
 - `role`
 - `category` (`concern-core` | `architecture-support` | `deprecated`)
 - `status` (`active` | `deprecated`)
@@ -69,24 +69,63 @@ Parsing assumptions:
 - for `module.css`, role is the segment before `module`
 - role suffix must be dot-separated (not hyphen-appended)
 
-## Input Scope Modes
+## Input Scope Profiles (V0.1.2)
 
-V0.1.1 defines these modes:
+V0.1.2 implements deterministic scope profiles selected by CLI.
 
-1. `all-files` (implemented)
-   - scans repository files with deterministic sorting
-2. `folder-targeted` (placeholder in spec)
-   - planned: scan only selected folder prefixes
-3. `changed-files` (placeholder in spec)
-   - planned: scan files from VCS diff set
+### Default scope
+- default scope is `repo`
+
+### `repo` scope
+- current repository-wide behavior
+- includes all reportable files under repository root, excluding explicit walk exclusions (`.git`, `node_modules`, `dist`, `coverage`, `.vite`)
+
+### `app` scope
+- includes explicit roots:
+  - `src/`
+  - `test/`
+  - `scripts/`
+- includes explicit root tooling files (when present):
+  - `package.json`
+  - `package-lock.json`
+  - `eslint.config.js`
+  - `eslint.config.mjs`
+  - `vite.config.ts`
+  - `vite.config.js`
+  - `vite.config.mjs`
+  - `tsconfig.json`
+  - `tsconfig.app.json`
+  - `tsconfig.node.json`
+- excludes docs roots by profile definition
+
+### `docs` scope
+- includes explicit roots:
+  - `doc/`
+  - `docs/`
+- includes explicit root doc file:
+  - `README.md`
+- excludes `src/` by profile definition
+
+### Invalid scope behavior
+- invalid scope values are treated as deterministic CLI usage errors
+- CLI prints usage/help text and exits non-zero
+
+## CLI Usage (V0.1.2)
+
+- `npm run validate:naming` (defaults to `--scope=repo`)
+- `npm run validate:naming -- --scope=repo`
+- `npm run validate:naming -- --scope=app`
+- `npm run validate:naming -- --scope=docs`
 
 ## Classification Outputs
 
-Stable classifications used by V0.1.1:
+Stable classifications used by V0.1.2:
 - `canonical`
 - `allowed-special-case`
 - `legacy-exception`
 - `invalid-ambiguous`
+
+Classification semantics are unchanged from V0.1.1. Scope profiles only change selected input paths.
 
 ## Finding Schema
 
@@ -100,16 +139,21 @@ Each finding uses a stable object shape:
 - `suggestedFix` (optional)
 - `details` (optional object)
 
+Report object includes:
+- `mode`
+- `scope`
+- `totalFilesScanned`
+- summary count objects
+- `findings`
+
 ### Special-case subtype metadata
 
-V0.1.1 keeps top-level classification `allowed-special-case` and adds deterministic subtype metadata in `details.specialCaseType`:
+V0.1.2 keeps top-level classification `allowed-special-case` and includes deterministic subtype metadata in `details.specialCaseType`:
 - `ecosystem-required`: `package.json`, `package-lock.json`, `tsconfig*.json`, `vite.config.*`, `eslint.config.*`
 - `barrel`: `index.ts`, `index.tsx`
 - `test-convention`: `*.test.*`, `*.spec.*`
 - `ambient-declaration`: `*.d.ts`
 - `conventional-doc`: `README.md`
-
-README policy in V0.1.1: `README.md` is treated as `allowed-special-case` with subtype `conventional-doc`.
 
 ### Deprecated role metadata
 
@@ -122,7 +166,7 @@ When a canonical-like parse resolves to a known deprecated role (currently `view
   - optional `deprecationNote`
 - validator does not auto-map deprecated role to modern roles (manual migration required)
 
-## Finding / Error Codes (V0.1.1)
+## Finding / Error Codes (V0.1.2)
 
 - `NAMING_CANONICAL`
 - `NAMING_ALLOWED_SPECIAL_CASE`
@@ -132,29 +176,26 @@ When a canonical-like parse resolves to a known deprecated role (currently `view
 - `NAMING_BAD_SEMANTIC_CASE`
 - `NAMING_ROLE_HYPHEN_AMBIGUITY`
 
-Code alignment note: `NAMING_INVALID_PATTERN` is deferred/removed from active V0.1.1 emission because unmatched filenames are intentionally classified as `NAMING_LEGACY_EXCEPTION` in report mode.
-
 ## Rollout Modes
 
-- `report` (V0.1.1 behavior)
+- `report` (V0.1.2 behavior)
   - always emits findings and summary
-  - never fails build in V0.1.1
+  - never fails build for naming findings in V0.1.2
 - `soft-fail` (deferred)
-  - planned targeted enforcement by folders or changed files
 - `hard-fail` (deferred)
-  - planned full enforcement with explicit exceptions
 
 ## Exit Code Behavior
 
-V0.1.1 report mode exit behavior:
-- process exits `0`
-- invalid findings are reported but do not fail command
+V0.1.2 report mode exit behavior:
+- valid runs exit `0`
+- naming invalid findings are reported but do not fail command
+- invalid CLI usage (e.g., unknown `--scope`) exits non-zero
 
 ## Allowed Special-Case Handling Rules
 
-V0.1.1 recognizes these special cases:
+V0.1.2 recognizes these special cases:
 - barrel files: `index.ts`, `index.tsx`
-- framework/tool required names (root/tooling config patterns):
+- framework/tool required names:
   - `package.json`
   - `package-lock.json`
   - `tsconfig*.json`
@@ -164,28 +205,37 @@ V0.1.1 recognizes these special cases:
 - ambient declarations: `*.d.ts`
 - conventional docs: `README.md`
 
-Special-case list is explicit and intentionally narrow in V0.1.1.
-
 ## Legacy Exception Handling Rules
 
-For incremental adoption, V0.1.1 classifies non-canonical in-scope files as `legacy-exception` when they do not clearly claim canonical syntax.
+For incremental adoption, V0.1.2 classifies non-canonical in-scope files as `legacy-exception` when they do not clearly claim canonical syntax.
 
 A file is `invalid-ambiguous` instead of `legacy-exception` when it presents canonical intent but violates contract deterministically, including:
 - unknown role segment in canonical position
 - deprecated role segment in canonical position
 - semantic-name casing violation in canonical position
-- hyphen-appended role ambiguity (e.g., `leftpanel-selector-wiring.ts`)
+- hyphen-appended role ambiguity
 
 ## Determinism Requirements
 
 - normalize path separators to `/`
+- scope profile include sets are explicit
+- deduplicate overlapping inclusions before classification
 - sort findings by normalized path ascending
 - stable classification and code assignment per filename
 - deterministic summary breakdown ordering
+- same scope + same repository state => identical counts and ordering
 
-## Non-Goals (V0.1.1)
+## Summary / Reporting Expectations by Scope
 
+- `repo`: full baseline for complete repository migration visibility
+- `app`: app-focused baseline to reduce docs-driven legacy-exception noise
+- `docs`: docs-focused baseline for documentation naming profile visibility
+
+## Non-Goals (V0.1.2)
+
+- changed-files mode (deferred)
 - no automatic rename suggestions beyond optional textual hints
 - no repository-wide rename migration
 - no automatic suppression generation
 - no cross-file semantic validation
+- no role taxonomy expansion for `provider`/`catalog`/`ids`/`anchor` in this slice

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.1** (report-mode polish pass).
+Current implementation target: **V0.1.2** (report-mode scope-profile polish pass).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -10,8 +10,13 @@ Define a deterministic V0.1 filename naming validator that runs in report mode o
 ### 2.1 Naming authority
 The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` as authoritative naming guidance.
 
-### 2.2 Scope mode (V0.1)
-V0.1 scans repository files in all-files mode with deterministic path ordering.
+### 2.2 Scope mode (V0.1.2)
+V0.1.2 supports deterministic scope profiles selected via CLI and applied before filename classification:
+- `repo` (default): repository-wide reportable files.
+- `app`: app-focused files (`src/`, `test/`, `scripts/`, and explicit root tooling files).
+- `docs`: docs-focused files (`doc/`, `docs/`, and root `README.md`).
+
+All scope profile inclusions are explicit and deterministic. Invalid scope inputs are treated as CLI usage errors.
 
 ### 2.3 Role registry metadata (V0.1.1)
 The validator uses a structured role registry with metadata fields:
@@ -61,14 +66,17 @@ Each finding includes code, severity, path, classification, message, ruleRef, an
 ### 4.2 Deterministic ordering
 Findings and summary output sort by normalized relative path.
 
-### 4.3 Summary breakdowns (V0.1.1)
+### 4.3 Summary breakdowns (V0.1.2)
 Report output includes deterministic summary breakdowns for:
 - classification counts
 - finding code counts
 - special-case subtype counts
 - warning role status/category counts (when metadata is present)
 
-### 4.4 Exit behavior (report mode)
+### 4.4 Scope-aware reporting metadata (V0.1.2)
+Report output includes selected scope metadata and deterministic file-count/findings summaries within that scope.
+
+### 4.5 Exit behavior (report mode)
 Report mode always exits with status code 0 and prints counts by classification.
 
 ## 5.0 Deferred Behavior

--- a/scripts/validate-naming.mjs
+++ b/scripts/validate-naming.mjs
@@ -1,16 +1,62 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runNamingValidator, summarizeFindings } from '../src/validators/naming-validator.logic.mjs';
+import {
+  runNamingValidator,
+  summarizeFindings,
+  listNamingValidatorScopes,
+  getScopeProfile,
+} from '../src/validators/naming-validator.logic.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repositoryRoot = path.resolve(__dirname, '..');
 
-const { findings, totalFilesScanned } = runNamingValidator(repositoryRoot);
+const parseScopeFromCli = argv => {
+  let selectedScope = 'repo';
+
+  for (const argument of argv) {
+    if (argument.startsWith('--scope=')) {
+      selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    if (argument === '--help' || argument === '-h') {
+      return { helpRequested: true, selectedScope };
+    }
+  }
+
+  return { helpRequested: false, selectedScope };
+};
+
+const usageLines = [
+  'Usage: npm run validate:naming -- --scope=<repo|app|docs>',
+  'Scopes:',
+  ...listNamingValidatorScopes().map(scope => {
+    const profile = getScopeProfile(scope);
+    return `  - ${scope}: ${profile?.description ?? ''}`;
+  }),
+  'Default scope: repo',
+];
+
+const { helpRequested, selectedScope } = parseScopeFromCli(process.argv.slice(2));
+
+if (helpRequested) {
+  console.log(usageLines.join('\n'));
+  process.exit(0);
+}
+
+if (!getScopeProfile(selectedScope)) {
+  console.error(`Invalid scope: ${selectedScope}`);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: selectedScope });
 const summary = summarizeFindings(findings);
 
 const report = {
   mode: 'report',
+  scope,
   totalFilesScanned,
   counts: summary.counts,
   codeCounts: summary.codeCounts,

--- a/src/validators/naming-validator.logic.mjs
+++ b/src/validators/naming-validator.logic.mjs
@@ -37,6 +37,37 @@ const REPORTABLE_EXTENSIONS = new Set([
 
 const EXCLUDED_DIRECTORIES = new Set(['.git', 'node_modules', 'dist', 'coverage', '.vite']);
 
+const ROOT_APP_FILES = new Set([
+  'package.json',
+  'package-lock.json',
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'vite.config.ts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'tsconfig.json',
+  'tsconfig.app.json',
+  'tsconfig.node.json',
+]);
+
+const SCOPE_PROFILES = {
+  repo: {
+    description: 'Repository-wide scan of all reportable files.',
+    includeRoots: ['.'],
+    includeRootFiles: [],
+  },
+  app: {
+    description: 'Application-focused scan (src/test/scripts and root tooling files).',
+    includeRoots: ['src', 'test', 'scripts'],
+    includeRootFiles: Array.from(ROOT_APP_FILES),
+  },
+  docs: {
+    description: 'Documentation-focused scan (doc/docs and root README).',
+    includeRoots: ['doc', 'docs'],
+    includeRootFiles: ['README.md'],
+  },
+};
+
 export const normalizePath = relativePath => relativePath.split(path.sep).join('/');
 
 const getSpecialCaseType = filePath => {
@@ -118,6 +149,111 @@ const isReportableFile = relativePath => {
   }
 
   return path.basename(relativePath) === 'package-lock.json' || path.basename(relativePath) === 'package.json';
+};
+
+const sortPaths = paths => Array.from(paths).sort((left, right) => left.localeCompare(right));
+
+const collectPathsFromRoot = (rootDirectory, rootRelativePath) => {
+  const normalizedRoot = normalizePath(rootRelativePath);
+  const absoluteRoot = path.resolve(rootDirectory, normalizedRoot);
+  if (!fs.existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  const stat = fs.statSync(absoluteRoot);
+  if (!stat.isDirectory()) {
+    return [];
+  }
+
+  const collected = [];
+
+  const walk = absoluteDirectoryPath => {
+    const entries = fs.readdirSync(absoluteDirectoryPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') && entry.name !== '.eslintrc') {
+        if (entry.isDirectory()) {
+          continue;
+        }
+      }
+
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRECTORIES.has(entry.name)) {
+          continue;
+        }
+
+        walk(path.join(absoluteDirectoryPath, entry.name));
+        continue;
+      }
+
+      const absolutePath = path.join(absoluteDirectoryPath, entry.name);
+      const relativePath = path.relative(rootDirectory, absolutePath);
+      const normalizedPath = normalizePath(relativePath);
+      if (isReportableFile(normalizedPath)) {
+        collected.push(normalizedPath);
+      }
+    }
+  };
+
+  walk(absoluteRoot);
+  return collected;
+};
+
+const collectRootFiles = (rootDirectory, rootFiles) => {
+  const collected = [];
+
+  for (const rootFile of rootFiles) {
+    const normalizedPath = normalizePath(rootFile);
+    const absolutePath = path.resolve(rootDirectory, normalizedPath);
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+
+    const stat = fs.statSync(absolutePath);
+    if (!stat.isFile()) {
+      continue;
+    }
+
+    if (isReportableFile(normalizedPath)) {
+      collected.push(normalizedPath);
+    }
+  }
+
+  return collected;
+};
+
+export const listNamingValidatorScopes = () => sortPaths(new Set(Object.keys(SCOPE_PROFILES)));
+
+export const getScopeProfile = scope => {
+  const normalizedScope = scope ?? 'repo';
+  return SCOPE_PROFILES[normalizedScope] ?? null;
+};
+
+export const collectRepositoryPaths = (rootDirectory, options = {}) => {
+  const selectedScope = options.scope ?? 'repo';
+  const profile = getScopeProfile(selectedScope);
+  if (!profile) {
+    throw new Error(`Invalid scope profile: ${selectedScope}`);
+  }
+
+  if (selectedScope === 'repo') {
+    return sortPaths(new Set(collectPathsFromRoot(rootDirectory, '.')));
+  }
+
+  const collected = new Set();
+
+  for (const includeRoot of profile.includeRoots) {
+    const paths = collectPathsFromRoot(rootDirectory, includeRoot);
+    for (const pathname of paths) {
+      collected.add(pathname);
+    }
+  }
+
+  for (const pathname of collectRootFiles(rootDirectory, profile.includeRootFiles)) {
+    collected.add(pathname);
+  }
+
+  return sortPaths(collected);
 };
 
 export const classifyPath = relativePath => {
@@ -240,48 +376,15 @@ export const classifyPath = relativePath => {
   };
 };
 
-export const collectRepositoryPaths = rootDirectory => {
-  const collected = [];
-
-  const walk = absoluteDirectoryPath => {
-    const entries = fs.readdirSync(absoluteDirectoryPath, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (entry.name.startsWith('.') && entry.name !== '.eslintrc') {
-        if (entry.isDirectory()) {
-          continue;
-        }
-      }
-
-      if (entry.isDirectory()) {
-        if (EXCLUDED_DIRECTORIES.has(entry.name)) {
-          continue;
-        }
-
-        walk(path.join(absoluteDirectoryPath, entry.name));
-        continue;
-      }
-
-      const absolutePath = path.join(absoluteDirectoryPath, entry.name);
-      const relativePath = path.relative(rootDirectory, absolutePath);
-      if (isReportableFile(relativePath)) {
-        collected.push(normalizePath(relativePath));
-      }
-    }
-  };
-
-  walk(rootDirectory);
-
-  return collected.sort((left, right) => left.localeCompare(right));
-};
-
-export const runNamingValidator = rootDirectory => {
-  const paths = collectRepositoryPaths(rootDirectory);
+export const runNamingValidator = (rootDirectory, options = {}) => {
+  const selectedScope = options.scope ?? 'repo';
+  const paths = collectRepositoryPaths(rootDirectory, { scope: selectedScope });
   const findings = paths.map(pathname => classifyPath(pathname));
 
   return {
     findings,
     totalFilesScanned: paths.length,
+    scope: selectedScope,
   };
 };
 

--- a/test/naming-validator.test.mjs
+++ b/test/naming-validator.test.mjs
@@ -1,6 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyPath, parseCanonicalName } from '../src/validators/naming-validator.logic.mjs';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import {
+  classifyPath,
+  parseCanonicalName,
+  collectRepositoryPaths,
+} from '../src/validators/naming-validator.logic.mjs';
 
 test('parse canonical filename with simple extension', () => {
   assert.deepEqual(parseCanonicalName('leftpanel.host.tsx'), {
@@ -86,4 +94,62 @@ test('classifies legacy exceptions for non-canonical legacy names', () => {
   const finding = classifyPath('src/App.tsx');
   assert.equal(finding.classification, 'legacy-exception');
   assert.equal(finding.code, 'NAMING_LEGACY_EXCEPTION');
+});
+
+test('repo scope includes docs + src + root config examples', () => {
+  const paths = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
+  assert.ok(paths.includes('src/validators/naming-validator.logic.mjs'));
+  assert.ok(paths.includes('doc/ConventionRoutines/NamingValidatorSpec.md'));
+  assert.ok(paths.includes('package.json'));
+});
+
+test('app scope excludes docs and includes src/test/scripts/root tooling files', () => {
+  const paths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
+  assert.ok(paths.includes('src/validators/naming-validator.logic.mjs'));
+  assert.ok(paths.includes('test/naming-validator.test.mjs'));
+  assert.ok(paths.includes('scripts/validate-naming.mjs'));
+  assert.ok(paths.includes('package.json'));
+  assert.equal(paths.some(p => p.startsWith('doc/')), false);
+  assert.equal(paths.some(p => p.startsWith('docs/')), false);
+});
+
+test('docs scope includes doc/docs and excludes src', () => {
+  const paths = collectRepositoryPaths(process.cwd(), { scope: 'docs' });
+  assert.ok(paths.includes('doc/ConventionRoutines/NamingValidatorSpec.md'));
+  assert.equal(paths.some(p => p.startsWith('src/')), false);
+});
+
+test('scope filtering output order is deterministic', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-scope-order-'));
+  try {
+    fs.mkdirSync(path.join(tempRoot, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(tempRoot, 'test'), { recursive: true });
+    fs.mkdirSync(path.join(tempRoot, 'doc'), { recursive: true });
+
+    fs.writeFileSync(path.join(tempRoot, 'src', 'z-last.logic.ts'), '');
+    fs.writeFileSync(path.join(tempRoot, 'src', 'a-first.logic.ts'), '');
+    fs.writeFileSync(path.join(tempRoot, 'test', 'c-mid.test.mjs'), '');
+    fs.writeFileSync(path.join(tempRoot, 'doc', 'b-guide.md'), '');
+    fs.writeFileSync(path.join(tempRoot, 'package.json'), '{}');
+
+    const first = collectRepositoryPaths(tempRoot, { scope: 'app' });
+    const second = collectRepositoryPaths(tempRoot, { scope: 'app' });
+
+    assert.deepEqual(first, second);
+    assert.deepEqual(first, [...first].sort((a, b) => a.localeCompare(b)));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('invalid CLI scope returns deterministic usage error and non-zero exit', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', 'scripts/validate-naming.mjs', '--scope=invalid-scope'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Invalid scope: invalid-scope/u);
+  assert.match(result.stderr, /Usage: npm run validate:naming -- --scope=<repo\|app\|docs>/u);
 });


### PR DESCRIPTION
### Motivation
- Reduce docs-driven noise in naming reports by enabling deterministic scope profiles so the same validator can be run against targeted parts of the repo without changing classification grammar.
- Preserve existing classification semantics and determinism while improving CLI/report usability for migration planning.

### Description
- Implemented deterministic scope profiles in the validator logic (`src/validators/naming-validator.logic.mjs`) with a central `SCOPE_PROFILES` map, explicit include roots and root-file lists, deduplication of overlapping inclusions, and deterministic sorting of collected paths.
- Extended `runNamingValidator` to accept a `--scope` option and return the selected scope in the report while keeping classification logic unchanged for chosen files.
- Added CLI scope parsing, usage/help text, and invalid-scope handling (non-zero exit) in `scripts/validate-naming.mjs`, and included scope metadata in the JSON report.
- Updated spec and NL skeleton docs to V0.1.2 (`doc/ConventionRoutines/NamingValidatorSpec.md`, `doc/nl-config/cfg-namingValidator.md`) and added targeted baseline summaries for `repo`, `app`, and `docs` under `doc/ComplianceAudits/`.
- Expanded unit tests (`test/naming-validator.test.mjs`) to cover scope filtering behavior, deterministic ordering, and invalid CLI scope behavior.

### Testing
- Ran `npm test` and all new and existing tests passed (36 tests, 0 failures). (ok)
- Ran `npm run validate:naming` and scope-specific runs: `--scope=repo`, `--scope=app`, `--scope=docs`, and verified outputs; repeated `app` and `docs` runs were identical, demonstrating determinism (ok).
- Verified invalid CLI scope returns deterministic usage text and non-zero exit (`--scope=wat`), and validated generated baseline summary docs for each scope (ok).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eaa8cdd308331a4eadd96a2b34f4e)