### PR TITLE
Add optional --target filtering to naming validator (file/dir targets, report metadata)

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -15,15 +15,34 @@ const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
   let configPath;
   let strict = false;
+  const targets = [];
 
-  for (const argument of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
     if (argument.startsWith('--scope=')) {
       selectedScope = argument.slice('--scope='.length);
       continue;
     }
 
+    if (argument === '--target') {
+      const rawTarget = argv[index + 1];
+      if (!rawTarget || rawTarget.startsWith('--')) {
+        throw new Error('Missing required value for --target');
+      }
+
+      targets.push(rawTarget.trim().replaceAll('\\', '/'));
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--target=')) {
+      targets.push(argument.slice('--target='.length).trim().replaceAll('\\', '/'));
+      continue;
+    }
+
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath, strict };
+      return { helpRequested: true, selectedScope, configPath, strict, targets };
     }
 
     if (argument.startsWith('--config=')) {
@@ -39,7 +58,7 @@ const parseScopeFromCli = argv => {
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, configPath, strict };
+  return { helpRequested: false, selectedScope, configPath, strict, targets };
 };
 
 const supportedScopes = listNamingValidatorScopes();
@@ -47,7 +66,7 @@ const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
 const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
 
 const usageLines = [
-  `Usage: calculogic-validate-naming [--scope=<${supportedScopesToken}>] [--config=<path>] [--strict]`,
+  `Usage: calculogic-validate-naming [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
   'Scopes:',
   ...supportedScopes.map(scope => {
     const profile = getScopeProfile(scope);
@@ -56,6 +75,8 @@ const usageLines = [
   'Default scope: repo',
   'Examples:',
   '  ✅ npm run validate:naming -- --scope=app',
+  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
+  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
   '  ✅ npm run validate:all -- --validators=naming --scope=docs',
   '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
   '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
@@ -99,7 +120,14 @@ try {
 const toolVersion = getValidatorToolVersion();
 const configDigest = config ? computeConfigDigest(config) : undefined;
 const startedAtDate = new Date();
-const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: parsed.selectedScope, config });
+let validatorResult;
+try {
+  validatorResult = runNamingValidator(repositoryRoot, { scope: parsed.selectedScope, config, targets: parsed.targets });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+const { findings, totalFilesScanned, scope, filters } = validatorResult;
 const endedAtDate = new Date();
 const summary = summarizeFindings(findings);
 
@@ -112,6 +140,7 @@ const report = {
   durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
   scope,
   totalFilesScanned,
+  filters,
   scopeSummary: {
     scope,
     reportableFilesInScope: totalFilesScanned,

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -15,15 +15,34 @@ const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
   let configPath;
   let strict = false;
+  const targets = [];
 
-  for (const argument of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
     if (argument.startsWith('--scope=')) {
       selectedScope = argument.slice('--scope='.length);
       continue;
     }
 
+    if (argument === '--target') {
+      const rawTarget = argv[index + 1];
+      if (!rawTarget || rawTarget.startsWith('--')) {
+        throw new Error('Missing required value for --target');
+      }
+
+      targets.push(rawTarget.trim().replaceAll('\\', '/'));
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--target=')) {
+      targets.push(argument.slice('--target='.length).trim().replaceAll('\\', '/'));
+      continue;
+    }
+
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath, strict };
+      return { helpRequested: true, selectedScope, configPath, strict, targets };
     }
 
     if (argument.startsWith('--config=')) {
@@ -39,7 +58,7 @@ const parseScopeFromCli = argv => {
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, configPath, strict };
+  return { helpRequested: false, selectedScope, configPath, strict, targets };
 };
 
 const supportedScopes = listNamingValidatorScopes();
@@ -47,7 +66,7 @@ const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
 const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
 
 const usageLines = [
-  `Usage: npm run validate:naming -- [--scope=<${supportedScopesToken}>] [--config=<path>] [--strict]`,
+  `Usage: npm run validate:naming -- [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
   'Scopes:',
   ...supportedScopes.map(scope => {
     const profile = getScopeProfile(scope);
@@ -56,6 +75,8 @@ const usageLines = [
   'Default scope: repo',
   'Examples:',
   '  ✅ npm run validate:naming -- --scope=app',
+  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
+  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
   '  ✅ npm run validate:all -- --validators=naming --scope=docs',
   '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
   '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
@@ -71,7 +92,7 @@ try {
   process.exit(1);
 }
 
-const { helpRequested, selectedScope, configPath, strict } = parsed;
+const { helpRequested, selectedScope, configPath, strict, targets } = parsed;
 
 if (helpRequested) {
   console.log(usageLines.join('\n'));
@@ -98,7 +119,14 @@ try {
 const toolVersion = getValidatorToolVersion();
 const configDigest = config ? computeConfigDigest(config) : undefined;
 const startedAtDate = new Date();
-const { findings, totalFilesScanned, scope } = runNamingValidator(repositoryRoot, { scope: selectedScope, config });
+let validatorResult;
+try {
+  validatorResult = runNamingValidator(repositoryRoot, { scope: selectedScope, config, targets });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+const { findings, totalFilesScanned, scope, filters } = validatorResult;
 const endedAtDate = new Date();
 const summary = summarizeFindings(findings);
 
@@ -111,6 +139,7 @@ const report = {
   durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
   scope,
   totalFilesScanned,
+  filters,
   scopeSummary: {
     scope,
     reportableFilesInScope: totalFilesScanned,

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -44,6 +44,9 @@ const isReportableFile = (relativePath, reportableExtensions = REPORTABLE_EXTENS
 
 const sortPaths = paths => Array.from(paths).sort((left, right) => left.localeCompare(right));
 
+const isPathOutsideRoot = relativePath =>
+  relativePath.startsWith('..') || path.isAbsolute(relativePath);
+
 const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {}) => {
   const normalizedRoot = normalizePath(rootRelativePath);
   const absoluteRoot = path.resolve(rootDirectory, normalizedRoot);
@@ -152,6 +155,78 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   const scopePathPredicate = buildScopePathPredicate(profile);
   const scopedPaths = allReportablePaths.filter(scopePathPredicate);
   return sortPaths(new Set(scopedPaths));
+};
+
+export const resolveNamingValidatorTargets = (rootDirectory, targets = []) => {
+  if (!targets?.length) {
+    return [];
+  }
+
+  const repositoryRoot = fs.realpathSync(rootDirectory);
+  const resolvedTargets = [];
+  const dedupeByAbsolutePath = new Set();
+
+  for (const rawTarget of targets) {
+    const trimmedTarget = String(rawTarget ?? '').trim();
+    const normalizedInput = trimmedTarget.replaceAll('\\', '/');
+
+    if (!normalizedInput) {
+      throw new Error('Target path must be a non-empty string.');
+    }
+
+    const absoluteCandidatePath = path.isAbsolute(trimmedTarget)
+      ? path.resolve(trimmedTarget)
+      : path.resolve(rootDirectory, normalizedInput);
+
+    if (!fs.existsSync(absoluteCandidatePath)) {
+      throw new Error(`Target path does not exist: ${normalizedInput}`);
+    }
+
+    const absoluteRealPath = fs.realpathSync(absoluteCandidatePath);
+    const relativeToRoot = path.relative(repositoryRoot, absoluteRealPath);
+    if (isPathOutsideRoot(relativeToRoot)) {
+      throw new Error(`Target path escapes repository root: ${normalizedInput}`);
+    }
+
+    if (dedupeByAbsolutePath.has(absoluteRealPath)) {
+      continue;
+    }
+
+    const targetStat = fs.statSync(absoluteRealPath);
+    const kind = targetStat.isDirectory() ? 'dir' : targetStat.isFile() ? 'file' : null;
+    if (!kind) {
+      throw new Error(`Target path must be a file or directory: ${normalizedInput}`);
+    }
+
+    dedupeByAbsolutePath.add(absoluteRealPath);
+    resolvedTargets.push({
+      absPath: absoluteRealPath,
+      relPath: relativeToRoot ? normalizePath(relativeToRoot) : '.',
+      kind,
+    });
+  }
+
+  return resolvedTargets.sort((left, right) => left.relPath.localeCompare(right.relPath));
+};
+
+export const filterRepositoryPathsByTargets = (rootDirectory, relativePaths, resolvedTargets = []) => {
+  if (!resolvedTargets.length) {
+    return sortPaths(new Set(relativePaths));
+  }
+
+  const selectedPaths = relativePaths.filter(relativePath => {
+    const absolutePath = path.resolve(rootDirectory, relativePath);
+
+    return resolvedTargets.some(target => {
+      if (target.kind === 'file') {
+        return absolutePath === target.absPath;
+      }
+
+      return absolutePath === target.absPath || absolutePath.startsWith(`${target.absPath}${path.sep}`);
+    });
+  });
+
+  return sortPaths(new Set(selectedPaths));
 };
 
 export const classifyPath = (relativePath, namingRolesRuntime) => {
@@ -292,16 +367,26 @@ export const classifyPath = (relativePath, namingRolesRuntime) => {
 
 export const runNamingValidator = (rootDirectory, options = {}) => {
   const selectedScope = options.scope ?? 'repo';
-  const paths = collectRepositoryPaths(rootDirectory, {
+  const inScopePaths = collectRepositoryPaths(rootDirectory, {
     scope: selectedScope,
     reportableExtensions: options.reportableExtensions,
   });
+  const resolvedTargets = resolveNamingValidatorTargets(rootDirectory, options.targets ?? []);
+  const paths = filterRepositoryPathsByTargets(rootDirectory, inScopePaths, resolvedTargets);
   const findings = paths.map(pathname => classifyPath(pathname, options.namingRolesRuntime));
 
   return {
     findings,
     totalFilesScanned: paths.length,
     scope: selectedScope,
+    filters: {
+      isFiltered: resolvedTargets.length > 0,
+      ...(resolvedTargets.length > 0
+        ? {
+            targets: resolvedTargets.map(target => target.relPath),
+          }
+        : {}),
+    },
   };
 };
 

--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -45,9 +45,10 @@ const deriveNamingRolesRuntime = config => {
   };
 };
 
-export const runNamingValidator = (repositoryRoot, { scope, config } = {}) =>
+export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) =>
   runNamingValidatorRuntime(repositoryRoot, {
     scope,
+    targets,
     reportableExtensions: deriveReportableExtensions(config),
     namingRolesRuntime: deriveNamingRolesRuntime(config),
   });

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -118,3 +118,65 @@ test('CLI explicit scope reports selected scope and scope summary metadata', () 
   assert.equal(report.scopeSummary.reportableFilesInScope, report.totalFilesScanned);
   assert.equal(report.scopeSummary.findingsGenerated, report.findings.length);
 });
+
+
+test('CLI no-target regression keeps scope behavior and unfiltered metadata', () => {
+  const result = runValidatorCli(['--scope=app']);
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.scope, 'app');
+  assert.equal(report.filters.isFiltered, false);
+  assert.equal(report.filters.targets, undefined);
+});
+
+test('CLI file target filters to one in-scope file and reports normalized targets', () => {
+  const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
+  const targetPath = appPaths.find(pathname => pathname.endsWith('.tsx') || pathname.endsWith('.ts')) ?? appPaths[0];
+  assert.ok(targetPath, 'Expected at least one app-scope path for target test');
+
+  const result = runValidatorCli(['--scope=app', `--target=${targetPath}`]);
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.filters.isFiltered, true);
+  assert.deepEqual(report.filters.targets, [targetPath]);
+  assert.deepEqual(report.findings.map(finding => finding.path), [targetPath]);
+});
+
+test('CLI directory target filters recursively within scope', () => {
+  const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
+  const targetDirectory = 'src';
+  const expectedPaths = appPaths.filter(pathname => pathname === targetDirectory || pathname.startsWith(`${targetDirectory}/`));
+  assert.ok(expectedPaths.length > 0, 'Expected src directory to contain app-scope reportable files');
+
+  const result = runValidatorCli(['--scope=app', '--target', targetDirectory]);
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.filters.isFiltered, true);
+  assert.deepEqual(report.filters.targets, [targetDirectory]);
+  assert.deepEqual(report.findings.map(finding => finding.path), expectedPaths);
+});
+
+test('CLI multiple targets apply union semantics', () => {
+  const appPaths = collectRepositoryPaths(process.cwd(), { scope: 'app' });
+  const targetDirectories = ['src', 'test'];
+  const expectedPaths = appPaths.filter(pathname =>
+    targetDirectories.some(target => pathname === target || pathname.startsWith(`${target}/`)),
+  );
+  assert.ok(expectedPaths.length > 0, 'Expected app scope to include files under src or test');
+
+  const result = runValidatorCli(['--scope=app', '--target=src', '--target', 'test']);
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.filters.isFiltered, true);
+  assert.deepEqual(report.filters.targets, targetDirectories);
+  assert.deepEqual(report.findings.map(finding => finding.path), expectedPaths);
+});
+
+test('CLI nonexistent target fails deterministically with stable message', () => {
+  const result = runValidatorCli(['--scope=app', '--target=src/does-not-exist-target']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Target path does not exist: src\/does-not-exist-target/u);
+});

--- a/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -1,4 +1,4 @@
-# Naming Validator Spec (V0.1.5)
+# Naming Validator Spec (V0.1.6)
 
 ## Purpose and Scope
 
@@ -129,12 +129,37 @@ Inclusion/exclusion summary:
 Invalid scope behavior:
 - Unknown scope values are usage errors with non-zero exit and valid-scope usage text.
 
-## CLI Usage (V0.1.2)
+## CLI Usage (V0.1.6)
 
 - `npm run validate:naming` (defaults to `--scope=repo`)
 - `npm run validate:naming -- --scope=repo`
 - `npm run validate:naming -- --scope=app`
 - `npm run validate:naming -- --scope=docs`
+- `npm run validate:naming -- --scope=app --target src/buildsurface`
+- `npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared`
+
+
+## Targeted runs (developer convenience, V0.1.6)
+
+Optional CLI filter flag:
+- `--target <path>`
+- `--target=<path>`
+- repeatable; union semantics when provided multiple times
+
+Path handling:
+- accepts repo-relative or absolute paths
+- target may be a file (exact path match) or directory (recursive descendants)
+- normalization stores report metadata in repo-relative `/`-separated form
+
+Filtering contract:
+- target filtering is applied after canonical scope discovery
+- selected scope remains authoritative and report `scope` remains unchanged
+- non-existent target path is deterministic non-zero error
+- existing targets that produce zero in-scope files produce valid empty report output
+
+Report metadata additions:
+- `filters.isFiltered` (boolean)
+- `filters.targets` (sorted normalized target list, only when filtering is active)
 
 ## Classification Outputs
 

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -1,7 +1,7 @@
 # cfg-namingValidator
 
 ## 0.0 Version
-Current implementation target: **V0.1.14** (validator config schema publication + strict unknown-key validation parity).
+Current implementation target: **V0.1.15** (optional --target path/folder filtering within scope).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -11,6 +11,22 @@ Define a deterministic V0.1 filename naming validator that runs in report mode o
 The validator reads rules from `doc/ConventionRoutines/FileNamingMasterList-V1_1.md` as authoritative naming guidance.
 
 ### 2.2 Scope mode (V0.1.11)
+### 2.2.1 Target filter mode (V0.1.15)
+V0.1.15 adds optional repeatable `--target` inputs for developer-convenience focused runs while preserving canonical scope semantics:
+- `--target <path>` and `--target=<path>` are both accepted and can be repeated
+- target may resolve to a file (exact-match) or directory (recursive prefix-match)
+- target paths can be repository-relative or absolute, with deterministic normalization to repository-relative `/` form for reporting
+- filtering applies after canonical scope discovery (`repo|app|docs|validator|system` remain authoritative)
+
+Deterministic validation and safety requirements:
+- each target is resolved via realpath and must remain within repository root
+- nonexistent targets are deterministic CLI usage/runtime errors with non-zero exit
+- target unions are deduplicated and sorted deterministically
+- when target filtering is active, report metadata includes:
+  - `filters.isFiltered = true`
+  - `filters.targets = [sorted repo-relative targets]`
+- when target filtering is inactive, metadata includes `filters.isFiltered = false` and omits `filters.targets`
+
 V0.1.11 supports deterministic scope profiles selected via CLI and applied before filename classification using explicit scope path predicates:
 - default/no `--scope` input resolves to `repo`
 - `repo`: repository-wide reportable files.


### PR DESCRIPTION
### Motivation
- Provide a developer-convenience filter so the naming validator can run quickly against one or more file/folder paths while preserving canonical `--scope` semantics and default behavior when `--target` is omitted. 
- Ensure filtering is deterministic, safe (no repo-escape), and observable in reports so targeted runs remain a local convenience and do not change the validator contract.

### Description
- Add repeatable CLI parsing for `--target <path>` and `--target=<path>` in both `calculogic-validator/scripts/validate-naming.mjs` and `calculogic-validator/bin/calculogic-validate-naming.mjs`, normalizing inputs (trim + `\`→`/`) and passing `targets` to the runtime. 
- Implement `resolveNamingValidatorTargets` and `filterRepositoryPathsByTargets` helpers in `calculogic-validator/src/naming/naming-validator.logic.mjs` that `realpath` targets, enforce containment inside repository root, classify target `kind: 'file'|'dir'`, deduplicate, sort, and apply union/filtering after canonical scope discovery. 
- Thread `targets` through the wiring layer (`naming-validator.wiring.mjs`) and change `runNamingValidator` to accept `targets` so CLIs can pass the filter without changing default calls. 
- Add report metadata `filters: { isFiltered: boolean, targets?: string[] }` to the validator result only when filtering is active and preserve `report.scope` semantics. 
- Update NL/spec docs (`doc/nl-config/cfg-namingValidator.md`, `doc/ConventionRoutines/NamingValidatorSpec.md`) to document `--target` semantics and safety/metadata contract. 
- Extend scope-contract tests (`calculogic-validator/test/naming-validator-scope-contract.test.mjs`) with automated cases covering: no-target regression, single file target, directory recursive target, multiple-target union, and deterministic nonexistent-target failure.

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran the full test suite with `npm test` and all tests passed (103 tests, 0 failures). 
- Exercised validator CLI scenarios: `npm run validate:naming` (default), `npm run validate:naming -- --scope=repo`, `npm run validate:naming -- --scope=app --target src`, and `npm run validate:naming -- --scope=docs --target doc`; each run produced expected JSON report shapes and exit behaviors (non-zero when warnings per existing exit policy, and deterministic non-zero on nonexistent `--target`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a235586e208331a20f4217472d45cd)