### PR TITLE
chore: remove unused naming role imports in naming validator wiring

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -1,8 +1,6 @@
 import { REPORTABLE_EXTENSIONS } from './registries/naming-extensions.knowledge.mjs';
 import {
   ROLE_METADATA,
-  ACTIVE_ROLES,
-  ROLE_SUFFIXES,
 } from './registries/naming-roles.knowledge.mjs';
 import {
   parseCanonicalName,


### PR DESCRIPTION
### Motivation
- Remove unused `ACTIVE_ROLES` and `ROLE_SUFFIXES` imports from the naming validator wiring file as a small nit cleanup to avoid unused symbols and potential linter warnings.

### Description
- Updated the import from `./registries/naming-roles.knowledge.mjs` to only import `ROLE_METADATA` in `calculogic-validator/src/naming/naming-validator.wiring.mjs`.

### Testing
- Ran `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a155e07a3483319b70130e9cd6b963)