### PR TITLE
docs: explicitly mark `validatorId` as deferred in naming report mapping

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -80,7 +80,7 @@ This contract is intentionally shape-level so slices can add deterministic detai
 Canonical envelope is the stable suite contract; some slices currently emit equivalent fields under different names until runner unification.
 
 - `validatorVersion` → `toolVersion`
-- `validatorId` → not yet emitted by the naming report (deferred)
+- `validatorId` → not yet emitted by the naming report (deferred; currently not present in naming output)
 - `configFingerprint` → `configDigest`
 - `summary` → `counts` + `codeCounts` (plus deterministic naming-specific breakdowns such as `specialCaseTypeCounts` and warning-category/status counts)
 - `findings[]` → `findings[]`


### PR DESCRIPTION
### Motivation
- Harden suite documentation by explicitly stating that the naming slice does not yet emit `validatorId`, improving clarity for consumers of the report envelope. 
- Ensure the bounded-category vocabulary guidance remains visible so future runtime taxonomy expansions trigger a docs update.

### Description
- Updated `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` to change the mapping entry to: `validatorId` → not yet emitted by the naming report (deferred; currently not present in naming output). 
- Confirmed the `NamingValidatorSpec.md` already contains the bounded-category maintenance note near the "Registry vocabulary vs config additions" paragraph and that `ValidatorDocsIndex.md` already references the deferred `validatorId`, so no further edits were required.

### Testing
- Applied the documentation patch and the file update was applied successfully. 
- Verified the mapping and nearby context using `rg` to search for `validatorId` and the mapping phrase and inspected the file with `nl`/`sed` to confirm the change. 
- Verified the maintenance note presence in `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` using `rg` and file inspection, with all checks returning the expected lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50aa1cc448331bf553bac0cb1ec99)