### PR TITLE
docs(validator): centralize suite contract and align validator docs

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -2,13 +2,13 @@
 
 ## 1) Overview
 
-`calculogic-validator` is the repository-local validator package in `calculogic-validator/`, including CLI binaries, host scripts, schema, and tests for naming and full validation workflows. In this repo, the recommended way to run it is from the **repo root** via npm scripts so command behavior, arguments, and report capture stay consistent with CI and team workflows.
+`calculogic-validator` is a repository-local, **modular, configurable, policy-driven validator suite** in `calculogic-validator/`, including CLI binaries, host scripts, schema, and tests for naming and full validation workflows. The suite is **report-first by default** and can escalate through policy modes when explicitly configured. Canonical suite contract and mode semantics are centralized in [`doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`](./doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md). In this repo, the recommended way to run it is from the **repo root** via npm scripts so command behavior, arguments, and report capture stay consistent with CI and team workflows.
 
 ## 2) Projected package layout (target)
 
 This is the intended target structure for the validator suite as refactors continue.
 Some folders and files shown below may not exist yet in the current state.
-The naming reflects suite-core boundaries, mini-scope roots (`naming/` now and `tree/` planned), and shared tools ownership.
+The naming reflects modular suite-core boundaries, slice roots (`naming/` now and `tree/` planned), configurable policy surfaces, and shared tools ownership.
 
 ```text
 calculogic-validator/

--- a/calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -339,3 +339,4 @@ This draft establishes grammar first. Later passes should synchronize wording/ex
    - new comment patterns where applicable
 4. Backfill legacy material incrementally during normal touchpoints.
 5. Validator/tooling enforcement remains intentionally deferred until draft grammar decisions are closed and convention wording is stabilized; this document does not define validator modes, parser APIs, or implementation behavior in this closure pass.
+6. Structural-address validation is expected to arrive as a future validator slice; when that slice is introduced, suite mode/policy semantics must follow the shared contract in [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md).

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -2,16 +2,20 @@
 
 ## Purpose and Scope
 
-This document defines the V0.1.2 filename naming validator slice for deterministic automation.
+This document defines the V0.1.6 filename naming validator slice for deterministic automation.
 
-V0.1.2 scope is intentionally narrow:
+## Suite Contract Alignment
+
+This naming slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md): Calculogic Validator is modular, configurable, policy-driven, and report-first by default. Mode policy changes exit behavior and optional fix execution, not detection.
+
+V0.1.6 scope is intentionally narrow:
 - filename validation only
 - report mode only
 - deterministic findings output
 - deterministic scope profiles for migration planning
 - no rename enforcement
 
-Out of scope for V0.1.2:
+Out of scope for V0.1.6:
 - structural addressing validation
 - NL↔Code numbering/parity validation
 - provenance token consistency checks
@@ -229,18 +233,20 @@ When a canonical-like parse resolves to a known deprecated role (currently `view
 
 ## Rollout Modes
 
-- `report` (V0.1.2 behavior)
+Mode semantics are centralized in the suite-wide matrix in [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md).
+
+Naming V0.1.6 currently implements:
+- `report` only (default behavior)
   - always emits findings and summary
-  - never fails build for naming findings in V0.1.2
-- `soft-fail` (deferred)
-- `hard-fail` (deferred)
+  - valid runs exit `0`
+  - naming invalid findings are reported but do not fail command
+  - invalid CLI usage (e.g., unknown `--scope`) exits non-zero
 
-## Exit Code Behavior
-
-V0.1.2 report mode exit behavior:
-- valid runs exit `0`
-- naming invalid findings are reported but do not fail command
-- invalid CLI usage (e.g., unknown `--scope`) exits non-zero
+Suite policy options are shared contracts but deferred for naming implementation:
+- `soft-fail`
+- `hard-fail`
+- `correct`
+- `replace`
 
 ## Allowed Special-Case Handling Rules
 

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -1,0 +1,56 @@
+# Validator Suite Contracts and Modes
+
+## 1) Identity and Vocabulary (Canonical)
+
+Calculogic Validator is a modular, configurable, policy-driven validator suite. It is report-first by default and can optionally escalate findings via soft-fail/hard-fail policies or execute deterministic fix plans (correct/replace) when explicitly enabled.
+
+Canonical terms:
+
+- **Modular**: the suite is slice-based (for example naming, tree, structural-addressing), and slices can evolve independently while sharing common contracts.
+- **Configurable / customizable**: adopters can tune resolved config profiles, scope roots, registries, thresholds, and allowlists without changing the core suite model.
+- **Extensible / pluggable**: new validator slices and rules can be added through registry/runner composition without rewriting existing slices.
+- **Policy-driven**: mode/policy controls exit behavior and optional fix-plan execution; mode does not redefine what is detected.
+- **Report-first**: every slice defaults to `report`, producing deterministic findings output before any enforcement or fix behavior is enabled.
+
+## 2) Shared Mode Matrix (Canonical)
+
+Suite-wide policies over the same findings:
+
+- `report`: report findings only; non-usage findings do not fail by default.
+- `soft-fail`: report findings and fail only under configured soft-fail thresholds/scope gates.
+- `hard-fail`: report findings and fail deterministically on configured hard-fail conditions.
+- `correct`: execute explicitly allowed safe fix plans in addition to reporting.
+- `replace`: execute explicitly allowed structural fix plans in addition to reporting.
+
+Normative rule:
+
+- **Modes must not change detection.** For identical inputs and config, the finding set is identical across modes. Modes only change:
+  1. exit code policy, and
+  2. whether a deterministic fix plan is executed.
+
+## 3) Shared Report Envelope (Canonical)
+
+Each validator slice should emit a stable high-level report envelope:
+
+- `validatorId`
+- `validatorVersion`
+- `mode`
+- `scope`
+- `targets[]` (optional)
+- `sourceSnapshot` (filesystem/git reference data; dirty/untracked diagnostics are metadata)
+- `configFingerprint` (hash/fingerprint of resolved config)
+- `summary` (stable counts)
+- `findings[]` (deterministically sorted)
+- `suggestedFix[]` (optional; when fix planning is enabled)
+- `appliedFix[]` (optional; only when fixes are actually executed)
+
+This contract is intentionally shape-level so slices can add deterministic details while preserving suite-wide comparability.
+
+## 4) Shared Determinism Rules (Canonical)
+
+All slices should follow these deterministic rules:
+
+- Normalize report paths to `/` separators.
+- Use stable ordering for findings and summary derivations.
+- Use explicit include/exclude sets per scope profile.
+- Same inputs (repo snapshot, args, resolved config) => same report.

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -10,6 +10,10 @@ This document defines a **Tree Structure Advisor** validator slice whose output 
 
 This slice exists to reduce “tree drift” as additional validators beyond naming are added.
 
+## Suite Contract Alignment
+
+This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor Draft V0.0.1 remains report-only even though additional policy modes exist suite-wide.
+
 ### In scope (V0.0.1)
 - Parse `<semantic-name>.<role>.<ext>` metadata when applicable
 - Use role registry metadata (role category/status) as structured signal
@@ -241,13 +245,14 @@ Report object SHOULD include:
 
 ## Rollout Modes
 
-V0.0.1:
+Mode semantics are centralized in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md).
+
+Tree advisor V0.0.1 implementation status:
 - `report` only
   - never fails due to tree findings
   - fails only on invalid CLI usage (unknown scope, nonexistent target)
 
-Deferred:
-- `soft-fail` / `hard-fail` modes for structural guidance (only after long stabilization)
+Suite policy options (`soft-fail`, `hard-fail`, `correct`, `replace`) are contract-level modes and are deferred for this slice.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Centralize suite-wide mode and report semantics to prevent conflicting mode definitions across validator-owned specs and to present a single source of truth for adoptors. 
- Align validator-owned docs to describe the suite as modular, configurable, extensible, policy-driven, and report-first by default, and remove wording/version drift in the naming spec. 
- Provide clear cross-references so future validator slices follow consistent reporting and mode behavior without changing detection logic.

### Description

- Added a new canonical contract document at `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` that defines identity/vocabulary, a shared mode matrix, a shared report envelope, and determinism rules. 
- Updated `calculogic-validator/README.md` to adopt the modular/configurable/policy-driven/report-first phrasing and link to the new contract doc. 
- Updated `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` to add a `Suite Contract Alignment` section, make the intro consistently `V0.1.6`, and replace the local rollout modes block with a reference to the shared mode matrix while noting this slice currently implements `report` only. 
- Updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to add a `Suite Contract Alignment` cross-reference and to reference the centralized mode contract while keeping the tree advisor `report`-only stance. 
- Updated `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` change-control guidance to note that structural-address validation will be a future validator slice and must follow the shared suite contract. 
- No runtime code, CLI behavior, schemas, or tests were changed; this is documentation-only.

### Testing

- Ran `git diff --check` to validate whitespace/patch sanity and it passed. 
- Ran repository text searches (`rg`) for the updated phrases and cross-reference links to confirm the affected files now reference `ValidatorSuite-Contracts-And-Modes.md` and that rollout/mode wording was centralized, which succeeded. 
- No code/unit tests were modified or required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d34e4aec8331a69e3e11e0e85c8a)