### PR TITLE
Print usage for runtime `--target` errors in validate-naming (script + bin) and tighten tests

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -125,6 +125,7 @@ try {
   validatorResult = runNamingValidator(repositoryRoot, { scope: parsed.selectedScope, config, targets: parsed.targets });
 } catch (error) {
   console.error(error.message);
+  console.error(usageLines.join('\n'));
   process.exit(1);
 }
 const { findings, totalFilesScanned, scope, filters } = validatorResult;

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -124,6 +124,7 @@ try {
   validatorResult = runNamingValidator(repositoryRoot, { scope: selectedScope, config, targets });
 } catch (error) {
   console.error(error.message);
+  console.error(usageLines.join('\n'));
   process.exit(1);
 }
 const { findings, totalFilesScanned, scope, filters } = validatorResult;

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -179,4 +179,5 @@ test('CLI nonexistent target fails deterministically with stable message', () =>
   const result = runValidatorCli(['--scope=app', '--target=src/does-not-exist-target']);
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Target path does not exist: src\/does-not-exist-target/u);
+  assert.match(result.stderr, /Usage: npm run validate:naming --/u);
 });

--- a/calculogic-validator/test/validator-package-bins.test.mjs
+++ b/calculogic-validator/test/validator-package-bins.test.mjs
@@ -40,6 +40,20 @@ test('calculogic-validate-naming bin returns naming report JSON', () => {
 });
 
 
+test('calculogic-validate-naming bin prints usage on runtime target resolution errors', () => {
+  const result = runBin([
+    '--experimental-strip-types',
+    'calculogic-validator/bin/calculogic-validate-naming.mjs',
+    '--scope=app',
+    '--target=does-not-exist',
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Target path does not exist: does-not-exist/u);
+  assert.match(result.stderr, /Usage: calculogic-validate-naming/u);
+});
+
+
 test('calculogic-validate bin accepts --config path', () => {
   const result = runBin([
     'calculogic-validator/bin/calculogic-validate.mjs',


### PR DESCRIPTION
### Motivation
- Make `--target` error handling consistent between the npm script entrypoint and the installed bin by ensuring runtime/target-resolution errors also print the full usage block. 
- Align runtime UX with existing CLI parse-error behavior so users always see the usage guidance when a target-related failure occurs. 
- Add deterministic tests to lock the improved behavior for both script and bin entrypoints.

### Description
- In `calculogic-validator/scripts/validate-naming.mjs` added printing of `usageLines.join('\n')` inside the `catch` that handles runtime errors from `runNamingValidator(...)`. 
- In `calculogic-validator/bin/calculogic-validate-naming.mjs` applied the same `console.error(usageLines.join('\n'))` in the runtime error `catch` so the bin and script match. 
- Updated `calculogic-validator/test/naming-validator-scope-contract.test.mjs` to assert that the script stderr for a nonexistent target includes the usage line (`/Usage: npm run validate:naming --/`). 
- Added a bin-level test to `calculogic-validator/test/validator-package-bins.test.mjs` that runs the naming bin with a nonexistent `--target` and asserts non-zero exit plus both the deterministic target error message and the `Usage: calculogic-validate-naming` text.

### Testing
- Ran the full test suite with `npm test` and observed all tests pass (TAP output showed all tests passing). 
- Ran the focused command `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs calculogic-validator/test/validator-package-bins.test.mjs` and the tests for the updated script and bin behavior passed. 
- New/updated tests assert that both the script and the bin now emit the error message and the usage block for runtime `--target` resolution failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a243a3bf808331a3dff3f748b2cee2)