### PR TITLE
Add validator registry and deterministic validate-all runner

### DIFF
--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -1,0 +1,85 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getScopeProfile, listNamingValidatorScopes } from '../src/naming/naming-validator.host.mjs';
+import { runValidatorRunner } from '../src/validator-runner.logic.mjs';
+import { listRegisteredValidators } from '../src/validator-registry.knowledge.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repositoryRoot = path.resolve(__dirname, '..', '..');
+
+const usageLines = [
+  'Usage: npm run validate:all -- [--scope=<repo|app|docs>] [--validators=<id1,id2>]',
+  'Validators:',
+  ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
+  'Scopes:',
+  ...listNamingValidatorScopes().map(scope => {
+    const profile = getScopeProfile(scope);
+    return `  - ${scope}: ${profile?.description ?? ''}`;
+  }),
+  'Default scope: validator default (repo for naming)',
+  'Default validators: all registered validators',
+];
+
+const parseCliArgs = argv => {
+  let selectedScope;
+  let validators;
+
+  for (const argument of argv) {
+    if (argument === '--help' || argument === '-h') {
+      return { helpRequested: true, selectedScope, validators };
+    }
+
+    if (argument.startsWith('--scope=')) {
+      selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    if (argument.startsWith('--validators=')) {
+      const raw = argument.slice('--validators='.length);
+      validators = raw
+        .split(',')
+        .map(value => value.trim())
+        .filter(Boolean);
+      continue;
+    }
+
+    throw new Error(`Invalid argument: ${argument}`);
+  }
+
+  return { helpRequested: false, selectedScope, validators };
+};
+
+let parsed;
+try {
+  parsed = parseCliArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+if (parsed.helpRequested) {
+  console.log(usageLines.join('\n'));
+  process.exit(0);
+}
+
+if (parsed.selectedScope && !getScopeProfile(parsed.selectedScope)) {
+  console.error(`Invalid scope: ${parsed.selectedScope}`);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+try {
+  const report = runValidatorRunner(repositoryRoot, {
+    scope: parsed.selectedScope,
+    validators: parsed.validators,
+  });
+
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(0);
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}

--- a/calculogic-validator/src/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/validator-registry.knowledge.mjs
@@ -1,0 +1,29 @@
+import {
+  runNamingValidator,
+  summarizeFindings,
+} from './naming/naming-validator.host.mjs';
+
+const runNamingValidatorHook = (repositoryRoot, options = {}) => {
+  const scope = options.scope;
+  const namingResult = runNamingValidator(repositoryRoot, { scope });
+  const summary = summarizeFindings(namingResult.findings);
+
+  return {
+    scope: namingResult.scope,
+    totalFilesScanned: namingResult.totalFilesScanned,
+    findings: namingResult.findings,
+    summary,
+  };
+};
+
+export const VALIDATOR_REGISTRY = [
+  {
+    id: 'naming',
+    description: 'Filename naming validator (report-mode).',
+    run: runNamingValidatorHook,
+  },
+];
+
+export const listRegisteredValidators = () => VALIDATOR_REGISTRY.map(validator => validator.id).sort((a, b) => a.localeCompare(b));
+
+export const getValidatorById = id => VALIDATOR_REGISTRY.find(validator => validator.id === id) ?? null;

--- a/calculogic-validator/src/validator-report.contracts.mjs
+++ b/calculogic-validator/src/validator-report.contracts.mjs
@@ -1,0 +1,23 @@
+export const CALCULOGIC_VALIDATOR_REPORT_VERSION = '0.1.0';
+
+/**
+ * Combined validator report contract (V0.1.0):
+ * {
+ *   version: string,
+ *   mode: 'report',
+ *   scope?: string,
+ *   startedAt: string,
+ *   endedAt: string,
+ *   durationMs: number,
+ *   validators: Array<{
+ *     id: string,
+ *     description: string,
+ *     scope?: string,
+ *     totalFilesScanned?: number,
+ *     counts?: Record<string, number>,
+ *     ...validatorSpecificSummaryPassThrough,
+ *     findings?: Array<unknown>,
+ *     meta?: Record<string, unknown>
+ *   }>
+ * }
+ */

--- a/calculogic-validator/src/validator-runner.logic.mjs
+++ b/calculogic-validator/src/validator-runner.logic.mjs
@@ -1,0 +1,62 @@
+import { CALCULOGIC_VALIDATOR_REPORT_VERSION } from './validator-report.contracts.mjs';
+import {
+  VALIDATOR_REGISTRY,
+  getValidatorById,
+} from './validator-registry.knowledge.mjs';
+
+const toValidatorReportEntry = (registryEntry, validatorResult) => {
+  const summary = validatorResult.summary ?? null;
+  const counts = summary?.counts;
+  const passThroughSummary = summary
+    ? Object.fromEntries(Object.entries(summary).filter(([key]) => key !== 'counts'))
+    : {};
+
+  return {
+    id: registryEntry.id,
+    description: registryEntry.description,
+    scope: validatorResult.scope,
+    totalFilesScanned: validatorResult.totalFilesScanned,
+    ...(counts ? { counts } : {}),
+    ...passThroughSummary,
+    findings: validatorResult.findings,
+    ...(validatorResult.meta ? { meta: validatorResult.meta } : {}),
+  };
+};
+
+const resolveValidatorsToRun = selectedValidatorIds => {
+  if (!selectedValidatorIds || selectedValidatorIds.length === 0) {
+    return VALIDATOR_REGISTRY;
+  }
+
+  const selectedSet = new Set(selectedValidatorIds);
+  for (const selectedId of selectedSet) {
+    if (!getValidatorById(selectedId)) {
+      throw new Error(`Unknown validator id: ${selectedId}`);
+    }
+  }
+
+  return VALIDATOR_REGISTRY.filter(validator => selectedSet.has(validator.id));
+};
+
+export const runValidatorRunner = (repositoryRoot, options = {}) => {
+  const startedAtDate = new Date();
+  const validatorsToRun = resolveValidatorsToRun(options.validators);
+  const scope = options.scope;
+
+  const validators = validatorsToRun.map(registryEntry => {
+    const result = registryEntry.run(repositoryRoot, { scope });
+    return toValidatorReportEntry(registryEntry, result);
+  });
+
+  const endedAtDate = new Date();
+
+  return {
+    version: CALCULOGIC_VALIDATOR_REPORT_VERSION,
+    mode: 'report',
+    ...(scope ? { scope } : {}),
+    startedAt: startedAtDate.toISOString(),
+    endedAt: endedAtDate.toISOString(),
+    durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
+    validators,
+  };
+};

--- a/calculogic-validator/test/validator-runner.test.mjs
+++ b/calculogic-validator/test/validator-runner.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  listRegisteredValidators,
+} from '../src/validator-registry.knowledge.mjs';
+import {
+  runValidatorRunner,
+} from '../src/validator-runner.logic.mjs';
+
+test('registry lists validators deterministically', () => {
+  assert.deepEqual(listRegisteredValidators(), ['naming']);
+});
+
+test('runner report includes naming validator in deterministic order', () => {
+  const report = runValidatorRunner(process.cwd(), { scope: 'app' });
+
+  assert.ok(report.version);
+  assert.ok(Array.isArray(report.validators));
+  assert.equal(report.validators.length, 1);
+  assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].scope, 'app');
+  assert.equal(typeof report.validators[0].totalFilesScanned, 'number');
+  assert.ok(Array.isArray(report.validators[0].findings));
+});
+
+test('validate-all CLI runs and returns naming validator report', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', 'calculogic-validator/scripts/validate-all.mjs', '--scope=docs'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 0);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].scope, 'docs');
+});

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -1,0 +1,62 @@
+# cfg-validatorRunner
+
+## 0.0 Version
+Current implementation target: **V0.1.0** (deterministic multi-validator runner core with registry-backed execution).
+
+## 1.0 Purpose
+Provide a deterministic runner that executes one or more registered validators and returns a single versioned combined report.
+
+## 2.0 Inputs and Source of Truth
+### 2.1 Validator registry
+The runner reads validator definitions from a deterministic registry in `calculogic-validator/src/validator-registry.knowledge.mjs`.
+
+### 2.2 Runtime options
+- `validators` (optional list of validator IDs)
+- `scope` (optional scope string forwarded to validators that support scope selection)
+
+### 2.3 Initial validator set
+V0.1.0 includes the naming validator only, wrapped through the registry run hook without changing naming-validator internals.
+
+## 3.0 Combined Report Contract
+### 3.1 Report envelope
+- `version`
+- `mode` (`report`)
+- optional `scope`
+- `startedAt`, `endedAt`, `durationMs`
+- `validators` (deterministic execution order)
+
+### 3.2 Validator entry shape
+Each validator entry includes:
+- `id`
+- `description`
+- `scope`
+- `totalFilesScanned`
+- `counts` (if available)
+- additional pass-through summary keys when provided (`codeCounts`, `specialCaseTypeCounts`, etc.)
+- `findings`
+- optional `meta`
+
+### 3.3 Ordering and determinism
+- Validator execution order matches registry declaration order.
+- Findings order from each validator is preserved as-is (no resorting in the runner).
+
+## 4.0 CLI Contract (`validate-all`)
+### 4.1 Inputs
+- `--help`
+- `--scope=<repo|app|docs>` (optional)
+- `--validators=<id1,id2>` (optional)
+
+### 4.2 Behavior
+- Resolves repository root deterministically from script location.
+- Executes runner with selected options.
+- Writes JSON report to stdout.
+- Exits `0` on success.
+- Exits `1` for usage errors (invalid flags, unknown validator IDs, invalid scope).
+
+## 5.0 Deferred Behavior
+Deferred to future slices:
+- enforcement/fail modes
+- changed-files mode
+- parallel validator execution
+- validator dependency graph orchestration
+- report persistence and baselining

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "node --test --experimental-strip-types test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs",
-    "validate:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs"
+    "validate:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs",
+    "validate:all": "node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- Provide a deterministic product core to run multiple validators through a single runner and produce a combined, versioned report. 
- Expose a stable registry so validators can be discovered and executed programmatically while preserving per-validator output shapes. 
- Keep existing naming-validator behavior unchanged and ensure deterministic validator + findings ordering.

### Description
- Add a shared report contract and version constant in `calculogic-validator/src/validator-report.contracts.mjs` describing the combined report envelope and per-validator entry shape. 
- Add a deterministic validator registry in `calculogic-validator/src/validator-registry.knowledge.mjs` that wraps the existing naming validator and exports `listRegisteredValidators()` and `getValidatorById()`. 
- Add the runner logic in `calculogic-validator/src/validator-runner.logic.mjs` which resolves validators to run (validates ids), executes them in registry order, and assembles a combined report preserving per-validator finding order. 
- Add a cross-platform CLI `calculogic-validator/scripts/validate-all.mjs` with `--help`, `--scope=<...>`, and `--validators=<id1,id2>` that prints the JSON report to stdout and exits deterministically on usage errors, and wire root npm script `validate:all` in `package.json`. 
- Add tests `calculogic-validator/test/validator-runner.test.mjs` covering deterministic registry listing, runner report shape/order, and a light CLI integration test; and add an NL-first config doc `doc/nl-config/cfg-validatorRunner.md` describing purpose, inputs, report shape, CLI contract, and deferred behavior.

### Testing
- Ran the full test suite with `npm test`, which completed successfully (all automated tests passed). 
- Verified the existing naming validator remains unchanged by running `npm run validate:naming -- --scope=app`, which produced the expected report and exited 0. 
- Verified the new runner/CLI with `npm run validate:all -- --scope=app` and `npm run validate:all -- --validators=naming --scope=docs`, both of which printed the combined JSON report including the naming results and exited 0.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12e9b81f483318d806aad652f9756)