### PR TITLE
Fix Vite doc-engine alias resolution and move doc-engine to runtime dependencies

### DIFF
--- a/doc/nl-shell/shell-spaHost.md
+++ b/doc/nl-shell/shell-spaHost.md
@@ -116,6 +116,8 @@ Coordinates with build tooling to ensure hydration entry points, but delegates n
 
 ### 9.3 Integration
 - Entry point referenced by src/main.tsx (or equivalent) to bootstrap the Calculogic application.
+- Vite alias contract: `@calculogic/doc-engine` resolves via an absolute path derived from `import.meta.url` so import-analysis is deterministic across importer locations.
+- Runtime package contract: `@calculogic/doc-engine` is declared under `dependencies` because SPA host runtime modules import it during app execution.
 
 ## 10. Implementation Passes
 ### 10.1 Pass Mapping

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^19.0.0",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^7.5.3",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "@calculogic/doc-engine": "file:calculogic-doc-engine"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
@@ -48,7 +49,6 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
     "vite": "^6.3.1",
-    "@calculogic/doc-engine": "file:calculogic-doc-engine",
     "@calculogic/report-capture": "file:calculogic-validator/tools/report-capture",
     "@calculogic/validator": "file:calculogic-validator"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@calculogic/doc-engine': './calculogic-doc-engine/src/index.ts',
+      '@calculogic/doc-engine': fileURLToPath(
+        new URL('./calculogic-doc-engine/src/index.ts', import.meta.url),
+      ),
     },
   },
 })


### PR DESCRIPTION
### Motivation
- Vite import-analysis could fail to resolve the relative alias `@calculogic/doc-engine` when resolution is computed relative to importing files instead of the project root, causing runtime import failures. 
- The package `@calculogic/doc-engine` is imported at runtime by the app and therefore must be declared in `dependencies` rather than `devDependencies`. 
- Changes follow the repository NL-first convention by recording the tooling/runtime contract in the SPA host NL skeleton before touching config files. 

### Description
- Updated `vite.config.ts` to import `fileURLToPath` and `URL` from `node:url` and set the alias to `fileURLToPath(new URL('./calculogic-doc-engine/src/index.ts', import.meta.url))` so the alias is an absolute, ESM-safe path. 
- Moved `@calculogic/doc-engine` from `devDependencies` to `dependencies` in `package.json` and preserved the `file:calculogic-doc-engine` spec. 
- Added a short note to `doc/nl-shell/shell-spaHost.md` documenting the alias and runtime dependency contract per the NL-first workflow. 
- No application imports were changed (for example `src/content/contentEngine.ts` remains unchanged). 

### Testing
- Ran `npm test` (unit/host tests) which executed the test suite and reported `115/116` tests passing and `1` failing test due to a missing `react` package caused by the blocked install environment. 
- Ran `npm run validate:naming -- --scope=app` which completed successfully. 
- A clean `npm install` and full runtime verification (including `npm run dev`/`npm run build`) could not be completed because `npm install` failed in this environment with registry access errors (`403 Forbidden`), so runtime start/build were not fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f8a8157083318c3a4b3656f1dc0f)