### PR TITLE
Extract naming validator into top-level calculogic-validator folder

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -1,0 +1,9 @@
+# calculogic-validator
+
+This folder contains the Calculogic naming validator tooling extracted from the builder app tree.
+
+- Core validator logic lives in `src/validators/`.
+- CLI entrypoint lives in `scripts/validate-naming.mjs`.
+- Validator tests live in `test/`.
+- Run from repository root with `npm run validate:naming`.
+- Canonical naming contract docs remain in `doc/ConventionRoutines/`.

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -9,7 +9,7 @@ import {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const repositoryRoot = path.resolve(__dirname, '..');
+const repositoryRoot = path.resolve(__dirname, '..', '..');
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';

--- a/calculogic-validator/src/validators/naming-validator.logic.mjs
+++ b/calculogic-validator/src/validators/naming-validator.logic.mjs
@@ -57,8 +57,8 @@ const SCOPE_PROFILES = {
     includeRootFiles: [],
   },
   app: {
-    description: 'Application-focused scan (src/test/scripts and root tooling files).',
-    includeRoots: ['src', 'test', 'scripts'],
+    description: 'Application-focused scan (src/test/calculogic-validator and root tooling files).',
+    includeRoots: ['src', 'test', 'calculogic-validator'],
     includeRootFiles: Array.from(ROOT_APP_FILES),
   },
   docs: {

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -8,7 +8,7 @@ import {
 } from '../src/validators/naming-validator.logic.mjs';
 
 const runValidatorCli = args =>
-  spawnSync(process.execPath, ['--experimental-strip-types', 'scripts/validate-naming.mjs', ...args], {
+  spawnSync(process.execPath, ['--experimental-strip-types', 'calculogic-validator/scripts/validate-naming.mjs', ...args], {
     cwd: process.cwd(),
     encoding: 'utf8',
   });
@@ -25,7 +25,7 @@ test('default/no-scope behavior resolves to repo', () => {
 
 test('--scope=repo aligns with repo contract roots', () => {
   const repoPaths = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
-  assert.ok(repoPaths.includes('src/validators/naming-validator.logic.mjs'));
+  assert.ok(repoPaths.includes('calculogic-validator/src/validators/naming-validator.logic.mjs'));
   assert.ok(repoPaths.includes('doc/ConventionRoutines/NamingValidatorSpec.md'));
   assert.ok(repoPaths.includes('README.md'));
 });
@@ -40,9 +40,9 @@ test('--scope=docs includes doc/**, docs/**, and root README.md only from root c
 
 test('--scope=app excludes doc/docs folders while including app roots and root tooling files', () => {
   const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
-  assert.ok(appPaths.includes('src/validators/naming-validator.logic.mjs'));
-  assert.ok(appPaths.includes('test/naming-validator.test.mjs'));
-  assert.ok(appPaths.includes('scripts/validate-naming.mjs'));
+  assert.ok(appPaths.includes('calculogic-validator/src/validators/naming-validator.logic.mjs'));
+  assert.ok(appPaths.includes('calculogic-validator/test/naming-validator.test.mjs'));
+  assert.ok(appPaths.includes('calculogic-validator/scripts/validate-naming.mjs'));
   assert.ok(appPaths.includes('package.json'));
   assert.equal(appPaths.some(pathname => pathname.startsWith('doc/')), false);
   assert.equal(appPaths.some(pathname => pathname.startsWith('docs/')), false);

--- a/calculogic-validator/test/naming-validator.test.mjs
+++ b/calculogic-validator/test/naming-validator.test.mjs
@@ -98,16 +98,16 @@ test('classifies legacy exceptions for non-canonical legacy names', () => {
 
 test('repo scope includes docs + src + root config examples', () => {
   const paths = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
-  assert.ok(paths.includes('src/validators/naming-validator.logic.mjs'));
+  assert.ok(paths.includes('calculogic-validator/src/validators/naming-validator.logic.mjs'));
   assert.ok(paths.includes('doc/ConventionRoutines/NamingValidatorSpec.md'));
   assert.ok(paths.includes('package.json'));
 });
 
 test('app scope excludes docs and includes src/test/scripts/root tooling files', () => {
   const paths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
-  assert.ok(paths.includes('src/validators/naming-validator.logic.mjs'));
-  assert.ok(paths.includes('test/naming-validator.test.mjs'));
-  assert.ok(paths.includes('scripts/validate-naming.mjs'));
+  assert.ok(paths.includes('calculogic-validator/src/validators/naming-validator.logic.mjs'));
+  assert.ok(paths.includes('calculogic-validator/test/naming-validator.test.mjs'));
+  assert.ok(paths.includes('calculogic-validator/scripts/validate-naming.mjs'));
   assert.ok(paths.includes('package.json'));
   assert.equal(paths.some(p => p.startsWith('doc/')), false);
   assert.equal(paths.some(p => p.startsWith('docs/')), false);
@@ -145,7 +145,7 @@ test('scope filtering output order is deterministic', () => {
 test('invalid CLI scope returns deterministic usage error and non-zero exit', () => {
   const result = spawnSync(
     process.execPath,
-    ['--experimental-strip-types', 'scripts/validate-naming.mjs', '--scope=invalid-scope'],
+    ['--experimental-strip-types', 'calculogic-validator/scripts/validate-naming.mjs', '--scope=invalid-scope'],
     { cwd: process.cwd(), encoding: 'utf8' },
   );
 

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.4** (scope filter enforcement + scope contract hardening).
+Current implementation target: **V0.1.5** (validator package extraction to top-level `calculogic-validator/`).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -39,6 +39,14 @@ Active roles:
 
 Deprecated historical roles:
 - view
+
+### 2.4 Repository layout contract (V0.1.5)
+Validator implementation assets live under top-level `calculogic-validator/`:
+- core logic: `calculogic-validator/src/validators/naming-validator.logic.mjs`
+- CLI entrypoint: `calculogic-validator/scripts/validate-naming.mjs`
+- validator tests: `calculogic-validator/test/*.test.mjs`
+
+Root `package.json` scripts remain the canonical invocation interface (`npm run validate:naming`, `npm test`).
 
 ## 3.0 Classification Contract
 ### 3.1 Canonical

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node --test --experimental-strip-types test/**/*.test.mjs",
-    "validate:naming": "node --experimental-strip-types scripts/validate-naming.mjs"
+    "test": "node --test --experimental-strip-types test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs",
+    "validate:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- Make the naming validator clearly separable from the builder app by extracting all validator assets into a top-level package-style folder. 
- Preserve existing validator behavior and CLI semantics while improving project layout and discoverability. 
- Update the NL contract first to reflect the layout change per the NL-first workflow. 

### Description
- Created `calculogic-validator/` and moved validator logic to `calculogic-validator/src/validators/naming-validator.logic.mjs`, CLI to `calculogic-validator/scripts/validate-naming.mjs`, and tests to `calculogic-validator/test/`. 
- Updated relative imports and CLI/test spawn paths so moved scripts and tests import `../src/validators/naming-validator.logic.mjs` and call `calculogic-validator/scripts/validate-naming.mjs` when invoked. 
- Adjusted the CLI repo-root computation to `path.resolve(__dirname, '..', '..')` to preserve repository scanning behavior from the new script location. 
- Updated the `app` scope profile to include `calculogic-validator` and changed root `package.json` scripts so `npm run validate:naming` runs the CLI from the new path and `npm test` also runs the moved validator tests. 
- Added `calculogic-validator/README.md` and bumped the naming-validator NL doc to V0.1.5 to record the repository layout contract. 

### Testing
- Ran `npm test`, which executed the full test matrix (including moved validator tests) and all tests passed (46/46). 
- Ran `npm run validate:naming` and validated it printed a JSON report successfully in `repo` scope. 
- Verified `npm run validate:naming -- --scope=app`, `--scope=docs`, and `--scope=repo` produce expected scope and file-count outputs. 
- All automated checks completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0dc055c888331b7a5ff51c825da35)