### PR TITLE
Add report-capture summarizer (latest-report) and tests

### DIFF
--- a/calculogic-validator/scripts/report-capture-summarize.mjs
+++ b/calculogic-validator/scripts/report-capture-summarize.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const defaultPrefixes = [
+  'naming-repo',
+  'naming-app',
+  'naming-docs',
+  'naming-validator',
+  'naming-system',
+  'validate-all-repo',
+  'validate-all-app',
+  'validate-all-docs',
+  'validate-all-validator',
+  'validate-all-system',
+];
+
+const parsePositiveInteger = (value, optionName) => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${optionName} must be a positive integer.`);
+  }
+
+  return parsed;
+};
+
+const parseOptions = argv => {
+  const options = {
+    dir: './.reports',
+    prefixes: defaultPrefixes,
+    top: 6,
+    warnSamples: 5,
+  };
+
+  for (const argument of argv) {
+    if (argument.startsWith('--dir=')) {
+      options.dir = argument.slice('--dir='.length);
+      continue;
+    }
+
+    if (argument.startsWith('--prefixes=')) {
+      const parsedPrefixes = argument
+        .slice('--prefixes='.length)
+        .split(',')
+        .map(prefix => prefix.trim())
+        .filter(Boolean);
+
+      if (parsedPrefixes.length === 0) {
+        throw new Error('--prefixes must provide at least one prefix.');
+      }
+
+      options.prefixes = parsedPrefixes;
+      continue;
+    }
+
+    if (argument.startsWith('--top=')) {
+      options.top = parsePositiveInteger(argument.slice('--top='.length), '--top');
+      continue;
+    }
+
+    if (argument.startsWith('--warn-samples=')) {
+      options.warnSamples = parsePositiveInteger(argument.slice('--warn-samples='.length), '--warn-samples');
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${argument}`);
+  }
+
+  return options;
+};
+
+const getLatestReportForPrefix = async ({ dir, prefix }) => {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const matchingFiles = entries
+    .filter(entry => entry.isFile() && entry.name.startsWith(`${prefix}-`) && entry.name.endsWith('.txt'))
+    .map(entry => entry.name);
+
+  if (matchingFiles.length === 0) {
+    throw new Error(`No report files found for prefix "${prefix}" in ${dir}`);
+  }
+
+  const reportsWithStats = await Promise.all(matchingFiles.map(async filename => {
+    const filePath = path.join(dir, filename);
+    const stats = await fs.stat(filePath);
+    return {
+      filename,
+      filePath,
+      mtimeMs: stats.mtimeMs,
+      bytes: stats.size,
+    };
+  }));
+
+  reportsWithStats.sort((a, b) => b.mtimeMs - a.mtimeMs || b.filename.localeCompare(a.filename));
+  return reportsWithStats[0];
+};
+
+const parseReportJson = async report => {
+  const raw = await fs.readFile(report.filePath, 'utf8');
+
+  try {
+    const parsed = JSON.parse(raw);
+    return { raw, parsed };
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${report.filename}: ${error.message}`);
+  }
+};
+
+const formatCodeCounts = ({ codeCounts, top }) => {
+  const entries = Object.entries(codeCounts ?? {});
+
+  if (entries.length === 0) {
+    return 'none';
+  }
+
+  return entries
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, top)
+    .map(([code, count]) => `${code}:${count}`)
+    .join(', ');
+};
+
+const printSummary = ({ prefix, report, parsedReport, top, warnSamples }) => {
+  const findings = Array.isArray(parsedReport.findings) ? parsedReport.findings : [];
+  const warnFindings = findings.filter(finding => finding?.severity === 'warn');
+  const warnSampleLines = warnFindings
+    .slice(0, warnSamples)
+    .map(finding => `${finding.code ?? 'unknown'}: ${finding.path ?? '(no path)'}`);
+
+  process.stdout.write(`=== ${prefix} (latest) ===\n`);
+  process.stdout.write(`file: ${report.filename} | bytes: ${report.bytes}\n`);
+  process.stdout.write(`scope: ${parsedReport.scope ?? 'unknown'} | totalFilesScanned: ${parsedReport.totalFilesScanned ?? 0} | findingsGenerated: ${parsedReport.findingsGenerated ?? findings.length}\n`);
+
+  const counts = parsedReport.counts ?? {};
+  process.stdout.write(`counts: canonical=${counts.canonical ?? 0}, allowed=${counts.allowed ?? 0}, legacy=${counts.legacy ?? 0}, invalid=${counts.invalid ?? 0}\n`);
+  process.stdout.write(`topCodeCounts(${top}): ${formatCodeCounts({ codeCounts: parsedReport.codeCounts, top })}\n`);
+  process.stdout.write(`warnCount: ${warnFindings.length}\n`);
+
+  if (warnSampleLines.length > 0) {
+    process.stdout.write(`warnSamples: ${warnSampleLines.join(' | ')}\n`);
+  }
+
+  process.stdout.write('\n');
+};
+
+const run = async () => {
+  const options = parseOptions(process.argv.slice(2));
+  const reportsDir = path.resolve(options.dir);
+
+  let hasFailures = false;
+
+  for (const prefix of options.prefixes) {
+    try {
+      const latestReport = await getLatestReportForPrefix({ dir: reportsDir, prefix });
+      const { parsed } = await parseReportJson(latestReport);
+      printSummary({
+        prefix,
+        report: latestReport,
+        parsedReport: parsed,
+        top: options.top,
+        warnSamples: options.warnSamples,
+      });
+    } catch (error) {
+      hasFailures = true;
+      process.stderr.write(`FAIL ${prefix}: ${error.message}\n`);
+    }
+  }
+
+  process.exit(hasFailures ? 1 : 0);
+};
+
+run().catch(error => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/calculogic-validator/test/report-capture.summarize.test.mjs
+++ b/calculogic-validator/test/report-capture.summarize.test.mjs
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const summarizerScriptPath = path.resolve('calculogic-validator/scripts/report-capture-summarize.mjs');
+
+const runSummarizer = args => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [summarizerScriptPath, ...args]);
+
+  let stdout = '';
+  let stderr = '';
+
+  child.stdout.on('data', chunk => {
+    stdout += chunk.toString();
+  });
+
+  child.stderr.on('data', chunk => {
+    stderr += chunk.toString();
+  });
+
+  child.on('error', reject);
+  child.on('close', code => {
+    resolve({ exitCode: code ?? 1, stdout, stderr });
+  });
+});
+
+const writeReport = ({ dir, filename, report, mtime }) => {
+  const reportPath = path.join(dir, filename);
+  fs.writeFileSync(reportPath, JSON.stringify(report));
+  fs.utimesSync(reportPath, mtime, mtime);
+};
+
+test('report-capture summarizer uses newest file and prints compact docs scope summary', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-'));
+
+  try {
+    writeReport({
+      dir: tempDir,
+      filename: 'naming-docs-2026-02-26_09-00-00.txt',
+      mtime: new Date('2026-02-26T09:00:00.000Z'),
+      report: {
+        scope: 'docs',
+        totalFilesScanned: 10,
+        findingsGenerated: 2,
+        counts: {
+          canonical: 8,
+          allowed: 1,
+          legacy: 0,
+          invalid: 1,
+        },
+        codeCounts: {
+          olderRule: 2,
+        },
+        findings: [
+          {
+            severity: 'warn',
+            code: 'olderRule',
+            path: 'doc/old.md',
+          },
+        ],
+      },
+    });
+
+    writeReport({
+      dir: tempDir,
+      filename: 'naming-docs-2026-02-26_10-00-00.txt',
+      mtime: new Date('2026-02-26T10:00:00.000Z'),
+      report: {
+        scope: 'docs',
+        totalFilesScanned: 11,
+        findingsGenerated: 3,
+        counts: {
+          canonical: 8,
+          allowed: 1,
+          legacy: 1,
+          invalid: 1,
+        },
+        codeCounts: {
+          warnRuleA: 2,
+          warnRuleB: 1,
+          infoRuleC: 4,
+        },
+        findings: [
+          {
+            severity: 'warn',
+            code: 'warnRuleA',
+            path: 'doc/new.md',
+          },
+          {
+            severity: 'error',
+            code: 'errRuleA',
+            path: 'doc/err.md',
+          },
+        ],
+      },
+    });
+
+    const result = await runSummarizer([
+      `--dir=${tempDir}`,
+      '--prefixes=naming-docs',
+      '--top=3',
+      '--warn-samples=1',
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /naming-docs/u);
+    assert.match(result.stdout, /naming-docs-2026-02-26_10-00-00\.txt/u);
+    assert.match(result.stdout, /scope:\s*docs/u);
+    assert.match(result.stdout, /warnCount:\s*1/u);
+    assert.match(result.stdout, /warnRuleA:\s*doc\/new\.md/u);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('report-capture summarizer exits non-zero when requested prefix has no report files', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-missing-'));
+
+  try {
+    const result = await runSummarizer([
+      `--dir=${tempDir}`,
+      '--prefixes=naming-missing',
+    ]);
+
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /FAIL naming-missing/u);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/doc/nl-config/cfg-reportCapture.md
+++ b/doc/nl-config/cfg-reportCapture.md
@@ -1,7 +1,7 @@
 # cfg-reportCapture
 
 ## 0.0 Version
-Current implementation target: **V0.0.0** (cross-platform CLI wrapper for command output capture).
+Current implementation target: **V0.1.0** (capture wrapper plus compact latest-report summarizer).
 
 ## 1.0 Purpose
 Provide a deterministic command wrapper that captures combined stdout/stderr into timestamped reports while still streaming output live to the terminal.
@@ -29,6 +29,9 @@ Root package scripts provide deterministic capture presets for naming and valida
 
 ### 2.5 Verifier workflow contract
 A repo-local verifier script (`calculogic-validator/scripts/report-capture-verify.mjs`) runs naming validation through report-capture for one or more scopes, parses the metadata JSON line, and asserts the generated report file exists in the configured reports directory and contains a full JSON naming report.
+
+### 2.6 Post-capture summarizer contract
+A repo-local summarizer script (`calculogic-validator/scripts/report-capture-summarize.mjs`) reads the latest captured JSON report per prefix from `./.reports` (or `--dir`) and prints compact per-scope summaries suitable for Codex/PR notes.
 
 ## 3.0 Build Concern
 ### 3.1 CLI host assembly
@@ -68,6 +71,9 @@ When `--json` is set, emit one compact JSON line to stderr with:
 ### 7.3 Verifier output summary
 The verifier emits one compact success line per scope (`OK naming:<scope> -> <path> (<bytes> bytes, <durationMs> ms)`) and exits non-zero when metadata or report assertions fail.
 
+### 7.4 Summarizer output summary
+The summarizer emits a compact block per prefix including latest file metadata, report scope totals, counts, top code counts, and warn samples. It exits non-zero when any requested prefix is missing a report or has invalid JSON.
+
 ## 8.0 ResultsStyle Concern
 Not applicable for this CLI feature.
 
@@ -85,3 +91,4 @@ Not applicable for this CLI feature.
 - Pass C: Add deterministic unit/integration-light tests.
 - Pass D: Wire local file dependency for `npx calculogic-report-capture` usage.
 - Pass E: Add report-capture verifier script + integration coverage for metadata/report integrity checks.
+- Pass F: Add latest-report summarizer script + deterministic tests for newest-file selection and missing-prefix failures.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "report:naming:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-system -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=system",
     "report:all:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=validator",
     "report:all:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-all-system -- node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs --scope=system",
-    "report:verify": "node calculogic-validator/scripts/report-capture-verify.mjs"
+    "report:verify": "node calculogic-validator/scripts/report-capture-verify.mjs",
+    "report:summarize": "node calculogic-validator/scripts/report-capture-summarize.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- Captured validator reports are large JSON files that are hard to review in terminals and UIs, so a compact, deterministic post-capture summarizer is needed for quick review and PR notes. 
- The change follows NL-first convention by adding the summarizer contract to `doc/nl-config/cfg-reportCapture.md` before implementation. 

### Description
- Add a read-only summarizer script `calculogic-validator/scripts/report-capture-summarize.mjs` that selects the newest `*.txt` report per prefix, parses the JSON, and prints a compact per-prefix block including `prefix`, `file`, `bytes`, `scope`, `totalFilesScanned`, `findingsGenerated`, `counts`, top `codeCounts` (default `--top=6`), and warn samples (default `--warn-samples=5`).
- The summarizer supports CLI options `--dir=<path>` (default `./.reports`), `--prefixes=<comma-list>` (defaults to naming and `validate-all-` prefixes), `--top=<n>`, and `--warn-samples=<n>`, and exits non-zero when a requested prefix has no report or when JSON parsing fails (error includes the filename).
- Add `report:summarize` npm script in `package.json` that runs the summarizer via `node calculogic-validator/scripts/report-capture-summarize.mjs`.
- Add deterministic tests at `calculogic-validator/test/report-capture.summarize.test.mjs` that verify newest-file selection and compact output fields, and a negative test asserting non-zero exit for a missing prefix. 

### Testing
- Ran the new summarizer unit tests with `node --test calculogic-validator/test/report-capture.summarize.test.mjs` and the two tests passed (exit `0`).
- Ran the full project test suite with `npm test` and observed all tests including the new summarizer tests pass (all suites succeeded, exit `0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f7ac05fc8331b174bd2fc0f87601)