### PR TITLE
Harden validate:naming scope contract semantics

### DIFF
--- a/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -1,4 +1,4 @@
-# Naming Validator Spec (V0.1.2)
+# Naming Validator Spec (V0.1.3)
 
 ## Purpose and Scope
 
@@ -109,6 +109,24 @@ V0.1.2 implements deterministic scope profiles selected by CLI.
 ### Invalid scope behavior
 - invalid scope values are treated as deterministic CLI usage errors
 - CLI prints usage/help text and exits non-zero
+
+## Scope Contract (V0.1.3)
+
+Supported scopes:
+- `repo`
+- `app`
+- `docs`
+
+Default behavior:
+- No `--scope` input is equivalent to `--scope=repo`.
+
+Inclusion/exclusion summary:
+- `repo`: all reportable files under repository root (minus explicit walker exclusions).
+- `app`: includes `src/**`, `test/**`, `scripts/**`, and explicit root tooling files; excludes `doc/**` and `docs/**`.
+- `docs`: includes `doc/**`, `docs/**`, and selected root conventional docs currently limited to `README.md`; excludes `src/**` by profile definition.
+
+Invalid scope behavior:
+- Unknown scope values are usage errors with non-zero exit and valid-scope usage text.
 
 ## CLI Usage (V0.1.2)
 

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.2** (report-mode scope-profile polish pass).
+Current implementation target: **V0.1.3** (scope contract hardening pass).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -10,11 +10,12 @@ Define a deterministic V0.1 filename naming validator that runs in report mode o
 ### 2.1 Naming authority
 The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` as authoritative naming guidance.
 
-### 2.2 Scope mode (V0.1.2)
-V0.1.2 supports deterministic scope profiles selected via CLI and applied before filename classification:
-- `repo` (default): repository-wide reportable files.
+### 2.2 Scope mode (V0.1.3)
+V0.1.3 supports deterministic scope profiles selected via CLI and applied before filename classification:
+- default/no `--scope` input resolves to `repo`
+- `repo`: repository-wide reportable files.
 - `app`: app-focused files (`src/`, `test/`, `scripts/`, and explicit root tooling files).
-- `docs`: docs-focused files (`doc/`, `docs/`, and root `README.md`).
+- `docs`: docs-focused files (`doc/`, `docs/`, and selected root conventional docs currently limited to `README.md`).
 
 All scope profile inclusions are explicit and deterministic. Invalid scope inputs are treated as CLI usage errors.
 

--- a/scripts/validate-naming.mjs
+++ b/scripts/validate-naming.mjs
@@ -51,6 +51,7 @@ if (!getScopeProfile(selectedScope)) {
   process.exit(1);
 }
 
+const selectedScopeProfile = getScopeProfile(selectedScope);
 const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: selectedScope });
 const summary = summarizeFindings(findings);
 
@@ -58,6 +59,11 @@ const report = {
   mode: 'report',
   scope,
   totalFilesScanned,
+  scopeContract: {
+    description: selectedScopeProfile?.description ?? '',
+    includeRoots: selectedScopeProfile?.includeRoots ?? [],
+    includeRootFiles: selectedScopeProfile?.includeRootFiles ?? [],
+  },
   counts: summary.counts,
   codeCounts: summary.codeCounts,
   specialCaseTypeCounts: summary.specialCaseTypeCounts,

--- a/src/validators/naming-validator.logic.mjs
+++ b/src/validators/naming-validator.logic.mjs
@@ -62,11 +62,17 @@ const SCOPE_PROFILES = {
     includeRootFiles: Array.from(ROOT_APP_FILES),
   },
   docs: {
-    description: 'Documentation-focused scan (doc/docs and root README).',
+    description: 'Documentation-focused scan (doc/docs and root conventional docs: README.md).',
     includeRoots: ['doc', 'docs'],
     includeRootFiles: ['README.md'],
   },
 };
+
+const cloneScopeProfile = profile => ({
+  description: profile.description,
+  includeRoots: [...profile.includeRoots],
+  includeRootFiles: [...profile.includeRootFiles],
+});
 
 export const normalizePath = relativePath => relativePath.split(path.sep).join('/');
 
@@ -226,7 +232,8 @@ export const listNamingValidatorScopes = () => sortPaths(new Set(Object.keys(SCO
 
 export const getScopeProfile = scope => {
   const normalizedScope = scope ?? 'repo';
-  return SCOPE_PROFILES[normalizedScope] ?? null;
+  const profile = SCOPE_PROFILES[normalizedScope];
+  return profile ? cloneScopeProfile(profile) : null;
 };
 
 export const collectRepositoryPaths = (rootDirectory, options = {}) => {

--- a/test/naming-validator-scope-contract.test.mjs
+++ b/test/naming-validator-scope-contract.test.mjs
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  collectRepositoryPaths,
+  getScopeProfile,
+  listNamingValidatorScopes,
+} from '../src/validators/naming-validator.logic.mjs';
+
+const runValidatorCli = args =>
+  spawnSync(process.execPath, ['--experimental-strip-types', 'scripts/validate-naming.mjs', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+test('scope registry exposes deterministic supported scopes', () => {
+  assert.deepEqual(listNamingValidatorScopes(), ['app', 'docs', 'repo']);
+});
+
+test('default/no-scope behavior resolves to repo', () => {
+  const implicit = collectRepositoryPaths(process.cwd());
+  const explicit = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
+  assert.deepEqual(implicit, explicit);
+});
+
+test('--scope=repo aligns with repo contract roots', () => {
+  const repoPaths = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
+  assert.ok(repoPaths.includes('src/validators/naming-validator.logic.mjs'));
+  assert.ok(repoPaths.includes('doc/ConventionRoutines/NamingValidatorSpec.md'));
+  assert.ok(repoPaths.includes('README.md'));
+});
+
+test('--scope=docs includes doc/**, docs/**, and root README.md only from root conventional docs set', () => {
+  const docsPaths = collectRepositoryPaths(process.cwd(), { scope: 'docs' });
+  assert.ok(docsPaths.includes('doc/ConventionRoutines/NamingValidatorSpec.md'));
+  assert.ok(docsPaths.includes('README.md'));
+  assert.equal(docsPaths.some(pathname => pathname.startsWith('src/')), false);
+  assert.equal(docsPaths.some(pathname => pathname === 'package.json'), false);
+});
+
+test('--scope=app excludes doc/docs folders while including app roots and root tooling files', () => {
+  const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
+  assert.ok(appPaths.includes('src/validators/naming-validator.logic.mjs'));
+  assert.ok(appPaths.includes('test/naming-validator.test.mjs'));
+  assert.ok(appPaths.includes('scripts/validate-naming.mjs'));
+  assert.ok(appPaths.includes('package.json'));
+  assert.equal(appPaths.some(pathname => pathname.startsWith('doc/')), false);
+  assert.equal(appPaths.some(pathname => pathname.startsWith('docs/')), false);
+});
+
+test('docs scope profile explicitly declares root conventional docs inclusion contract', () => {
+  const profile = getScopeProfile('docs');
+  assert.deepEqual(profile, {
+    description: 'Documentation-focused scan (doc/docs and root conventional docs: README.md).',
+    includeRoots: ['doc', 'docs'],
+    includeRootFiles: ['README.md'],
+  });
+});
+
+test('invalid scope handling is deterministic (usage error + non-zero exit)', () => {
+  const result = runValidatorCli(['--scope=not-a-scope']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Invalid scope: not-a-scope/u);
+  assert.match(result.stderr, /Usage: npm run validate:naming -- --scope=<repo\|app\|docs>/u);
+});
+
+test('CLI default scope report is repo', () => {
+  const result = runValidatorCli([]);
+  assert.equal(result.status, 0);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.scope, 'repo');
+});
+
+test('CLI explicit scope reports selected scope', () => {
+  const result = runValidatorCli(['--scope=docs']);
+  assert.equal(result.status, 0);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.scope, 'docs');
+  assert.deepEqual(report.scopeContract.includeRoots, ['doc', 'docs']);
+  assert.deepEqual(report.scopeContract.includeRootFiles, ['README.md']);
+});


### PR DESCRIPTION
### Motivation
- Make `--scope=docs` semantics explicit and deterministic so humans and automation can rely on a stable contract. 
- Provide a single source-of-truth for supported scopes to avoid scattered conditionals and ambiguous behavior. 
- Lock scope behavior with tests and surface the chosen scope contract in CLI JSON output for easier automation/debugging.

### Description
- Consolidated scope profiles into `SCOPE_PROFILES` in `src/validators/naming-validator.logic.mjs` and clarified the `docs` profile to explicitly include `doc/**`, `docs/**`, and the root conventional doc `README.md`. 
- Returned cloned scope profile objects from `getScopeProfile` to avoid accidental mutation of shared profile data. 
- Added `scopeContract` metadata to the CLI report in `scripts/validate-naming.mjs` so the JSON output includes `description`, `includeRoots`, and `includeRootFiles` for the selected scope. 
- Added a focused test file `test/naming-validator-scope-contract.test.mjs` to assert default scope = `repo`, `repo|app|docs` semantics, docs-scope inclusion of `README.md`, app-scope exclusion of docs, and deterministic invalid-scope handling. 
- Updated spec and NL config docs: `doc/ConventionRoutines/NamingValidatorSpec.md` (now V0.1.3, added a Scope Contract section) and `doc/nl-config/cfg-namingValidator.md` (updated to V0.1.3 and clarified scope text).

### Testing
- Ran `npm run validate:naming` (default) and it completed successfully and reported `scope: "repo"`. 
- Ran `npm run validate:naming -- --scope=repo`, `--scope=app`, and `--scope=docs` and each produced successful JSON reports matching the documented `includeRoots`/`includeRootFiles`. 
- Ran `npm run validate:naming -- --scope=not-a-scope` and verified a deterministic usage error with a non-zero exit. 
- Ran the repo test suite with `npm test` (including the new scope-contract tests) and all tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb1cfec0883318d972a5e6a07205f)