### PR TITLE
Fix validator config dot-pattern and allow optional root $schema

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -69,7 +69,7 @@ Legacy imports from `src/validators/naming-validator.logic.mjs` remain supported
 ## Validator config schema and strictness
 
 - Published schema: `calculogic-validator/src/validator-config.schema.json`.
-- Runtime validation is strict and rejects unknown keys at the same levels the schema disallows them (root, `naming`, `naming.reportableExtensions`, `naming.roles`, and each `naming.roles.add[]` entry).
+- Runtime validation is strict and rejects unknown keys at the same levels the schema disallows them (`naming`, `naming.reportableExtensions`, `naming.roles`, and each `naming.roles.add[]` entry; root allows optional `$schema` as an editor hint and normalization ignores it).
 
 Tool-agnostic schema reference example for editor integration:
 

--- a/calculogic-validator/src/validator-config.logic.mjs
+++ b/calculogic-validator/src/validator-config.logic.mjs
@@ -154,7 +154,7 @@ const validateConfig = config => {
     fail('root must be an object.');
   }
 
-  assertOnlyKeys(config, ['version', 'naming'], 'root');
+  assertOnlyKeys(config, ['version', 'naming', '$schema'], 'root');
 
   if (config.version !== VALIDATOR_CONFIG_VERSION) {
     fail(`version must be "${VALIDATOR_CONFIG_VERSION}".`);

--- a/calculogic-validator/src/validator-config.schema.json
+++ b/calculogic-validator/src/validator-config.schema.json
@@ -6,6 +6,9 @@
   "additionalProperties": false,
   "required": ["version"],
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "version": {
       "const": "0.1"
     },
@@ -21,7 +24,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "pattern": "^\\\\."
+                "pattern": "^\\."
               }
             }
           }

--- a/calculogic-validator/test/validator-config-strictness.test.mjs
+++ b/calculogic-validator/test/validator-config-strictness.test.mjs
@@ -28,6 +28,24 @@ test('fails when config root contains unknown key', () => {
   }
 });
 
+
+
+test('allows optional root $schema editor hint key and normalizes deterministically', () => {
+  const tempPath = writeTempConfig('tmp-config-with-root-schema-key.json', {
+    $schema: './calculogic-validator/src/validator-config.schema.json',
+    version: '0.1',
+  });
+
+  try {
+    const config = loadValidatorConfigFromFile(tempPath, { cwd: '/' });
+    assert.deepEqual(config, {
+      version: '0.1',
+    });
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
 test('fails when naming contains unknown key', () => {
   const tempPath = writeTempConfig('tmp-config-unknown-naming-key.json', {
     version: '0.1',

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -103,7 +103,7 @@ Validator config contract includes a publishable JSON Schema for editor/tool int
 - schema `properties.version.const` must match runtime `VALIDATOR_CONFIG_VERSION`
 
 Runtime and schema strictness are intentionally aligned. Unknown keys are rejected at the following levels:
-- root object
+- root object (except optional `$schema` editor-hint key, ignored by runtime normalization)
 - `naming`
 - `naming.reportableExtensions`
 - `naming.roles`


### PR DESCRIPTION
### Motivation
- The schema regex for `naming.reportableExtensions.add[]` accidentally matched a leading backslash instead of a literal dot, causing valid extensions like `.py` to be rejected.  
- README examples and editor usage include a root `"$schema"` hint, but runtime strictness rejected unknown root keys, creating an inconsistency between schema/editor usage and runtime validation.

### Description
- Corrected the extension item pattern in `calculogic-validator/src/validator-config.schema.json` from `"^\\."` to `"^\\."` (JSON-escaped `^\.`) so extensions must start with a literal dot.  
- Added an optional root `"$schema": { "type": "string" }` property to `calculogic-validator/src/validator-config.schema.json` while keeping `additionalProperties: false` and `required: ["version"]`.  
- Allowed `"$schema"` in the runtime root whitelist by updating `assertOnlyKeys(config, ['version', 'naming'], 'root')` to `assertOnlyKeys(config, ['version', 'naming', '$schema'], 'root')` in `calculogic-validator/src/validator-config.logic.mjs`.  
- Added a strictness test `allows optional root $schema editor hint key and normalizes deterministically` to `calculogic-validator/test/validator-config-strictness.test.mjs` that verifies a config containing `"$schema"` loads and normalizes to `{ version: '0.1' }`.  
- Updated docs: clarified strictness wording in `calculogic-validator/README.md` and updated the NL contract `doc/nl-config/cfg-namingValidator.md` per NL-first workflow to document the root `$schema` exception.

### Testing
- Ran `npm ci` successfully to install dependencies.  
- Ran `npm test` and all validator and app tests passed; test run completed with all suites passing (98 tests passing after the change).  
- The newly added strictness test for root `"$schema"` passed as part of the test suite run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2283f63c88331b432b73ca506b22b)