### PR TITLE
validator: add exit codes + --strict mode

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -9,10 +9,12 @@ import {
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
+import { deriveExitCodeFromFindings } from '../src/validator-exit-code.logic.mjs';
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
   let configPath;
+  let strict = false;
 
   for (const argument of argv) {
     if (argument.startsWith('--scope=')) {
@@ -21,7 +23,7 @@ const parseScopeFromCli = argv => {
     }
 
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath };
+      return { helpRequested: true, selectedScope, configPath, strict };
     }
 
     if (argument.startsWith('--config=')) {
@@ -29,14 +31,19 @@ const parseScopeFromCli = argv => {
       continue;
     }
 
+    if (argument === '--strict') {
+      strict = true;
+      continue;
+    }
+
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, configPath };
+  return { helpRequested: false, selectedScope, configPath, strict };
 };
 
 const usageLines = [
-  'Usage: calculogic-validate-naming [--scope=<repo|app|docs>] [--config=<path>]',
+  'Usage: calculogic-validate-naming [--scope=<repo|app|docs|validator|system>] [--config=<path>] [--strict]',
   'Scopes:',
   ...listNamingValidatorScopes().map(scope => {
     const profile = getScopeProfile(scope);
@@ -114,4 +121,4 @@ const report = {
 };
 
 console.log(JSON.stringify(report, null, 2));
-process.exit(0);
+process.exit(deriveExitCodeFromFindings(findings, { strict: parsed.strict }));

--- a/calculogic-validator/bin/calculogic-validate.mjs
+++ b/calculogic-validator/bin/calculogic-validate.mjs
@@ -6,9 +6,10 @@ import { listRegisteredValidators } from '../src/validator-registry.knowledge.mj
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
+import { deriveExitCodeFromRunnerReport } from '../src/validator-exit-code.logic.mjs';
 
 const usageLines = [
-  'Usage: calculogic-validate [--scope=<repo|app|docs>] [--validators=<id1,id2>] [--config=<path>]',
+  'Usage: calculogic-validate [--scope=<repo|app|docs|validator|system>] [--validators=<id1,id2>] [--config=<path>] [--strict]',
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
@@ -24,10 +25,11 @@ const parseCliArgs = argv => {
   let selectedScope;
   let validators;
   let configPath;
+  let strict = false;
 
   for (const argument of argv) {
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, validators, configPath };
+      return { helpRequested: true, selectedScope, validators, configPath, strict };
     }
 
     if (argument.startsWith('--scope=')) {
@@ -49,10 +51,15 @@ const parseCliArgs = argv => {
       continue;
     }
 
+    if (argument === '--strict') {
+      strict = true;
+      continue;
+    }
+
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, validators, configPath };
+  return { helpRequested: false, selectedScope, validators, configPath, strict };
 };
 
 let parsed;
@@ -90,7 +97,7 @@ try {
   });
 
   console.log(JSON.stringify(report, null, 2));
-  process.exit(0);
+  process.exit(deriveExitCodeFromRunnerReport(report, { strict: parsed.strict }));
 } catch (error) {
   console.error(error.message);
   console.error(usageLines.join('\n'));

--- a/calculogic-validator/scripts/report-capture-verify.mjs
+++ b/calculogic-validator/scripts/report-capture-verify.mjs
@@ -112,8 +112,12 @@ const runScopeVerification = async ({ scope, reportsDir, repositoryRoot, hostPat
     throw new Error(`Report path is not inside reports directory for ${scope}: ${metadata.path}`);
   }
 
-  if (typeof metadata.exitCode !== 'number' || metadata.exitCode !== 0 || execution.exitCode !== 0) {
-    throw new Error(`Expected zero exit code for ${scope}, got metadata.exitCode=${metadata.exitCode}, process.exitCode=${execution.exitCode}`);
+  if (typeof metadata.exitCode !== 'number') {
+    throw new Error(`Expected numeric metadata.exitCode for ${scope}, got ${metadata.exitCode}`);
+  }
+
+  if (metadata.exitCode !== execution.exitCode) {
+    throw new Error(`Mismatched exit code for ${scope}: metadata.exitCode=${metadata.exitCode}, process.exitCode=${execution.exitCode}`);
   }
 
   if (typeof metadata.bytes !== 'number' || metadata.bytes <= 0) {

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -4,11 +4,12 @@ import { listRegisteredValidators } from '../src/validator-registry.knowledge.mj
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
+import { deriveExitCodeFromRunnerReport } from '../src/validator-exit-code.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
 const usageLines = [
-  'Usage: npm run validate:all -- [--scope=<repo|app|docs|validator|system>] [--validators=<id1,id2>] [--config=<path>]',
+  'Usage: npm run validate:all -- [--scope=<repo|app|docs|validator|system>] [--validators=<id1,id2>] [--config=<path>] [--strict]',
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
@@ -24,10 +25,11 @@ const parseCliArgs = argv => {
   let selectedScope;
   let validators;
   let configPath;
+  let strict = false;
 
   for (const argument of argv) {
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, validators, configPath };
+      return { helpRequested: true, selectedScope, validators, configPath, strict };
     }
 
     if (argument.startsWith('--scope=')) {
@@ -49,10 +51,15 @@ const parseCliArgs = argv => {
       continue;
     }
 
+    if (argument === '--strict') {
+      strict = true;
+      continue;
+    }
+
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, validators, configPath };
+  return { helpRequested: false, selectedScope, validators, configPath, strict };
 };
 
 let parsed;
@@ -89,7 +96,7 @@ try {
   });
 
   console.log(JSON.stringify(report, null, 2));
-  process.exit(0);
+  process.exit(deriveExitCodeFromRunnerReport(report, { strict: parsed.strict }));
 } catch (error) {
   console.error(error.message);
   console.error(usageLines.join('\n'));

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -7,12 +7,14 @@ import {
 import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
+import { deriveExitCodeFromFindings } from '../src/validator-exit-code.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
   let configPath;
+  let strict = false;
 
   for (const argument of argv) {
     if (argument.startsWith('--scope=')) {
@@ -21,7 +23,7 @@ const parseScopeFromCli = argv => {
     }
 
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath };
+      return { helpRequested: true, selectedScope, configPath, strict };
     }
 
     if (argument.startsWith('--config=')) {
@@ -29,14 +31,19 @@ const parseScopeFromCli = argv => {
       continue;
     }
 
+    if (argument === '--strict') {
+      strict = true;
+      continue;
+    }
+
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, configPath };
+  return { helpRequested: false, selectedScope, configPath, strict };
 };
 
 const usageLines = [
-  'Usage: npm run validate:naming -- [--scope=<repo|app|docs|validator|system>] [--config=<path>]',
+  'Usage: npm run validate:naming -- [--scope=<repo|app|docs|validator|system>] [--config=<path>] [--strict]',
   'Scopes:',
   ...listNamingValidatorScopes().map(scope => {
     const profile = getScopeProfile(scope);
@@ -54,7 +61,7 @@ try {
   process.exit(1);
 }
 
-const { helpRequested, selectedScope, configPath } = parsed;
+const { helpRequested, selectedScope, configPath, strict } = parsed;
 
 if (helpRequested) {
   console.log(usageLines.join('\n'));
@@ -113,4 +120,4 @@ const report = {
 };
 
 console.log(JSON.stringify(report, null, 2));
-process.exit(0);
+process.exit(deriveExitCodeFromFindings(findings, { strict }));

--- a/calculogic-validator/src/validator-exit-code.logic.mjs
+++ b/calculogic-validator/src/validator-exit-code.logic.mjs
@@ -1,0 +1,24 @@
+const toBooleanStrictOption = options => Boolean(options?.strict);
+
+export const deriveExitCodeFromFindings = (findings = [], options = {}) => {
+  const hasWarn = findings.some(finding => finding?.severity === 'warn');
+  const hasLegacyException = findings.some(finding => finding?.classification === 'legacy-exception');
+
+  if (hasWarn) {
+    return 2;
+  }
+
+  if (toBooleanStrictOption(options) && hasLegacyException) {
+    return 1;
+  }
+
+  return 0;
+};
+
+export const deriveExitCodeFromRunnerReport = (report, options = {}) => {
+  const findings = Array.isArray(report?.validators)
+    ? report.validators.flatMap(validator => (Array.isArray(validator?.findings) ? validator.findings : []))
+    : [];
+
+  return deriveExitCodeFromFindings(findings, options);
+};

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -102,14 +102,14 @@ test('invalid scope handling is deterministic (usage error + non-zero exit)', ()
 
 test('CLI default scope report is repo', () => {
   const result = runValidatorCli([]);
-  assert.equal(result.status, 0);
+  assert.ok([0, 1, 2].includes(result.status));
   const report = JSON.parse(result.stdout);
   assert.equal(report.scope, 'repo');
 });
 
 test('CLI explicit scope reports selected scope and scope summary metadata', () => {
   const result = runValidatorCli(['--scope=docs']);
-  assert.equal(result.status, 0);
+  assert.ok([0, 1, 2].includes(result.status));
   const report = JSON.parse(result.stdout);
   assert.equal(report.scope, 'docs');
   assert.deepEqual(report.scopeContract.includeRoots, ['doc', 'docs']);

--- a/calculogic-validator/test/report-capture.scopes.integration.test.mjs
+++ b/calculogic-validator/test/report-capture.scopes.integration.test.mjs
@@ -26,12 +26,12 @@ const runReportCapture = (prefix, scriptPath, scope, outputDir) => new Promise((
 
   child.on('error', reject);
   child.on('close', code => {
-    if (code === 0) {
-      resolve();
+    if (typeof code !== 'number') {
+      reject(new Error(`report capture returned non-numeric exit code for ${prefix}`));
       return;
     }
 
-    reject(new Error(`report capture exited with code ${code} for ${prefix}`));
+    resolve(code);
   });
 });
 
@@ -48,7 +48,8 @@ test('report-capture host emits naming reports for repo/app/docs/validator/syste
       const prefix = `naming-${scope}`;
       const before = reportFilesForPrefix(tempDir, prefix);
 
-      await runReportCapture(prefix, 'calculogic-validator/scripts/validate-naming.mjs', scope, tempDir);
+      const exitCode = await runReportCapture(prefix, 'calculogic-validator/scripts/validate-naming.mjs', scope, tempDir);
+      assert.ok([0, 1, 2].includes(exitCode));
 
       const after = reportFilesForPrefix(tempDir, prefix);
       assert.equal(after.length, before.length + 1);
@@ -73,7 +74,8 @@ test('report-capture host emits validate-all reports for repo/app/docs/validator
       const prefix = `validate-all-${scope}`;
       const before = reportFilesForPrefix(tempDir, prefix);
 
-      await runReportCapture(prefix, 'calculogic-validator/scripts/validate-all.mjs', scope, tempDir);
+      const exitCode = await runReportCapture(prefix, 'calculogic-validator/scripts/validate-all.mjs', scope, tempDir);
+      assert.ok([0, 1, 2].includes(exitCode));
 
       const after = reportFilesForPrefix(tempDir, prefix);
       assert.equal(after.length, before.length + 1);

--- a/calculogic-validator/test/validator-exit-codes.test.mjs
+++ b/calculogic-validator/test/validator-exit-codes.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const repositoryRoot = process.cwd();
+const namingScriptPath = path.resolve(repositoryRoot, 'calculogic-validator/scripts/validate-naming.mjs');
+const validateAllScriptPath = path.resolve(repositoryRoot, 'calculogic-validator/scripts/validate-all.mjs');
+
+const writeFixtureRepo = async fixtureDir => {
+  await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
+  await fs.writeFile(
+    path.join(fixtureDir, 'package.json'),
+    JSON.stringify({ name: 'validator-exit-codes-fixture', version: '1.0.0' }, null, 2),
+    'utf8',
+  );
+  await fs.writeFile(path.join(fixtureDir, 'src/App.tsx'), 'export const App = () => null;\n', 'utf8');
+};
+
+const runNodeScript = (scriptPath, args, cwd) =>
+  spawnSync(process.execPath, ['--experimental-strip-types', scriptPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+const parseJsonStdout = result => {
+  assert.equal(typeof result.stdout, 'string');
+  return JSON.parse(result.stdout);
+};
+
+test('validate-naming exits 2 by default when warnings are present', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+    await fs.writeFile(path.join(fixtureDir, 'src/rightpanel.widget.ts'), 'export const widget = {};\n', 'utf8');
+
+    const result = runNodeScript(namingScriptPath, [], fixtureDir);
+    assert.equal(result.status, 2);
+
+    const report = parseJsonStdout(result);
+    assert.ok(Array.isArray(report.findings));
+    assert.ok(report.findings.some(finding => finding?.severity === 'warn'));
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('validate-naming exits 0 by default and 1 in strict mode for legacy-exception-only findings', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    const defaultResult = runNodeScript(namingScriptPath, [], fixtureDir);
+    assert.equal(defaultResult.status, 0);
+    const defaultReport = parseJsonStdout(defaultResult);
+    assert.ok(defaultReport.findings.some(finding => finding?.classification === 'legacy-exception'));
+    assert.equal(defaultReport.findings.some(finding => finding?.severity === 'warn'), false);
+
+    const strictResult = runNodeScript(namingScriptPath, ['--strict'], fixtureDir);
+    assert.equal(strictResult.status, 1);
+    const strictReport = parseJsonStdout(strictResult);
+    assert.ok(strictReport.findings.some(finding => finding?.classification === 'legacy-exception'));
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('validate-all mirrors exit policy from aggregated findings', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+    await fs.writeFile(path.join(fixtureDir, 'src/rightpanel.widget.ts'), 'export const widget = {};\n', 'utf8');
+
+    const warningResult = runNodeScript(validateAllScriptPath, [], fixtureDir);
+    assert.equal(warningResult.status, 2);
+    const warningReport = parseJsonStdout(warningResult);
+    assert.ok(Array.isArray(warningReport.validators));
+
+    await fs.rm(path.join(fixtureDir, 'src/rightpanel.widget.ts'));
+
+    const defaultLegacyResult = runNodeScript(validateAllScriptPath, [], fixtureDir);
+    assert.equal(defaultLegacyResult.status, 0);
+
+    const strictLegacyResult = runNodeScript(validateAllScriptPath, ['--strict'], fixtureDir);
+    assert.equal(strictLegacyResult.status, 1);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/validator-package-bins.test.mjs
+++ b/calculogic-validator/test/validator-package-bins.test.mjs
@@ -22,7 +22,7 @@ test('calculogic-validate bin runs naming validator and returns JSON', () => {
     '--validators=naming',
   ]);
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.ok([0, 1, 2].includes(result.status), result.stderr);
   const report = JSON.parse(result.stdout);
   assert.ok(Array.isArray(report.validators));
 });
@@ -33,7 +33,7 @@ test('calculogic-validate-naming bin returns naming report JSON', () => {
     '--scope=app',
   ]);
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.ok([0, 1, 2].includes(result.status), result.stderr);
   const report = JSON.parse(result.stdout);
   assert.equal(report.scope, 'app');
   assert.equal(typeof report.totalFilesScanned, 'number');
@@ -48,7 +48,7 @@ test('calculogic-validate bin accepts --config path', () => {
     '--config=calculogic-validator/test/fixtures/validator-config.extensions.contracts.json',
   ]);
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.ok([0, 1, 2].includes(result.status), result.stderr);
   const report = JSON.parse(result.stdout);
   assert.equal(report.validators[0].id, 'naming');
 });

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.12** (scope contract split + deterministic report metadata: toolVersion/configDigest/timing).
+Current implementation target: **V0.1.13** (CI-friendly exit codes with optional strict legacy-exception enforcement).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -152,8 +152,18 @@ Report output includes additive scope observability metadata:
 
 This metadata is additive and does not alter legacy report-mode findings behavior.
 
-### 4.6 Exit behavior (report mode)
-Report mode always exits with status code 0 and prints counts by classification.
+### 4.6 Exit behavior (report mode, V0.1.13)
+Report mode always prints full JSON report payload to stdout in non-usage-error flows, then exits with deterministic CI-oriented status:
+- default mode: exit `2` when any finding has `severity="warn"`.
+- strict mode (`--strict`): exit `2` when any warning exists; otherwise exit `1` when any finding has `classification="legacy-exception"`.
+- exit `0` when neither warning criteria nor strict legacy criteria are present.
+
+Priority order is deterministic:
+1. warnings (`severity="warn"`) dominate and force exit `2`.
+2. strict legacy-exception enforcement produces exit `1` only when no warnings exist.
+3. otherwise success is exit `0`.
+
+Invalid CLI usage and argument parse errors remain exit `1`.
 
 ## 5.0 Deferred Behavior
 Deferred to later slices:

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -1,7 +1,7 @@
 # cfg-validatorRunner
 
 ## 0.0 Version
-Current implementation target: **V0.1.2** (deterministic multi-validator runner core with report metadata envelope support).
+Current implementation target: **V0.1.3** (deterministic multi-validator runner report with CI-friendly CLI exit policy).
 
 ## 1.0 Purpose
 Provide a deterministic runner that executes one or more registered validators and returns a single versioned combined report.
@@ -54,12 +54,15 @@ Each validator entry includes:
 - `--scope=<repo|app|docs|validator|system>` (optional)
 - `--validators=<id1,id2>` (optional)
 - `--config=<path>` (optional JSON config path)
+- `--strict` (optional legacy-exception enforcement when no warnings are present)
 
 ### 4.2 Behavior
 - Resolves repository root deterministically from script location.
 - Executes runner with selected options.
 - Writes JSON report to stdout.
-- Exits `0` on success.
+- Exits `2` when any aggregated finding has `severity="warn"`.
+- Exits `1` only in strict mode when no warnings exist and any aggregated finding has `classification="legacy-exception"`.
+- Exits `0` when neither condition applies.
 - Exits `1` for usage errors (invalid flags, unknown validator IDs, invalid scope).
 
 ## 5.0 Deferred Behavior


### PR DESCRIPTION
### Motivation
- Make validator CLIs behave like CI tools by returning deterministic non-zero exit codes when warnings or (optionally) legacy-exceptions are present while preserving existing JSON report output to stdout. 
- Provide a single, reusable exit-code derivation so both single-validator and multi-validator runner CLIs share the same policy.

### Description
- Add `calculogic-validator/src/validator-exit-code.logic.mjs` exposing `deriveExitCodeFromFindings(findings, { strict })` and `deriveExitCodeFromRunnerReport(report, { strict })` implementing the policy: warnings → `2`, strict+legacy-exception → `1`, otherwise `0`.
- Parse `--strict` in naming CLIs and validate-all CLIs (both `scripts/` and `bin/` entrypoints) and use the new derivation to `process.exit(...)` after printing the JSON report to stdout (`calculogic-validator/scripts/validate-naming.mjs`, `calculogic-validator/bin/calculogic-validate-naming.mjs`, `calculogic-validator/scripts/validate-all.mjs`, `calculogic-validator/bin/calculogic-validate.mjs`).
- Relax report-capture verification to check that `metadata.exitCode` is numeric and matches the child `execution.exitCode` instead of requiring zero, so report capture remains valid when validators exit non-zero (`calculogic-validator/scripts/report-capture-verify.mjs`).
- Make CLI integration tests resilient to non-zero (healthy) report exits and add an integration test suite covering exit-code behaviors (`calculogic-validator/test/naming-validator-scope-contract.test.mjs`, `calculogic-validator/test/report-capture.scopes.integration.test.mjs`, `calculogic-validator/test/validator-package-bins.test.mjs`, new `calculogic-validator/test/validator-exit-codes.test.mjs`).
- Update NL skeleton docs to record the new exit-code contract and `--strict` option (`doc/nl-config/cfg-namingValidator.md`, `doc/nl-config/cfg-validatorRunner.md`).

### Testing
- Ran `npm ci` successfully to install dependencies.
- Ran full test suite with `npm test` and all tests passed (final run: all test cases passed).
- Verified CLI behavior: `npm run validate:naming -- --scope=repo` and `npm run validate:all -- --scope=repo` returned exit `2` in this repository due to existing `warn` findings, which matches the implemented policy.
- Confirmed `npm run report:verify` succeeds with the new report-capture verification changes and report files are produced and validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20e34600c8331971bf4c471eeee38)