### PR TITLE
Enforce scope filtering in naming validator; add scope observability metadata and tests

### DIFF
--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.3** (scope contract hardening pass).
+Current implementation target: **V0.1.4** (scope filter enforcement + scope contract hardening).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -10,14 +10,14 @@ Define a deterministic V0.1 filename naming validator that runs in report mode o
 ### 2.1 Naming authority
 The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` as authoritative naming guidance.
 
-### 2.2 Scope mode (V0.1.3)
-V0.1.3 supports deterministic scope profiles selected via CLI and applied before filename classification:
+### 2.2 Scope mode (V0.1.4)
+V0.1.4 supports deterministic scope profiles selected via CLI and applied before filename classification using explicit scope path predicates:
 - default/no `--scope` input resolves to `repo`
 - `repo`: repository-wide reportable files.
 - `app`: app-focused files (`src/`, `test/`, `scripts/`, and explicit root tooling files).
 - `docs`: docs-focused files (`doc/`, `docs/`, and selected root conventional docs currently limited to `README.md`).
 
-All scope profile inclusions are explicit and deterministic. Invalid scope inputs are treated as CLI usage errors.
+Scope predicates are evaluated on normalized repository-relative paths before report findings are generated. Invalid scope inputs are treated as CLI usage errors.
 
 ### 2.3 Role registry metadata (V0.1.1)
 The validator uses a structured role registry with metadata fields:
@@ -77,7 +77,15 @@ Report output includes deterministic summary breakdowns for:
 ### 4.4 Scope-aware reporting metadata (V0.1.2)
 Report output includes selected scope metadata and deterministic file-count/findings summaries within that scope.
 
-### 4.5 Exit behavior (report mode)
+### 4.5 Scope observability metadata (V0.1.4)
+Report output includes additive scope observability metadata:
+- `scopeSummary.scope`
+- `scopeSummary.reportableFilesInScope`
+- `scopeSummary.findingsGenerated`
+
+This metadata is additive and does not alter legacy report-mode findings behavior.
+
+### 4.6 Exit behavior (report mode)
 Report mode always exits with status code 0 and prints counts by classification.
 
 ## 5.0 Deferred Behavior

--- a/scripts/validate-naming.mjs
+++ b/scripts/validate-naming.mjs
@@ -59,6 +59,11 @@ const report = {
   mode: 'report',
   scope,
   totalFilesScanned,
+  scopeSummary: {
+    scope,
+    reportableFilesInScope: totalFilesScanned,
+    findingsGenerated: findings.length,
+  },
   scopeContract: {
     description: selectedScopeProfile?.description ?? '',
     includeRoots: selectedScopeProfile?.includeRoots ?? [],

--- a/src/validators/naming-validator.logic.mjs
+++ b/src/validators/naming-validator.logic.mjs
@@ -159,7 +159,7 @@ const isReportableFile = relativePath => {
 
 const sortPaths = paths => Array.from(paths).sort((left, right) => left.localeCompare(right));
 
-const collectPathsFromRoot = (rootDirectory, rootRelativePath) => {
+const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.') => {
   const normalizedRoot = normalizePath(rootRelativePath);
   const absoluteRoot = path.resolve(rootDirectory, normalizedRoot);
   if (!fs.existsSync(absoluteRoot)) {
@@ -205,27 +205,19 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath) => {
   return collected;
 };
 
-const collectRootFiles = (rootDirectory, rootFiles) => {
-  const collected = [];
+const buildScopePathPredicate = profile => {
+  const includeRootSet = new Set(profile.includeRoots.map(normalizePath));
+  const includeRootFileSet = new Set(profile.includeRootFiles.map(normalizePath));
 
-  for (const rootFile of rootFiles) {
-    const normalizedPath = normalizePath(rootFile);
-    const absolutePath = path.resolve(rootDirectory, normalizedPath);
-    if (!fs.existsSync(absolutePath)) {
-      continue;
+  return relativePath => {
+    const normalizedPath = normalizePath(relativePath);
+    if (normalizedPath.includes('/')) {
+      const firstSegment = normalizedPath.split('/')[0];
+      return includeRootSet.has(firstSegment);
     }
 
-    const stat = fs.statSync(absolutePath);
-    if (!stat.isFile()) {
-      continue;
-    }
-
-    if (isReportableFile(normalizedPath)) {
-      collected.push(normalizedPath);
-    }
-  }
-
-  return collected;
+    return includeRootFileSet.has(normalizedPath);
+  };
 };
 
 export const listNamingValidatorScopes = () => sortPaths(new Set(Object.keys(SCOPE_PROFILES)));
@@ -243,24 +235,15 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
     throw new Error(`Invalid scope profile: ${selectedScope}`);
   }
 
+  const allReportablePaths = collectPathsFromRoot(rootDirectory, '.');
+
   if (selectedScope === 'repo') {
-    return sortPaths(new Set(collectPathsFromRoot(rootDirectory, '.')));
+    return sortPaths(new Set(allReportablePaths));
   }
 
-  const collected = new Set();
-
-  for (const includeRoot of profile.includeRoots) {
-    const paths = collectPathsFromRoot(rootDirectory, includeRoot);
-    for (const pathname of paths) {
-      collected.add(pathname);
-    }
-  }
-
-  for (const pathname of collectRootFiles(rootDirectory, profile.includeRootFiles)) {
-    collected.add(pathname);
-  }
-
-  return sortPaths(collected);
+  const scopePathPredicate = buildScopePathPredicate(profile);
+  const scopedPaths = allReportablePaths.filter(scopePathPredicate);
+  return sortPaths(new Set(scopedPaths));
 };
 
 export const classifyPath = relativePath => {

--- a/test/naming-validator-scope-contract.test.mjs
+++ b/test/naming-validator-scope-contract.test.mjs
@@ -57,6 +57,22 @@ test('docs scope profile explicitly declares root conventional docs inclusion co
   });
 });
 
+
+test('scoped path sets diverge by contract (docs excludes app roots and app excludes docs roots)', () => {
+  const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
+  const docsPaths = collectRepositoryPaths(process.cwd(), { scope: 'docs' });
+  const repoPaths = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
+
+  assert.notDeepEqual(appPaths, docsPaths);
+  assert.ok(repoPaths.length >= appPaths.length);
+  assert.ok(repoPaths.length >= docsPaths.length);
+  assert.equal(docsPaths.some(pathname => pathname.startsWith('src/')), false);
+  assert.equal(docsPaths.some(pathname => pathname.startsWith('test/')), false);
+  assert.equal(docsPaths.some(pathname => pathname.startsWith('scripts/')), false);
+  assert.equal(appPaths.some(pathname => pathname.startsWith('doc/')), false);
+  assert.equal(appPaths.some(pathname => pathname.startsWith('docs/')), false);
+});
+
 test('invalid scope handling is deterministic (usage error + non-zero exit)', () => {
   const result = runValidatorCli(['--scope=not-a-scope']);
   assert.notEqual(result.status, 0);
@@ -71,11 +87,14 @@ test('CLI default scope report is repo', () => {
   assert.equal(report.scope, 'repo');
 });
 
-test('CLI explicit scope reports selected scope', () => {
+test('CLI explicit scope reports selected scope and scope summary metadata', () => {
   const result = runValidatorCli(['--scope=docs']);
   assert.equal(result.status, 0);
   const report = JSON.parse(result.stdout);
   assert.equal(report.scope, 'docs');
   assert.deepEqual(report.scopeContract.includeRoots, ['doc', 'docs']);
   assert.deepEqual(report.scopeContract.includeRootFiles, ['README.md']);
+  assert.equal(report.scopeSummary.scope, 'docs');
+  assert.equal(report.scopeSummary.reportableFilesInScope, report.totalFilesScanned);
+  assert.equal(report.scopeSummary.findingsGenerated, report.findings.length);
 });


### PR DESCRIPTION
### Motivation
- Fix a regression where `--scope=app`, `--scope=docs`, and `--scope=repo` could produce indistinguishable outputs by ensuring the selected scope actually filters the scanned file set before classification. 
- Harden the scope contract so behavior aligns with the documented CLI usage (default `repo`, `app` includes `src/test/scripts` + root tooling, `docs` includes `doc/docs` + `README.md`).
- Preserve existing invalid-scope UX (usage text + non-zero exit) and keep report-mode semantics intact.

### Description
- Apply a deterministic scope predicate over a single repository reportable-path set by adding `buildScopePathPredicate(...)` and changing `collectRepositoryPaths(...)` to collect all reportable paths once and then filter by the scope predicate for `app`/`docs`, returning full set for `repo`.
- Add additive observability metadata to the report under `scopeSummary` with `scope`, `reportableFilesInScope`, and `findingsGenerated` to make scope verification easier without breaking existing keys.
- Update tests to assert scope divergence and metadata: strengthened `test/naming-validator-scope-contract.test.mjs` to check that `app` and `docs` path sets differ and to validate the new `scopeSummary` fields.
- Update NL doc `doc/nl-config/cfg-namingValidator.md` to V0.1.4 documenting explicit scope path predicates and the new scope observability metadata.
- Files changed: `src/validators/naming-validator.logic.mjs`, `scripts/validate-naming.mjs`, `test/naming-validator-scope-contract.test.mjs`, `doc/nl-config/cfg-namingValidator.md`.

### Testing
- Ran unit tests: `npm run test -- test/naming-validator*.test.mjs` and observed all tests passing (46 tests, 0 failures).
- Ran CLI validations and spot-checked scope behavior with: `npm run validate:naming -- --scope=app`, `npm run validate:naming -- --scope=docs`, `npm run validate:naming -- --scope=repo`, and `npm run validate:naming` (default); outputs show distinct file counts and presence/absence per scope (e.g. `app` includes `src/test/scripts` and excludes `doc/docs`, `docs` includes `doc/docs` and `README.md` and excludes `src/test/scripts`, `repo`/default include both).
- Verified invalid scope handling with `npm run validate:naming -- --scope=not-a-scope` returns non-zero and prints `Invalid scope:` plus usage text.
- All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb6af3eb88331b0bcd1e87ee85f80)