### PR TITLE
docs(validator): make report-capture registry-safe and expose validator commands

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -13,6 +13,16 @@ npm run validate:naming -- --scope=app
 npm run validate:naming -- --scope=docs
 ```
 
+Run full validator suite:
+
+```bash
+npm run validate:all
+npm run validate:all -- --scope=repo
+npm run validate:all -- --scope=app
+npm run validate:all -- --scope=docs
+npm run validate:all -- --validators=naming --scope=app
+```
+
 Run validator health check:
 
 ```bash
@@ -22,14 +32,22 @@ npm run health:validator
 Capture command output into timestamped report files:
 
 ```bash
-npx calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app
-npx calculogic-report-capture --prefix validator-health --keep 20 -- npm run health:validator
-npx calculogic-report-capture --dir .local-reports --keep 50 -- npm run validate:naming -- --scope=repo
+npm exec -- calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app
+npm exec -- calculogic-report-capture --prefix validator-health --keep 20 -- npm run health:validator
+npm exec -- calculogic-report-capture --dir .local-reports --keep 50 -- npm run validate:naming -- --scope=repo
 ```
+
+Offline / locked registry note:
+
+- Preferred: `npm exec -- calculogic-report-capture ...` (requires dependencies already installed via `npm ci` or `npm install`).
+- Strict no-download mode: `npx --no-install calculogic-report-capture ...`
+- Example: `npx --no-install calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app`
 
 By default, `calculogic-report-capture` writes report files to OS cache storage.
 Use `--dir` to write to a repo-local or custom directory.
 Use `--json` if you want machine-readable metadata that includes the report path.
+CI tip: use `--dir .local-reports` (or another workspace folder) so the report can be uploaded as an artifact.
+If you use a repo-local report directory, add it to `.gitignore`.
 
 - Canonical validator module now lives in `src/naming/` (`naming-validator.host.mjs` / `naming-validator.wiring.mjs` / `naming-validator.logic.mjs` / `naming-validator.contracts.mjs`).
 - CLI entrypoint lives in `scripts/validate-naming.mjs`.


### PR DESCRIPTION
### Motivation

- Avoid failures in restricted CI/sandbox environments where `npx` may attempt network fetches and receive `403` errors. 
- Make validator entrypoints and example invocations easy to discover and copy/paste, including the newer `validate:all` runner and `health:validator` check. 

### Description

- Updated only `calculogic-validator/README.md` to add a `validate:all` Commands section with scoped and subset examples such as `npm run validate:all -- --validators=naming --scope=app`.
- Replaced plain `npx calculogic-report-capture ...` examples with local-first invocations using `npm exec -- calculogic-report-capture ...` in the three capture examples.
- Added a short "Offline / locked registry" note that documents the preferred `npm exec -- ...` usage and the strict no-download fallback `npx --no-install calculogic-report-capture ...`, including a copy/paste-ready `npx --no-install` example.
- Clarified report destination behavior and added a CI tip to use `--dir .local-reports` so generated reports can be uploaded as artifacts, plus a reminder to add a repo-local reports dir to `.gitignore`.

### Testing

- Verified the updated README contents by printing and reviewing the file (inspected `calculogic-validator/README.md` via local file display); the new commands and notes are present and formatted correctly.
- Confirmed the diff shows only `calculogic-validator/README.md` was changed and the intended lines were inserted.
- No automated unit/test-suite changes were made and no tests were run as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a137c83ac08331961f2504746aaa7e)