### PR TITLE
Add canonical envelope fields and sourceSnapshot to validator reports

### DIFF
--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -134,12 +134,14 @@ try {
     ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
     : undefined;
 
+  const toolVersion = getValidatorToolVersion();
+
   const report = runValidatorRunner(repositoryRoot, {
     scope: parsed.selectedScope,
     validators: parsed.validators,
     config,
     targets: parsed.targets,
-    toolVersion: getValidatorToolVersion(),
+    toolVersion,
     ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -9,6 +9,7 @@ import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 import { deriveExitCodeFromFindings } from '../src/validator-exit-code.logic.mjs';
 import { detectNpmArgForwardingFootgun } from '../src/npm-arg-forwarding-guard.logic.mjs';
+import { getSourceSnapshot } from '../src/source-snapshot.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
@@ -148,8 +149,11 @@ const summary = summarizeFindings(findings);
 
 const report = {
   mode: 'report',
+  validatorId: 'naming',
   toolVersion,
+  ...(toolVersion ? { validatorVersion: toolVersion } : {}),
   ...(configDigest ? { configDigest } : {}),
+  sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot }),
   startedAt: startedAtDate.toISOString(),
   endedAt: endedAtDate.toISOString(),
   durationMs: endedAtDate.getTime() - startedAtDate.getTime(),

--- a/calculogic-validator/src/source-snapshot.logic.mjs
+++ b/calculogic-validator/src/source-snapshot.logic.mjs
@@ -1,0 +1,54 @@
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const runGit = (cwd, args) =>
+  spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const parseStatusDiagnostics = statusOutput => {
+  const lines = statusOutput
+    .split('\n')
+    .map(line => line.trimEnd())
+    .filter(Boolean);
+
+  const untrackedCount = lines.filter(line => line.startsWith('??')).length;
+  const changedCount = lines.length - untrackedCount;
+
+  return {
+    isDirty: lines.length > 0,
+    changedCount,
+    untrackedCount,
+  };
+};
+
+export const getSourceSnapshot = ({ cwd }) => {
+  const baseSnapshot = { source: 'fs' };
+
+  if (!cwd || !existsSync(`${cwd}/.git`)) {
+    return baseSnapshot;
+  }
+
+  const headShaResult = runGit(cwd, ['rev-parse', 'HEAD']);
+  if (headShaResult.error || headShaResult.status !== 0) {
+    return baseSnapshot;
+  }
+
+  const statusResult = runGit(cwd, ['status', '--porcelain']);
+  if (statusResult.error || statusResult.status !== 0) {
+    return {
+      ...baseSnapshot,
+      gitRef: 'HEAD',
+      gitHeadSha: headShaResult.stdout.trim(),
+    };
+  }
+
+  return {
+    ...baseSnapshot,
+    gitRef: 'HEAD',
+    gitHeadSha: headShaResult.stdout.trim(),
+    diagnostics: parseStatusDiagnostics(statusResult.stdout),
+  };
+};

--- a/calculogic-validator/src/validator-report.contracts.mjs
+++ b/calculogic-validator/src/validator-report.contracts.mjs
@@ -7,12 +7,25 @@ export const CALCULOGIC_VALIDATOR_REPORT_VERSION = '0.1.0';
  *   mode: 'report',
  *   scope?: string,
  *   toolVersion?: string,
+ *   validatorId?: string,
+ *   validatorVersion?: string,
  *   configDigest?: string,
+ *   sourceSnapshot?: {
+ *     source: 'fs',
+ *     gitRef?: 'HEAD',
+ *     gitHeadSha?: string,
+ *     diagnostics?: {
+ *       isDirty: boolean,
+ *       changedCount: number,
+ *       untrackedCount: number
+ *     }
+ *   },
  *   startedAt: string,
  *   endedAt: string,
  *   durationMs: number,
  *   validators: Array<{
  *     id: string,
+ *     validatorId?: string,
  *     description: string,
  *     scope?: string,
  *     totalFilesScanned?: number,

--- a/calculogic-validator/src/validator-runner.logic.mjs
+++ b/calculogic-validator/src/validator-runner.logic.mjs
@@ -3,6 +3,7 @@ import {
   VALIDATOR_REGISTRY,
   getValidatorById,
 } from './validator-registry.knowledge.mjs';
+import { getSourceSnapshot } from './source-snapshot.logic.mjs';
 
 const toValidatorReportEntry = (registryEntry, validatorResult) => {
   const summary = validatorResult.summary ?? null;
@@ -13,6 +14,7 @@ const toValidatorReportEntry = (registryEntry, validatorResult) => {
 
   return {
     id: registryEntry.id,
+    validatorId: registryEntry.id,
     description: registryEntry.description,
     scope: validatorResult.scope,
     totalFilesScanned: validatorResult.totalFilesScanned,
@@ -51,13 +53,17 @@ export const runValidatorRunner = (repositoryRoot, options = {}) => {
   });
 
   const endedAtDate = new Date();
+  const sourceSnapshot = getSourceSnapshot({ cwd: repositoryRoot });
 
   return {
     version: CALCULOGIC_VALIDATOR_REPORT_VERSION,
     mode: 'report',
     ...(scope ? { scope } : {}),
+    validatorId: 'runner',
     ...(options.toolVersion ? { toolVersion: options.toolVersion } : {}),
+    ...(options.toolVersion ? { validatorVersion: options.toolVersion } : {}),
     ...(options.configDigest ? { configDigest: options.configDigest } : {}),
+    sourceSnapshot,
     startedAt: startedAtDate.toISOString(),
     endedAt: endedAtDate.toISOString(),
     durationMs: endedAtDate.getTime() - startedAtDate.getTime(),

--- a/calculogic-validator/test/validator-runner.test.mjs
+++ b/calculogic-validator/test/validator-runner.test.mjs
@@ -16,9 +16,12 @@ test('runner report includes naming validator in deterministic order', () => {
   const report = runValidatorRunner(process.cwd(), { scope: 'app' });
 
   assert.ok(report.version);
+  assert.equal(report.validatorId, 'runner');
+  assert.equal(report.sourceSnapshot?.source, 'fs');
   assert.ok(Array.isArray(report.validators));
   assert.equal(report.validators.length, 1);
   assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].validatorId, 'naming');
   assert.equal(report.validators[0].scope, 'app');
   assert.equal(typeof report.validators[0].totalFilesScanned, 'number');
   assert.ok(Array.isArray(report.validators[0].findings));
@@ -34,6 +37,7 @@ test('validate-all CLI runs and returns naming validator report', () => {
   assert.equal(result.status, 0);
   const report = JSON.parse(result.stdout);
   assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].validatorId, 'naming');
   assert.equal(report.validators[0].scope, 'docs');
 });
 
@@ -41,6 +45,7 @@ test('runner forwards targets and includes naming filter meta when filtering is 
   const report = runValidatorRunner(process.cwd(), { scope: 'app', validators: ['naming'], targets: ['src'] });
 
   assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].validatorId, 'naming');
   assert.equal(report.validators[0].meta?.filters?.isFiltered, true);
   assert.deepEqual(report.validators[0].meta?.filters?.targets, ['src']);
 });
@@ -49,5 +54,6 @@ test('runner omits naming filter meta when no targets are provided', () => {
   const report = runValidatorRunner(process.cwd(), { scope: 'app', validators: ['naming'] });
 
   assert.equal(report.validators[0].id, 'naming');
+  assert.equal(report.validators[0].validatorId, 'naming');
   assert.equal(report.validators[0].meta?.filters, undefined);
 });

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -8,7 +8,7 @@
 > - `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
 
 ## 0.0 Version
-Current implementation target: **V0.1.15** (optional --target path/folder filtering within scope).
+Current implementation target: **V0.1.16** (canonical report-envelope aliases and source snapshot metadata).
 
 ## 1.0 Purpose
 Define a deterministic V0.1 filename naming validator that runs in report mode only and classifies repository filenames against the canonical naming contract.
@@ -199,6 +199,16 @@ Priority order is deterministic:
 3. otherwise success is exit `0`.
 
 Invalid CLI usage and argument parse errors remain exit `1`.
+
+### 4.7 Canonical envelope aliases and source snapshot metadata (V0.1.16)
+Naming CLI report output remains backward compatible and additive while exposing canonical envelope aliases:
+- `validatorId = "naming"`
+- `validatorVersion = toolVersion` (when tool version is available)
+- `sourceSnapshot` for deterministic runtime source observability with at least:
+  - `source = "fs"`
+  - optional git metadata when available (`gitRef = "HEAD"`, `gitHeadSha`, and `diagnostics` containing `isDirty`, `changedCount`, `untrackedCount`)
+
+When git is unavailable or repository git metadata cannot be resolved, report output still includes `sourceSnapshot.source = "fs"` and omits git-only fields.
 
 ## 5.0 Deferred Behavior
 Deferred to later slices:

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -1,7 +1,7 @@
 # cfg-validatorRunner
 
 ## 0.0 Version
-Current implementation target: **V0.1.4** (deterministic multi-validator runner target pass-through and per-validator filter metadata).
+Current implementation target: **V0.1.5** (canonical report-envelope aliases and source snapshot metadata).
 
 ## 1.0 Purpose
 Provide a deterministic runner that executes one or more registered validators and returns a single versioned combined report.
@@ -30,13 +30,17 @@ Runner accepts optional host-provided report metadata:
 - `mode` (`report`)
 - optional `scope`
 - optional `toolVersion`
+- optional `validatorId` (canonical alias, stable runner identity)
+- optional `validatorVersion` (canonical alias of tool version when provided)
 - optional `configDigest`
+- optional `sourceSnapshot` (`source = "fs"` plus optional git metadata/diagnostics)
 - `startedAt`, `endedAt`, `durationMs`
 - `validators` (deterministic execution order)
 
 ### 3.2 Validator entry shape
 Each validator entry includes:
 - `id`
+- optional `validatorId` (canonical alias of `id`)
 - `description`
 - `scope`
 - `totalFilesScanned`


### PR DESCRIPTION
### Motivation
- Ensure runtime reports emit canonical envelope fields for clearer provenance and consumer compatibility (`validatorId`, `validatorVersion`) and capture source state via `sourceSnapshot`.
- Keep the change additive and backward compatible so existing consumers of `toolVersion` / `configDigest` keep working.
- Provide a deterministic, minimal source snapshot (filesystem + optional git diagnostics) to aid CI debugging without adding timestamps.

### Description
- Added a shared source snapshot helper `getSourceSnapshot({ cwd })` in `calculogic-validator/src/source-snapshot.logic.mjs` that always returns `{ source: 'fs' }` and conditionally includes git fields (`gitRef`, `gitHeadSha`, `diagnostics`) when git is present and usable.
- Updated the naming CLI `scripts/validate-naming.mjs` to include `validatorId: 'naming'`, `validatorVersion` (when `toolVersion` exists), and `sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot })` while preserving all existing fields.
- Updated the runner in `src/validator-runner.logic.mjs` to emit top-level `validatorId: 'runner'`, optional `validatorVersion` (from `options.toolVersion`), and top-level `sourceSnapshot`; also added a per-validator `validatorId` alias in each validator entry while keeping `id` for compatibility.
- Documented the new optional fields in `src/validator-report.contracts.mjs` and updated NL-first documentation files `doc/nl-config/cfg-namingValidator.md` and `doc/nl-config/cfg-validatorRunner.md` to reflect the changes.

### Testing
- Ran unit tests with `node --test calculogic-validator/test/validator-runner.test.mjs` and all tests passed.
- Verified `validate:naming` CLI emits the new fields by running `npm run -s validate:naming -- --scope=app` and asserting presence of `validatorId`, `validatorVersion`, and `sourceSnapshot.source` (check succeeded).
- Verified `validate:all` CLI emits top-level `validatorId`, `validatorVersion`, and `sourceSnapshot.source` by running `npm run -s validate:all -- --scope=app` and asserting the same (check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50cc5e6b483319473129cd8b3f8ef)