### PR TITLE
docs(validator): align help text and command guidance

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -4,6 +4,12 @@ This folder contains the Calculogic naming validator tooling extracted from the 
 
 ## Commands
 
+## npm argument forwarding (wrong vs right)
+
+- ✅ Correct: `npm run validate:naming -- --scope=app`
+- ❌ Incorrect: `npm run validate:naming --scope=app`
+- npm consumes script arguments unless you place `--` before validator flags.
+
 Run naming validator:
 
 ```bash
@@ -40,9 +46,8 @@ npm exec -- calculogic-report-capture --dir .local-reports --keep 50 -- npm run 
 
 Offline / locked registry note:
 
-- Preferred: `npm exec -- calculogic-report-capture ...` (requires dependencies already installed via `npm ci` or `npm install`).
-- Strict no-download mode: `npx --no-install calculogic-report-capture ...`
-- Example: `npx --no-install calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app`
+- Preferred (deps already installed): `npm exec -- calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app`
+- Strict no-download: `npx --no-install calculogic-report-capture --keep 20 -- npm run validate:naming -- --scope=app`
 
 By default, `calculogic-report-capture` writes report files to OS cache storage.
 Use `--dir` to write to a repo-local or custom directory.

--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -42,14 +42,24 @@ const parseScopeFromCli = argv => {
   return { helpRequested: false, selectedScope, configPath, strict };
 };
 
+const supportedScopes = listNamingValidatorScopes();
+const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
+const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
+
 const usageLines = [
-  'Usage: calculogic-validate-naming [--scope=<repo|app|docs|validator|system>] [--config=<path>] [--strict]',
+  `Usage: calculogic-validate-naming [--scope=<${supportedScopesToken}>] [--config=<path>] [--strict]`,
   'Scopes:',
-  ...listNamingValidatorScopes().map(scope => {
+  ...supportedScopes.map(scope => {
     const profile = getScopeProfile(scope);
     return `  - ${scope}: ${profile?.description ?? ''}`;
   }),
   'Default scope: repo',
+  'Examples:',
+  '  ✅ npm run validate:naming -- --scope=app',
+  '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
+  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
+  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=repo --strict',
 ];
 
 let parsed;

--- a/calculogic-validator/bin/calculogic-validate.mjs
+++ b/calculogic-validator/bin/calculogic-validate.mjs
@@ -8,17 +8,27 @@ import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 import { deriveExitCodeFromRunnerReport } from '../src/validator-exit-code.logic.mjs';
 
+const supportedScopes = listValidatorScopes();
+const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
+const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
+
 const usageLines = [
-  'Usage: calculogic-validate [--scope=<repo|app|docs|validator|system>] [--validators=<id1,id2>] [--config=<path>] [--strict]',
+  `Usage: calculogic-validate [--scope=<${supportedScopesToken}>] [--validators=<id1,id2>] [--config=<path>] [--strict]`,
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
-  ...listValidatorScopes().map(scope => {
+  ...supportedScopes.map(scope => {
     const profile = getValidatorScopeProfile(scope);
     return `  - ${scope}: ${profile?.description ?? ''}`;
   }),
   'Default scope: validator default (repo for naming)',
   'Default validators: all registered validators',
+  'Examples:',
+  '  ✅ npm run validate:naming -- --scope=app',
+  '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
+  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
+  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=repo --strict',
 ];
 
 const parseCliArgs = argv => {

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -8,17 +8,27 @@ import { deriveExitCodeFromRunnerReport } from '../src/validator-exit-code.logic
 
 const repositoryRoot = resolveRepositoryRoot();
 
+const supportedScopes = listValidatorScopes();
+const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
+const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
+
 const usageLines = [
-  'Usage: npm run validate:all -- [--scope=<repo|app|docs|validator|system>] [--validators=<id1,id2>] [--config=<path>] [--strict]',
+  `Usage: npm run validate:all -- [--scope=<${supportedScopesToken}>] [--validators=<id1,id2>] [--config=<path>] [--strict]`,
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
-  ...listValidatorScopes().map(scope => {
+  ...supportedScopes.map(scope => {
     const profile = getValidatorScopeProfile(scope);
     return `  - ${scope}: ${profile?.description ?? ''}`;
   }),
   'Default scope: validator default (repo for naming)',
   'Default validators: all registered validators',
+  'Examples:',
+  '  ✅ npm run validate:naming -- --scope=app',
+  '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
+  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
+  '  ✅ npm run validate:all -- --scope=repo --strict',
 ];
 
 const parseCliArgs = argv => {

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -42,14 +42,24 @@ const parseScopeFromCli = argv => {
   return { helpRequested: false, selectedScope, configPath, strict };
 };
 
+const supportedScopes = listNamingValidatorScopes();
+const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
+const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
+
 const usageLines = [
-  'Usage: npm run validate:naming -- [--scope=<repo|app|docs|validator|system>] [--config=<path>] [--strict]',
+  `Usage: npm run validate:naming -- [--scope=<${supportedScopesToken}>] [--config=<path>] [--strict]`,
   'Scopes:',
-  ...listNamingValidatorScopes().map(scope => {
+  ...supportedScopes.map(scope => {
     const profile = getScopeProfile(scope);
     return `  - ${scope}: ${profile?.description ?? ''}`;
   }),
   'Default scope: repo',
+  'Examples:',
+  '  ✅ npm run validate:naming -- --scope=app',
+  '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
+  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
+  '  ✅ npm run validate:naming -- --scope=repo --strict',
 ];
 
 let parsed;


### PR DESCRIPTION
### Motivation

- Make validator CLI and npm-script docs unambiguous by showing the real supported scope set, correct npm arg-forwarding pattern, and consistent examples. 
- Prevent the common npm forwarding footgun by explicitly showing the `npm run … -- …` shape and a single “wrong vs right” example in the README. 
- Provide consistent offline/locked-registry guidance so users have a preferred (`npm exec -- …`) and a strict no-download (`npx --no-install …`) option.

### Description

- Derive and render the usage scope token dynamically from the scope registries and present the canonical scope set in usage lines (uses `listValidatorScopes()` and `listNamingValidatorScopes()` and a preferred ordering filter). 
- Add a consistent `Examples:` block to every entrypoint help output (bins and npm-script wrappers) including npm forwarding, direct `node` invocation, and one `--strict` example. 
- Normalize npm-script help text in `scripts/validate-all.mjs` and `scripts/validate-naming.mjs` to match the bins and include the same examples and scope token. 
- Add a README callout near the top with a single explicit “wrong vs right” npm forwarding example and normalize the offline/locked-registry guidance to the two canonical forms.

Files changed: `calculogic-validator/bin/calculogic-validate.mjs`, `calculogic-validator/bin/calculogic-validate-naming.mjs`, `calculogic-validator/scripts/validate-all.mjs`, `calculogic-validator/scripts/validate-naming.mjs`, and `calculogic-validator/README.md`.

### Testing

- Ran `npm ci` and it completed successfully. 
- Ran `npm test` and all tests passed (`97` tests; `0` failures). 
- Verified CLI help outputs by running `node calculogic-validator/bin/calculogic-validate-naming.mjs --help` and `node calculogic-validator/bin/calculogic-validate.mjs --help`, which show the full scope set and the new `Examples` block. 
- Verified npm-script help outputs by running `npm run validate:naming -- --help` and `npm run validate:all -- --help`, which display the updated usage token, scopes, and examples.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a218a35c108331b0c1dcc8856521f0)