### PR TITLE
Split scopes: add validator & system; update scope profiles, CLI, tests, and report-capture scripts

### DIFF
--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -7,7 +7,7 @@ import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 const repositoryRoot = resolveRepositoryRoot();
 
 const usageLines = [
-  'Usage: npm run validate:all -- [--scope=<repo|app|docs>] [--validators=<id1,id2>] [--config=<path>]',
+  'Usage: npm run validate:all -- [--scope=<repo|app|docs|validator|system>] [--validators=<id1,id2>] [--config=<path>]',
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -35,7 +35,7 @@ const parseScopeFromCli = argv => {
 };
 
 const usageLines = [
-  'Usage: npm run validate:naming -- [--scope=<repo|app|docs>] [--config=<path>]',
+  'Usage: npm run validate:naming -- [--scope=<repo|app|docs|validator|system>] [--config=<path>]',
   'Scopes:',
   ...listNamingValidatorScopes().map(scope => {
     const profile = getScopeProfile(scope);

--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -7,14 +7,24 @@ export const SCOPE_PROFILES = {
     includeRootFiles: [],
   },
   app: {
-    description: 'Application-focused scan (src/test/calculogic-validator and root tooling files).',
-    includeRoots: ['src', 'test', 'calculogic-validator'],
-    includeRootFiles: Array.from(ROOT_APP_FILES),
+    description: 'Application-only scan (src/** and test/**).',
+    includeRoots: ['src', 'test'],
+    includeRootFiles: [],
   },
   docs: {
     description: 'Documentation-focused scan (doc/docs and root conventional docs: README.md).',
     includeRoots: ['doc', 'docs'],
     includeRootFiles: ['README.md'],
+  },
+  validator: {
+    description: 'Validator-only scan (calculogic-validator/**).',
+    includeRoots: ['calculogic-validator'],
+    includeRootFiles: [],
+  },
+  system: {
+    description: 'System/tooling files scan (root package/tsconfig/eslint/vite files).',
+    includeRoots: [],
+    includeRootFiles: Array.from(ROOT_APP_FILES),
   },
 };
 

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -14,7 +14,7 @@ const runValidatorCli = args =>
   });
 
 test('scope registry exposes deterministic supported scopes', () => {
-  assert.deepEqual(listNamingValidatorScopes(), ['app', 'docs', 'repo']);
+  assert.deepEqual(listNamingValidatorScopes(), ['app', 'docs', 'repo', 'system', 'validator']);
 });
 
 test('default/no-scope behavior resolves to repo', () => {
@@ -38,14 +38,37 @@ test('--scope=docs includes doc/**, docs/**, and root README.md only from root c
   assert.equal(docsPaths.some(pathname => pathname === 'package.json'), false);
 });
 
-test('--scope=app excludes doc/docs folders while including app roots and root tooling files', () => {
+test('--scope=app includes src/test and excludes docs, validator, and root tooling files', () => {
   const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
-  assert.ok(appPaths.includes('calculogic-validator/src/validators/naming-validator.logic.mjs'));
-  assert.ok(appPaths.includes('calculogic-validator/test/naming-validator.test.mjs'));
-  assert.ok(appPaths.includes('calculogic-validator/scripts/validate-naming.mjs'));
-  assert.ok(appPaths.includes('package.json'));
+  assert.ok(appPaths.some(pathname => pathname.startsWith('src/')));
+  assert.ok(appPaths.some(pathname => pathname.startsWith('test/')));
   assert.equal(appPaths.some(pathname => pathname.startsWith('doc/')), false);
   assert.equal(appPaths.some(pathname => pathname.startsWith('docs/')), false);
+  assert.equal(appPaths.some(pathname => pathname.startsWith('calculogic-validator/')), false);
+  assert.equal(appPaths.includes('package.json'), false);
+});
+
+test('--scope=validator includes calculogic-validator only and excludes app/docs/system files', () => {
+  const validatorPaths = collectRepositoryPaths(process.cwd(), { scope: 'validator' });
+  assert.ok(validatorPaths.includes('calculogic-validator/scripts/validate-naming.mjs'));
+  assert.ok(validatorPaths.some(pathname => pathname.startsWith('calculogic-validator/src/')));
+  assert.ok(validatorPaths.some(pathname => pathname.startsWith('calculogic-validator/test/')));
+  assert.equal(validatorPaths.some(pathname => pathname.startsWith('src/')), false);
+  assert.equal(validatorPaths.some(pathname => pathname.startsWith('doc/')), false);
+  assert.equal(validatorPaths.some(pathname => pathname.startsWith('docs/')), false);
+  assert.equal(validatorPaths.includes('package.json'), false);
+});
+
+test('--scope=system includes root tooling files only and excludes all folders', () => {
+  const systemPaths = collectRepositoryPaths(process.cwd(), { scope: 'system' });
+  assert.ok(systemPaths.includes('package.json'));
+  assert.ok(systemPaths.includes('tsconfig.json'));
+  assert.equal(systemPaths.some(pathname => pathname.startsWith('src/')), false);
+  assert.equal(systemPaths.some(pathname => pathname.startsWith('test/')), false);
+  assert.equal(systemPaths.some(pathname => pathname.startsWith('doc/')), false);
+  assert.equal(systemPaths.some(pathname => pathname.startsWith('docs/')), false);
+  assert.equal(systemPaths.some(pathname => pathname.startsWith('calculogic-validator/')), false);
+  assert.equal(systemPaths.some(pathname => pathname.includes('/')), false);
 });
 
 test('docs scope profile explicitly declares root conventional docs inclusion contract', () => {
@@ -57,20 +80,17 @@ test('docs scope profile explicitly declares root conventional docs inclusion co
   });
 });
 
-
-test('scoped path sets diverge by contract (docs excludes app roots and app excludes docs roots)', () => {
+test('scoped path sets diverge by contract', () => {
   const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
   const docsPaths = collectRepositoryPaths(process.cwd(), { scope: 'docs' });
-  const repoPaths = collectRepositoryPaths(process.cwd(), { scope: 'repo' });
+  const validatorPaths = collectRepositoryPaths(process.cwd(), { scope: 'validator' });
+  const systemPaths = collectRepositoryPaths(process.cwd(), { scope: 'system' });
 
   assert.notDeepEqual(appPaths, docsPaths);
-  assert.ok(repoPaths.length >= appPaths.length);
-  assert.ok(repoPaths.length >= docsPaths.length);
-  assert.equal(docsPaths.some(pathname => pathname.startsWith('src/')), false);
-  assert.equal(docsPaths.some(pathname => pathname.startsWith('test/')), false);
-  assert.equal(docsPaths.some(pathname => pathname.startsWith('scripts/')), false);
-  assert.equal(appPaths.some(pathname => pathname.startsWith('doc/')), false);
-  assert.equal(appPaths.some(pathname => pathname.startsWith('docs/')), false);
+  assert.notDeepEqual(validatorPaths, appPaths);
+  assert.notDeepEqual(validatorPaths, docsPaths);
+  assert.notDeepEqual(validatorPaths, systemPaths);
+  assert.equal(systemPaths.some(pathname => pathname.includes('/')), false);
 });
 
 test('invalid scope handling is deterministic (usage error + non-zero exit)', () => {

--- a/calculogic-validator/test/naming-validator.test.mjs
+++ b/calculogic-validator/test/naming-validator.test.mjs
@@ -118,14 +118,14 @@ test('repo scope includes docs + src + root config examples', () => {
   assert.ok(paths.includes('package.json'));
 });
 
-test('app scope excludes docs and includes src/test/scripts/root tooling files', () => {
+test('app scope includes only src/test and excludes docs, validator, and system root files', () => {
   const paths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
-  assert.ok(paths.includes('calculogic-validator/src/validators/naming-validator.logic.mjs'));
-  assert.ok(paths.includes('calculogic-validator/test/naming-validator.test.mjs'));
-  assert.ok(paths.includes('calculogic-validator/scripts/validate-naming.mjs'));
-  assert.ok(paths.includes('package.json'));
+  assert.ok(paths.some(p => p.startsWith('src/')));
+  assert.ok(paths.some(p => p.startsWith('test/')));
   assert.equal(paths.some(p => p.startsWith('doc/')), false);
   assert.equal(paths.some(p => p.startsWith('docs/')), false);
+  assert.equal(paths.some(p => p.startsWith('calculogic-validator/')), false);
+  assert.equal(paths.includes('package.json'), false);
 });
 
 test('docs scope includes doc/docs and excludes src', () => {

--- a/calculogic-validator/test/report-capture.scopes.integration.test.mjs
+++ b/calculogic-validator/test/report-capture.scopes.integration.test.mjs
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 
-const scopes = ['repo', 'app', 'docs'];
+const scopes = ['repo', 'app', 'docs', 'validator', 'system'];
 const hostPath = path.resolve('calculogic-validator/tools/report-capture/src/report-capture.host.mjs');
 
 const runReportCapture = (prefix, scriptPath, scope, outputDir) => new Promise((resolve, reject) => {
@@ -40,7 +40,7 @@ const reportFilesForPrefix = (dirPath, prefix) => fs
   .filter(name => name.startsWith(`${prefix}-`) && name.endsWith('.txt'))
   .sort();
 
-test('report-capture host emits naming reports for repo/app/docs scopes', async () => {
+test('report-capture host emits naming reports for repo/app/docs/validator/system scopes', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-scopes-naming-'));
 
   try {
@@ -65,7 +65,7 @@ test('report-capture host emits naming reports for repo/app/docs scopes', async 
   }
 });
 
-test('report-capture host emits validate-all reports for repo/app/docs scopes', async () => {
+test('report-capture host emits validate-all reports for repo/app/docs/validator/system scopes', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-scopes-all-'));
 
   try {

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.10** (runtime config supports additive role-registry extensions and documentation role taxonomy).
+Current implementation target: **V0.1.11** (scope contract split into app/docs/validator/system with repo as full scan).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -10,12 +10,14 @@ Define a deterministic V0.1 filename naming validator that runs in report mode o
 ### 2.1 Naming authority
 The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` as authoritative naming guidance.
 
-### 2.2 Scope mode (V0.1.4)
-V0.1.4 supports deterministic scope profiles selected via CLI and applied before filename classification using explicit scope path predicates:
+### 2.2 Scope mode (V0.1.11)
+V0.1.11 supports deterministic scope profiles selected via CLI and applied before filename classification using explicit scope path predicates:
 - default/no `--scope` input resolves to `repo`
 - `repo`: repository-wide reportable files.
-- `app`: app-focused files (`src/`, `test/`, `calculogic-validator/`, and explicit root tooling files).
+- `app`: application-focused files (`src/` and `test/` only).
 - `docs`: docs-focused files (`doc/`, `docs/`, and selected root conventional docs currently limited to `README.md`).
+- `validator`: validator implementation files (`calculogic-validator/` only).
+- `system`: root tooling files only (`package.json`, `package-lock.json`, `tsconfig*.json`, `eslint.config.*`, `vite.config.*`).
 
 Scope predicates are evaluated on normalized repository-relative paths before report findings are generated. Invalid scope inputs are treated as CLI usage errors.
 
@@ -59,14 +61,14 @@ Validator implementation assets live under top-level `calculogic-validator/`:
 
 Root `package.json` scripts remain the canonical invocation interface (`npm run validate:naming`, `npm run validate:all`, `npm run health:validator`, `npm test`) while local package bins are testable via `npm exec` through the file dependency `@calculogic/validator`.
 
-### 2.5 Health-check contract (V0.1.8)
+### 2.5 Health-check contract (V0.1.11)
 Health-check entrypoint lives at `calculogic-validator/scripts/validator-health-check.host.mjs` and is exposed via root script `npm run health:validator`.
 Stable installable health bin entrypoint lives at `calculogic-validator/bin/calculogic-validator-health.mjs`.
 
-The health-check performs deterministic, CI-friendly assertions for scope profiles `repo`, `app`, and `docs`:
+The health-check performs deterministic, CI-friendly assertions for scope profiles `repo`, `app`, `docs`, `validator`, and `system`:
 - required scope profiles must resolve via host API
 - repeated in-process runs per scope must keep stable summary-level outputs (`totalFilesScanned`, `counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`)
-- docs contract checks ensure scope documentation continues to state that `app` includes `src/`, `test/`, and `calculogic-validator/`
+- docs contract checks ensure scope documentation continues to state app/docs/validator/system split behavior
 
 Health-check behavior is fail-fast semantics: any contract violation returns non-zero exit status.
 

--- a/doc/nl-config/cfg-reportCapture.md
+++ b/doc/nl-config/cfg-reportCapture.md
@@ -24,6 +24,9 @@ Report filenames are deterministic and filesystem-safe:
 - Prefix defaults to `report`
 - Timestamp is local time and zero-padded
 
+### 2.4 Scope capture presets
+Root package scripts provide deterministic capture presets for naming and validate-all across `repo`, `app`, `docs`, `validator`, and `system` scopes, writing files to repo-local `./.reports/` for safe exclusion from validator walking behavior.
+
 ## 3.0 Build Concern
 ### 3.1 CLI host assembly
 Host module parses argv, resolves directory defaults, warns about pending prune deletions, starts capture run, and exits with the wrapped command exit code.

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -1,7 +1,7 @@
 # cfg-validatorRunner
 
 ## 0.0 Version
-Current implementation target: **V0.1.0** (deterministic multi-validator runner core with registry-backed execution).
+Current implementation target: **V0.1.1** (deterministic multi-validator runner core with split scope profiles including validator/system).
 
 ## 1.0 Purpose
 Provide a deterministic runner that executes one or more registered validators and returns a single versioned combined report.
@@ -44,7 +44,7 @@ Each validator entry includes:
 ## 4.0 CLI Contract (`validate-all`)
 ### 4.1 Inputs
 - `--help`
-- `--scope=<repo|app|docs>` (optional)
+- `--scope=<repo|app|docs|validator|system>` (optional)
 - `--validators=<id1,id2>` (optional)
 - `--config=<path>` (optional JSON config path)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "report:naming:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=docs",
     "report:all:repo": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-repo -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=repo",
     "report:all:app": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-app -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=app",
-    "report:all:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=docs"
+    "report:all:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=docs",
+    "report:naming:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=validator",
+    "report:naming:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-system -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=system",
+    "report:all:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=validator",
+    "report:all:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-system -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=system"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- Prevent mixing of validator and root tooling files with application scans by splitting scope profiles so `app` no longer includes `calculogic-validator` or root tooling files and adding dedicated `validator` and `system` scopes. 
- Provide deterministic, repo-local report capture presets for the new scopes so CI/devs can persist full JSON reports per-scope without the validator walking the report directory. 

### Description
- Updated the core scope registry in `calculogic-validator/src/validator-scopes.knowledge.mjs` to add `validator` and `system` profiles and change `app` to include only `src` and `test`, with `system` including `ROOT_APP_FILES` as root-only files. 
- Updated CLI usage help text in `calculogic-validator/scripts/validate-naming.mjs` and `calculogic-validator/scripts/validate-all.mjs` to list `--scope=<repo|app|docs|validator|system>`. 
- Adjusted scope contract tests and validator tests in `calculogic-validator/test/naming-validator-scope-contract.test.mjs` and `calculogic-validator/test/naming-validator.test.mjs` to assert the new boundaries for `app`, add assertions for `validator` and `system`, and update the deterministic divergence checks. 
- Extended the report-capture integration test `calculogic-validator/test/report-capture.scopes.integration.test.mjs` to exercise all five scopes (`repo`,`app`,`docs`,`validator`,`system`). 
- Added repo-level report-capture npm scripts in `package.json` for the new scopes: `report:naming:validator`, `report:naming:system`, `report:all:validator`, and `report:all:system`. 
- Updated NL-first documentation files (`doc/nl-config/cfg-namingValidator.md`, `doc/nl-config/cfg-reportCapture.md`, `doc/nl-config/cfg-validatorRunner.md`) to reflect the new scope split and capture presets prior to implementation. 

### Testing
- Ran the naming-specific tests: `node --test --experimental-strip-types calculogic-validator/test/naming-validator-scope-contract.test.mjs calculogic-validator/test/naming-validator.test.mjs calculogic-validator/test/report-capture.scopes.integration.test.mjs`, and they passed. 
- Ran the full test suite with `npm test` and all tests passed. 
- Verified CLI behavior by running `node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=validator` and `--scope=system`, and each returned the expected scoped report JSON. 
- Exercised report capture scripts with `npm run report:naming:validator`, `npm run report:naming:system`, `npm run report:all:validator`, and `npm run report:all:system`, and each created `.reports/*-*.txt` outputs containing the expected scope metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f30cae148331ab615937265c2769)