### PR TITLE
Add scope-specific report capture scripts and integration coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.reports/

--- a/calculogic-validator/test/report-capture.scopes.integration.test.mjs
+++ b/calculogic-validator/test/report-capture.scopes.integration.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const scopes = ['repo', 'app', 'docs'];
+const hostPath = path.resolve('calculogic-validator/tools/report-capture/src/report-capture.host.mjs');
+
+const runReportCapture = (prefix, scriptPath, scope, outputDir) => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [
+    hostPath,
+    '--dir',
+    outputDir,
+    '--keep',
+    '50',
+    '--prefix',
+    prefix,
+    '--',
+    process.execPath,
+    '--experimental-strip-types',
+    scriptPath,
+    `--scope=${scope}`,
+  ]);
+
+  child.on('error', reject);
+  child.on('close', code => {
+    if (code === 0) {
+      resolve();
+      return;
+    }
+
+    reject(new Error(`report capture exited with code ${code} for ${prefix}`));
+  });
+});
+
+const reportFilesForPrefix = (dirPath, prefix) => fs
+  .readdirSync(dirPath)
+  .filter(name => name.startsWith(`${prefix}-`) && name.endsWith('.txt'))
+  .sort();
+
+test('report-capture host emits naming reports for repo/app/docs scopes', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-scopes-naming-'));
+
+  try {
+    for (const scope of scopes) {
+      const prefix = `naming-${scope}`;
+      const before = reportFilesForPrefix(tempDir, prefix);
+
+      await runReportCapture(prefix, 'calculogic-validator/scripts/validate-naming.mjs', scope, tempDir);
+
+      const after = reportFilesForPrefix(tempDir, prefix);
+      assert.equal(after.length, before.length + 1);
+
+      const newest = after.at(-1);
+      assert.ok(newest, `missing report file for ${prefix}`);
+
+      const reportContent = fs.readFileSync(path.join(tempDir, newest), 'utf8');
+      assert.ok(reportContent.includes(`"scope": "${scope}"`));
+      assert.ok(reportContent.includes('"mode": "report"'));
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('report-capture host emits validate-all reports for repo/app/docs scopes', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-scopes-all-'));
+
+  try {
+    for (const scope of scopes) {
+      const prefix = `validate-all-${scope}`;
+      const before = reportFilesForPrefix(tempDir, prefix);
+
+      await runReportCapture(prefix, 'calculogic-validator/scripts/validate-all.mjs', scope, tempDir);
+
+      const after = reportFilesForPrefix(tempDir, prefix);
+      assert.equal(after.length, before.length + 1);
+
+      const newest = after.at(-1);
+      assert.ok(newest, `missing report file for ${prefix}`);
+
+      const reportContent = fs.readFileSync(path.join(tempDir, newest), 'utf8');
+      assert.ok(reportContent.includes(`"scope": "${scope}"`));
+      assert.ok(reportContent.includes('"mode": "report"'));
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,13 @@
     "test": "node --test --experimental-strip-types test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs",
     "validate:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs",
     "validate:all": "node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs",
-    "health:validator": "node --experimental-strip-types calculogic-validator/scripts/validator-health-check.host.mjs"
+    "health:validator": "node --experimental-strip-types calculogic-validator/scripts/validator-health-check.host.mjs",
+    "report:naming:repo": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-repo -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=repo",
+    "report:naming:app": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-app -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=app",
+    "report:naming:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=docs",
+    "report:all:repo": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-repo -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=repo",
+    "report:all:app": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-app -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=app",
+    "report:all:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=docs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- Provide deterministic, repo-local capture of full validator outputs for each scope (`repo`, `app`, `docs`) so long JSON reports are not truncated in terminal/VS Code views.
- Keep captured outputs out of validator scanning noise by writing to a dot-directory inside the repo and preventing accidental commits.
- Make it easy to invoke per-scope captures via `npm` and to prove the capture mechanism works with automated integration tests.

### Description
- Added `.reports/` to `.gitignore` so captured outputs are kept local and not committed (file: `.gitignore`).
- Added six npm scripts to `package.json` to capture report files to `./.reports/` using the existing `@calculogic/report-capture` wrapper: `report:naming:repo`, `report:naming:app`, `report:naming:docs`, `report:all:repo`, `report:all:app`, and `report:all:docs`, each using `--json --dir ./.reports --keep 20` with deterministic `naming-<scope>` or `validate-all-<scope>` prefixes (file: `package.json`).
- Added an integration test `calculogic-validator/test/report-capture.scopes.integration.test.mjs` that invokes the report-capture host directly for each scope and asserts a single new `*.txt` report file is produced and that the file content includes `"scope": "<scope>"` and `"mode": "report"` for both naming and validate-all runs.

### Testing
- Ran `npm test`, which executed the new integration test and the existing test suite; all tests passed (`78` tests, `0` failures).
- Executed the new capture scripts end-to-end with `npm run report:naming:docs && npm run report:naming:app && npm run report:naming:repo && npm run report:all:docs && npm run report:all:app && npm run report:all:repo`, which completed successfully and produced report files under `./.reports/` as advertised.
- The integration test verifies the host writes exactly one new `naming-<scope>-*.txt` / `validate-all-<scope>-*.txt` file per run and that the files contain the expected `"scope"` and `"mode"` text checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1efe7d5e883318e3fd6ae151f7db1)