### PR TITLE
Add npm v7+ env fallback for npm arg-forwarding guard

### DIFF
--- a/calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs
+++ b/calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs
@@ -11,6 +11,9 @@ const parseOriginalArgv = npmConfigArgvJson => {
   }
 };
 
+const KNOWN_SCOPES = new Set(['repo', 'app', 'docs', 'validator', 'system']);
+const DETECTION_ORDER = ['scope', 'validators', 'target', 'config', 'strict'];
+
 const findFlagTokenIndex = (tokens, supportedFlagNames) => {
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
@@ -27,6 +30,61 @@ const findFlagTokenIndex = (tokens, supportedFlagNames) => {
 };
 
 const hasForwardedSupportedFlag = (argv, supportedFlagNames) => findFlagTokenIndex(argv, supportedFlagNames) >= 0;
+
+const isTruthyNpmConfig = value => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes';
+};
+
+const getSuspiciousNpmConfigFlags = (env, supportedFlagNames) => {
+  const supported = new Set(supportedFlagNames);
+  const detected = [];
+
+  if (supported.has('scope') && KNOWN_SCOPES.has(env.npm_config_scope)) {
+    detected.push('scope');
+  }
+
+  if (
+    supported.has('validators')
+    && typeof env.npm_config_validators === 'string'
+    && env.npm_config_validators.trim() !== ''
+  ) {
+    const validatorsValue = env.npm_config_validators.trim();
+    if (/(^|,)\s*naming\s*(,|$)/iu.test(validatorsValue) || validatorsValue.includes(',')) {
+      detected.push('validators');
+    }
+  }
+
+  if (supported.has('target') && typeof env.npm_config_target === 'string' && env.npm_config_target.trim() !== '') {
+    detected.push('target');
+  }
+
+  if (supported.has('config') && typeof env.npm_config_config === 'string' && env.npm_config_config.trim() !== '') {
+    detected.push('config');
+  }
+
+  if (supported.has('strict') && isTruthyNpmConfig(env.npm_config_strict)) {
+    detected.push('strict');
+  }
+
+  return DETECTION_ORDER.filter(flagName => detected.includes(flagName));
+};
+
+const buildFallbackMessage = (scriptName, detectedFlags) => {
+  const sampleFlag = detectedFlags[0] ?? 'scope';
+  const detectedSummary = detectedFlags.map(flagName => `--${flagName}`).join(', ');
+
+  return [
+    'Detected npm argument forwarding issue: you passed validator flags to npm instead of the script. Use: npm run <script> -- <args>',
+    ...(detectedSummary ? [`Detected npm_config flags: ${detectedSummary}`] : []),
+    `Wrong: npm run ${scriptName} --${sampleFlag}=<value>`,
+    `Right: npm run ${scriptName} -- --${sampleFlag}=<value>`,
+  ].join('\n');
+};
 
 const deriveHintArgs = (originalArgv, supportedFlagNames) => {
   const index = findFlagTokenIndex(originalArgv, supportedFlagNames);
@@ -53,24 +111,34 @@ export const detectNpmArgForwardingFootgun = ({
   lifecycleEvent,
   expectedLifecycleEvent,
   supportedFlagNames,
+  env = process.env,
 }) => {
   if (lifecycleEvent !== expectedLifecycleEvent) {
     return null;
   }
 
   const originalArgv = parseOriginalArgv(npmConfigArgvJson);
-  if (!originalArgv) {
-    return null;
-  }
+  if (originalArgv) {
+    const hintArg = deriveHintArgs(originalArgv, supportedFlagNames);
+    if (!hintArg) {
+      return null;
+    }
 
-  const hintArg = deriveHintArgs(originalArgv, supportedFlagNames);
-  if (!hintArg) {
-    return null;
+    if (hasForwardedSupportedFlag(argv, supportedFlagNames)) {
+      return null;
+    }
+
+    return `Detected npm argument forwarding issue: use "npm run ${expectedLifecycleEvent} -- ${hintArg}" (note the extra --).`;
   }
 
   if (hasForwardedSupportedFlag(argv, supportedFlagNames)) {
     return null;
   }
 
-  return `Detected npm argument forwarding issue: use "npm run ${expectedLifecycleEvent} -- ${hintArg}" (note the extra --).`;
+  const suspiciousFlags = getSuspiciousNpmConfigFlags(env, supportedFlagNames);
+  if (suspiciousFlags.length === 0) {
+    return null;
+  }
+
+  return buildFallbackMessage(expectedLifecycleEvent, suspiciousFlags);
 };

--- a/calculogic-validator/test/npm-arg-forwarding-guard.test.mjs
+++ b/calculogic-validator/test/npm-arg-forwarding-guard.test.mjs
@@ -2,13 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { detectNpmArgForwardingFootgun } from '../src/npm-arg-forwarding-guard.logic.mjs';
 
-test('returns null when npm_config_argv is missing', () => {
+test('returns null when npm_config_argv is missing and fallback has no suspicious env flags', () => {
   const message = detectNpmArgForwardingFootgun({
     argv: [],
     npmConfigArgvJson: undefined,
     lifecycleEvent: 'validate:naming',
     expectedLifecycleEvent: 'validate:naming',
     supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: {},
   });
 
   assert.equal(message, null);
@@ -21,6 +22,7 @@ test('returns null when lifecycle event mismatches expected script', () => {
     lifecycleEvent: 'test',
     expectedLifecycleEvent: 'validate:naming',
     supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: {},
   });
 
   assert.equal(message, null);
@@ -33,6 +35,7 @@ test('returns null when npm original args have no supported flags', () => {
     lifecycleEvent: 'validate:naming',
     expectedLifecycleEvent: 'validate:naming',
     supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: {},
   });
 
   assert.equal(message, null);
@@ -45,6 +48,7 @@ test('returns guidance message when npm original args contain supported flags bu
     lifecycleEvent: 'validate:naming',
     expectedLifecycleEvent: 'validate:naming',
     supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: {},
   });
 
   assert.equal(
@@ -60,7 +64,77 @@ test('returns null when forwarded argv already includes supported flags', () => 
     lifecycleEvent: 'validate:naming',
     expectedLifecycleEvent: 'validate:naming',
     supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: {},
   });
 
   assert.equal(message, null);
+});
+
+test('returns message when lifecycle matches and npm_config_scope is valid scope and argv lacks flags', () => {
+  const message = detectNpmArgForwardingFootgun({
+    argv: [],
+    npmConfigArgvJson: undefined,
+    lifecycleEvent: 'validate:naming',
+    expectedLifecycleEvent: 'validate:naming',
+    supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: { npm_config_scope: 'app' },
+  });
+
+  assert.equal(typeof message, 'string');
+  assert.match(message, /Detected npm argument forwarding issue/u);
+  assert.match(message, /Detected npm_config flags: --scope/u);
+});
+
+test('returns message when lifecycle matches and npm_config_target present and argv lacks flags', () => {
+  const message = detectNpmArgForwardingFootgun({
+    argv: [],
+    npmConfigArgvJson: undefined,
+    lifecycleEvent: 'validate:naming',
+    expectedLifecycleEvent: 'validate:naming',
+    supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: { npm_config_target: 'src/tabs/build' },
+  });
+
+  assert.equal(typeof message, 'string');
+  assert.match(message, /Detected npm_config flags: --target/u);
+});
+
+test('returns null when argv already includes flag even if npm_config_scope present', () => {
+  const message = detectNpmArgForwardingFootgun({
+    argv: ['--scope=app'],
+    npmConfigArgvJson: undefined,
+    lifecycleEvent: 'validate:naming',
+    expectedLifecycleEvent: 'validate:naming',
+    supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: { npm_config_scope: 'app' },
+  });
+
+  assert.equal(message, null);
+});
+
+test('returns null when npm_config_scope is not a known validator scope', () => {
+  const message = detectNpmArgForwardingFootgun({
+    argv: [],
+    npmConfigArgvJson: undefined,
+    lifecycleEvent: 'validate:naming',
+    expectedLifecycleEvent: 'validate:naming',
+    supportedFlagNames: ['scope', 'target', 'config', 'strict'],
+    env: { npm_config_scope: '@someone/package' },
+  });
+
+  assert.equal(message, null);
+});
+
+test('returns message for validate:all when npm_config_validators indicates forwarded validator intent', () => {
+  const message = detectNpmArgForwardingFootgun({
+    argv: [],
+    npmConfigArgvJson: undefined,
+    lifecycleEvent: 'validate:all',
+    expectedLifecycleEvent: 'validate:all',
+    supportedFlagNames: ['scope', 'target', 'config', 'strict', 'validators'],
+    env: { npm_config_validators: 'naming' },
+  });
+
+  assert.equal(typeof message, 'string');
+  assert.match(message, /Detected npm_config flags: --validators/u);
 });

--- a/calculogic-validator/test/validator-exit-codes.test.mjs
+++ b/calculogic-validator/test/validator-exit-codes.test.mjs
@@ -116,3 +116,28 @@ test('validate-all fails fast when npm script args are not forwarded', () => {
   assert.match(result.stderr, /Detected npm argument forwarding issue/);
   assert.match(result.stderr, /Usage: npm run validate:all --/);
 });
+
+
+test('validate-naming fails fast in env-only npm v7+ style forwarding footgun case', () => {
+  const result = runNodeScript(namingScriptPath, [], repositoryRoot, {
+    npm_lifecycle_event: 'validate:naming',
+    npm_config_scope: 'app',
+    npm_config_argv: undefined,
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Detected npm argument forwarding issue/);
+  assert.match(result.stderr, /Usage: npm run validate:naming --/);
+});
+
+test('validate-all fails fast in env-only npm v7+ style forwarding footgun case', () => {
+  const result = runNodeScript(validateAllScriptPath, [], repositoryRoot, {
+    npm_lifecycle_event: 'validate:all',
+    npm_config_validators: 'naming',
+    npm_config_argv: undefined,
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Detected npm argument forwarding issue/);
+  assert.match(result.stderr, /Usage: npm run validate:all --/);
+});

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -68,6 +68,10 @@ Each validator entry includes:
 ### 4.2 Behavior
 - Resolves repository root deterministically from script location.
 - Forwards `--target` values to target-aware validators as convenience filters applied within selected scope.
+- Performs npm argument-forwarding footgun detection before parsing CLI:
+  - Primary path: if `npm_config_argv` is parseable, detect supported validator flags supplied to npm while absent in forwarded argv.
+  - Fallback path (npm v7+ / Codespaces): when `npm_config_argv` is unavailable, use deterministic `npm_config_<flag>` heuristics gated by lifecycle event and only when forwarded argv lacks supported flags.
+  - Fallback suspicious env detection uses stable ordering and low-false-positive rules: known scopes (`repo|app|docs|validator|system`), non-empty target/config, truthy strict (`true|1|yes`), and validator list indicators (`naming` or comma-list).
 - Executes runner with selected options.
 - Writes JSON report to stdout.
 - Exits `2` when any aggregated finding has `severity="warn"`.


### PR DESCRIPTION
### Motivation

- The existing npm arg-forwarding guard relied solely on `process.env.npm_config_argv`, which is often missing in npm v7+ / Codespaces, allowing users who pass flags to npm (e.g. `npm run validate:naming --scope=app`) to silently run with default options instead of failing fast.
- Provide a deterministic, low-false-positive fallback that detects this “forgot the extra `--`” footgun using lifecycle-gated `npm_config_<flag>` env vars so incorrect invocations fail fast with a clear, stable message.

### Description

- Extended `detectNpmArgForwardingFootgun` in `calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs` to preserve the existing `npm_config_argv` path and add a fallback path that inspects `npm_config_scope`, `npm_config_target`, `npm_config_config`, `npm_config_strict`, and `npm_config_validators` with deterministic ordering (`scope`, `validators`, `target`, `config`, `strict`).
- Added helpers `isTruthyNpmConfig`, `getSuspiciousNpmConfigFlags`, and `buildFallbackMessage` and a `KNOWN_SCOPES` whitelist to reduce false positives and keep messages deterministic and concise.
- Kept the guard strictly lifecycle-gated (only when `npm_lifecycle_event` matches the expected script) and ensured it never triggers when the corresponding supported flags are already present in `process.argv`.
- Updated NL contract `doc/nl-config/cfg-validatorRunner.md` and added/modified tests in `calculogic-validator/test/npm-arg-forwarding-guard.test.mjs` and `calculogic-validator/test/validator-exit-codes.test.mjs` to cover both the `npm_config_argv` path and the new env-only fallback cases.

### Testing

- Added unit tests in `calculogic-validator/test/npm-arg-forwarding-guard.test.mjs` covering both the original `npm_config_argv` path and the env-only fallback cases (valid `npm_config_scope`, `npm_config_target`, `npm_config_validators`, forwarded-argv no-trigger, and unknown-scope no-trigger), and all unit tests passed.
- Added integration/script-level tests in `calculogic-validator/test/validator-exit-codes.test.mjs` that spawn the `validate:naming` and `validate:all` scripts in env-only scenarios (e.g. `npm_lifecycle_event=validate:naming` with `npm_config_scope=app` and no `npm_config_argv`) and asserted exit status `1` plus usage guidance, and these tests passed.
- Ran the full test suite with `npm test` and the entire suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a275ccf1588331bac38c6a3a943453)