### PR TITLE
docs: surface `validatorId` as deferred in naming mapping and add bounded-taxonomy maintenance note

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -78,6 +78,7 @@ Registry vocabulary vs config additions:
 - The default role registry is the runtime baseline used by naming validation.
 - Config can add roles (add-only).
 - `FileNamingMasterList-V1_1.md` remains the source-of-truth taxonomy, while the naming slice currently uses a bounded category vocabulary for deterministic checks.
+- If runtime-supported category values expand beyond the bounded set listed here, update this section and the master-list compatibility note accordingly.
 
 Deprecated historical roles:
 - `view` (`deprecated`, `deprecated`) — historical pre-current concern split term.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -80,6 +80,7 @@ This contract is intentionally shape-level so slices can add deterministic detai
 Canonical envelope is the stable suite contract; some slices currently emit equivalent fields under different names until runner unification.
 
 - `validatorVersion` → `toolVersion`
+- `validatorId` → not yet emitted by the naming report (deferred)
 - `configFingerprint` → `configDigest`
 - `summary` → `counts` + `codeCounts` (plus deterministic naming-specific breakdowns such as `specialCaseTypeCounts` and warning-category/status counts)
 - `findings[]` → `findings[]`

--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -5,7 +5,7 @@ Purpose: quick routing map for validator documentation so readers can distinguis
 ## 1) Canonical suite contracts
 
 - `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`  
-  Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes. Read this first when interpreting validator behavior.
+  Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes, with `validatorId` currently deferred in naming output. Read this first when interpreting validator behavior.
 
 ## 2) Naming
 


### PR DESCRIPTION
### Motivation
- Clarify the suite-to-slice report mapping by explicitly documenting that `validatorId` is not yet emitted by the naming slice and add a small maintenance reminder to keep the bounded category vocabulary accurate as runtime taxonomy evolves.

### Description
- Added a `validatorId` → not yet emitted by the naming report (deferred) line to the `Current report mapping (naming slice)` section in `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`.
- Inserted a one-line maintenance note under `Registry vocabulary vs config additions` in `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` that instructs updating this section and the master-list compatibility note if runtime-supported category values expand.
- Updated `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to briefly mention that `validatorId` is currently deferred in naming output so the index reflects the mapping nit fix.

### Testing
- Verified the mapping and note additions by searching the modified files with `rg` for `validatorId` and the maintenance sentence, which returned the new lines successfully.
- Inspected the working-tree diffs with `git diff` to confirm the three files contain only the intended documentation edits and no runtime changes, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f4c3d5148331a3f5dc81a0811770)