### PR TITLE
Fix report summarizer handling for missing captures and validate-all reports

### DIFF
--- a/calculogic-validator/scripts/report-capture-summarize.mjs
+++ b/calculogic-validator/scripts/report-capture-summarize.mjs
@@ -30,6 +30,7 @@ const parseOptions = argv => {
     prefixes: defaultPrefixes,
     top: 6,
     warnSamples: 5,
+    strict: false,
   };
 
   for (const argument of argv) {
@@ -63,6 +64,11 @@ const parseOptions = argv => {
       continue;
     }
 
+    if (argument === '--strict') {
+      options.strict = true;
+      continue;
+    }
+
     throw new Error(`Unknown option: ${argument}`);
   }
 
@@ -76,7 +82,7 @@ const getLatestReportForPrefix = async ({ dir, prefix }) => {
     .map(entry => entry.name);
 
   if (matchingFiles.length === 0) {
-    throw new Error(`No report files found for prefix "${prefix}" in ${dir}`);
+    return null;
   }
 
   const reportsWithStats = await Promise.all(matchingFiles.map(async filename => {
@@ -120,6 +126,11 @@ const formatCodeCounts = ({ codeCounts, top }) => {
 };
 
 const printSummary = ({ prefix, report, parsedReport, top, warnSamples }) => {
+  if (Array.isArray(parsedReport.validators)) {
+    printRunnerSummary({ prefix, report, parsedReport, top });
+    return;
+  }
+
   const findings = Array.isArray(parsedReport.findings) ? parsedReport.findings : [];
   const warnFindings = findings.filter(finding => finding?.severity === 'warn');
   const warnSampleLines = warnFindings
@@ -128,10 +139,15 @@ const printSummary = ({ prefix, report, parsedReport, top, warnSamples }) => {
 
   process.stdout.write(`=== ${prefix} (latest) ===\n`);
   process.stdout.write(`file: ${report.filename} | bytes: ${report.bytes}\n`);
-  process.stdout.write(`scope: ${parsedReport.scope ?? 'unknown'} | totalFilesScanned: ${parsedReport.totalFilesScanned ?? 0} | findingsGenerated: ${parsedReport.findingsGenerated ?? findings.length}\n`);
+  process.stdout.write(`scope: ${parsedReport.scope ?? 'unknown'} | totalFilesScanned: ${parsedReport.totalFilesScanned ?? 0} | findingsGenerated: ${parsedReport.scopeSummary?.findingsGenerated ?? parsedReport.findingsGenerated ?? findings.length}\n`);
 
   const counts = parsedReport.counts ?? {};
-  process.stdout.write(`counts: canonical=${counts.canonical ?? 0}, allowed=${counts.allowed ?? 0}, legacy=${counts.legacy ?? 0}, invalid=${counts.invalid ?? 0}\n`);
+  const hasNamingCountShape = Object.prototype.hasOwnProperty.call(counts, 'allowed-special-case');
+  const countsLine = hasNamingCountShape
+    ? `counts: canonical=${counts.canonical ?? 0}, allowedSpecialCase=${counts['allowed-special-case'] ?? 0}, legacyException=${counts['legacy-exception'] ?? 0}, invalidAmbiguous=${counts['invalid-ambiguous'] ?? 0}`
+    : `counts: canonical=${counts.canonical ?? 0}, allowed=${counts.allowed ?? 0}, legacy=${counts.legacy ?? 0}, invalid=${counts.invalid ?? 0}`;
+
+  process.stdout.write(`${countsLine}\n`);
   process.stdout.write(`topCodeCounts(${top}): ${formatCodeCounts({ codeCounts: parsedReport.codeCounts, top })}\n`);
   process.stdout.write(`warnCount: ${warnFindings.length}\n`);
 
@@ -142,15 +158,55 @@ const printSummary = ({ prefix, report, parsedReport, top, warnSamples }) => {
   process.stdout.write('\n');
 };
 
+const printRunnerSummary = ({ prefix, report, parsedReport, top }) => {
+  const validators = parsedReport.validators;
+  process.stdout.write(`=== ${prefix} (latest) ===\n`);
+  process.stdout.write(`file: ${report.filename} | bytes: ${report.bytes}\n`);
+  process.stdout.write(`scope: ${parsedReport.scope ?? '(none)'} | validators: ${validators.length} | durationMs: ${parsedReport.durationMs ?? '(n/a)'}\n`);
+
+  for (const validator of validators) {
+    const findings = Array.isArray(validator?.findings) ? validator.findings : [];
+    const warnCount = findings.filter(finding => finding?.severity === 'warn').length;
+    const countsEntries = Object.entries(validator?.counts ?? {});
+    const countsLine = countsEntries.length === 0
+      ? 'none'
+      : countsEntries.map(([key, value]) => `${key}=${value}`).join(', ');
+
+    process.stdout.write(`validator: ${validator?.id ?? '(unknown)'} | totalFilesScanned: ${validator?.totalFilesScanned ?? 0}\n`);
+    process.stdout.write(`counts: ${countsLine}\n`);
+    process.stdout.write(`warnCount: ${warnCount}\n`);
+    process.stdout.write(`topCodeCounts(${top}): ${formatCodeCounts({ codeCounts: validator?.codeCounts, top })}\n`);
+  }
+
+  process.stdout.write('\n');
+};
+
 const run = async () => {
   const options = parseOptions(process.argv.slice(2));
   const reportsDir = path.resolve(options.dir);
+
+  try {
+    await fs.stat(reportsDir);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      process.stderr.write(`No reports directory found at ${reportsDir}. Run a report capture command first (e.g. npm run report:naming:docs).\n`);
+      process.exit(options.strict ? 1 : 0);
+    }
+
+    throw error;
+  }
 
   let hasFailures = false;
 
   for (const prefix of options.prefixes) {
     try {
       const latestReport = await getLatestReportForPrefix({ dir: reportsDir, prefix });
+      if (!latestReport) {
+        process.stderr.write(`SKIP ${prefix}: no report files found in ${reportsDir}\n`);
+        hasFailures ||= options.strict;
+        continue;
+      }
+
       const { parsed } = await parseReportJson(latestReport);
       printSummary({
         prefix,

--- a/calculogic-validator/test/report-capture.summarize.behavior.test.mjs
+++ b/calculogic-validator/test/report-capture.summarize.behavior.test.mjs
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const summarizerScriptPath = path.resolve('calculogic-validator/scripts/report-capture-summarize.mjs');
+
+const runSummarizer = args => {
+  const result = spawnSync(process.execPath, [summarizerScriptPath, ...args], {
+    encoding: 'utf8',
+  });
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+};
+
+test('missing reports directory is non-fatal by default', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-behavior-'));
+
+  try {
+    const missingDir = path.join(tempDir, 'missing');
+    const result = runSummarizer([
+      `--dir=${missingDir}`,
+      '--prefixes=naming-docs',
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+    assert.match(result.stderr, /No reports directory found/u);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('missing prefix is SKIP when reports directory exists', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-behavior-'));
+
+  try {
+    const result = runSummarizer([
+      `--dir=${tempDir}`,
+      '--prefixes=naming-docs',
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+    assert.match(result.stderr, /SKIP naming-docs/u);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('naming report summarizes naming classification keys and warn count', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-behavior-'));
+
+  try {
+    const reportPath = path.join(tempDir, 'naming-docs-2026-02-27_00-00-00.txt');
+    fs.writeFileSync(reportPath, JSON.stringify({
+      scope: 'docs',
+      totalFilesScanned: 13,
+      counts: {
+        canonical: 8,
+        'allowed-special-case': 2,
+        'legacy-exception': 1,
+        'invalid-ambiguous': 2,
+      },
+      codeCounts: {
+        namingWarnA: 2,
+        namingWarnB: 1,
+      },
+      findings: [
+        {
+          severity: 'warn',
+          code: 'namingWarnA',
+          path: 'doc/example.md',
+        },
+      ],
+      scopeSummary: {
+        findingsGenerated: 5,
+      },
+    }));
+
+    const result = runSummarizer([
+      `--dir=${tempDir}`,
+      '--prefixes=naming-docs',
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /scope:\s*docs/u);
+    assert.match(result.stdout, /allowedSpecialCase=/u);
+    assert.match(result.stdout, /warnCount:\s*1/u);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('validate-all runner report summarizes validators without top-level findings assumptions', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-behavior-'));
+
+  try {
+    const reportPath = path.join(tempDir, 'validate-all-docs-2026-02-27_00-00-00.txt');
+    fs.writeFileSync(reportPath, JSON.stringify({
+      mode: 'report',
+      scope: 'docs',
+      validators: [
+        {
+          id: 'naming-validator',
+          totalFilesScanned: 9,
+          counts: {
+            canonical: 7,
+            invalid: 2,
+          },
+          findings: [
+            {
+              severity: 'warn',
+              code: 'ruleA',
+              path: 'doc/bad.md',
+            },
+          ],
+          codeCounts: {
+            ruleA: 1,
+          },
+        },
+      ],
+    }));
+
+    const result = runSummarizer([
+      `--dir=${tempDir}`,
+      '--prefixes=validate-all-docs',
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /validator:\s*naming-validator/u);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/report-capture.summarize.test.mjs
+++ b/calculogic-validator/test/report-capture.summarize.test.mjs
@@ -116,17 +116,18 @@ test('report-capture summarizer uses newest file and prints compact docs scope s
   }
 });
 
-test('report-capture summarizer exits non-zero when requested prefix has no report files', async () => {
+test('report-capture summarizer exits non-zero in strict mode when requested prefix has no report files', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-summarize-missing-'));
 
   try {
     const result = await runSummarizer([
       `--dir=${tempDir}`,
       '--prefixes=naming-missing',
+      '--strict',
     ]);
 
     assert.notEqual(result.exitCode, 0);
-    assert.match(result.stderr, /FAIL naming-missing/u);
+    assert.match(result.stderr, /SKIP naming-missing/u);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Prevent the summarizer from failing noisily when `./.reports` is absent by making the missing reports directory a non-fatal condition by default.  
- Make per-prefix absence non-fatal so the summarizer can skip missing prefixes instead of emitting repeated `ENOENT` failures.  
- Correctly render naming report counts and support `validate-all` (runner) report shapes so summaries reflect real report shapes instead of assuming top-level `findings` and generic count keys.

### Description
- Add a `--strict` CLI flag and a pre-check for the resolved reports directory in `calculogic-validator/scripts/report-capture-summarize.mjs`, printing a single helpful message and exiting `0` by default (or `1` when `--strict`).
- Change `getLatestReportForPrefix()` to return `null` when no matching files exist and emit `SKIP <prefix>` during processing (counting as a failure only in `--strict` mode) instead of throwing. 
- Update `printSummary()` to detect naming-specific count keys (e.g. `allowed-special-case`, `legacy-exception`, `invalid-ambiguous`) and use `scopeSummary.findingsGenerated` as a fallback for `findingsGenerated`; add `printRunnerSummary()` to summarize `validators[]` entries for `validate-all` runner reports. 
- Files changed: updated `calculogic-validator/scripts/report-capture-summarize.mjs` and tests updated/added: `calculogic-validator/test/report-capture.summarize.test.mjs` (adjusted strict-mode assertion) and new `calculogic-validator/test/report-capture.summarize.behavior.test.mjs` (behavior tests covering missing dir, missing prefix skip, naming counts, and runner summaries).

### Testing
- Ran the summarizer-specific tests with `node --test calculogic-validator/test/report-capture.summarize.test.mjs calculogic-validator/test/report-capture.summarize.behavior.test.mjs` and observed all subtests pass.  
- Ran the full project test suite with `npm test` and `node --test ...` coverage, and the test run completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fb350ed4833197a02ce4bf692166)