### PR TITLE
feat(validator): add --target support to validate:all and naming validator filter metadata

### DIFF
--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -13,7 +13,7 @@ const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
 const supportedScopesToken = preferredScopeOrder.filter(scope => supportedScopes.includes(scope)).join('|');
 
 const usageLines = [
-  `Usage: npm run validate:all -- [--scope=<${supportedScopesToken}>] [--validators=<id1,id2>] [--config=<path>] [--strict]`,
+  `Usage: npm run validate:all -- [--scope=<${supportedScopesToken}>] [--validators=<id1,id2>] [--target=<path>]... [--config=<path>] [--strict]`,
   'Validators:',
   ...listRegisteredValidators().map(validatorId => `  - ${validatorId}`),
   'Scopes:',
@@ -26,6 +26,8 @@ const usageLines = [
   'Examples:',
   '  ✅ npm run validate:naming -- --scope=app',
   '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+  '  ✅ npm run validate:all -- --validators=naming --scope=app --target src/buildsurface',
+  '  ✅ npm run validate:all -- --target src --target test',
   '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
   '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
   '  ✅ npm run validate:all -- --scope=repo --strict',
@@ -36,14 +38,33 @@ const parseCliArgs = argv => {
   let validators;
   let configPath;
   let strict = false;
+  const targets = [];
 
-  for (const argument of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
     if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, validators, configPath, strict };
+      return { helpRequested: true, selectedScope, validators, configPath, strict, targets };
     }
 
     if (argument.startsWith('--scope=')) {
       selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    if (argument === '--target') {
+      const rawTarget = argv[index + 1];
+      if (!rawTarget || rawTarget.startsWith('--')) {
+        throw new Error('Missing required value for --target');
+      }
+
+      targets.push(rawTarget.trim().replaceAll('\\', '/'));
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--target=')) {
+      targets.push(argument.slice('--target='.length).trim().replaceAll('\\', '/'));
       continue;
     }
 
@@ -69,7 +90,7 @@ const parseCliArgs = argv => {
     throw new Error(`Invalid argument: ${argument}`);
   }
 
-  return { helpRequested: false, selectedScope, validators, configPath, strict };
+  return { helpRequested: false, selectedScope, validators, configPath, strict, targets };
 };
 
 let parsed;
@@ -101,6 +122,7 @@ try {
     scope: parsed.selectedScope,
     validators: parsed.validators,
     config,
+    targets: parsed.targets,
     toolVersion: getValidatorToolVersion(),
     ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });

--- a/calculogic-validator/src/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/validator-registry.knowledge.mjs
@@ -6,14 +6,26 @@ import {
 const runNamingValidatorHook = (repositoryRoot, options = {}) => {
   const scope = options.scope;
   const config = options.config;
-  const namingResult = runNamingValidator(repositoryRoot, { scope, config });
+  const targets = options.targets;
+  const namingResult = runNamingValidator(repositoryRoot, { scope, config, targets });
   const summary = summarizeFindings(namingResult.findings);
+  const hasFilterMetadata = Boolean(namingResult.filters?.isFiltered);
 
   return {
     scope: namingResult.scope,
     totalFilesScanned: namingResult.totalFilesScanned,
     findings: namingResult.findings,
     summary,
+    ...(hasFilterMetadata
+      ? {
+          meta: {
+            filters: {
+              isFiltered: true,
+              targets: namingResult.filters.targets,
+            },
+          },
+        }
+      : {}),
   };
 };
 

--- a/calculogic-validator/src/validator-runner.logic.mjs
+++ b/calculogic-validator/src/validator-runner.logic.mjs
@@ -43,9 +43,10 @@ export const runValidatorRunner = (repositoryRoot, options = {}) => {
   const validatorsToRun = resolveValidatorsToRun(options.validators);
   const scope = options.scope;
   const config = options.config;
+  const targets = options.targets;
 
   const validators = validatorsToRun.map(registryEntry => {
-    const result = registryEntry.run(repositoryRoot, { scope, config });
+    const result = registryEntry.run(repositoryRoot, { scope, config, targets });
     return toValidatorReportEntry(registryEntry, result);
   });
 

--- a/calculogic-validator/test/validate-all.targets.integration.test.mjs
+++ b/calculogic-validator/test/validate-all.targets.integration.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const repositoryRoot = process.cwd();
+const validateAllScriptPath = path.resolve(repositoryRoot, 'calculogic-validator/scripts/validate-all.mjs');
+
+const runValidateAll = (fixtureDir, args) =>
+  spawnSync(process.execPath, ['--experimental-strip-types', validateAllScriptPath, ...args], {
+    cwd: fixtureDir,
+    encoding: 'utf8',
+  });
+
+const writeFixtureRepo = async fixtureDir => {
+  await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
+  await fs.mkdir(path.join(fixtureDir, 'test'), { recursive: true });
+
+  await fs.writeFile(
+    path.join(fixtureDir, 'package.json'),
+    JSON.stringify({ name: 'validate-all-targets-fixture', version: '1.0.0' }, null, 2),
+    'utf8',
+  );
+  await fs.writeFile(path.join(fixtureDir, 'src/right-panel.widget.ts'), 'export const widget = {}\n', 'utf8');
+  await fs.writeFile(path.join(fixtureDir, 'src/app-shell.logic.ts'), 'export const logic = {}\n', 'utf8');
+  await fs.writeFile(path.join(fixtureDir, 'test/unit.spec.ts'), 'export const spec = true\n', 'utf8');
+};
+
+test('validate-all accepts --target and emits naming validator filter metadata', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-all-targets-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    const result = runValidateAll(fixtureDir, ['--validators=naming', '--scope=app', '--target', 'src']);
+
+    assert.equal(result.status, 2);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.validators[0].id, 'naming');
+    assert.equal(report.validators[0].meta.filters.isFiltered, true);
+    assert.deepEqual(report.validators[0].meta.filters.targets, ['src']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('validate-all returns deterministic error for nonexistent --target', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-all-targets-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    const result = runValidateAll(fixtureDir, ['--validators=naming', '--scope=app', '--target', 'does-not-exist']);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Target path does not exist: does-not-exist/u);
+    assert.match(result.stderr, /Usage: npm run validate:all/u);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/validator-runner.test.mjs
+++ b/calculogic-validator/test/validator-runner.test.mjs
@@ -36,3 +36,18 @@ test('validate-all CLI runs and returns naming validator report', () => {
   assert.equal(report.validators[0].id, 'naming');
   assert.equal(report.validators[0].scope, 'docs');
 });
+
+test('runner forwards targets and includes naming filter meta when filtering is active', () => {
+  const report = runValidatorRunner(process.cwd(), { scope: 'app', validators: ['naming'], targets: ['src'] });
+
+  assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].meta?.filters?.isFiltered, true);
+  assert.deepEqual(report.validators[0].meta?.filters?.targets, ['src']);
+});
+
+test('runner omits naming filter meta when no targets are provided', () => {
+  const report = runValidatorRunner(process.cwd(), { scope: 'app', validators: ['naming'] });
+
+  assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].meta?.filters, undefined);
+});

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -1,7 +1,7 @@
 # cfg-validatorRunner
 
 ## 0.0 Version
-Current implementation target: **V0.1.3** (deterministic multi-validator runner report with CI-friendly CLI exit policy).
+Current implementation target: **V0.1.4** (deterministic multi-validator runner target pass-through and per-validator filter metadata).
 
 ## 1.0 Purpose
 Provide a deterministic runner that executes one or more registered validators and returns a single versioned combined report.
@@ -14,6 +14,7 @@ The runner reads validator definitions from a deterministic registry in `calculo
 - `validators` (optional list of validator IDs)
 - `scope` (optional scope string forwarded to validators that support scope selection)
 - `config` (optional loaded validator config object from JSON contract V0.1)
+- `targets` (optional repeatable path filters forwarded to validators that implement target-aware filtering)
 
 ### 2.3 Initial validator set
 V0.1.0 includes the naming validator only, wrapped through the registry run hook without changing naming-validator internals.
@@ -44,6 +45,13 @@ Each validator entry includes:
 - `findings`
 - optional `meta`
 
+### 3.4 Per-validator filter metadata (V0.1.4)
+- Runner preserves report schema compatibility by attaching optional filter metadata only to validator entries that actively use filtering.
+- For naming validator, when target filtering is active:
+  - `validators[n].meta.filters.isFiltered = true`
+  - `validators[n].meta.filters.targets = [sorted, deduped, repository-relative paths with '/' separators]`
+- When no targets are provided, naming validator entries omit `meta.filters` entirely.
+
 ### 3.3 Ordering and determinism
 - Validator execution order matches registry declaration order.
 - Findings order from each validator is preserved as-is (no resorting in the runner).
@@ -53,17 +61,20 @@ Each validator entry includes:
 - `--help`
 - `--scope=<repo|app|docs|validator|system>` (optional)
 - `--validators=<id1,id2>` (optional)
+- `--target=<path>` or `--target <path>` (optional, repeatable)
 - `--config=<path>` (optional JSON config path)
 - `--strict` (optional legacy-exception enforcement when no warnings are present)
 
 ### 4.2 Behavior
 - Resolves repository root deterministically from script location.
+- Forwards `--target` values to target-aware validators as convenience filters applied within selected scope.
 - Executes runner with selected options.
 - Writes JSON report to stdout.
 - Exits `2` when any aggregated finding has `severity="warn"`.
 - Exits `1` only in strict mode when no warnings exist and any aggregated finding has `classification="legacy-exception"`.
 - Exits `0` when neither condition applies.
 - Exits `1` for usage errors (invalid flags, unknown validator IDs, invalid scope).
+- Exits `1` for malformed target input (e.g., missing `--target` value) and deterministic target resolution errors (e.g., nonexistent target).
 
 ## 5.0 Deferred Behavior
 Deferred to future slices:


### PR DESCRIPTION
### Motivation
- Provide developer convenience for running `validate:all` with the same `--target` filter semantics already supported by the naming validator. 
- Preserve existing scope-first semantics while allowing repeatable repository-relative target filters to be forwarded through the runner. 
- Keep report schema stable by adding per-validator `meta.filters` only when filtering is active.

### Description
- Extend `calculogic-validator/scripts/validate-all.mjs` to parse repeatable `--target=<path>` and `--target <path>` forms and include deterministic missing-value usage errors, and update usage/examples accordingly. (file updated)
- Thread `targets` through `runValidatorRunner` by adding `targets` to runner options and passing `{ scope, config, targets }` to registry hooks. (file updated)
- Update the naming validator registry hook to forward `targets` into the naming runtime and to emit `meta.filters` only when filtering is active (`isFiltered: true` and `targets: [...]` normalized/sorted). (file updated)
- Followed NL-first: updated `doc/nl-config/cfg-validatorRunner.md` to V0.1.4 documenting `targets` runtime option, CLI contract, and per-validator filter metadata behavior. (doc updated)

### Testing
- Added an integration test `calculogic-validator/test/validate-all.targets.integration.test.mjs` covering successful `--target` filtering and deterministic nonexistent-target error, and extended `validator-runner` tests to assert presence/absence of `meta.filters`.
- Ran tests: `node --test calculogic-validator/test/validate-all.targets.integration.test.mjs calculogic-validator/test/validator-runner.test.mjs calculogic-validator/test/naming-validator-scope-contract.test.mjs` and `node --test calculogic-validator/test/validator-runner.test.mjs calculogic-validator/test/validate-all.targets.integration.test.mjs`, and all tests passed (24 and 7 tests respectively, 0 failures).
- Verified deterministic error messages include `Target path does not exist` and usage lines on failure paths as required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2410da6a48331beea146c40a5612d)