### PR TITLE
docs(validator): document projected package layout

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -4,7 +4,85 @@
 
 `calculogic-validator` is the repository-local validator package in `calculogic-validator/`, including CLI binaries, host scripts, schema, and tests for naming and full validation workflows. In this repo, the recommended way to run it is from the **repo root** via npm scripts so command behavior, arguments, and report capture stay consistent with CI and team workflows.
 
-## 2) Quickstart (repo root)
+## 2) Projected package layout (target)
+
+This is the intended target structure for the validator suite as refactors continue.
+Some folders and files shown below may not exist yet in the current state.
+The naming reflects suite-core boundaries, mini-scope roots (`naming/` now and `tree/` planned), and shared tools ownership.
+
+```text
+calculogic-validator/
+├─ LICENSE
+├─ README.md
+├─ package.json
+├─ doc/
+│  ├─ ConventionRoutines/             # validator-operationalized conventions only
+│  ├─ ValidatorSpecs/                 # specs that are package-owned (runner/tree advisor/etc.)
+│  └─ Indexes/                        # optional: “where to find things” maps
+├─ bin/                               # suite-level CLIs (entrypoints)
+│  ├─ calculogic-validate.mjs
+│  ├─ calculogic-validate-naming.mjs
+│  └─ calculogic-validator-health.mjs
+├─ scripts/                           # suite-level workflows (thin orchestration)
+│  ├─ validate-all.mjs
+│  ├─ validate-naming.mjs
+│  ├─ validator-health-check.host.mjs
+│  ├─ report-capture-verify.mjs
+│  └─ report-capture-summarize.mjs
+├─ src/                               # suite-core only (shared infra + compat boundary)
+│  ├─ index.mjs
+│  ├─ core/
+│  │  ├─ repository-root.logic.mjs
+│  │  ├─ npm-arg-forwarding-guard.logic.mjs
+│  │  ├─ validator-exit-code.logic.mjs
+│  │  ├─ validator-report.contracts.mjs
+│  │  ├─ validator-report-meta.logic.mjs
+│  │  ├─ validator-runner.logic.mjs
+│  │  ├─ validator-registry.knowledge.mjs
+│  │  ├─ validator-scopes.knowledge.mjs
+│  │  ├─ validator-root-files.knowledge.mjs
+│  │  └─ config/
+│  │     ├─ validator-config.contracts.mjs
+│  │     ├─ validator-config.logic.mjs
+│  │     └─ validator-config.schema.json
+│  └─ compat/                         # SHIMS ONLY (policy-bound)
+│     └─ (temporary files only)        # e.g. old-path re-exports during refactor
+├─ test/                              # suite-core tests + suite integration tests
+│  ├─ core/                           # runner/config/report/scope tests
+│  ├─ integration/                    # validate-all.targets.integration, etc.
+│  ├─ fixtures/                       # suite-wide fixtures (only if truly shared)
+│  └─ compat/                         # optional: tests that assert shims are tracked/overdue/etc.
+├─ naming/                            # naming validator scope root (mini-scope)
+│  ├─ README.md                       # optional (what lives here)
+│  ├─ scripts/                        # optional (suite scripts can delegate here)
+│  │  └─ validate-naming.mjs
+│  ├─ src/
+│  │  ├─ naming-validator.host.mjs
+│  │  ├─ naming-validator.wiring.mjs
+│  │  ├─ naming-validator.logic.mjs
+│  │  ├─ naming-validator.contracts.mjs
+│  │  ├─ registries/                  # *.knowledge.*
+│  │  └─ rules/                       # *.logic.*
+│  └─ test/
+│     ├─ naming-validator.test.mjs
+│     ├─ naming-validator-scope-contract.test.mjs
+│     ├─ naming-missing-role.test.mjs
+│     └─ fixtures/                    # naming-only fixtures (if any)
+├─ tree/                              # future tree-advisor validator scope root
+│  ├─ scripts/
+│  ├─ src/
+│  └─ test/
+└─ tools/
+   └─ report-capture/
+      ├─ package.json
+      └─ src/
+         ├─ report-capture.host.mjs
+         ├─ report-capture.logic.mjs
+         ├─ report-capture.contracts.mjs
+         └─ report-capture.knowledge.mjs
+```
+
+## 3) Quickstart (repo root)
 
 ```bash
 npm ci
@@ -25,7 +103,7 @@ What this does:
 >
 > Use `--` before validator flags so npm forwards them to the script.
 
-## 3) Root npm workflows (recommended)
+## 4) Root npm workflows (recommended)
 
 Use these from the repository root.
 
@@ -75,7 +153,7 @@ npm run report:summarize
 - `report:verify`: checks report-capture wiring/outputs.
 - `report:summarize`: summarizes captured reports.
 
-## 4) Validator binaries (direct invocation)
+## 5) Validator binaries (direct invocation)
 
 These binaries are defined in `calculogic-validator/package.json` and can be executed directly from repo root.
 
@@ -91,7 +169,7 @@ What each binary does:
 - `calculogic-validate-naming.mjs`: naming-only validator entrypoint.
 - `calculogic-validator-health.mjs`: validator health/diagnostic entrypoint.
 
-## 5) Scopes and targets
+## 6) Scopes and targets
 
 Common scopes used in this repository:
 
@@ -113,7 +191,7 @@ npm run validate:all -- --scope=system
 
 Use scope-specific `report:*` commands when you want one-command capture per target/scope combination.
 
-## 6) Strict config and schema
+## 7) Strict config and schema
 
 Validator config schema:
 
@@ -141,13 +219,13 @@ Example:
 }
 ```
 
-## 7) Report capture notes
+## 8) Report capture notes
 
 - Report scripts write JSON capture metadata to `./.reports` in this repository.
 - Keep count/retention is handled by script-level `--keep` values.
 - Use `npm run report:verify` after setup changes.
 - Use `npm run report:summarize` for a concise overview of recent captures.
 
-## 8) Compatibility note
+## 9) Compatibility note
 
 Legacy imports from `src/validators/naming-validator.logic.mjs` remain supported via a thin re-export shim to the canonical naming validator host entrypoint.


### PR DESCRIPTION
### Motivation

- Provide an explicit, shared target folder/file layout for the validator suite to guide ongoing refactors and future scope extraction. 
- Make it clear what the intended "target" layout is vs the current repository contents so readers and contributors can align on naming and ownership boundaries. 

### Description

- Add a new `## 2) Projected package layout (target)` section to `calculogic-validator/README.md` immediately after the Overview. 
- Insert the provided projected folder/file tree as a fenced `text` code block, preserving inline comments and alignment exactly as supplied. 
- Renumber subsequent README section headings so the document numbering remains consistent after the insertion. 
- This is a documentation-only change and makes no runtime or behavioral modifications. 

### Testing

- No automated tests were added or required for this documentation-only change and existing CI/unit tests were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4836af97883319a58847b58f32321)