### PR TITLE
docs(validator): align naming taxonomy and report envelope mapping

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -411,6 +411,15 @@ All role registry entries MUST declare one status from the bounded list below.
 - Deprecated roles MUST include a deprecation note and migration intent (manual migration intent is acceptable; no automatic mapping promise required).
 - Role meaning changes MUST update the semantics definition block in this document first, then any downstream validator/spec references.
 
+#### Validator taxonomy compatibility (naming slice)
+
+- This master list defines the full intended taxonomy, including richer categories such as `concern-style`, `indexing-registry`, and `integration-adapter`.
+- The current naming validator runtime uses a bounded subset of category values for deterministic checks (`concern-core`, `architecture-support`, `documentation`, `deprecated`).
+- Adoption path for runtime compatibility:
+  - use config to add roles and map them to currently supported runtime categories where needed
+  - treat richer master-list categories as governance/semantic intent until validator category handling expands
+- Current slice taxonomy constraint note: runtime currently treats `build-style` and `results-style` as concern-aligned roles under `concern-core` for deterministic naming checks. This is an implementation taxonomy constraint in the naming slice today, not a semantic redefinition of those roles in this master list.
+
 ### Role Semantics Definitions
 
 Each role below has an explicit deterministic definition: meaning, purpose/use-cases, non-goals, category, and status.

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -53,11 +53,11 @@ V0.1.2 uses a structured role registry with metadata:
 The role registry source-of-truth is `FileNamingMasterList-V1_1.md`.
 
 - `role`
-- `category` (`concern-core` | `architecture-support` | `deprecated`)
+- `category` (`concern-core` | `architecture-support` | `documentation` | `deprecated`)
 - `status` (`active` | `deprecated`)
 - `notes` (optional)
 
-Implemented roles in the current naming slice:
+Default runtime registry roles in the naming slice:
 - `host` (`architecture-support`, `active`)
 - `wiring` (`architecture-support`, `active`)
 - `contracts` (`architecture-support`, `active`)
@@ -67,8 +67,17 @@ Implemented roles in the current naming slice:
 - `knowledge` (`concern-core`, `active`)
 - `results` (`concern-core`, `active`)
 - `results-style` (`concern-core`, `active`)
+- `spec` (`documentation`, `active`)
+- `policy` (`documentation`, `active`)
+- `workflow` (`documentation`, `active`)
+- `plan` (`documentation`, `active`)
+- `audit` (`documentation`, `active`)
+- `healthcheck` (`documentation`, `active`)
 
-Registry vocabulary may expand beyond the currently implemented subset; report-first behavior remains default and no enforcement is applied by default.
+Registry vocabulary vs config additions:
+- The default role registry is the runtime baseline used by naming validation.
+- Config can add roles (add-only).
+- `FileNamingMasterList-V1_1.md` remains the source-of-truth taxonomy, while the naming slice currently uses a bounded category vocabulary for deterministic checks.
 
 Deprecated historical roles:
 - `view` (`deprecated`, `deprecated`) — historical pre-current concern split term.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -75,6 +75,16 @@ Each validator slice should emit a stable high-level report envelope:
 
 This contract is intentionally shape-level so slices can add deterministic details while preserving suite-wide comparability.
 
+### Current report mapping (naming slice)
+
+Canonical envelope is the stable suite contract; some slices currently emit equivalent fields under different names until runner unification.
+
+- `validatorVersion` → `toolVersion`
+- `configFingerprint` → `configDigest`
+- `summary` → `counts` + `codeCounts` (plus deterministic naming-specific breakdowns such as `specialCaseTypeCounts` and warning-category/status counts)
+- `findings[]` → `findings[]`
+- `sourceSnapshot` → not yet emitted by the naming report (deferred)
+
 ## 7) Shared Determinism Rules (Canonical)
 
 All slices should follow these deterministic rules:

--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -5,7 +5,7 @@ Purpose: quick routing map for validator documentation so readers can distinguis
 ## 1) Canonical suite contracts
 
 - `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`  
-  Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing. Read this first when interpreting validator behavior.
+  Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes. Read this first when interpreting validator behavior.
 
 ## 2) Naming
 
@@ -13,7 +13,7 @@ Purpose: quick routing map for validator documentation so readers can distinguis
   Canonical naming authority (roles, grammar, exception policy, rollout guidance). Read when defining or reviewing naming rules.
 
 - `doc/ConventionRoutines/NamingValidatorSpec.md`  
-  Naming-slice validator spec (scope profiles, classification contract, report details, current report/strict exit behavior). Read when implementing or validating naming checks.
+  Naming-slice validator spec (scope profiles, classification contract, report details, current report/strict exit behavior), including the current runtime category vocabulary for naming role metadata. Read when implementing or validating naming checks.
 
 ## 3) Tree advisor
 


### PR DESCRIPTION
### Motivation

- Eliminate doc vs implementation drift by aligning naming docs with the runtime role registry and category vocabulary.
- Make explicit the relationship between the full master taxonomy and the naming validator’s bounded runtime taxonomy so readers aren’t confused about scope and determinism.
- Surface a simple mapping from the suite's canonical report envelope to the concrete fields emitted by the naming slice so suite contracts and current reports can be compared easily.

### Description

- Updated `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` to list the default runtime role registry (including `host`, `wiring`, `contracts`, `build`, `build-style`, `logic`, `knowledge`, `results`, `results-style`, `spec`, `policy`, `workflow`, `plan`, `audit`, `healthcheck`, and deprecated `view`) and expanded the category vocabulary to include `documentation`, plus added a short "Registry vocabulary vs config additions" clarification. 
- Added a new `Validator taxonomy compatibility (naming slice)` subsection to `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` that explains the master list is the full intended taxonomy while the naming slice uses a bounded subset for deterministic checks and documents the current `build-style`/`results-style` treatment as an implementation constraint. 
- Added `Current report mapping (naming slice)` to `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` mapping canonical envelope fields to the naming report equivalents (for example `validatorVersion` → `toolVersion`, `configFingerprint` → `configDigest`, `summary` → `counts` + `codeCounts`, `findings[]` → `findings[]`) and marking `sourceSnapshot` as deferred for this slice. 
- Updated `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to include breadcrumbs that point readers at the runtime naming category vocabulary and the canonical-envelope → current-slice mapping note.

### Testing

- Verified the updated role list against the runtime registry in `calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs` using file inspection. 
- Inspected `calculogic-validator/scripts/validate-naming.mjs` to confirm the naming report emits the concrete fields referenced in the new report-mapping note. 
- Ran targeted searches with `rg` to confirm presence of the new taxonomy-compatibility and report-mapping text and absence of contradictory "implemented subset" phrasing. 
- Reviewed the changed files via local diffs/file previews to ensure the edits are docs-only and consistent with the acceptance criteria; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e30d2338833192352c7e25668a1a)