### PR TITLE
docs: align naming-validator app scope with extracted calculogic-validator

### DIFF
--- a/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -1,4 +1,4 @@
-# Naming Validator Spec (V0.1.3)
+# Naming Validator Spec (V0.1.5)
 
 ## Purpose and Scope
 
@@ -85,7 +85,7 @@ V0.1.2 implements deterministic scope profiles selected by CLI.
 - includes explicit roots:
   - `src/`
   - `test/`
-  - `scripts/`
+  - `calculogic-validator/`
 - includes explicit root tooling files (when present):
   - `package.json`
   - `package-lock.json`
@@ -123,7 +123,7 @@ Default behavior:
 
 Inclusion/exclusion summary:
 - `repo`: all reportable files under repository root (minus explicit walker exclusions).
-- `app`: includes `src/**`, `test/**`, `scripts/**`, and explicit root tooling files; excludes `doc/**` and `docs/**`.
+- `app`: includes `src/**`, `test/**`, `calculogic-validator/**`, and explicit root tooling files; excludes `doc/**` and `docs/**`.
 - `docs`: includes `doc/**`, `docs/**`, and selected root conventional docs currently limited to `README.md`; excludes `src/**` by profile definition.
 
 Invalid scope behavior:

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -14,7 +14,7 @@ The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1
 V0.1.4 supports deterministic scope profiles selected via CLI and applied before filename classification using explicit scope path predicates:
 - default/no `--scope` input resolves to `repo`
 - `repo`: repository-wide reportable files.
-- `app`: app-focused files (`src/`, `test/`, `scripts/`, and explicit root tooling files).
+- `app`: app-focused files (`src/`, `test/`, `calculogic-validator/`, and explicit root tooling files).
 - `docs`: docs-focused files (`doc/`, `docs/`, and selected root conventional docs currently limited to `README.md`).
 
 Scope predicates are evaluated on normalized repository-relative paths before report findings are generated. Invalid scope inputs are treated as CLI usage errors.


### PR DESCRIPTION
### Motivation
- Update Naming Validator documentation so the documented `app` scope roots match the extracted validator package layout (validator assets now live under `calculogic-validator/`).

### Description
- Edit `doc/ConventionRoutines/NamingValidatorSpec.md` to replace `scripts/` with `calculogic-validator/` in the `app` Input Scope Profiles and to update the Scope Contract inclusion summary accordingly, and bump the spec title from `V0.1.3` to `V0.1.5` for extraction-alignment clarity.
- Edit `doc/nl-config/cfg-namingValidator.md` (section `2.2 Scope mode (V0.1.4)`) to describe `app` as `src/`, `test/`, `calculogic-validator/` (plus explicit root tooling files).

### Testing
- Ran automated checks: `npm test`, `npm run validate:naming -- --scope=app`, `npm run validate:naming -- --scope=docs`, and `npm run validate:naming -- --scope=repo`, and all exited successfully with the validator CLI reporting `scopeContract.includeRoots` for `--scope=app` as `["src","test","calculogic-validator"]`, matching the updated docs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e70cabc083319395c560dde6a3d2)