### PR TITLE
Add NAMING_MISSING_ROLE classification for filename-only missing role cases

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -114,6 +114,26 @@ export const getScopeProfile = scope => {
   return profile ? cloneScopeProfile(profile) : null;
 };
 
+const detectMissingRoleCandidate = basename => {
+  const segments = basename.split('.');
+
+  if (segments.length === 2) {
+    return {
+      semanticNameCandidate: segments[0],
+      extension: segments[1],
+    };
+  }
+
+  if (segments.length === 3 && segments[1] === 'module' && segments[2] === 'css') {
+    return {
+      semanticNameCandidate: segments[0],
+      extension: 'module.css',
+    };
+  }
+
+  return null;
+};
+
 export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   const selectedScope = options.scope ?? 'repo';
   const profile = getScopeProfile(selectedScope);
@@ -154,6 +174,20 @@ export const classifyPath = (relativePath, namingRolesRuntime) => {
 
   const parsed = parseCanonicalName(basename);
   if (parsed) {
+    const missingRoleCandidate = detectMissingRoleCandidate(basename);
+    if (missingRoleCandidate && parsed.role === 'module' && parsed.extension === 'css') {
+      return {
+        code: 'NAMING_MISSING_ROLE',
+        severity: 'info',
+        path: normalizedPath,
+        classification: 'legacy-exception',
+        message: 'Filename appears to be missing the role segment; canonical format is <semantic-name>.<role>.<ext>.',
+        ruleRef: 'doc/ConventionRoutines/FileNamingMasterList-V1_1.md#canonical-pattern',
+        suggestedFix: 'Rename to <semantic-name>.<role>.<ext> using an active role.',
+        details: missingRoleCandidate,
+      };
+    }
+
     const roleMetadata = getRoleMetadata(parsed.role, runtime.roleMetadata);
 
     if (isUnknownOrInactiveRole(parsed.role, roleMetadata, runtime.activeRoles)) {
@@ -229,6 +263,20 @@ export const classifyPath = (relativePath, namingRolesRuntime) => {
       message: `Role "${ambiguity.role}" appears hyphen-appended instead of dot-separated.`,
       ruleRef: 'FileNamingMasterList-V1_1.md#role-suffix-separation-rule-important',
       suggestedFix: 'Rename using <semantic-name>.<role>.<ext>.',
+    };
+  }
+
+  const missingRoleCandidate = detectMissingRoleCandidate(basename);
+  if (missingRoleCandidate) {
+    return {
+      code: 'NAMING_MISSING_ROLE',
+      severity: 'info',
+      path: normalizedPath,
+      classification: 'legacy-exception',
+      message: 'Filename appears to be missing the role segment; canonical format is <semantic-name>.<role>.<ext>.',
+      ruleRef: 'doc/ConventionRoutines/FileNamingMasterList-V1_1.md#canonical-pattern',
+      suggestedFix: 'Rename to <semantic-name>.<role>.<ext> using an active role.',
+      details: missingRoleCandidate,
     };
   }
 

--- a/calculogic-validator/test/naming-missing-role.test.mjs
+++ b/calculogic-validator/test/naming-missing-role.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyPath } from '../src/naming/naming-validator.host.mjs';
+
+test('classifies two-segment reportable filename as missing role', () => {
+  const finding = classifyPath('src/App.tsx');
+  assert.equal(finding.code, 'NAMING_MISSING_ROLE');
+});
+
+test('keeps hyphen-appended role ambiguity precedence', () => {
+  const finding = classifyPath('src/leftpanel-wiring.ts');
+  assert.equal(finding.code, 'NAMING_ROLE_HYPHEN_AMBIGUITY');
+});
+
+test('classifies module.css two-part semantic pattern as missing role', () => {
+  const finding = classifyPath('src/buildsurface.module.css');
+  assert.equal(finding.code, 'NAMING_MISSING_ROLE');
+  assert.equal(finding.details?.extension, 'module.css');
+});
+
+test('preserves allowed special-case behavior', () => {
+  const finding = classifyPath('README.md');
+  assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
+});

--- a/calculogic-validator/test/naming-validator.test.mjs
+++ b/calculogic-validator/test/naming-validator.test.mjs
@@ -90,10 +90,10 @@ test('classifies README as conventional-doc special case', () => {
   assert.equal(finding.details?.specialCaseType, 'conventional-doc');
 });
 
-test('classifies legacy exceptions for non-canonical legacy names', () => {
+test('classifies missing-role teaching case for non-canonical two-segment names', () => {
   const finding = classifyPath('src/App.tsx');
   assert.equal(finding.classification, 'legacy-exception');
-  assert.equal(finding.code, 'NAMING_LEGACY_EXCEPTION');
+  assert.equal(finding.code, 'NAMING_MISSING_ROLE');
 });
 
 test('repo scope includes docs + src + root config examples', () => {


### PR DESCRIPTION
### Motivation

- Teach the naming validator to emit a dedicated, low-severity finding when a reportable filename appears to be missing the role segment (examples: `App.tsx`, `buildsurface.module.css`).
- Provide a deterministic, filename-only detection that does not guess roles or change canonical parsing behavior.
- Preserve existing special-case handling and hyphen-appended ambiguity precedence so no regressions occur for reserved names or `NAMING_ROLE_HYPHEN_AMBIGUITY` cases.

### Description

- Added a helper `detectMissingRoleCandidate(basename)` in `calculogic-validator/src/naming/naming-validator.logic.mjs` that returns `{ semanticNameCandidate, extension }` for two-segment names (`<name>.<ext>`) and `*.module.css` (`<name>.module.css`) or `null` otherwise.
- Emit a new finding with `code: "NAMING_MISSING_ROLE"`, `severity: "info"`, `classification: "legacy-exception"`, `ruleRef: 'doc/ConventionRoutines/FileNamingMasterList-V1_1.md#canonical-pattern'`, `suggestedFix: 'Rename to <semantic-name>.<role>.<ext> using an active role.'`, and `details` containing the detection payload; this runs after the hyphen-role ambiguity check in `classifyPath()` so ambiguity still wins.
- Special-case: ensure `*.module.css` teaching case is handled without producing a canonical parse/unknown-role error by checking for the missing-role candidate in the canonical branch as well.
- Added unit tests in `calculogic-validator/test/naming-missing-role.test.mjs` and updated the existing expectation for `src/App.tsx` in `calculogic-validator/test/naming-validator.test.mjs` to reflect the new `NAMING_MISSING_ROLE` finding.

### Testing

- Ran the full test suite with `npm test` at the repository root, which executes `node --test` over `test/**/*.test.mjs` and `calculogic-validator/test/**/*.test.mjs`, and all tests passed.
- New unit tests include checks that `classifyPath('src/App.tsx')` and `classifyPath('src/buildsurface.module.css')` return `NAMING_MISSING_ROLE`, that `classifyPath('src/leftpanel-wiring.ts')` remains `NAMING_ROLE_HYPHEN_AMBIGUITY`, and that `README.md` remains an allowed special case.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1662ee2b0833187abaeb51f878b34)