### PR TITLE
Add stable metadata (toolVersion, configDigest, timestamps) to validator JSON reports

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -8,6 +8,7 @@ import {
 } from '../src/naming/naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
@@ -78,11 +79,20 @@ try {
   process.exit(1);
 }
 
+const toolVersion = getValidatorToolVersion();
+const configDigest = config ? computeConfigDigest(config) : undefined;
+const startedAtDate = new Date();
 const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: parsed.selectedScope, config });
+const endedAtDate = new Date();
 const summary = summarizeFindings(findings);
 
 const report = {
   mode: 'report',
+  toolVersion,
+  ...(configDigest ? { configDigest } : {}),
+  startedAt: startedAtDate.toISOString(),
+  endedAt: endedAtDate.toISOString(),
+  durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
   scope,
   totalFilesScanned,
   scopeSummary: {

--- a/calculogic-validator/bin/calculogic-validate.mjs
+++ b/calculogic-validator/bin/calculogic-validate.mjs
@@ -5,6 +5,7 @@ import { runValidatorRunner } from '../src/validator-runner.logic.mjs';
 import { listRegisteredValidators } from '../src/validator-registry.knowledge.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 
 const usageLines = [
   'Usage: calculogic-validate [--scope=<repo|app|docs>] [--validators=<id1,id2>] [--config=<path>]',
@@ -84,6 +85,8 @@ try {
     scope: parsed.selectedScope,
     validators: parsed.validators,
     config,
+    toolVersion: getValidatorToolVersion(),
+    ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 
   console.log(JSON.stringify(report, null, 2));

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -3,6 +3,7 @@ import { runValidatorRunner } from '../src/validator-runner.logic.mjs';
 import { listRegisteredValidators } from '../src/validator-registry.knowledge.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
@@ -83,6 +84,8 @@ try {
     scope: parsed.selectedScope,
     validators: parsed.validators,
     config,
+    toolVersion: getValidatorToolVersion(),
+    ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 
   console.log(JSON.stringify(report, null, 2));

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -6,6 +6,7 @@ import {
 } from '../src/naming/naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
@@ -77,11 +78,20 @@ try {
   process.exit(1);
 }
 
+const toolVersion = getValidatorToolVersion();
+const configDigest = config ? computeConfigDigest(config) : undefined;
+const startedAtDate = new Date();
 const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: selectedScope, config });
+const endedAtDate = new Date();
 const summary = summarizeFindings(findings);
 
 const report = {
   mode: 'report',
+  toolVersion,
+  ...(configDigest ? { configDigest } : {}),
+  startedAt: startedAtDate.toISOString(),
+  endedAt: endedAtDate.toISOString(),
+  durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
   scope,
   totalFilesScanned,
   scopeSummary: {

--- a/calculogic-validator/src/validator-report-meta.logic.mjs
+++ b/calculogic-validator/src/validator-report-meta.logic.mjs
@@ -1,0 +1,39 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const validatorPackageJsonPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'package.json',
+);
+
+export const getValidatorToolVersion = () => {
+  const packageJsonRaw = fs.readFileSync(validatorPackageJsonPath, 'utf8');
+  const packageJson = JSON.parse(packageJsonRaw);
+  return packageJson.version;
+};
+
+const normalizeForStableStringify = value => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeForStableStringify);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map(key => [key, normalizeForStableStringify(value[key])]),
+    );
+  }
+
+  return value;
+};
+
+export const stableStringify = value => JSON.stringify(normalizeForStableStringify(value));
+
+export const sha256Hex = text => crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+
+export const computeConfigDigest = config => sha256Hex(stableStringify(config));
+

--- a/calculogic-validator/src/validator-report.contracts.mjs
+++ b/calculogic-validator/src/validator-report.contracts.mjs
@@ -6,6 +6,8 @@ export const CALCULOGIC_VALIDATOR_REPORT_VERSION = '0.1.0';
  *   version: string,
  *   mode: 'report',
  *   scope?: string,
+ *   toolVersion?: string,
+ *   configDigest?: string,
  *   startedAt: string,
  *   endedAt: string,
  *   durationMs: number,

--- a/calculogic-validator/src/validator-runner.logic.mjs
+++ b/calculogic-validator/src/validator-runner.logic.mjs
@@ -55,6 +55,8 @@ export const runValidatorRunner = (repositoryRoot, options = {}) => {
     version: CALCULOGIC_VALIDATOR_REPORT_VERSION,
     mode: 'report',
     ...(scope ? { scope } : {}),
+    ...(options.toolVersion ? { toolVersion: options.toolVersion } : {}),
+    ...(options.configDigest ? { configDigest: options.configDigest } : {}),
     startedAt: startedAtDate.toISOString(),
     endedAt: endedAtDate.toISOString(),
     durationMs: endedAtDate.getTime() - startedAtDate.getTime(),

--- a/calculogic-validator/test/validator-report-meta.test.mjs
+++ b/calculogic-validator/test/validator-report-meta.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
+
+test('getValidatorToolVersion matches calculogic-validator/package.json version', () => {
+  const packageJsonPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'package.json',
+  );
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+  assert.equal(getValidatorToolVersion(), packageJson.version);
+});
+
+test('validate-naming report includes stable configDigest when config is supplied', () => {
+  const config = loadValidatorConfigFromFile(
+    'calculogic-validator/test/fixtures/validator-config.extensions.contracts.json',
+    { cwd: process.cwd() },
+  );
+  const expectedDigest = computeConfigDigest(config);
+
+  const runWithConfig = () =>
+    spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'calculogic-validator/scripts/validate-naming.mjs',
+        '--scope=docs',
+        '--config=calculogic-validator/test/fixtures/validator-config.extensions.contracts.json',
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+
+  const first = runWithConfig();
+  const second = runWithConfig();
+
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(second.status, 0, second.stderr);
+
+  const firstReport = JSON.parse(first.stdout);
+  const secondReport = JSON.parse(second.stdout);
+
+  assert.equal(firstReport.toolVersion, getValidatorToolVersion());
+  assert.equal(firstReport.configDigest, expectedDigest);
+  assert.equal(secondReport.configDigest, expectedDigest);
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.11** (scope contract split into app/docs/validator/system with repo as full scan).
+Current implementation target: **V0.1.12** (scope contract split + deterministic report metadata: toolVersion/configDigest/timing).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -97,6 +97,15 @@ Runtime behavior for role additions:
 - runtime active role set = roles with `status=active` from runtime role metadata
 - runtime role suffix list = runtime role keys sorted by descending length for hyphen-role ambiguity detection
 - filename classification uses the runtime role structures when supplied, and default registries when omitted
+
+
+### 2.7 Report metadata contract (V0.1.12)
+Naming report JSON includes deterministic metadata fields for CI/debug sharing while preserving all prior fields:
+- `toolVersion`: loaded from `calculogic-validator/package.json` `version`.
+- `configDigest`: `sha256(stableStringify(config))` when `--config` is supplied.
+- `startedAt`, `endedAt`, `durationMs`: execution timing for each naming report invocation.
+
+`stableStringify` sorts object keys recursively and preserves array order to keep digest generation deterministic across runs.
 
 ## 3.0 Classification Contract
 ### 3.1 Canonical

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -1,7 +1,7 @@
 # cfg-validatorRunner
 
 ## 0.0 Version
-Current implementation target: **V0.1.1** (deterministic multi-validator runner core with split scope profiles including validator/system).
+Current implementation target: **V0.1.2** (deterministic multi-validator runner core with report metadata envelope support).
 
 ## 1.0 Purpose
 Provide a deterministic runner that executes one or more registered validators and returns a single versioned combined report.
@@ -18,11 +18,18 @@ The runner reads validator definitions from a deterministic registry in `calculo
 ### 2.3 Initial validator set
 V0.1.0 includes the naming validator only, wrapped through the registry run hook without changing naming-validator internals.
 
+### 2.4 Metadata injections
+Runner accepts optional host-provided report metadata:
+- `toolVersion` (validator package version)
+- `configDigest` (stable digest of normalized loaded config)
+
 ## 3.0 Combined Report Contract
 ### 3.1 Report envelope
 - `version`
 - `mode` (`report`)
 - optional `scope`
+- optional `toolVersion`
+- optional `configDigest`
 - `startedAt`, `endedAt`, `durationMs`
 - `validators` (deterministic execution order)
 


### PR DESCRIPTION
### Motivation
- Make validator JSON outputs more CI-friendly and debuggable by adding deterministic tool/config metadata and timing while preserving existing fields.
- Ensure `configDigest` is stable across runs by hashing a normalized representation of the loaded config so reports are comparable in CI and tooling. 

### Description
- Added a new helper module `calculogic-validator/src/validator-report-meta.logic.mjs` exporting `getValidatorToolVersion()`, `stableStringify()`, `sha256Hex()`, and `computeConfigDigest()` for deterministic metadata generation.
- Updated naming entrypoints (`scripts/validate-naming.mjs` and `bin/calculogic-validate-naming.mjs`) to capture `startedAt`/`endedAt`/`durationMs` and include top-level `toolVersion` and optional `configDigest` in the printed JSON without removing existing fields.
- Updated multi-runner entrypoints (`scripts/validate-all.mjs` and `bin/calculogic-validate.mjs`) to compute `toolVersion` and optional `configDigest` and pass them into `runValidatorRunner`, and extended `runValidatorRunner` to accept optional `toolVersion`/`configDigest` injections and include them in the report envelope.
- Updated the report contract doc comment in `src/validator-report.contracts.mjs` and the NL skeletons (`doc/nl-config/cfg-namingValidator.md`, `doc/nl-config/cfg-validatorRunner.md`) to document the new optional top-level metadata fields, and added `calculogic-validator/test/validator-report-meta.test.mjs` to assert metadata behavior.

### Testing
- Ran `npm ci` and `npm test` and all tests passed successfully.
- Executed `npm run validate:naming -- --scope=docs` and confirmed the JSON includes `toolVersion`, `startedAt`, `endedAt`, and `durationMs`.
- Executed `npm run validate:all -- --scope=docs` and confirmed the combined report includes `toolVersion` at the top-level and validators payloads remain unchanged.
- Verified digest stability by running the naming script twice with the same config (`--config=...`) and asserting identical `configDigest` values, and the new unit tests (`calculogic-validator/test/validator-report-meta.test.mjs`) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2095f5ddc8331a3593d688f9803d2)