### PR TITLE
Add validator health check command and document validator commands

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -2,6 +2,35 @@
 
 This folder contains the Calculogic naming validator tooling extracted from the builder app tree.
 
+## Commands
+
+Run naming validator:
+
+```bash
+npm run validate:naming
+npm run validate:naming -- --scope=repo
+npm run validate:naming -- --scope=app
+npm run validate:naming -- --scope=docs
+```
+
+Run validator health check:
+
+```bash
+npm run health:validator
+```
+
+Capture command output into timestamped report files:
+
+```bash
+npx calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app
+npx calculogic-report-capture --prefix validator-health --keep 20 -- npm run health:validator
+npx calculogic-report-capture --dir .local-reports --keep 50 -- npm run validate:naming -- --scope=repo
+```
+
+By default, `calculogic-report-capture` writes report files to OS cache storage.
+Use `--dir` to write to a repo-local or custom directory.
+Use `--json` if you want machine-readable metadata that includes the report path.
+
 - Canonical validator module now lives in `src/naming/` (`naming-validator.host.mjs` / `naming-validator.wiring.mjs` / `naming-validator.logic.mjs` / `naming-validator.contracts.mjs`).
 - CLI entrypoint lives in `scripts/validate-naming.mjs`.
 - Validator tests live in `test/`.

--- a/calculogic-validator/scripts/validator-health-check.host.mjs
+++ b/calculogic-validator/scripts/validator-health-check.host.mjs
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  runNamingValidator,
+  summarizeFindings,
+  getScopeProfile,
+} from '../src/naming/naming-validator.host.mjs';
+import fs from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repositoryRoot = path.resolve(__dirname, '..', '..');
+
+const SCOPES = ['repo', 'app', 'docs'];
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const runScopeSummary = scope => {
+  const { findings, totalFilesScanned } = runNamingValidator(repositoryRoot, { scope });
+  const summary = summarizeFindings(findings);
+
+  return {
+    totalFilesScanned,
+    counts: summary.counts,
+    codeCounts: summary.codeCounts,
+    specialCaseTypeCounts: summary.specialCaseTypeCounts,
+    warningRoleStatusCounts: summary.warningRoleStatusCounts,
+    warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
+  };
+};
+
+const assertDeterministicScope = scope => {
+  const profile = getScopeProfile(scope);
+  assert(profile, `Missing naming validator scope profile: ${scope}`);
+
+  const firstRun = runScopeSummary(scope);
+  const secondRun = runScopeSummary(scope);
+
+  assert(
+    firstRun.totalFilesScanned === secondRun.totalFilesScanned,
+    `Non-deterministic totalFilesScanned for scope=${scope}`,
+  );
+
+  const comparableKeys = [
+    'counts',
+    'codeCounts',
+    'specialCaseTypeCounts',
+    'warningRoleStatusCounts',
+    'warningRoleCategoryCounts',
+  ];
+
+  for (const key of comparableKeys) {
+    const firstSerialized = JSON.stringify(firstRun[key]);
+    const secondSerialized = JSON.stringify(secondRun[key]);
+    assert(
+      firstSerialized === secondSerialized,
+      `Non-deterministic summary.${key} for scope=${scope}`,
+    );
+  }
+};
+
+const assertAppScopeDocs = () => {
+  const docsToValidate = [
+    path.resolve(repositoryRoot, 'doc/ConventionRoutines/NamingValidatorSpec.md'),
+    path.resolve(repositoryRoot, 'doc/nl-config/cfg-namingValidator.md'),
+  ];
+
+  const requiredMentions = ['src/', 'test/', 'calculogic-validator/'];
+
+  for (const absoluteDocPath of docsToValidate) {
+    const content = fs.readFileSync(absoluteDocPath, 'utf8');
+    for (const requiredMention of requiredMentions) {
+      assert(
+        content.includes(requiredMention),
+        `Docs drift detected in ${path.relative(repositoryRoot, absoluteDocPath)}: missing "${requiredMention}" mention for app scope`,
+      );
+    }
+  }
+};
+
+const main = () => {
+  for (const scope of SCOPES) {
+    assertDeterministicScope(scope);
+  }
+
+  assertAppScopeDocs();
+
+  console.log('OK: naming validator deterministic for repo|app|docs');
+  console.log('OK: docs match app scope roots');
+};
+
+try {
+  main();
+  process.exit(0);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Validator health check failed: ${message}`);
+  process.exit(1);
+}

--- a/calculogic-validator/test/validator-health-check.test.mjs
+++ b/calculogic-validator/test/validator-health-check.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repositoryRoot = path.resolve(__dirname, '..', '..');
+
+test('validator health check exits successfully', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', 'calculogic-validator/scripts/validator-health-check.host.mjs'],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+    },
+  );
+
+  assert.equal(result.status, 0, `Expected exit code 0, got ${result.status}\n${result.stderr}`);
+  assert.match(result.stdout, /OK:/);
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.6** (naming validator modularized under `src/naming/` with compatibility shim).
+Current implementation target: **V0.1.7** (adds deterministic validator health-check host script and command discoverability docs).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -49,6 +49,16 @@ Validator implementation assets live under top-level `calculogic-validator/`:
 - validator tests: `calculogic-validator/test/*.test.mjs`
 
 Root `package.json` scripts remain the canonical invocation interface (`npm run validate:naming`, `npm test`).
+
+### 2.5 Health-check contract (V0.1.7)
+Health-check entrypoint lives at `calculogic-validator/scripts/validator-health-check.host.mjs` and is exposed via root script `npm run health:validator`.
+
+The health-check performs deterministic, CI-friendly assertions for scope profiles `repo`, `app`, and `docs`:
+- required scope profiles must resolve via host API
+- repeated in-process runs per scope must keep stable summary-level outputs (`totalFilesScanned`, `counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`)
+- docs contract checks ensure scope documentation continues to state that `app` includes `src/`, `test/`, and `calculogic-validator/`
+
+Health-check behavior is fail-fast semantics: any contract violation returns non-zero exit status.
 
 ## 3.0 Classification Contract
 ### 3.1 Canonical

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "node --test --experimental-strip-types test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs",
     "validate:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs",
-    "validate:all": "node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs"
+    "validate:all": "node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs",
+    "health:validator": "node --experimental-strip-types calculogic-validator/scripts/validator-health-check.host.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation

- Provide a small, CI-friendly health check that asserts the naming validator remains deterministic and that scope/docs contracts do not drift. 
- Make validator commands and report-capture usage discoverable in the `calculogic-validator` README for fast onboarding. 
- Follow NL-first conventions by recording the health-check contract in the NL skeleton before wiring code. 

### Description

- Add `calculogic-validator/scripts/validator-health-check.host.mjs` which imports the host API (`runNamingValidator`, `summarizeFindings`, `getScopeProfile`) and for each scope in `['repo','app','docs']` verifies the scope profile exists, runs the validator twice in-process, and asserts deterministic summary-level outputs (`totalFilesScanned`, `counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`).
- Add a lightweight docs-drift check in the health-check that reads `doc/ConventionRoutines/NamingValidatorSpec.md` and `doc/nl-config/cfg-namingValidator.md` and asserts they mention the `app` roots `src/`, `test/`, and `calculogic-validator/`.
- Wire a root npm script: `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a131e28b4c83318c33c6ff6e21271e)