### PR TITLE
docs(doc-engine): clarify core package vs runtime/service identity boundaries

### DIFF
--- a/doc/doc-engine/Architecture.md
+++ b/doc/doc-engine/Architecture.md
@@ -3,29 +3,40 @@
 ## Goal
 Deliver a fully operational right-side generic Content Drawer in the Interface repo before extracting doc-engine code to another repository.
 
+Canonical identity/deployment/ownership model: see `Identity-Deployment-Ownership.md` in this hub.
+
 ## Boundary
-### Stays in Interface repo
+### Stays host/UI (Interface repo)
 - Drawer shell/UI composition
 - Open/close state orchestration
 - Provider registration wiring
+- Host-specific providers and app-specific content packs
 
-### Moves to doc-engine repo later
-- Content schema package
-- Providers (docs, knowledge DB, config/form/quiz extraction)
+### Belongs to doc-engine core package boundary
+- Content schema/contracts package
 - Resolver and normalization utilities
+- Provider registry and deterministic routing helpers
+- Provider interfaces and normalized outcome semantics
+
+### Belongs to doc-engine runtime/service boundary (optional)
+- Official/runtime providers that require DB/governance/search/indexing
+- DB adapters and policy/governance enforcement
+- Runtime API surface for remote resolution
+- Deployment target may be standalone service or merged into headless runtime engine
 
 ## Core components
-1. **Content Drawer UI**
-   - Generic renderer for normalized `ContentNode` blocks/sections.
-2. **Provider Registry**
+1. **Content Drawer UI (Host-owned shell)**
+   - Generic renderer for normalized `ContentNode`/DocNode blocks/sections.
+2. **Provider Registry (Core)**
    - Namespace-routed providers (`docs:*`, `knowledge:*`, etc.).
-3. **Resolver**
-   - Deterministic `resolveContent` pipeline returning `ContentNode | NotFound`.
-4. **Static Docs Provider (Phase 0)**
+3. **Resolver (Core)**
+   - Deterministic `resolveContent` pipeline returning normalized outcomes.
+4. **Static Docs Provider (Host/provider class example)**
    - In-memory registry for builder docs.
-5. **Future Providers (Phase 1+)**
-   - Governed Knowledge DB provider.
-   - Config/form/quiz metadata extraction provider.
+5. **Future Providers (Qualified by provider class)**
+   - Host-specific providers stay with host/UI repo.
+   - Official/runtime providers may move with runtime/service extraction.
+   - Plugin providers can remain third-party and contract-compatible.
 
 ## Deterministic routing model
 - Parse namespace from `contentId`.

--- a/doc/doc-engine/Contracts.md
+++ b/doc/doc-engine/Contracts.md
@@ -1,7 +1,9 @@
 # Doc Engine Contracts
 
+Canonical terminology and boundary model: see `Identity-Deployment-Ownership.md`.
+
 ## Content Addressing
-- `contentId`: stable identifier with namespace prefix.
+- `contentId` (aka doc identity key): stable identifier with namespace prefix.
   - Examples: `docs.builder.logic.overview`, `knowledge.public.naming.guide`
 - `anchorId`: optional stable heading/block identifier.
 
@@ -18,7 +20,7 @@
 - `meta: { title, summary?, artifactType, tags[], keywords[], conceptIds[], intentTags[], sourceTier, visibility, status, scope, version }`
 - `content: { headings[], blocks[] }`
 
-## Context envelope (optional)
+## ContextEnvelope (optional)
 Used for analytics and routing without changing content identity.
 
 ```
@@ -30,8 +32,24 @@ Used for analytics and routing without changing content identity.
 }
 ```
 
+## Contract stability across embedded + remote deployments
+- **Embedded deployment**: host imports core and `resolveContent()` returns normalized outcomes in-process.
+- **Remote deployment**: host calls runtime API (HTTP/IPC) and receives the same normalized outcome shape.
+- Deployment location must not change contract semantics; only transport/location changes.
+
+Normalized outcome classes to preserve across both modes:
+- `Found`
+- `Missing`
+- `NoProvider`
+- `InvalidRef`
+
+## Provider classes and ownership
+- **Host providers (UI repo)**: app-specific docs, workflow-specific packs, and local integrations.
+- **Official providers (doc-engine/runtime)**: centrally maintained providers for governed/runtime-backed stores.
+- **Plugin providers (third party)**: external providers that implement the same provider contract.
 
 ## Extraction staging contract (current)
-- Runtime implementation is staged in `src/doc-engine/*` as the future package lift boundary.
-- Runtime modules in this boundary must not import from `src/components/*` or `src/tabs/*`.
-- Default app wiring registers a `docs` provider so existing ids (for example `docs:doc-build`) remain valid.
+- Core-package implementation is staged in `src/doc-engine/*` as the future package lift boundary.
+- Modules in this boundary must not import from `src/components/*` or `src/tabs/*`.
+- Default app wiring registers a host `docs` provider so existing ids (for example `docs:doc-build`) remain valid.
+- Runtime/service extraction is a later topology decision and may be merged into the headless runtime engine.

--- a/doc/doc-engine/Identity-Deployment-Ownership.md
+++ b/doc/doc-engine/Identity-Deployment-Ownership.md
@@ -1,0 +1,142 @@
+# Doc-Engine Identity, Deployment, and Ownership (Canonical)
+
+## 1) Purpose
+
+Doc-engine exists to provide a portable, UI-agnostic content resolution system that any host UI (including this interface app, other UIs, and plugin surfaces) can call through a stable contract.
+
+It is designed around:
+- deterministic resolution,
+- pluggable providers,
+- stable content identity,
+- normalized outcomes.
+
+Non-goals:
+- It is not a UI component system.
+- It is not coupled to one repo's folder layout or one app's drawer implementation.
+- It must not assume a single host application as the only consumer.
+
+## 2) Terminology
+
+- **DocNode**: canonical normalized document payload shape returned by doc-engine. In this repo, historical references to `ContentNode` mean the same normalized node and are treated as the current type name until a rename is executed.
+- **docId/contentId**: stable content identity key, typically namespaced (for example `docs:doc-build`).
+- **anchorId**: optional stable target within a document/node for deep linking.
+- **ContextEnvelope**: optional call context metadata for routing/analytics/policy that must not change doc identity.
+
+Supporting terms:
+- **Doc Store**: one or more underlying sources of content (static packs, plugin sources, DB-backed stores).
+- **Resolver**: deterministic orchestration pipeline that maps request -> normalized outcome.
+- **Registry**: routing/lookup map from namespace/capability to provider.
+- **Provider**: source adapter implementing contract-compatible resolution from one store class.
+
+## 3) Two-Layer Model
+
+### Layer A: Doc-Engine Core (Package Boundary)
+
+Contains:
+- contracts and types,
+- resolver pipeline and normalized outcomes,
+- registry abstractions,
+- normalization and validation utilities.
+
+Must not contain:
+- UI components,
+- host app orchestration,
+- app-specific content packs,
+- app wiring/state management.
+
+### Layer B: Doc-Engine Runtime (Engine/Service Boundary)
+
+Becomes relevant when DB-backed docs, user/project docs, governed search, indexing, or policy enforcement is required.
+
+This runtime may be either:
+- a standalone service/subsystem, or
+- a module merged into the headless runtime engine.
+
+Runtime exposes a stable API that returns core-contract outcomes:
+- `Found`,
+- `Missing`,
+- `NoProvider`,
+- `InvalidRef`.
+
+## 4) Deployment Modes
+
+### Embedded Mode
+- Host UI imports doc-engine core package.
+- Providers are registered in-process by the host.
+- Best for local/dev simplicity, low-latency local resolution, and offline-friendly operation.
+
+### Remote Mode
+- Host UI calls runtime API (HTTP/IPC).
+- Runtime uses core contracts internally.
+- Best for centralized governance, shared indexing/search controls, and unified DB-backed access.
+
+Tradeoffs:
+- **Latency**: embedded is typically lower per-call latency; remote adds network hop.
+- **Governance/source-of-truth**: remote centralizes policy and lifecycle controls.
+- **DB access**: remote can directly enforce DB/data policy boundaries; embedded can avoid DB entirely.
+- **Dev/offline simplicity**: embedded is simpler for isolated local workflows.
+
+## 5) Doc Store Sources (Deterministic, Multi-Source)
+
+Doc-engine supports deterministic resolution across multiple source classes:
+- bundled/static docs,
+- plugin-provided docs (installed/registered),
+- repo-provided docs (official packs from this or other repos),
+- user/project docs in DB.
+
+Rule: **document identity remains stable while source can vary by trust/visibility tier**.
+
+## 6) DB Relationship Model
+
+When runtime mode is used, doc-engine runtime requires access to the same DB cluster(s) used by the headless runtime engine (shared infra), while preserving clear ownership boundaries.
+
+Two valid patterns:
+- **Shared tables**: doc-engine reads doc-like records that are stored with user configuration records.
+- **Dedicated schema/tables**: doc-engine owns doc-specific tables while sharing database infrastructure.
+
+Embedded mode can operate without DB dependencies.
+
+## 7) Ownership Boundaries (What Lives Where)
+
+- **Host UI repo owns**:
+  - content drawer shell and rendering composition,
+  - UI state orchestration,
+  - provider registration wiring,
+  - app-specific content packs and host-specific providers.
+
+- **Doc-engine core package/repo owns**:
+  - contracts/types,
+  - resolver/registry,
+  - normalization pipeline,
+  - provider interfaces and deterministic outcome semantics.
+
+- **Doc-engine runtime (if separated) owns**:
+  - DB adapters,
+  - governance/search/indexing subsystems,
+  - official/runtime provider packs (if shipped centrally).
+
+## 8) Extraction Strategy
+
+- **Phase 0 (current)**: incubate in this repo with strict boundary discipline.
+- **Phase 1**: extract core as `@calculogic/doc-engine` package.
+- **Phase 2**: decide runtime topology:
+  - standalone runtime service, or
+  - merged module in headless runtime engine.
+
+Keep-contracts-stable checklist:
+- preserve outcome union semantics (`Found | Missing | NoProvider | InvalidRef`),
+- preserve identity fields (`docId/contentId`, `anchorId`, `ContextEnvelope` behavior),
+- preserve deterministic resolver behavior,
+- preserve host/runtime parity of normalized response shape.
+
+## 9) Repo-Organization Implications (Decision Support)
+
+In this repo today:
+- keep host UI artifacts under `src/components/*`, `src/content/*`, and app composition layers,
+- keep core-boundary implementation under `src/doc-engine/*` with import discipline,
+- treat runtime/DB adapters as separate-phase artifacts (do not leak into host UI folders).
+
+Owner-root rules:
+- any artifact implementing core contracts/resolver/registry belongs to the doc-engine owner-root,
+- any artifact implementing drawer visuals or app orchestration belongs to host/UI owner-root,
+- any DB/governance/search adapter belongs to runtime owner-root (even if co-deployed with headless runtime engine).

--- a/doc/doc-engine/README.md
+++ b/doc/doc-engine/README.md
@@ -15,11 +15,14 @@ This hub defines the in-repo standards and architecture for the Interface/Builde
 - `doc/ConventionRoutines/NL-First-Workflow.md`
 
 ## Documents in this hub
+- `Identity-Deployment-Ownership.md` (canonical identity + boundaries)
 - `StandardsSummary.md`
 - `ContributionChecklist.md`
 - `Architecture.md`
 - `Contracts.md`
 - `ContentDrawerMVP.md`
+
+Other doc-engine restatements elsewhere are non-canonical unless explicitly referenced from this hub.
 
 ## Legacy portable documents (consolidated from `doc/DocEngine`)
 - `Overview-Architecture.md`

--- a/src/doc-engine/EXTRACTION-CHECKLIST.md
+++ b/src/doc-engine/EXTRACTION-CHECKLIST.md
@@ -1,10 +1,10 @@
-# Doc Engine Extraction + Repoint Imports Checklist
+# Doc Engine Core Package Extraction + Repoint Imports Checklist
 
-Use this checklist when moving doc-engine into an external package (planned name: `@calculogic/doc-engine`).
+Use this checklist when moving doc-engine **core package boundaries** into an external package (planned name: `@calculogic/doc-engine`).
 
 ## 1) Public API surface to preserve
 
-The package should export the same API currently provided by `src/doc-engine/index.ts`:
+The core package should export the same API currently provided by `src/doc-engine/index.ts`:
 
 - `ContentProviderRegistry`
 - `splitNamespace`
@@ -27,9 +27,9 @@ Until extraction is complete, keep using the same discipline with the local barr
 - ❌ `from '../doc-engine/registry.ts'`
 - ❌ `from '../doc-engine/types.ts'`
 
-## 3) Explicitly not part of doc-engine package
+## 3) Explicitly not part of core package
 
-Do **not** move these into `@calculogic/doc-engine`:
+Do **not** move these into `@calculogic/doc-engine` core package:
 
 - App content providers under `src/content/providers/*`
 - App content packs under `src/content/packs/*`
@@ -38,10 +38,18 @@ Do **not** move these into `@calculogic/doc-engine`:
 
 These are host-app responsibilities that consume doc-engine contracts.
 
-## 4) Repointing steps
+## 4) Repointing steps (core package)
 
-1. Create `@calculogic/doc-engine` with the `src/doc-engine/*` module contents.
+1. Create `@calculogic/doc-engine` with the `src/doc-engine/*` **core** module contents.
 2. Publish/consume package in the interface repository.
 3. Replace local imports from `src/doc-engine/index.ts` with `@calculogic/doc-engine`.
 4. Keep provider registration in app composition (for example, `src/content/contentEngine.ts`).
-5. Run tests to ensure registry behavior (`namespaced ids`, provider resolution, and `not_found`) still passes.
+5. Run tests to ensure registry behavior (`namespaced ids`, provider resolution, normalized misses) still passes.
+
+## 5) Runtime/service note (separate phase)
+
+Runtime/service extraction is a separate phase decision:
+- It may become a standalone doc-engine runtime service, or
+- It may be merged into the headless runtime engine.
+
+DB adapters, governance/search/indexing, and official runtime providers are **not** required to move during core package extraction.


### PR DESCRIPTION
### Motivation
- Make the doc-engine portability model explicit and non-contradictory so future extraction, ownership, and DB-sharing decisions are unambiguous.
- Separate the portable, UI-agnostic `Doc-Engine Core` contract from an optional `Doc-Engine Runtime` service topology and declare the `UI Content Drawer` as host-owned.
- Provide a canonical place to record terminology, deployment modes, provider classes, and extraction phases so downstream docs and repo layout choices remain consistent.

### Description
- Added a canonical identity doc at `doc/doc-engine/Identity-Deployment-Ownership.md` that defines purpose/non-goals, terminology (`DocNode`, `contentId`, `anchorId`, `ContextEnvelope`), the two-layer model (core package vs optional runtime), deployment modes, doc-store sources, DB relationship patterns, ownership boundaries, extraction strategy, and repo-organization implications.
- Updated `doc/doc-engine/Architecture.md` to reference the new canonical identity doc and split the Architecture boundary into three explicit buckets: host/UI-owned, doc-engine core package-owned, and doc-engine runtime/service-owned (optional), and qualified provider movement by provider class.
- Updated `doc/doc-engine/Contracts.md` to align terminology with the identity doc, add explicit contract stability language for embedded vs remote (`resolveContent()` parity), preserve normalized outcome classes (`Found | Missing | NoProvider | InvalidRef`), and introduce the `Host / Official / Plugin` provider class distinctions.
- Updated `src/doc-engine/EXTRACTION-CHECKLIST.md` to explicitly scope it to **core package** extraction, keep import-discipline and "not part of core" lists, and add a clear note that runtime/service extraction is a separate later-phase decision.
- Updated `doc/doc-engine/README.md` to add `Identity-Deployment-Ownership.md` as the canonical identity doc and mark other restatements non-canonical unless referenced from this hub.

### Testing
- Confirmed the new canonical doc exists with `test -f doc/doc-engine/Identity-Deployment-Ownership.md` and the check passed.
- Verified references and alignment via ripgrep searches such as `rg -n "Identity-Deployment-Ownership.md|non-canonical|Host providers|Official providers|Plugin providers|Embedded deployment|Remote deployment" doc/doc-engine/*.md src/doc-engine/EXTRACTION-CHECKLIST.md` and the expected matches were found.
- Verified the unqualified phrase `Moves to doc-engine repo later` no longer appears in the targeted docs using `rg -n "Moves to doc-engine repo later" doc/doc-engine src/doc-engine/EXTRACTION-CHECKLIST.md` and the check returned no unqualified occurrences.
- Confirmed the doc hub README lists the canonical identity doc and that cross-links to the new doc appear in `Architecture.md` and `Contracts.md` via automated search, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a28c5c76a483318ab8e048dbce6584)