### PR TITLE
Add calculogic-report-capture CLI (streaming + file + retention)

### DIFF
--- a/calculogic-validator/test/report-capture.test.mjs
+++ b/calculogic-validator/test/report-capture.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import {
+  formatTimestamp,
+  pruneReports,
+  shouldPrune,
+} from '../tools/report-capture/src/report-capture.logic.mjs';
+
+const createTempDir = async () => fs.mkdtemp(path.join(os.tmpdir(), 'report-capture-test-'));
+
+test('formatTimestamp formats deterministic local timestamp token', () => {
+  const fixed = new Date(2026, 1, 26, 18, 41, 3);
+  assert.equal(formatTimestamp(fixed), '2026-02-26_18-41-03');
+});
+
+test('pruneReports keeps newest N reports by mtime', async () => {
+  const tempDir = await createTempDir();
+
+  try {
+    for (let i = 0; i < 5; i += 1) {
+      const filePath = path.join(tempDir, `report-2026-02-2${i}_00-00-00.txt`);
+      await fs.writeFile(filePath, `report-${i}`);
+      const mtime = new Date(2026, 1, i + 1, 12, 0, 0);
+      await fs.utimes(filePath, mtime, mtime);
+    }
+
+    await pruneReports(tempDir, { prefix: 'report', keep: 2 });
+
+    const remaining = (await fs.readdir(tempDir)).sort();
+    assert.deepEqual(remaining, ['report-2026-02-23_00-00-00.txt', 'report-2026-02-24_00-00-00.txt']);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('shouldPrune reflects --no-prune setting', () => {
+  assert.equal(shouldPrune({ noPrune: true }), false);
+  assert.equal(shouldPrune({ noPrune: false }), true);
+});
+
+test('host propagates child exit code and writes report file', async () => {
+  const tempDir = await createTempDir();
+
+  try {
+    const hostPath = path.resolve('calculogic-validator/tools/report-capture/src/report-capture.host.mjs');
+    const exitCode = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [
+        hostPath,
+        '--dir',
+        tempDir,
+        '--keep',
+        '50',
+        '--',
+        process.execPath,
+        '-e',
+        'process.exit(7)',
+      ]);
+
+      child.on('error', reject);
+      child.on('close', code => resolve(code));
+    });
+
+    assert.equal(exitCode, 7);
+
+    const reports = (await fs.readdir(tempDir)).filter(name => name.startsWith('report-') && name.endsWith('.txt'));
+    assert.equal(reports.length, 1);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/tools/report-capture/package.json
+++ b/calculogic-validator/tools/report-capture/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@calculogic/report-capture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "bin": {
+    "calculogic-report-capture": "./src/report-capture.host.mjs"
+  }
+}

--- a/calculogic-validator/tools/report-capture/src/report-capture.contracts.mjs
+++ b/calculogic-validator/tools/report-capture/src/report-capture.contracts.mjs
@@ -1,0 +1,12 @@
+export const REPORT_CAPTURE_CONTRACTS_VERSION = '0.0.0';
+
+export const REPORT_CAPTURE_METADATA_KEYS = Object.freeze([
+  'path',
+  'exitCode',
+  'bytes',
+  'startedAt',
+  'endedAt',
+  'durationMs',
+  'dir',
+  'prefix',
+]);

--- a/calculogic-validator/tools/report-capture/src/report-capture.host.mjs
+++ b/calculogic-validator/tools/report-capture/src/report-capture.host.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import {
+  buildReportFilename,
+  listMatchingReports,
+  pruneReports,
+  sanitizePrefix,
+  shouldPrune,
+} from './report-capture.logic.mjs';
+import { getDefaultReportsDir } from './report-capture.knowledge.mjs';
+
+const parsePositiveInt = (value, fallback) => {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const parseArgs = argv => {
+  const separatorIndex = argv.indexOf('--');
+  if (separatorIndex === -1) {
+    throw new Error('Missing command separator "--" and wrapped command.');
+  }
+
+  const flagArgs = argv.slice(0, separatorIndex);
+  const commandArgs = argv.slice(separatorIndex + 1);
+  if (commandArgs.length === 0) {
+    throw new Error('Missing wrapped command after "--".');
+  }
+
+  const options = {
+    dir: null,
+    keep: 20,
+    noPrune: false,
+    prefix: 'report',
+    warnOnPrune: true,
+    json: false,
+  };
+
+  for (let i = 0; i < flagArgs.length; i += 1) {
+    const arg = flagArgs[i];
+
+    if (arg === '--dir') {
+      const value = flagArgs[i + 1];
+      if (!value) throw new Error('Missing value for --dir');
+      options.dir = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--keep') {
+      const value = flagArgs[i + 1];
+      if (!value) throw new Error('Missing value for --keep');
+      options.keep = parsePositiveInt(value, 20);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--no-prune') {
+      options.noPrune = true;
+      continue;
+    }
+
+    if (arg === '--prefix') {
+      const value = flagArgs[i + 1];
+      if (!value) throw new Error('Missing value for --prefix');
+      options.prefix = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--warn-on-prune') {
+      options.warnOnPrune = true;
+      continue;
+    }
+
+    if (arg === '--no-warn-on-prune') {
+      options.warnOnPrune = false;
+      continue;
+    }
+
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return {
+    options: {
+      ...options,
+      prefix: sanitizePrefix(options.prefix),
+    },
+    command: commandArgs[0],
+    commandArgs: commandArgs.slice(1),
+  };
+};
+
+const resolveWindowsCommand = command => {
+  if (process.platform !== 'win32') {
+    return command;
+  }
+
+  const ext = path.extname(command);
+  if (ext) {
+    return command;
+  }
+
+  const pathValue = process.env.PATH || '';
+  const pathEntries = pathValue.split(path.delimiter).filter(Boolean);
+  const pathextValue = process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD';
+  const pathext = pathextValue.split(';').filter(Boolean);
+
+  for (const directory of pathEntries) {
+    for (const extension of pathext) {
+      const candidate = path.join(directory, `${command}${extension.toLowerCase()}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return command;
+};
+
+const run = async () => {
+  const startedAt = new Date();
+  const { options, command, commandArgs } = parseArgs(process.argv.slice(2));
+
+  const reportDir = path.resolve(process.cwd(), options.dir ?? getDefaultReportsDir());
+  await fsp.mkdir(reportDir, { recursive: true });
+
+  if (shouldPrune({ noPrune: options.noPrune }) && options.warnOnPrune) {
+    const existing = await listMatchingReports(reportDir, { prefix: options.prefix });
+    if (existing.length >= options.keep) {
+      process.stderr.write(`WARNING: This run will prune reports beyond the newest ${options.keep}. Save anything you want to keep before continuing.\n`);
+    }
+  }
+
+  const reportPath = path.join(reportDir, buildReportFilename({ prefix: options.prefix, date: startedAt }));
+  const reportStream = fs.createWriteStream(reportPath, { flags: 'a' });
+
+  const resolvedCommand = resolveWindowsCommand(command);
+  const child = spawn(resolvedCommand, commandArgs, {
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+
+  let bytes = 0;
+  child.stdout.on('data', chunk => {
+    bytes += chunk.length;
+    process.stdout.write(chunk);
+    reportStream.write(chunk);
+  });
+
+  child.stderr.on('data', chunk => {
+    bytes += chunk.length;
+    process.stderr.write(chunk);
+    reportStream.write(chunk);
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', code => resolve(code ?? 1));
+  });
+
+  await new Promise((resolve, reject) => {
+    reportStream.end(error => (error ? reject(error) : resolve()));
+  });
+
+  if (shouldPrune({ noPrune: options.noPrune })) {
+    await pruneReports(reportDir, { prefix: options.prefix, keep: options.keep });
+  }
+
+  const endedAt = new Date();
+  if (options.json) {
+    const metadata = {
+      path: reportPath,
+      exitCode,
+      bytes,
+      startedAt: startedAt.toISOString(),
+      endedAt: endedAt.toISOString(),
+      durationMs: endedAt.getTime() - startedAt.getTime(),
+      dir: reportDir,
+      prefix: options.prefix,
+    };
+    process.stderr.write(`${JSON.stringify(metadata)}\n`);
+  }
+
+  process.exit(exitCode);
+};
+
+run().catch(error => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/calculogic-validator/tools/report-capture/src/report-capture.knowledge.mjs
+++ b/calculogic-validator/tools/report-capture/src/report-capture.knowledge.mjs
@@ -1,0 +1,23 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export const getDefaultCacheBaseDir = (platform = process.platform, env = process.env, homeDir = os.homedir()) => {
+  if (platform === 'win32') {
+    return env.LOCALAPPDATA && env.LOCALAPPDATA.trim()
+      ? env.LOCALAPPDATA
+      : path.join(homeDir, 'AppData', 'Local');
+  }
+
+  if (platform === 'darwin') {
+    return path.join(homeDir, 'Library', 'Caches');
+  }
+
+  if (env.XDG_CACHE_HOME && env.XDG_CACHE_HOME.trim()) {
+    return env.XDG_CACHE_HOME;
+  }
+
+  return path.join(homeDir, '.cache');
+};
+
+export const getDefaultReportsDir = (platform = process.platform, env = process.env, homeDir = os.homedir()) =>
+  path.join(getDefaultCacheBaseDir(platform, env, homeDir), 'calculogic-report-capture', 'reports');

--- a/calculogic-validator/tools/report-capture/src/report-capture.logic.mjs
+++ b/calculogic-validator/tools/report-capture/src/report-capture.logic.mjs
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const pad2 = value => String(value).padStart(2, '0');
+
+export const formatTimestamp = date => {
+  const year = date.getFullYear();
+  const month = pad2(date.getMonth() + 1);
+  const day = pad2(date.getDate());
+  const hours = pad2(date.getHours());
+  const minutes = pad2(date.getMinutes());
+  const seconds = pad2(date.getSeconds());
+  return `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+};
+
+export const sanitizePrefix = prefix => {
+  const safe = String(prefix ?? 'report').replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return safe || 'report';
+};
+
+export const buildReportFilename = ({ prefix = 'report', date = new Date() } = {}) =>
+  `${sanitizePrefix(prefix)}-${formatTimestamp(date)}.txt`;
+
+export const shouldPrune = ({ noPrune = false } = {}) => !noPrune;
+
+const isMatchingReport = ({ fileName, prefix }) => fileName.startsWith(`${prefix}-`) && fileName.endsWith('.txt');
+
+export const listMatchingReports = async (directory, { prefix = 'report' } = {}) => {
+  const safePrefix = sanitizePrefix(prefix);
+  let entries;
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+
+  const stats = await Promise.all(entries
+    .filter(entry => entry.isFile() && isMatchingReport({ fileName: entry.name, prefix: safePrefix }))
+    .map(async entry => {
+      const filePath = path.join(directory, entry.name);
+      const fileStat = await fs.stat(filePath);
+      return {
+        fileName: entry.name,
+        filePath,
+        mtimeMs: fileStat.mtimeMs,
+      };
+    }));
+
+  stats.sort((left, right) => right.mtimeMs - left.mtimeMs || left.fileName.localeCompare(right.fileName));
+  return stats;
+};
+
+export const pruneReports = async (directory, { prefix = 'report', keep = 20 } = {}) => {
+  const safeKeep = Math.max(0, Number.parseInt(String(keep), 10) || 0);
+  const reports = await listMatchingReports(directory, { prefix });
+  const toDelete = reports.slice(safeKeep);
+
+  await Promise.all(toDelete.map(report => fs.unlink(report.filePath)));
+
+  return {
+    kept: reports.slice(0, safeKeep),
+    deleted: toDelete,
+  };
+};

--- a/doc/nl-config/cfg-reportCapture.md
+++ b/doc/nl-config/cfg-reportCapture.md
@@ -1,0 +1,77 @@
+# cfg-reportCapture
+
+## 0.0 Version
+Current implementation target: **V0.0.0** (cross-platform CLI wrapper for command output capture).
+
+## 1.0 Purpose
+Provide a deterministic command wrapper that captures combined stdout/stderr into timestamped reports while still streaming output live to the terminal.
+
+## 2.0 Inputs and Source of Truth
+### 2.1 CLI interface contract
+The wrapper accepts pre-command flags (`--dir`, `--keep`, `--no-prune`, `--prefix`, `--warn-on-prune`, `--no-warn-on-prune`, `--json`) followed by a required command after `--`.
+
+### 2.2 Default report directory
+When `--dir` is not provided, report output uses an OS-appropriate user cache base:
+- Linux: `$XDG_CACHE_HOME` else `~/.cache`
+- macOS: `~/Library/Caches`
+- Windows: `%LOCALAPPDATA%` else `~/AppData/Local`
+
+Reports live under `<cacheBase>/calculogic-report-capture/reports`.
+
+### 2.3 Filename contract
+Report filenames are deterministic and filesystem-safe:
+- `<prefix>-YYYY-MM-DD_HH-MM-SS.txt`
+- Prefix defaults to `report`
+- Timestamp is local time and zero-padded
+
+## 3.0 Build Concern
+### 3.1 CLI host assembly
+Host module parses argv, resolves directory defaults, warns about pending prune deletions, starts capture run, and exits with the wrapped command exit code.
+
+### 3.2 Spawn contract
+Child process uses `spawn(command, args, { stdio: ['inherit', 'pipe', 'pipe'] })` and avoids shell mode.
+
+### 3.3 Windows command resolution
+When platform is Windows and command is extensionless, resolve via PATH + PATHEXT (`.cmd`, `.exe`, `.bat`, etc.) before spawn.
+
+## 4.0 BuildStyle Concern
+Not applicable for this CLI feature.
+
+## 5.0 Logic Concern
+### 5.1 Timestamp and filename helpers
+Helpers format timestamps and derive safe filenames/prefixes deterministically.
+
+### 5.2 Prune logic
+Prune logic matches `${prefix}-*.txt`, sorts by `mtimeMs` descending, keeps newest `N`, and deletes older files.
+
+### 5.3 Prune gating logic
+A dedicated helper controls whether pruning is active (`--no-prune` disables).
+
+## 6.0 Knowledge Concern
+### 6.1 OS cache directory knowledge
+Knowledge module maps current platform and environment variables to the default cache path.
+
+## 7.0 Results Concern
+### 7.1 Output stream behavior
+Stdout and stderr both stream to terminal and are appended to the same report file.
+
+### 7.2 JSON metadata output
+When `--json` is set, emit one compact JSON line to stderr with:
+- `path`, `exitCode`, `bytes`, `startedAt`, `endedAt`, `durationMs`, `dir`, `prefix`
+
+## 8.0 ResultsStyle Concern
+Not applicable for this CLI feature.
+
+## 9.0 Assembly Pattern
+1. Parse options and command split at `--`.
+2. Resolve output directory and report filename.
+3. Optionally pre-warn if current report count implies post-run pruning.
+4. Run child command while teeing output to terminal and report file.
+5. Close report file, optionally prune, optionally emit JSON metadata.
+6. Exit with child exit code.
+
+## 10.0 Implementation Passes
+- Pass A: Add helper modules (knowledge + logic + contracts).
+- Pass B: Implement host orchestration and command execution.
+- Pass C: Add deterministic unit/integration-light tests.
+- Pass D: Wire local file dependency for `npx calculogic-report-capture` usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@calculogic/report-capture": "file:calculogic-validator/tools/report-capture",
         "@eslint/js": "^9.22.0",
         "@types/json-logic-js": "^2.0.8",
         "@types/mustache": "^4.2.5",
@@ -30,6 +31,14 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
         "vite": "^6.3.1"
+      }
+    },
+    "calculogic-validator/tools/report-capture": {
+      "name": "@calculogic/report-capture",
+      "version": "0.0.0",
+      "dev": true,
+      "bin": {
+        "calculogic-report-capture": "src/report-capture.host.mjs"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -327,6 +336,10 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@calculogic/report-capture": {
+      "resolved": "calculogic-validator/tools/report-capture",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "globals": "^16.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "@calculogic/report-capture": "file:calculogic-validator/tools/report-capture"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a cross-platform CLI wrapper that runs an arbitrary command, streams combined stdout/stderr live, and records the combined output to timestamped report files. 
- Avoid littering the repo by default by using an OS-appropriate cache dir while allowing `--dir` to override for repo-local workflows. 
- Support retention (prune oldest) with an explicit pre-run warning when configured to prune so CI/locally generated reports remain manageable.

### Description
- Added NL-first spec `doc/nl-config/cfg-reportCapture.md` describing CLI contract, default cache dir, filename contract, prune behavior and assembly steps. 
- New local tool package at `calculogic-validator/tools/report-capture/` with `package.json` exposing the bin `calculogic-report-capture`. 
- Implemented host orchestrator `src/report-capture.host.mjs` to parse flags (split at `--`), resolve report directory (OS cache fallback), warn before prune if applicable, spawn the wrapped command with `stdio: ['inherit','pipe','pipe']`, tee stdout+stderr to terminal and a timestamped report file, emit optional one-line JSON metadata to stderr, and exit with the wrapped command exit code. 
- Added deterministic helpers in `src/report-capture.logic.mjs` for timestamp formatting (`formatTimestamp`), prefix sanitization, filename construction, listing and pruning reports by `mtimeMs`, and prune gating. 
- Added OS cache-dir knowledge in `src/report-capture.knowledge.mjs` implementing Linux/macOS/Windows rules for the default reports directory. 
- Exported minimal metadata contract in `src/report-capture.contracts.mjs`. 
- Wired the tool as a root dev dependency via `@calculogic/report-capture: file:calculogic-validator/tools/report-capture` and updated `package-lock.json` so `npx calculogic-report-capture` resolves locally. 
- Added tests `calculogic-validator/test/report-capture.test.mjs` covering timestamp formatting, pruning behavior, `--no-prune` gating, and a light integration asserting exit-code propagation and report creation.

### Testing
- Ran the full test suite with `npm test`, and all tests passed (`50` tests, `0` failures). 
- Performed runtime validation with `npx calculogic-report-capture --dir <temp> --keep 2 -- node -e "console.log('hi'); console.error('err')"` which streamed `hi`/`err` to the terminal, wrote a report file containing both streams, and returned the expected exit behavior in CI-like invocation (validated exit/contents).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12a55c65c83318a2263d1d1e90880)