### PR TITLE
Add report-capture verifier for naming scope reports

### DIFF
--- a/calculogic-validator/scripts/report-capture-verify.mjs
+++ b/calculogic-validator/scripts/report-capture-verify.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const supportedScopes = ['repo', 'app', 'docs', 'validator', 'system'];
+
+const parseScopes = argv => {
+  const scopesArg = argv.find(argument => argument.startsWith('--scopes='));
+  if (!scopesArg) {
+    return supportedScopes;
+  }
+
+  const requestedScopes = scopesArg
+    .slice('--scopes='.length)
+    .split(',')
+    .map(scope => scope.trim())
+    .filter(Boolean);
+
+  if (requestedScopes.length === 0) {
+    throw new Error('At least one scope must be provided when using --scopes.');
+  }
+
+  const invalidScopes = requestedScopes.filter(scope => !supportedScopes.includes(scope));
+  if (invalidScopes.length > 0) {
+    throw new Error(`Invalid scopes: ${invalidScopes.join(', ')}`);
+  }
+
+  return requestedScopes;
+};
+
+const parseMetadataFromStderr = stderr => {
+  const metadataLine = stderr
+    .split(/\r?\n/u)
+    .map(line => line.trim())
+    .filter(line => line.startsWith('{') && line.includes('"path"'))
+    .at(-1);
+
+  if (!metadataLine) {
+    throw new Error('Missing report-capture metadata JSON line on stderr.');
+  }
+
+  try {
+    return JSON.parse(metadataLine);
+  } catch {
+    throw new Error(`Malformed report-capture metadata JSON: ${metadataLine}`);
+  }
+};
+
+const ensurePathInsideDir = (targetPath, expectedDir) => {
+  const relative = path.relative(expectedDir, targetPath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+};
+
+const runScopeVerification = async ({ scope, reportsDir, repositoryRoot, hostPath, namingValidatorPath }) => {
+  const prefix = `naming-${scope}`;
+  const commandArgs = [
+    hostPath,
+    '--dir',
+    reportsDir,
+    '--keep',
+    '20',
+    '--prefix',
+    prefix,
+    '--json',
+    '--',
+    process.execPath,
+    '--experimental-strip-types',
+    namingValidatorPath,
+    `--scope=${scope}`,
+  ];
+
+  const execution = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, commandArgs, {
+      cwd: repositoryRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', chunk => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({
+        exitCode: code ?? 1,
+        stdout,
+        stderr,
+      });
+    });
+  });
+
+  const metadata = parseMetadataFromStderr(execution.stderr);
+  const expectedDir = path.resolve(repositoryRoot, reportsDir);
+  const resolvedMetadataDir = path.resolve(repositoryRoot, metadata.dir);
+
+  if (resolvedMetadataDir !== expectedDir) {
+    throw new Error(`Unexpected metadata.dir for ${scope}: ${metadata.dir}`);
+  }
+
+  const resolvedReportPath = path.resolve(repositoryRoot, metadata.path);
+  if (!ensurePathInsideDir(resolvedReportPath, expectedDir)) {
+    throw new Error(`Report path is not inside reports directory for ${scope}: ${metadata.path}`);
+  }
+
+  if (typeof metadata.exitCode !== 'number' || metadata.exitCode !== 0 || execution.exitCode !== 0) {
+    throw new Error(`Expected zero exit code for ${scope}, got metadata.exitCode=${metadata.exitCode}, process.exitCode=${execution.exitCode}`);
+  }
+
+  if (typeof metadata.bytes !== 'number' || metadata.bytes <= 0) {
+    throw new Error(`Expected positive metadata.bytes for ${scope}, got ${metadata.bytes}`);
+  }
+
+  const reportStats = await fs.stat(resolvedReportPath).catch(() => null);
+  if (!reportStats || !reportStats.isFile()) {
+    throw new Error(`Missing report file for ${scope}: ${resolvedReportPath}`);
+  }
+
+  const reportContent = await fs.readFile(resolvedReportPath, 'utf8');
+  let parsedReport;
+  try {
+    parsedReport = JSON.parse(reportContent);
+  } catch {
+    throw new Error(`Report file is not valid JSON for ${scope}: ${resolvedReportPath}`);
+  }
+
+  if (parsedReport.mode !== 'report') {
+    throw new Error(`Expected report.mode="report" for ${scope}.`);
+  }
+
+  if (parsedReport.scope !== scope) {
+    throw new Error(`Expected report.scope="${scope}", received "${parsedReport.scope}".`);
+  }
+
+  if (!Array.isArray(parsedReport.findings)) {
+    throw new Error(`Expected report.findings array for ${scope}.`);
+  }
+
+  if (typeof parsedReport.totalFilesScanned !== 'number') {
+    throw new Error(`Expected numeric report.totalFilesScanned for ${scope}.`);
+  }
+
+  const relativeReportPath = path.relative(repositoryRoot, resolvedReportPath);
+  process.stdout.write(`OK naming:${scope} -> ${relativeReportPath} (${metadata.bytes} bytes, ${metadata.durationMs} ms)\n`);
+};
+
+const run = async () => {
+  const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  const reportsDir = process.env.REPORTS_DIR || './.reports';
+  const hostPath = path.resolve(repositoryRoot, 'calculogic-validator/tools/report-capture/src/report-capture.host.mjs');
+  const namingValidatorPath = path.resolve(repositoryRoot, 'calculogic-validator/scripts/validate-naming.mjs');
+  const scopes = parseScopes(process.argv.slice(2));
+
+  let hasFailures = false;
+
+  for (const scope of scopes) {
+    try {
+      await runScopeVerification({
+        scope,
+        reportsDir,
+        repositoryRoot,
+        hostPath,
+        namingValidatorPath,
+      });
+    } catch (error) {
+      hasFailures = true;
+      process.stderr.write(`FAIL naming:${scope} -> ${error.message}\n`);
+    }
+  }
+
+  process.exit(hasFailures ? 1 : 0);
+};
+
+run().catch(error => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/calculogic-validator/test/report-capture.verify.integration.test.mjs
+++ b/calculogic-validator/test/report-capture.verify.integration.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const verifierScriptPath = path.resolve('calculogic-validator/scripts/report-capture-verify.mjs');
+
+const runVerifier = ({ reportsDir, scopes }) => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [
+    verifierScriptPath,
+    `--scopes=${scopes.join(',')}`,
+  ], {
+    env: {
+      ...process.env,
+      REPORTS_DIR: reportsDir,
+    },
+  });
+
+  let stdout = '';
+  let stderr = '';
+
+  child.stdout.on('data', chunk => {
+    stdout += chunk.toString();
+  });
+
+  child.stderr.on('data', chunk => {
+    stderr += chunk.toString();
+  });
+
+  child.on('error', reject);
+  child.on('close', code => {
+    resolve({ exitCode: code ?? 1, stdout, stderr });
+  });
+});
+
+test('report-capture verifier emits and validates docs scope report in custom reports dir', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-verify-'));
+
+  try {
+    const result = await runVerifier({
+      reportsDir: tempDir,
+      scopes: ['docs'],
+    });
+
+    assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+
+    const files = fs.readdirSync(tempDir).filter(name => /^naming-docs-.*\.txt$/u.test(name));
+    assert.equal(files.length, 1, `expected one report file, got ${files.join(',')}`);
+
+    const reportPath = path.join(tempDir, files[0]);
+    const parsedReport = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    assert.equal(parsedReport.scope, 'docs');
+    assert.equal(parsedReport.mode, 'report');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/doc/nl-config/cfg-reportCapture.md
+++ b/doc/nl-config/cfg-reportCapture.md
@@ -27,6 +27,9 @@ Report filenames are deterministic and filesystem-safe:
 ### 2.4 Scope capture presets
 Root package scripts provide deterministic capture presets for naming and validate-all across `repo`, `app`, `docs`, `validator`, and `system` scopes, writing files to repo-local `./.reports/` for safe exclusion from validator walking behavior.
 
+### 2.5 Verifier workflow contract
+A repo-local verifier script (`calculogic-validator/scripts/report-capture-verify.mjs`) runs naming validation through report-capture for one or more scopes, parses the metadata JSON line, and asserts the generated report file exists in the configured reports directory and contains a full JSON naming report.
+
 ## 3.0 Build Concern
 ### 3.1 CLI host assembly
 Host module parses argv, resolves directory defaults, warns about pending prune deletions, starts capture run, and exits with the wrapped command exit code.
@@ -62,6 +65,9 @@ Stdout and stderr both stream to terminal and are appended to the same report fi
 When `--json` is set, emit one compact JSON line to stderr with:
 - `path`, `exitCode`, `bytes`, `startedAt`, `endedAt`, `durationMs`, `dir`, `prefix`
 
+### 7.3 Verifier output summary
+The verifier emits one compact success line per scope (`OK naming:<scope> -> <path> (<bytes> bytes, <durationMs> ms)`) and exits non-zero when metadata or report assertions fail.
+
 ## 8.0 ResultsStyle Concern
 Not applicable for this CLI feature.
 
@@ -78,3 +84,4 @@ Not applicable for this CLI feature.
 - Pass B: Implement host orchestration and command execution.
 - Pass C: Add deterministic unit/integration-light tests.
 - Pass D: Wire local file dependency for `npx calculogic-report-capture` usage.
+- Pass E: Add report-capture verifier script + integration coverage for metadata/report integrity checks.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "report:naming:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=validator",
     "report:naming:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-system -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=system",
     "report:all:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=validator",
-    "report:all:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-system -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=system"
+    "report:all:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-system -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=system",
+    "report:verify": "node calculogic-validator/scripts/report-capture-verify.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- Prevent UI truncation of long validator output by deterministically capturing and verifying full report files produced by `report-capture` when running the naming validator. 
- Provide a lightweight repo-local verifier that asserts metadata + report integrity (path, bytes, exit code, and JSON shape) so reviewers can open complete reports without guesswork. 
- Follow NL-first convention by documenting the verifier workflow in the `cfg-reportCapture` NL skeleton before adding code. 

### Description
- Add `calculogic-validator/scripts/report-capture-verify.mjs`, a CLI that runs `calculogic-validator/tools/report-capture/src/report-capture.host.mjs` wrapping `scripts/validate-naming.mjs`, parses the last JSON metadata line from stderr, and validates `metadata.dir`, `metadata.path`, `metadata.bytes`, and `metadata.exitCode`, then reads and JSON-parses the captured report file and asserts `report.mode === 'report'`, `report.scope === <scope>`, `Array.isArray(report.findings)`, and `typeof report.totalFilesScanned === 'number'`. 
- Verifier supports `--scopes=<csv>` to run a subset and `REPORTS_DIR` env to override the reports directory (default `./.reports`), prints compact summary lines like `OK naming:<scope> -> <relative path> (<bytes> bytes, <durationMs> ms)`, and exits non-zero on any assertion failure. 
- Add integration test `calculogic-validator/test/report-capture.verify.integration.test.mjs` which runs the verifier for the `docs` scope into a temp directory and asserts a `naming-docs-*.txt` report exists and parses correctly. 
- Add npm script `report:verify` to root `package.json` and update `doc/nl-config/cfg-reportCapture.md` with the verifier workflow and summary-output contract. 

### Testing
- Ran the verifier directly with `node calculogic-validator/scripts/report-capture-verify.mjs --scopes=docs` and observed a successful summary line; the run completed with exit code 0. (Succeeded.)
- Ran the new integration test with `node --test --experimental-strip-types calculogic-validator/test/report-capture.verify.integration.test.mjs` and it passed. (Succeeded.)
- Executed `npm run report:verify -- --scopes=docs` to validate the packaged script invocation and it printed the expected `OK naming:docs` line and returned zero. (Succeeded.)
- Ran the full test suite via `npm test` (which includes the new integration test) and all tests passed. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f5e6ec84833184e98475e29fe158)