### PR TITLE
Add validator config JSON Schema and enforce strict unknown-key validation

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -60,3 +60,28 @@ If you use a repo-local report directory, add it to `.gitignore`.
 ## Compatibility shim
 
 Legacy imports from `src/validators/naming-validator.logic.mjs` remain supported via a thin re-export shim to the canonical host entrypoint.
+
+## Validator config schema and strictness
+
+- Published schema: `calculogic-validator/src/validator-config.schema.json`.
+- Runtime validation is strict and rejects unknown keys at the same levels the schema disallows them (root, `naming`, `naming.reportableExtensions`, `naming.roles`, and each `naming.roles.add[]` entry).
+
+Tool-agnostic schema reference example for editor integration:
+
+```json
+{
+  "$schema": "./calculogic-validator/src/validator-config.schema.json",
+  "version": "0.1",
+  "naming": {
+    "roles": {
+      "add": [
+        {
+          "role": "provider",
+          "category": "architecture-support",
+          "status": "active"
+        }
+      ]
+    }
+  }
+}
+```

--- a/calculogic-validator/src/validator-config.logic.mjs
+++ b/calculogic-validator/src/validator-config.logic.mjs
@@ -9,6 +9,15 @@ const fail = message => {
   throw new Error(`Invalid validator config: ${message}`);
 };
 
+const assertOnlyKeys = (obj, allowedKeys, pathLabel) => {
+  const allowed = new Set(allowedKeys);
+  Object.keys(obj).forEach(key => {
+    if (!allowed.has(key)) {
+      fail(`${pathLabel} contains unknown key "${key}".`);
+    }
+  });
+};
+
 const normalizeReportableExtensions = additions =>
   Array.from(new Set(additions.map(extension => extension.trim())));
 
@@ -62,7 +71,16 @@ const normalizeConfig = config => {
 };
 
 const validateReportableExtensionAdditions = config => {
-  const additions = config?.naming?.reportableExtensions?.add;
+  const reportableExtensions = config?.naming?.reportableExtensions;
+  if (reportableExtensions !== undefined) {
+    if (!reportableExtensions || typeof reportableExtensions !== 'object' || Array.isArray(reportableExtensions)) {
+      fail('naming.reportableExtensions must be an object when provided.');
+    }
+
+    assertOnlyKeys(reportableExtensions, ['add'], 'naming.reportableExtensions');
+  }
+
+  const additions = reportableExtensions?.add;
   if (additions === undefined) {
     return;
   }
@@ -88,6 +106,8 @@ const validateRoleAdditionEntry = (entry, index) => {
     fail(`naming.roles.add[${index}] must be an object.`);
   }
 
+  assertOnlyKeys(entry, ['role', 'category', 'status', 'notes'], `naming.roles.add[${index}]`);
+
   if (typeof entry.role !== 'string' || entry.role.trim().length === 0) {
     fail(`naming.roles.add[${index}].role must be a non-empty string.`);
   }
@@ -108,7 +128,16 @@ const validateRoleAdditionEntry = (entry, index) => {
 };
 
 const validateRoleAdditions = config => {
-  const additions = config?.naming?.roles?.add;
+  const roles = config?.naming?.roles;
+  if (roles !== undefined) {
+    if (!roles || typeof roles !== 'object' || Array.isArray(roles)) {
+      fail('naming.roles must be an object when provided.');
+    }
+
+    assertOnlyKeys(roles, ['add'], 'naming.roles');
+  }
+
+  const additions = roles?.add;
   if (additions === undefined) {
     return;
   }
@@ -125,8 +154,19 @@ const validateConfig = config => {
     fail('root must be an object.');
   }
 
+  assertOnlyKeys(config, ['version', 'naming'], 'root');
+
   if (config.version !== VALIDATOR_CONFIG_VERSION) {
     fail(`version must be "${VALIDATOR_CONFIG_VERSION}".`);
+  }
+
+  const naming = config.naming;
+  if (naming !== undefined) {
+    if (!naming || typeof naming !== 'object' || Array.isArray(naming)) {
+      fail('naming must be an object when provided.');
+    }
+
+    assertOnlyKeys(naming, ['reportableExtensions', 'roles'], 'naming');
   }
 
   validateReportableExtensionAdditions(config);

--- a/calculogic-validator/src/validator-config.schema.json
+++ b/calculogic-validator/src/validator-config.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calculogic.dev/schemas/validator-config.schema.json",
+  "title": "Calculogic Validator Config",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "const": "0.1"
+    },
+    "naming": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reportableExtensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "add": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^\\\\."
+              }
+            }
+          }
+        },
+        "roles": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "add": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["role", "category", "status"],
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "category": {
+                    "enum": ["concern-core", "architecture-support", "documentation", "deprecated"]
+                  },
+                  "status": {
+                    "enum": ["active", "deprecated"]
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/calculogic-validator/test/validator-config-schema-sync.test.mjs
+++ b/calculogic-validator/test/validator-config-schema-sync.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { VALIDATOR_CONFIG_VERSION } from '../src/validator-config.contracts.mjs';
+
+test('validator config schema version const matches runtime contract version', () => {
+  const schemaPath = path.join(process.cwd(), 'calculogic-validator/src/validator-config.schema.json');
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+
+  assert.equal(schema?.properties?.version?.const, VALIDATOR_CONFIG_VERSION);
+});

--- a/calculogic-validator/test/validator-config-strictness.test.mjs
+++ b/calculogic-validator/test/validator-config-strictness.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
+
+const fixturePath = 'calculogic-validator/test/fixtures/validator-config.roles.contracts.json';
+
+const writeTempConfig = (filename, payload) => {
+  const tempPath = path.join(process.cwd(), `calculogic-validator/test/fixtures/${filename}`);
+  fs.writeFileSync(tempPath, JSON.stringify(payload));
+  return tempPath;
+};
+
+test('fails when config root contains unknown key', () => {
+  const tempPath = writeTempConfig('tmp-config-unknown-root-key.json', {
+    version: '0.1',
+    extra: true,
+  });
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(tempPath, { cwd: '/' }),
+      /Invalid validator config: root contains unknown key "extra"\./u,
+    );
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
+test('fails when naming contains unknown key', () => {
+  const tempPath = writeTempConfig('tmp-config-unknown-naming-key.json', {
+    version: '0.1',
+    naming: {
+      foo: {},
+    },
+  });
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(tempPath, { cwd: '/' }),
+      /Invalid validator config: naming contains unknown key "foo"\./u,
+    );
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
+test('fails when role entry contains unknown key', () => {
+  const tempPath = writeTempConfig('tmp-config-unknown-role-entry-key.json', {
+    version: '0.1',
+    naming: {
+      roles: {
+        add: [{ role: 'x', category: 'documentation', status: 'active', extra: 1 }],
+      },
+    },
+  });
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(tempPath, { cwd: '/' }),
+      /Invalid validator config: naming\.roles\.add\[0\] contains unknown key "extra"\./u,
+    );
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
+test('still loads existing roles fixture under strict validation', () => {
+  const config = loadValidatorConfigFromFile(fixturePath, { cwd: process.cwd() });
+
+  assert.equal(config.version, '0.1');
+  assert.equal(config.naming?.roles?.add?.[0]?.role, 'provider');
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.13** (CI-friendly exit codes with optional strict legacy-exception enforcement).
+Current implementation target: **V0.1.14** (validator config schema publication + strict unknown-key validation parity).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -97,6 +97,17 @@ Runtime behavior for role additions:
 - runtime active role set = roles with `status=active` from runtime role metadata
 - runtime role suffix list = runtime role keys sorted by descending length for hyphen-role ambiguity detection
 - filename classification uses the runtime role structures when supplied, and default registries when omitted
+
+Validator config contract includes a publishable JSON Schema for editor/tool integration:
+- schema path: `calculogic-validator/src/validator-config.schema.json`
+- schema `properties.version.const` must match runtime `VALIDATOR_CONFIG_VERSION`
+
+Runtime and schema strictness are intentionally aligned. Unknown keys are rejected at the following levels:
+- root object
+- `naming`
+- `naming.reportableExtensions`
+- `naming.roles`
+- each `naming.roles.add[]` entry object
 
 
 ### 2.7 Report metadata contract (V0.1.12)


### PR DESCRIPTION
### Motivation
- Publish a shareable JSON Schema for the validator config so editors/tools can reference the contract and keep it in sync with runtime behavior.
- Ensure runtime validation enforces the same strictness as the schema by rejecting unknown keys at the same object levels.
- Provide automated tests that assert schema/version parity and that runtime strictness rejects unexpected keys while preserving existing fixtures.

### Description
- Added `calculogic-validator/src/validator-config.schema.json` implementing a strict schema with `additionalProperties: false` at root, `naming`, `naming.reportableExtensions`, `naming.roles`, and each `naming.roles.add[]` entry, and enforcing `version.const`, extension pattern, role/category/status enums, and role-entry shape.
- Updated runtime validation in `calculogic-validator/src/validator-config.logic.mjs` to add `assertOnlyKeys(obj, allowedKeys, pathLabel)` checks at the same levels (root, `naming`, `naming.reportableExtensions`, `naming.roles`, and per-role entry) while preserving existing type/shape checks and normalization.
- Added tests: `calculogic-validator/test/validator-config-schema-sync.test.mjs` (verifies schema `version.const` matches `VALIDATOR_CONFIG_VERSION`) and `calculogic-validator/test/validator-config-strictness.test.mjs` (creates temp configs to assert runtime failures for unknown keys and verifies existing fixture still loads).
- Updated documentation: `calculogic-validator/README.md` (schema location and example, note about strict runtime rejection) and `doc/nl-config/cfg-namingValidator.md` (bumped to V0.1.14 and documented schema/strictness policy).

### Testing
- Ran `npm ci` to install dependencies successfully.
- Ran full test suite with `npm test`; all tests passed (including the two new tests): schema/version sync and strictness checks succeeded.
- Verified the existing fixture `calculogic-validator/test/fixtures/validator-config.roles.contracts.json` still loads under the stricter runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a213a0ed548331a46bcfab0425f2f5)