### PR TITLE
Remove doc-engine shims and enforce package-boundary imports

### DIFF
--- a/calculogic-doc-engine/README.md
+++ b/calculogic-doc-engine/README.md
@@ -1,6 +1,6 @@
 # @calculogic/doc-engine
 
-Doc-engine core package extracted from app; app currently consumes via shims in `src/doc-engine/*`.
+Doc-engine core package extracted from app; host app consumes it via `@calculogic/doc-engine`.
 
 ## Public exports
 

--- a/calculogic-doc-engine/doc/Hub/EXTRACTION-CHECKLIST.md
+++ b/calculogic-doc-engine/doc/Hub/EXTRACTION-CHECKLIST.md
@@ -1,6 +1,6 @@
 # Doc Engine Core Package Extraction + Repoint Imports Checklist
 
-Use this checklist for doc-engine **core package boundaries** now that local package extraction is complete. Publishing/consumption as `@calculogic/doc-engine` is a later phase.
+Use this checklist for doc-engine **core package boundaries** now that local package extraction is complete and host consumption is through `@calculogic/doc-engine`.
 
 ## 1) Public API surface to preserve
 
@@ -23,12 +23,6 @@ In the interface app, import doc-engine APIs from the package root only:
 - ❌ `import { ContentProviderRegistry } from '@calculogic/doc-engine/registry';`
 - ❌ `import type { ContentProvider } from '@calculogic/doc-engine/types';`
 
-The host app currently still uses shims under `src/doc-engine/*` (thin re-exports). Until host imports are repointed, keep using the same discipline with the local barrel:
-
-- ✅ `from '../doc-engine/index.ts'`
-- ❌ `from '../doc-engine/registry.ts'`
-- ❌ `from '../doc-engine/types.ts'`
-
 ## 3) Explicitly not part of core package
 
 Do **not** move these into `@calculogic/doc-engine` core package:
@@ -44,7 +38,7 @@ These are host-app responsibilities that consume doc-engine contracts.
 
 1. Keep `calculogic-doc-engine/src/*` as the source of truth for core modules.
 2. Publish/consume package in the interface repository when ready.
-3. Replace host imports from `src/doc-engine/index.ts` shims with `@calculogic/doc-engine`.
+3. Ensure host imports use `@calculogic/doc-engine` package-root APIs only (no host shims, no deep imports).
 4. Keep provider registration in app composition (for example, `src/content/contentEngine.ts`).
 5. Run tests to ensure registry behavior (`namespaced ids`, provider resolution, normalized misses) still passes.
 

--- a/src/content/contentEngine.ts
+++ b/src/content/contentEngine.ts
@@ -6,7 +6,7 @@
  * Invariants: Singleton instance is created once per module load, docs provider is registered under the `docs` namespace.
  */
 
-import { ContentProviderRegistry } from '../doc-engine/index.ts';
+import { ContentProviderRegistry } from '@calculogic/doc-engine';
 import { DOCS_PROVIDER } from './providers/docs.logic.ts';
 
 // ─────────────────────────────────────────────

--- a/src/content/contentResolutionAdapter.ts
+++ b/src/content/contentResolutionAdapter.ts
@@ -12,7 +12,7 @@ import type {
   InvalidRef,
   MissingContent,
   NoProvider,
-} from '../doc-engine/index.ts';
+} from '@calculogic/doc-engine';
 import { contentProviderRegistry } from './contentEngine';
 
 export type DrawerContentResolution =

--- a/src/content/providers/docs.logic.ts
+++ b/src/content/providers/docs.logic.ts
@@ -8,7 +8,7 @@
 
 import { HEADER_DOC_DEFINITIONS, type HeaderDocDefinition } from '../packs/header-docs/header-docs.knowledge.ts';
 import { isHeaderDocId } from '../packs/header-docs/header-doc.knowledge.ts';
-import type { ContentProvider } from '../../doc-engine/index.ts';
+import type { ContentProvider } from '@calculogic/doc-engine';
 
 export const DOCS_PROVIDER: ContentProvider<unknown, HeaderDocDefinition> = {
   resolveContent: ({ contentId, anchorId }) => {

--- a/src/doc-engine/index.ts
+++ b/src/doc-engine/index.ts
@@ -1,2 +1,0 @@
-export { ContentProviderRegistry, parseContentRef, splitNamespace } from '@calculogic/doc-engine';
-export type * from '@calculogic/doc-engine';

--- a/src/doc-engine/registry.ts
+++ b/src/doc-engine/registry.ts
@@ -1,1 +1,0 @@
-export { ContentProviderRegistry, parseContentRef, splitNamespace } from '@calculogic/doc-engine';

--- a/src/doc-engine/types.ts
+++ b/src/doc-engine/types.ts
@@ -1,1 +1,0 @@
-export type * from '@calculogic/doc-engine';

--- a/test/doc-engine-package-boundary.test.mjs
+++ b/test/doc-engine-package-boundary.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const srcRoot = path.join(repoRoot, 'src');
+
+const forbiddenNeedles = [
+  '../doc-engine/',
+  '../../doc-engine/',
+  'src/doc-engine/',
+  'calculogic-doc-engine/src/',
+];
+
+const isScannable = (p) =>
+  p.endsWith('.ts') || p.endsWith('.tsx') || p.endsWith('.js') || p.endsWith('.mjs');
+
+function walk(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (entry.isFile() && isScannable(full)) out.push(full);
+  }
+  return out;
+}
+
+test('doc-engine is consumed only via @calculogic/doc-engine (no shims/deep imports)', () => {
+  const files = walk(srcRoot);
+  const violations = [];
+
+  for (const file of files) {
+    const rel = path.relative(repoRoot, file).replaceAll('\\', '/');
+    const text = fs.readFileSync(file, 'utf8');
+
+    for (const needle of forbiddenNeedles) {
+      if (text.includes(needle)) {
+        violations.push({ file: rel, needle });
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
### Motivation
- The extracted `calculogic-doc-engine` package is now stable so the host app should consume it via the package root only to avoid shim/backdoor deep-imports. 
- Add a guard to prevent accidental reintroduction of local shims or deep imports and keep the app/package boundary explicit.

### Description
- Repointed host imports to the package root by replacing local shim imports with `@calculogic/doc-engine` in `src/content/contentEngine.ts`, `src/content/contentResolutionAdapter.ts`, and `src/content/providers/docs.logic.ts`.
- Removed the legacy shim files under `src/doc-engine/` (`index.ts`, `registry.ts`, `types.ts`).
- Updated docs in `calculogic-doc-engine/README.md` and `calculogic-doc-engine/doc/Hub/EXTRACTION-CHECKLIST.md` to state that the host consumes doc-engine via `@calculogic/doc-engine` and removed outdated shim guidance.
- Added a guard test `test/doc-engine-package-boundary.test.mjs` that recursively scans `src/` and fails if any file imports via shim/deep-import needles (`../doc-engine/`, `../../doc-engine/`, `src/doc-engine/`, `calculogic-doc-engine/src/`).
- Kept existing Vite/TypeScript alias and `tsconfig` wiring unchanged as requested.

### Testing
- Ran `npm test` and all tests passed (test run completed successfully).
- Ran `npm run build` and the build completed successfully.
- Ran `npm run validate:naming -- --scope=app` and `npm run validate:naming -- --scope=docs` and both validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b06e62f883319868039b4e9a2237)