### PR TITLE
Add validator --config loader and CLI plumbing (reportable extensions override)

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -7,9 +7,11 @@ import {
   getScopeProfile,
 } from '../src/naming/naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
+  let configPath;
 
   for (const argument of argv) {
     if (argument.startsWith('--scope=')) {
@@ -18,17 +20,22 @@ const parseScopeFromCli = argv => {
     }
 
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope };
+      return { helpRequested: true, selectedScope, configPath };
+    }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
+      continue;
     }
 
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope };
+  return { helpRequested: false, selectedScope, configPath };
 };
 
 const usageLines = [
-  'Usage: calculogic-validate-naming [--scope=<repo|app|docs>]',
+  'Usage: calculogic-validate-naming [--scope=<repo|app|docs>] [--config=<path>]',
   'Scopes:',
   ...listNamingValidatorScopes().map(scope => {
     const profile = getScopeProfile(scope);
@@ -59,7 +66,19 @@ if (!getScopeProfile(parsed.selectedScope)) {
 
 const selectedScopeProfile = getScopeProfile(parsed.selectedScope);
 const repositoryRoot = resolveRepositoryRoot();
-const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: parsed.selectedScope });
+
+let config;
+try {
+  config = parsed.configPath
+    ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
+    : undefined;
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: parsed.selectedScope, config });
 const summary = summarizeFindings(findings);
 
 const report = {

--- a/calculogic-validator/bin/calculogic-validate.mjs
+++ b/calculogic-validator/bin/calculogic-validate.mjs
@@ -4,9 +4,10 @@ import { getValidatorScopeProfile, listValidatorScopes } from '../src/validator-
 import { runValidatorRunner } from '../src/validator-runner.logic.mjs';
 import { listRegisteredValidators } from '../src/validator-registry.knowledge.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 
 const usageLines = [
-  'Usage: calculogic-validate [--scope=<repo|app|docs>] [--validators=<id1,id2>]',
+  'Usage: calculogic-validate [--scope=<repo|app|docs>] [--validators=<id1,id2>] [--config=<path>]',
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
@@ -21,14 +22,20 @@ const usageLines = [
 const parseCliArgs = argv => {
   let selectedScope;
   let validators;
+  let configPath;
 
   for (const argument of argv) {
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, validators };
+      return { helpRequested: true, selectedScope, validators, configPath };
     }
 
     if (argument.startsWith('--scope=')) {
       selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
       continue;
     }
 
@@ -44,7 +51,7 @@ const parseCliArgs = argv => {
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, validators };
+  return { helpRequested: false, selectedScope, validators, configPath };
 };
 
 let parsed;
@@ -69,9 +76,14 @@ if (parsed.selectedScope && !getValidatorScopeProfile(parsed.selectedScope)) {
 
 try {
   const repositoryRoot = resolveRepositoryRoot();
+  const config = parsed.configPath
+    ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
+    : undefined;
+
   const report = runValidatorRunner(repositoryRoot, {
     scope: parsed.selectedScope,
     validators: parsed.validators,
+    config,
   });
 
   console.log(JSON.stringify(report, null, 2));

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -2,11 +2,12 @@ import { getValidatorScopeProfile, listValidatorScopes } from '../src/validator-
 import { runValidatorRunner } from '../src/validator-runner.logic.mjs';
 import { listRegisteredValidators } from '../src/validator-registry.knowledge.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
 const usageLines = [
-  'Usage: npm run validate:all -- [--scope=<repo|app|docs>] [--validators=<id1,id2>]',
+  'Usage: npm run validate:all -- [--scope=<repo|app|docs>] [--validators=<id1,id2>] [--config=<path>]',
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
@@ -21,14 +22,20 @@ const usageLines = [
 const parseCliArgs = argv => {
   let selectedScope;
   let validators;
+  let configPath;
 
   for (const argument of argv) {
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, validators };
+      return { helpRequested: true, selectedScope, validators, configPath };
     }
 
     if (argument.startsWith('--scope=')) {
       selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
       continue;
     }
 
@@ -44,7 +51,7 @@ const parseCliArgs = argv => {
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, validators };
+  return { helpRequested: false, selectedScope, validators, configPath };
 };
 
 let parsed;
@@ -68,9 +75,14 @@ if (parsed.selectedScope && !getValidatorScopeProfile(parsed.selectedScope)) {
 }
 
 try {
+  const config = parsed.configPath
+    ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
+    : undefined;
+
   const report = runValidatorRunner(repositoryRoot, {
     scope: parsed.selectedScope,
     validators: parsed.validators,
+    config,
   });
 
   console.log(JSON.stringify(report, null, 2));

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -5,11 +5,13 @@ import {
   getScopeProfile,
 } from '../src/naming/naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
+  let configPath;
 
   for (const argument of argv) {
     if (argument.startsWith('--scope=')) {
@@ -18,15 +20,22 @@ const parseScopeFromCli = argv => {
     }
 
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope };
+      return { helpRequested: true, selectedScope, configPath };
     }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
+      continue;
+    }
+
+    throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope };
+  return { helpRequested: false, selectedScope, configPath };
 };
 
 const usageLines = [
-  'Usage: npm run validate:naming -- --scope=<repo|app|docs>',
+  'Usage: npm run validate:naming -- [--scope=<repo|app|docs>] [--config=<path>]',
   'Scopes:',
   ...listNamingValidatorScopes().map(scope => {
     const profile = getScopeProfile(scope);
@@ -35,7 +44,16 @@ const usageLines = [
   'Default scope: repo',
 ];
 
-const { helpRequested, selectedScope } = parseScopeFromCli(process.argv.slice(2));
+let parsed;
+try {
+  parsed = parseScopeFromCli(process.argv.slice(2));
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+const { helpRequested, selectedScope, configPath } = parsed;
 
 if (helpRequested) {
   console.log(usageLines.join('\n'));
@@ -49,7 +67,17 @@ if (!getScopeProfile(selectedScope)) {
 }
 
 const selectedScopeProfile = getScopeProfile(selectedScope);
-const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: selectedScope });
+
+let config;
+try {
+  config = configPath ? loadValidatorConfigFromFile(configPath, { cwd: process.cwd() }) : undefined;
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: selectedScope, config });
 const summary = summarizeFindings(findings);
 
 const report = {

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -25,9 +25,9 @@ export const normalizePath = relativePath => relativePath.split(path.sep).join('
 
 export { parseCanonicalName, getSpecialCaseType, isAllowedSpecialCase };
 
-const isReportableFile = relativePath => {
+const isReportableFile = (relativePath, reportableExtensions = REPORTABLE_EXTENSIONS) => {
   const extension = path.extname(relativePath);
-  if (REPORTABLE_EXTENSIONS.has(extension)) {
+  if (reportableExtensions.has(extension)) {
     return true;
   }
 
@@ -36,7 +36,7 @@ const isReportableFile = relativePath => {
 
 const sortPaths = paths => Array.from(paths).sort((left, right) => left.localeCompare(right));
 
-const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.') => {
+const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {}) => {
   const normalizedRoot = normalizePath(rootRelativePath);
   const absoluteRoot = path.resolve(rootDirectory, normalizedRoot);
   if (!fs.existsSync(absoluteRoot)) {
@@ -48,6 +48,7 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.') => {
     return [];
   }
 
+  const reportableExtensions = options.reportableExtensions ?? REPORTABLE_EXTENSIONS;
   const collected = [];
 
   const walk = absoluteDirectoryPath => {
@@ -72,7 +73,7 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.') => {
       const absolutePath = path.join(absoluteDirectoryPath, entry.name);
       const relativePath = path.relative(rootDirectory, absolutePath);
       const normalizedPath = normalizePath(relativePath);
-      if (isReportableFile(normalizedPath)) {
+      if (isReportableFile(normalizedPath, reportableExtensions)) {
         collected.push(normalizedPath);
       }
     }
@@ -112,7 +113,9 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
     throw new Error(`Invalid scope profile: ${selectedScope}`);
   }
 
-  const allReportablePaths = collectPathsFromRoot(rootDirectory, '.');
+  const allReportablePaths = collectPathsFromRoot(rootDirectory, '.', {
+    reportableExtensions: options.reportableExtensions,
+  });
 
   if (selectedScope === 'repo') {
     return sortPaths(new Set(allReportablePaths));
@@ -232,7 +235,10 @@ export const classifyPath = relativePath => {
 
 export const runNamingValidator = (rootDirectory, options = {}) => {
   const selectedScope = options.scope ?? 'repo';
-  const paths = collectRepositoryPaths(rootDirectory, { scope: selectedScope });
+  const paths = collectRepositoryPaths(rootDirectory, {
+    scope: selectedScope,
+    reportableExtensions: options.reportableExtensions,
+  });
   const findings = paths.map(pathname => classifyPath(pathname));
 
   return {

--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -1,1 +1,36 @@
-export * from './naming-validator.logic.mjs';
+import { REPORTABLE_EXTENSIONS } from './registries/naming-extensions.knowledge.mjs';
+import {
+  parseCanonicalName,
+  getSpecialCaseType,
+  isAllowedSpecialCase,
+  normalizePath,
+  listNamingValidatorScopes,
+  getScopeProfile,
+  collectRepositoryPaths,
+  classifyPath,
+  runNamingValidator as runNamingValidatorRuntime,
+  summarizeFindings,
+} from './naming-validator.logic.mjs';
+
+const deriveReportableExtensions = config => {
+  const additions = config?.naming?.reportableExtensions?.add ?? [];
+  return new Set([...REPORTABLE_EXTENSIONS, ...additions]);
+};
+
+export const runNamingValidator = (repositoryRoot, { scope, config } = {}) =>
+  runNamingValidatorRuntime(repositoryRoot, {
+    scope,
+    reportableExtensions: deriveReportableExtensions(config),
+  });
+
+export {
+  parseCanonicalName,
+  getSpecialCaseType,
+  isAllowedSpecialCase,
+  normalizePath,
+  listNamingValidatorScopes,
+  getScopeProfile,
+  collectRepositoryPaths,
+  classifyPath,
+  summarizeFindings,
+};

--- a/calculogic-validator/src/validator-config.contracts.mjs
+++ b/calculogic-validator/src/validator-config.contracts.mjs
@@ -1,0 +1,1 @@
+export const VALIDATOR_CONFIG_VERSION = '0.1';

--- a/calculogic-validator/src/validator-config.logic.mjs
+++ b/calculogic-validator/src/validator-config.logic.mjs
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { VALIDATOR_CONFIG_VERSION } from './validator-config.contracts.mjs';
+
+const fail = message => {
+  throw new Error(`Invalid validator config: ${message}`);
+};
+
+const normalizeConfig = config => {
+  const normalized = {
+    version: VALIDATOR_CONFIG_VERSION,
+  };
+
+  const additions = config?.naming?.reportableExtensions?.add;
+  if (additions) {
+    normalized.naming = {
+      reportableExtensions: {
+        add: Array.from(new Set(additions.map(extension => extension.trim()))),
+      },
+    };
+  }
+
+  return normalized;
+};
+
+const validateConfig = config => {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    fail('root must be an object.');
+  }
+
+  if (config.version !== VALIDATOR_CONFIG_VERSION) {
+    fail(`version must be "${VALIDATOR_CONFIG_VERSION}".`);
+  }
+
+  const additions = config?.naming?.reportableExtensions?.add;
+  if (additions === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(additions)) {
+    fail('naming.reportableExtensions.add must be an array of strings.');
+  }
+
+  additions.forEach((extension, index) => {
+    if (typeof extension !== 'string') {
+      fail(`naming.reportableExtensions.add[${index}] must be a string starting with ".".`);
+    }
+
+    const trimmed = extension.trim();
+    if (!trimmed.startsWith('.')) {
+      fail(`naming.reportableExtensions.add[${index}] must start with ".".`);
+    }
+  });
+};
+
+export const loadValidatorConfigFromFile = (configPath, { cwd = process.cwd() } = {}) => {
+  if (!configPath || typeof configPath !== 'string') {
+    fail('path must be a non-empty string.');
+  }
+
+  const resolvedPath = path.resolve(cwd, configPath);
+
+  let rawJson;
+  try {
+    rawJson = fs.readFileSync(resolvedPath, 'utf8');
+  } catch {
+    throw new Error(`Failed to read validator config file: ${resolvedPath}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    throw new Error(`Failed to parse validator config JSON: ${resolvedPath}`);
+  }
+
+  validateConfig(parsed);
+  return normalizeConfig(parsed);
+};

--- a/calculogic-validator/src/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/validator-registry.knowledge.mjs
@@ -5,7 +5,8 @@ import {
 
 const runNamingValidatorHook = (repositoryRoot, options = {}) => {
   const scope = options.scope;
-  const namingResult = runNamingValidator(repositoryRoot, { scope });
+  const config = options.config;
+  const namingResult = runNamingValidator(repositoryRoot, { scope, config });
   const summary = summarizeFindings(namingResult.findings);
 
   return {

--- a/calculogic-validator/src/validator-runner.logic.mjs
+++ b/calculogic-validator/src/validator-runner.logic.mjs
@@ -42,9 +42,10 @@ export const runValidatorRunner = (repositoryRoot, options = {}) => {
   const startedAtDate = new Date();
   const validatorsToRun = resolveValidatorsToRun(options.validators);
   const scope = options.scope;
+  const config = options.config;
 
   const validators = validatorsToRun.map(registryEntry => {
-    const result = registryEntry.run(repositoryRoot, { scope });
+    const result = registryEntry.run(repositoryRoot, { scope, config });
     return toValidatorReportEntry(registryEntry, result);
   });
 

--- a/calculogic-validator/test/fixtures/validator-config.extensions.contracts.json
+++ b/calculogic-validator/test/fixtures/validator-config.extensions.contracts.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1",
+  "naming": {
+    "reportableExtensions": {
+      "add": [".py"]
+    }
+  }
+}

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -77,7 +77,7 @@ test('invalid scope handling is deterministic (usage error + non-zero exit)', ()
   const result = runValidatorCli(['--scope=not-a-scope']);
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Invalid scope: not-a-scope/u);
-  assert.match(result.stderr, /Usage: npm run validate:naming -- --scope=<repo\|app\|docs>/u);
+  assert.match(result.stderr, /Usage: npm run validate:naming/u);
 });
 
 test('CLI default scope report is repo', () => {

--- a/calculogic-validator/test/naming-validator.test.mjs
+++ b/calculogic-validator/test/naming-validator.test.mjs
@@ -151,5 +151,5 @@ test('invalid CLI scope returns deterministic usage error and non-zero exit', ()
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Invalid scope: invalid-scope/u);
-  assert.match(result.stderr, /Usage: npm run validate:naming -- --scope=<repo\|app\|docs>/u);
+  assert.match(result.stderr, /Usage: npm run validate:naming/u);
 });

--- a/calculogic-validator/test/validator-config.extensions.integration.test.mjs
+++ b/calculogic-validator/test/validator-config.extensions.integration.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runNamingValidator } from '../src/naming/naming-validator.host.mjs';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+
+test('config reportableExtensions.add includes .py files in scan set', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'validator-config-ext-'));
+
+  try {
+    fs.mkdirSync(path.join(tempRoot, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tempRoot, 'src', 'script.py'), 'print("hello")\n');
+
+    const withoutConfig = runNamingValidator(tempRoot, { scope: 'repo' });
+    const config = loadValidatorConfigFromFile(
+      'calculogic-validator/test/fixtures/validator-config.extensions.contracts.json',
+      { cwd: process.cwd() },
+    );
+    const withConfig = runNamingValidator(tempRoot, { scope: 'repo', config });
+
+    assert.equal(withoutConfig.totalFilesScanned, 0);
+    assert.equal(withConfig.totalFilesScanned, 1);
+    assert.equal(withConfig.findings[0].path, 'src/script.py');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/validator-config.extensions.test.mjs
+++ b/calculogic-validator/test/validator-config.extensions.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+
+const fixturePath = 'calculogic-validator/test/fixtures/validator-config.extensions.contracts.json';
+
+test('loads validator config and normalizes reportable extension additions', () => {
+  const config = loadValidatorConfigFromFile(fixturePath, { cwd: process.cwd() });
+
+  assert.equal(config.version, '0.1');
+  assert.deepEqual(config.naming?.reportableExtensions?.add, ['.py']);
+});
+
+test('fails when version is not supported', () => {
+  const invalidPath = path.join(process.cwd(), 'calculogic-validator/test/fixtures/tmp-invalid-version.json');
+  fs.writeFileSync(invalidPath, JSON.stringify({ version: '9.9' }));
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(invalidPath, { cwd: '/' }),
+      /Invalid validator config: version must be "0.1"\./u,
+    );
+  } finally {
+    fs.rmSync(invalidPath, { force: true });
+  }
+});
+
+test('fails when extension entries do not start with dot', () => {
+  const invalidPath = path.join(process.cwd(), 'calculogic-validator/test/fixtures/tmp-invalid-extension.json');
+  fs.writeFileSync(
+    invalidPath,
+    JSON.stringify({
+      version: '0.1',
+      naming: { reportableExtensions: { add: ['py'] } },
+    }),
+  );
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(invalidPath, { cwd: '/' }),
+      /Invalid validator config: naming\.reportableExtensions\.add\[0\] must start with "\."\./u,
+    );
+  } finally {
+    fs.rmSync(invalidPath, { force: true });
+  }
+});

--- a/calculogic-validator/test/validator-package-bins.test.mjs
+++ b/calculogic-validator/test/validator-package-bins.test.mjs
@@ -38,3 +38,29 @@ test('calculogic-validate-naming bin returns naming report JSON', () => {
   assert.equal(report.scope, 'app');
   assert.equal(typeof report.totalFilesScanned, 'number');
 });
+
+
+test('calculogic-validate bin accepts --config path', () => {
+  const result = runBin([
+    'calculogic-validator/bin/calculogic-validate.mjs',
+    '--scope=app',
+    '--validators=naming',
+    '--config=calculogic-validator/test/fixtures/validator-config.extensions.contracts.json',
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.validators[0].id, 'naming');
+});
+
+test('calculogic-validate-naming bin fails deterministically on invalid config', () => {
+  const result = runBin([
+    'calculogic-validator/bin/calculogic-validate-naming.mjs',
+    '--scope=app',
+    '--config=calculogic-validator/test/fixtures/not-found.json',
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Failed to read validator config file:/u);
+  assert.match(result.stderr, /Usage: calculogic-validate-naming/u);
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -64,6 +64,16 @@ The health-check performs deterministic, CI-friendly assertions for scope profil
 
 Health-check behavior is fail-fast semantics: any contract violation returns non-zero exit status.
 
+### 2.6 Validator config contract (V0.1)
+Naming validator supports optional runtime config input with deterministic JSON contract:
+- `version` must equal `"0.1"`
+- optional `naming.reportableExtensions.add` array
+- each extension entry must be a string starting with `.`
+
+Runtime behavior in this slice is additive-only for reportable extension collection:
+- derived reportable extensions = default registry union `config.naming.reportableExtensions.add`
+- defaults remain unchanged when config is omitted
+
 ## 3.0 Classification Contract
 ### 3.1 Canonical
 Classify as canonical when filename parses as `<semantic-name>.<role>.<ext>` (including `.module.css`) with kebab-case semantic name and known role.

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -13,6 +13,7 @@ The runner reads validator definitions from a deterministic registry in `calculo
 ### 2.2 Runtime options
 - `validators` (optional list of validator IDs)
 - `scope` (optional scope string forwarded to validators that support scope selection)
+- `config` (optional loaded validator config object from JSON contract V0.1)
 
 ### 2.3 Initial validator set
 V0.1.0 includes the naming validator only, wrapped through the registry run hook without changing naming-validator internals.
@@ -45,6 +46,7 @@ Each validator entry includes:
 - `--help`
 - `--scope=<repo|app|docs>` (optional)
 - `--validators=<id1,id2>` (optional)
+- `--config=<path>` (optional JSON config path)
 
 ### 4.2 Behavior
 - Resolves repository root deterministically from script location.


### PR DESCRIPTION
### Motivation

- Provide a deterministic JSON config mechanism (V0.1) so users can supply runtime options to validators in a reproducible way.
- Thread `--config=<path>` through all validator CLIs and the runner so registered validators can receive config without changing no-config behavior.
- Apply config-driven extension overrides only to naming validator `reportableExtensions.add` in this slice so new file types can be reported without changing defaults.

### Description

- Added a config contract `VALIDATOR_CONFIG_VERSION = '0.1'` in `calculogic-validator/src/validator-config.contracts.mjs` and a loader/validator `loadValidatorConfigFromFile` in `calculogic-validator/src/validator-config.logic.mjs` that parses, validates, normalizes (trim/dedupe) and emits deterministic errors for invalid JSON.
- Threaded the optional `config` through the runner by updating `runValidatorRunner` to pass `{ scope, config }` into registry runs and updated `validator-registry.knowledge.mjs` to forward `config` into the naming run hook.
- Implemented naming wiring/runtime changes in `calculogic-validator/src/naming/naming-validator.wiring.mjs` to compute `reportableExtensions = default ∪ config.naming.reportableExtensions.add` and updated `naming-validator.logic.mjs` to accept an injected `reportableExtensions` set used by `isReportableFile` and `collectRepositoryPaths` while keeping default behavior unchanged when no config is provided.
- Added `--config=<path>` parsing, usage text, deterministic error handling, and config loading to `calculogic-validator/scripts/validate-all.mjs`, `calculogic-validator/scripts/validate-naming.mjs`, `calculogic-validator/bin/calculogic-validate.mjs`, and `calculogic-validator/bin/calculogic-validate-naming.mjs`.
- Added fixture and tests: `calculogic-validator/test/fixtures/validator-config.extensions.contracts.json`, unit tests `calculogic-validator/test/validator-config.extensions.test.mjs`, integration test `calculogic-validator/test/validator-config.extensions.integration.test.mjs`, and CLI/bin assertions in `calculogic-validator/test/validator-package-bins.test.mjs`; also updated a couple of existing usage assertions to accept the expanded usage text.
- Updated NL-first docs `doc/nl-config/cfg-validatorRunner.md` and `doc/nl-config/cfg-namingValidator.md` to declare the config contract and CLI `--config` inputs before implementation.

### Testing

- Ran `npm test` with the new unit and integration tests which completed successfully (all tests passed).
- Ran `npm run validate:naming -- --scope=app` and verified the report runs and prints JSON successfully (exit 0).
- Ran `npm run validate:all -- --scope=app` and verified the combined runner report runs and prints JSON successfully (exit 0).
- Ran `node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app --config=calculogic-validator/test/fixtures/validator-config.extensions.contracts.json` and confirmed `.py` files are included when configured and that invalid config paths produce deterministic errors (both cases succeeded as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a150133f0c83318d3060d79da13cbf)