### PR TITLE
Add documentation role category and canonical documentation roles

### DIFF
--- a/calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs
@@ -8,6 +8,12 @@ export const ROLE_REGISTRY = [
   { role: 'knowledge', category: 'concern-core', status: 'active' },
   { role: 'results', category: 'concern-core', status: 'active' },
   { role: 'results-style', category: 'concern-core', status: 'active' },
+  { role: 'spec', category: 'documentation', status: 'active' },
+  { role: 'policy', category: 'documentation', status: 'active' },
+  { role: 'workflow', category: 'documentation', status: 'active' },
+  { role: 'plan', category: 'documentation', status: 'active' },
+  { role: 'audit', category: 'documentation', status: 'active' },
+  { role: 'healthcheck', category: 'documentation', status: 'active' },
   {
     role: 'view',
     category: 'deprecated',

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -4,7 +4,7 @@ export const EXCLUDED_DIRECTORIES = new Set(['.git', 'node_modules', 'dist', 'co
 
 export { ROOT_APP_FILES };
 
-export const TEST_CONVENTION_PATTERN = /\.test\.[^.]+$|\.spec\.[^.]+$/u;
+export const TEST_CONVENTION_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/u;
 export const AMBIENT_DECLARATION_PATTERN = /\.d\.ts$/u;
 export const TSCONFIG_PATTERN = /^tsconfig(\..+)?\.json$/u;
 export const TOOLING_CONFIG_PATTERN = /^vite\.config\.[^.]+$|^eslint\.config\.[^.]+$/u;

--- a/calculogic-validator/src/validator-config.logic.mjs
+++ b/calculogic-validator/src/validator-config.logic.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { VALIDATOR_CONFIG_VERSION } from './validator-config.contracts.mjs';
 
-const VALID_ROLE_CATEGORIES = new Set(['concern-core', 'architecture-support', 'deprecated']);
+const VALID_ROLE_CATEGORIES = new Set(['concern-core', 'architecture-support', 'documentation', 'deprecated']);
 const VALID_ROLE_STATUSES = new Set(['active', 'deprecated']);
 
 const fail = message => {
@@ -94,7 +94,7 @@ const validateRoleAdditionEntry = (entry, index) => {
 
   if (!VALID_ROLE_CATEGORIES.has(entry.category)) {
     fail(
-      `naming.roles.add[${index}].category must be one of: concern-core, architecture-support, deprecated.`,
+      `naming.roles.add[${index}].category must be one of: concern-core, architecture-support, documentation, deprecated.`,
     );
   }
 

--- a/calculogic-validator/test/naming-validator.test.mjs
+++ b/calculogic-validator/test/naming-validator.test.mjs
@@ -36,6 +36,14 @@ test('classifies canonical valid example', () => {
   assert.equal(finding.code, 'NAMING_CANONICAL');
 });
 
+test('classifies documentation spec role as canonical with role metadata', () => {
+  const finding = classifyPath('doc/ConventionRoutines/cscs.spec.md');
+  assert.equal(finding.classification, 'canonical');
+  assert.equal(finding.code, 'NAMING_CANONICAL');
+  assert.equal(finding.details?.roleCategory, 'documentation');
+  assert.equal(finding.details?.roleStatus, 'active');
+});
+
 test('classifies unknown role as invalid-ambiguous', () => {
   const finding = classifyPath('src/rightpanel.widget.ts');
   assert.equal(finding.classification, 'invalid-ambiguous');
@@ -70,6 +78,13 @@ test('classifies barrel special case with subtype', () => {
 
 test('classifies test convention special case with subtype', () => {
   const finding = classifyPath('test/content-provider-registry.test.mjs');
+  assert.equal(finding.classification, 'allowed-special-case');
+  assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
+  assert.equal(finding.details?.specialCaseType, 'test-convention');
+});
+
+test('classifies spec test convention file with code extension as special case', () => {
+  const finding = classifyPath('test/content-provider-registry.spec.ts');
   assert.equal(finding.classification, 'allowed-special-case');
   assert.equal(finding.code, 'NAMING_ALLOWED_SPECIAL_CASE');
   assert.equal(finding.details?.specialCaseType, 'test-convention');

--- a/calculogic-validator/test/validator-config.roles.test.mjs
+++ b/calculogic-validator/test/validator-config.roles.test.mjs
@@ -91,7 +91,7 @@ test('fails when naming.roles.add category or status is invalid', () => {
   try {
     assert.throws(
       () => loadValidatorConfigFromFile(invalidCategoryPath, { cwd: '/' }),
-      /Invalid validator config: naming\.roles\.add\[0\]\.category must be one of: concern-core, architecture-support, deprecated\./u,
+      /Invalid validator config: naming\.roles\.add\[0\]\.category must be one of: concern-core, architecture-support, documentation, deprecated\./u,
     );
 
     assert.throws(

--- a/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -390,6 +390,7 @@ All role registry entries MUST declare one category from the bounded list below.
 - `concern-core`: core Calculogic concern roles that represent primary concern responsibilities.
 - `concern-style`: style-partner concern roles dedicated to visual/layout styling concerns.
 - `architecture-support`: architecture support/wiring/composition/contract boundary roles.
+- `documentation`: documentation-only filename roles (spec/policy/workflow/plan/audit/healthcheck).
 - `indexing-registry`: stable indexing/catalog/inventory/anchor/identifier-style roles.
 - `integration-adapter`: adapter/mapper/resolver boundary translation roles (defined now for deterministic future use).
 - `deprecated`: historical role segments retained for detection and migration guidance.
@@ -509,6 +510,79 @@ Each role below has an explicit deterministic definition: meaning, purpose/use-c
   - not a mixed junk drawer with unclear ownership
   - not replacing clear concern files where concern ownership is explicit
 - **Category:** `architecture-support`
+- **Status:** `active`
+
+
+##### `spec`
+
+- **Meaning:** canonical specification/contract documentation for a defined scope.
+- **Purpose / use-cases:**
+  - definitive behavioral/structural specs used as implementation references
+  - bounded contracts expressed in documentation form
+- **Non-goals / misuse examples:**
+  - not governance rules or mandates (use `policy`)
+  - not procedural step-by-step routines (use `workflow`)
+- **Category:** `documentation`
+- **Status:** `active`
+
+##### `policy`
+
+- **Meaning:** governance and rule-setting documentation that defines must/should decisions.
+- **Purpose / use-cases:**
+  - coding/process policy statements
+  - stable decision rules and constraints for contributors
+- **Non-goals / misuse examples:**
+  - not implementation planning timelines (use `plan`)
+  - not one-off findings snapshots (use `audit`)
+- **Category:** `documentation`
+- **Status:** `active`
+
+##### `workflow`
+
+- **Meaning:** procedural documentation for repeatable routines and sequences.
+- **Purpose / use-cases:**
+  - step-by-step operational runbooks
+  - recurring contributor workflows
+- **Non-goals / misuse examples:**
+  - not normative governance requirements (use `policy`)
+  - not canonical behavior contracts (use `spec`)
+- **Category:** `documentation`
+- **Status:** `active`
+
+##### `plan`
+
+- **Meaning:** forward-looking planning documents for intended future work.
+- **Purpose / use-cases:**
+  - roadmap slices and planned implementation phases
+  - scoped intent docs for upcoming changes
+- **Non-goals / misuse examples:**
+  - not completed-state verification records (use `audit`/`healthcheck`)
+  - not normative rules for all contributors (use `policy`)
+- **Category:** `documentation`
+- **Status:** `active`
+
+##### `audit`
+
+- **Meaning:** point-in-time audit/reconciliation findings for a defined scope.
+- **Purpose / use-cases:**
+  - one-off conformance checks
+  - reconciliation snapshots and discrepancy reports
+- **Non-goals / misuse examples:**
+  - not recurring routine status tracking (use `healthcheck`)
+  - not future intent planning (use `plan`)
+- **Category:** `documentation`
+- **Status:** `active`
+
+##### `healthcheck`
+
+- **Meaning:** recurring health/status check documentation for operational visibility.
+- **Purpose / use-cases:**
+  - periodic status checks with repeated cadence
+  - lightweight system/process health reporting
+- **Non-goals / misuse examples:**
+  - not one-off deep-dive reconciliations (use `audit`)
+  - not step-by-step runbook procedures (use `workflow`)
+- **Category:** `documentation`
 - **Status:** `active`
 
 ##### `contracts`

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.9** (runtime config supports additive role-registry extensions for naming classification).
+Current implementation target: **V0.1.10** (runtime config supports additive role-registry extensions and documentation role taxonomy).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -22,7 +22,7 @@ Scope predicates are evaluated on normalized repository-relative paths before re
 ### 2.3 Role registry metadata (V0.1.1)
 The validator uses a structured role registry with metadata fields:
 - `role`
-- `category` (`concern-core`, `architecture-support`, `deprecated`)
+- `category` (`concern-core`, `architecture-support`, `documentation`, `deprecated`)
 - `status` (`active`, `deprecated`)
 - optional `notes`
 
@@ -36,6 +36,12 @@ Active roles:
 - knowledge
 - results
 - results-style
+- spec
+- policy
+- workflow
+- plan
+- audit
+- healthcheck
 
 Deprecated historical roles:
 - view
@@ -71,7 +77,7 @@ Naming validator supports optional runtime config input with deterministic JSON 
 - each extension entry must be a string starting with `.`
 - optional `naming.roles.add` array of role metadata objects:
   - required `role` string
-  - required `category` from `concern-core | architecture-support | deprecated`
+  - required `category` from `concern-core | architecture-support | documentation | deprecated`
   - required `status` from `active | deprecated`
   - optional `notes` string
 
@@ -95,7 +101,7 @@ Runtime behavior for role additions:
 Classify as canonical when filename parses as `<semantic-name>.<role>.<ext>` (including `.module.css`) with kebab-case semantic name and known role.
 
 ### 3.2 Allowed special case
-Classify as allowed special case for reserved filenames and patterns including barrel files, framework-required names, test files, ambient declaration files, and README convention docs.
+Classify as allowed special case for reserved filenames and patterns including barrel files, framework-required names, test files (`*.test.<code-ext>` / `*.spec.<code-ext>`), ambient declaration files, and README convention docs.
 
 Allowed special-case findings include `details.specialCaseType` values:
 - `ecosystem-required`


### PR DESCRIPTION
### Motivation
- Introduce a dedicated `documentation` role category so documentation files can be recognized as canonical filename roles without requiring per-repo config. 
- Provide a small, high-signal set of documentation roles (no catch-all) to enable migration toward canonical doc filenames like `cscs.spec.md` and `file-naming-masterlist.policy.md`. 
- Align validator config schema and validator behavior so adopters can add documentation roles in config and the runtime recognizes them consistently.

### Description
- Added six active documentation roles to the default registry in `calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs`: `spec`, `policy`, `workflow`, `plan`, `audit`, and `healthcheck`. 
- Allowed `documentation` in the validator config vocabulary by updating `VALID_ROLE_CATEGORIES` and the deterministic error message in `calculogic-validator/src/validator-config.logic.mjs`, and updated the corresponding test expectation in `calculogic-validator/test/validator-config.roles.test.mjs`. 
- Added validator coverage asserting `classifyPath('doc/ConventionRoutines/cscs.spec.md')` returns canonical with `details.roleCategory === 'documentation'` and `details.roleStatus === 'active'` in `calculogic-validator/test/naming-validator.test.mjs`, and preserved code-oriented `*.spec/*` test-convention behavior by narrowing the `TEST_CONVENTION_PATTERN` in `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`. 
- Documented the new category and concise role semantics (no catch-all) in `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, and updated the NL skeleton `doc/nl-config/cfg-namingValidator.md` to reflect the new taxonomy and config vocabulary.

### Testing
- Ran the full test suite with `npm test --silent`, and all tests passed. 
- Updated and executed unit tests in `calculogic-validator/test/validator-config.roles.test.mjs` and `calculogic-validator/test/naming-validator.test.mjs`, which passed under the updated behavior. 
- Verified validator classification behavior by exercising `classifyPath` scenarios for canonical docs and preserved special-case detection for code test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16e5dffe883318b241cc452c60ff1)