### PR TITLE
docs: harden Tree Manifest inputs, advisory patterns, shim diagnostics, and naming doc cross-links

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -14,14 +14,15 @@
 
 ## Related Documents
 
-- **Validator / Naming Check Script Spec:** *(add path when created; suggested future path: `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md`)*
-- **Provenance Token Spec (NL/C):** *(add path if separated later; otherwise this document is currently the source for filename normalization rules)*
+- **Validator / Naming Check Script Spec:** `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md`
+- **Validator Suite Contracts / Modes:** `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`
+- **Provenance Token Spec (NL/C):** Deferred as a separate spec; this document is currently the source for filename normalization rules.
 - **Architecture / Module Boundary Docs:**
   - `calculogic-validator/doc/ConventionRoutines/CSCS.md`
   - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `doc/ConventionRoutines/NL-First-Workflow.md`
-- **Health Check / Reconciliation Docs (naming-related findings):** *(add specific `doc/HealthChecks/...` and/or reconciliation docs when a naming-focused pass exists)*
+- **Health Check / Reconciliation Docs (naming-related findings):** Deferred until a naming-focused pass is published under `doc/HealthChecks/...`.
 
 ## Change Control Rules
 
@@ -1096,6 +1097,10 @@ When adding a new role, explicitly classify whether it is a concern-aligned role
 ## Validator Rollout Guidance (V1.2)
 
 Validation should support incremental adoption.
+
+Mode semantics are centralized in `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` (`report`, `soft-fail`, `hard-fail`, `correct`, `replace`).
+
+Report-first remains the default adoption posture; enforcement should be introduced incrementally.
 
 ### Recommended validator modes
 

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -22,6 +22,10 @@ Out of scope for V0.1.6:
 - auto-fix or rename execution
 - broad migration/cleanup enforcement
 
+## Version labeling note
+
+Subsections labeled `(V0.1.2)` indicate the last version where that subsection materially changed; the overall document version remains V0.1.6.
+
 ## Source-of-Truth References
 
 Primary naming authority:
@@ -46,12 +50,14 @@ Filename grammar is unchanged from V0.1.1.
 ## Role Registry Metadata (V0.1.2)
 
 V0.1.2 uses a structured role registry with metadata:
+The role registry source-of-truth is `FileNamingMasterList-V1_1.md`.
+
 - `role`
 - `category` (`concern-core` | `architecture-support` | `deprecated`)
 - `status` (`active` | `deprecated`)
 - `notes` (optional)
 
-Active roles:
+Implemented roles in the current naming slice:
 - `host` (`architecture-support`, `active`)
 - `wiring` (`architecture-support`, `active`)
 - `contracts` (`architecture-support`, `active`)
@@ -61,6 +67,8 @@ Active roles:
 - `knowledge` (`concern-core`, `active`)
 - `results` (`concern-core`, `active`)
 - `results-style` (`concern-core`, `active`)
+
+Registry vocabulary may expand beyond the currently implemented subset; report-first behavior remains default and no enforcement is applied by default.
 
 Deprecated historical roles:
 - `view` (`deprecated`, `deprecated`) — historical pre-current concern split term.

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -122,6 +122,42 @@ Notes:
 
 ---
 
+## Tree Snapshot Inputs (TreeManifest / TreeSnapshot)
+
+Tree advisor analysis input is a deterministic **TreeSnapshot** (also called a TreeManifest): a stable list of repo-relative paths selected for analysis.
+
+### Snapshot sources
+
+TreeSnapshot may come from one of two sources:
+- `fs` snapshot (always available): filesystem walk results after scope + target filtering
+- `git` snapshot (optional): committed tree listing for a selected git ref when `.git` is present
+
+Typical `git` usage is `gitRef=HEAD`.
+
+Important metadata clarifications:
+- `HEAD` is a git ref / snapshot selector, not a filename role
+- `git status --porcelain` is optional diagnostics metadata (for dirty/untracked visibility) and is not required for basic tree-advisor operation
+
+### Determinism rules (snapshot-specific)
+
+- normalize all paths to `/`
+- stably sort snapshot entries
+- same snapshot inputs and same options => same report output
+
+### Recommended shape-level schema (doc-only)
+
+- `sourceSnapshot.source`: `fs | git`
+- `sourceSnapshot.gitRef`: optional string (for example `HEAD`)
+- `sourceSnapshot.diagnostics`: optional object (dirty/untracked counts or booleans)
+- `entries[]`:
+  - `path`
+  - `kind`: `file | dir` (optional)
+  - `parsed`: optional naming metadata
+    - `semanticName`
+    - `role`
+
+---
+
 ## Input Scope Profiles
 
 Tree advisor scope selection should reuse the existing validator scope discovery model (repo/app/docs/validator/system), plus optional target filtering.
@@ -155,6 +191,41 @@ Detect when one validator subsystem has a rich internal namespace (`rules/`, `re
 Detect when subpackages (e.g., `tools/report-capture`) contain mixed surfaces that should remain isolated from library code.
 
 All scoring thresholds MUST be explicit constants in code and reported in `details`.
+
+## Recommendation Patterns (Advisory Only)
+
+The following outputs are advisory recommendation patterns only. They are not mandatory rules and should be emitted as explainable `suggested-reorg` findings.
+
+### 1) Semantic-family folder recommendation
+
+When one semantic family is scattered across unrelated folders beyond configured thresholds, recommend consolidation under a family root such as:
+- `<semantic-name>/...`
+- `<semantic-family>/...`
+
+This is recommendation output (`suggested-reorg`) and not an enforcement requirement.
+
+### 2) Concern subfolder recommendation under a family
+
+When a semantic family has multi-file and multi-lane presence and is not already cleanly scoped by a higher family folder, recommend concern subfolders such as:
+- `<semantic-family>/build/...`
+- `<semantic-family>/logic/...`
+- `<semantic-family>/knowledge/...`
+
+This recommendation should trigger only when it reduces lane entropy or improves navigation, and remains advisory-only.
+
+Naming metadata reuse note:
+- Treat parsed naming metadata (`<semantic-name>.<role>.<ext>`) as a primary lane signal.
+
+## Compat / Shim Health Signals (Advisory Diagnostics)
+
+Shim/compat detection is a tree-health diagnostic layer in report-first mode:
+- detect shim-like files via folder signals (`compat/`, `shims/`, `adapters/`) and/or naming needles (`shim`, `compat`, `adapter`, `bridge`, `migration`)
+- detect scatter when shim-like entries appear across many unrelated folders
+- recommend a discoverable surface (for example `src/compat/` or `src/compat/shims/`) only when shim-like files already exist
+
+Constraints:
+- do not require creation of empty `compat/` folders
+- report findings are advisory diagnostics only (not pass/fail by default)
 
 ---
 
@@ -213,6 +284,9 @@ Suggested codes (V0.0.1):
 - `TREE_MISSING_NAMESPACE_ROOT`
 - `TREE_SUBSYSTEM_SCAFFOLD_ASYMMETRY`
 - `TREE_TOOL_SURFACE_MIX`
+- `TREE_SHIM_SURFACE_PRESENT` (`info`)
+- `TREE_SHIM_SCATTERED` (`warn`/`info`)
+- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`/`info`)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make the Tree Structure Advisor spec explicit about deterministic snapshot inputs and clarify `gitRef` usage so analyses are reproducible and metadata does not get misinterpreted as a filename role. 
- Document advisory-only recommendation patterns (semantic-family consolidation and concern subfolders) so the advisor emits explainable suggestions rather than prescriptive rules. 
- Surface shim/compat diagnostics as discoverable, advisory health signals and centralize suite-mode references and naming doc cross-links to prevent drift between master lists and validator specs. 

### Description
- Added a `Tree Snapshot Inputs (TreeManifest / TreeSnapshot)` section to `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` that defines `fs` vs optional `git` snapshots, clarifies `HEAD` as a git-ref selector (not a filename role), documents optional `git status --porcelain` diagnostics, lists determinism rules, and provides a recommended shape-level schema. 
- Added `Recommendation Patterns (Advisory Only)` to the tree advisor spec describing `semantic-family` consolidation and `concern` subfolder recommendations and tied these recommendations to parsed naming metadata (`<semantic-name>.<role>.<ext>`). 
- Added `Compat / Shim Health Signals (Advisory Diagnostics)` guidance and expanded suggested finding codes in the tree advisor spec with shim diagnostics: `TREE_SHIM_SURFACE_PRESENT`, `TREE_SHIM_SCATTERED`, and `TREE_SHIM_OUTSIDE_COMPAT`. 
- Replaced placeholder wording in `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` by linking to `NamingValidatorSpec.md` and `ValidatorSuite-Contracts-And-Modes.md`, and converted unresolved references into explicit “Deferred” notes; also centralized rollout-mode wording to reference the suite contract and canonical mode names. 
- Inserted a compact `Version labeling note` in `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` clarifying that subsection `(V0.1.2)` markers indicate the last change to that subsection while the document is overall `V0.1.6`, and clarified that the role-registry source-of-truth is `FileNamingMasterList-V1_1.md` while distinguishing implemented roles vs registry vocabulary. 

### Testing
- Ran targeted greps for stale placeholders and identifiers (`add path when created`, `suggested future path`, `placeholder`, `TODO`) across the edited docs and confirmed the placeholder phrases were removed or converted to explicit “Deferred” notes (command succeeded). 
- Verified referenced docs exist at the linked paths by checking file presence for `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` and `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` (file checks succeeded). 
- Performed a commit of the three edited files (`calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`, `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`, `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md`) which succeeded and produced a single docs-only commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d92fb56c8331b0ffd16bfbcfd60d)