### PR TITLE
docs: align validator report metadata docs and root workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,20 @@ Open `http://localhost:5173`.
 ## Current Scripts
 
 ```bash
-npm run dev      # Start Vite dev server
-npm run lint     # Run ESLint
-npm run build    # Type-check + production build
-npm test         # Run unit tests with node:test
-npm run preview  # Preview the built app locally
+npm run dev              # Start Vite dev server
+npm run lint             # Run ESLint
+npm run build            # Type-check + production build
+npm test                 # Run unit tests with node:test
+npm run preview          # Preview the built app locally
+npm run validate:naming  # Run validator naming workflow
+npm run validate:all     # Run full validator suite workflow
+npm run health:validator # Run validator environment/health checks
+# Optional report capture workflows:
+# npm run report:naming:*
+# npm run report:all:*
 ```
+
+For validator workflow details and report commands, see `calculogic-validator/README.md`.
 
 ## Project Structure (Current)
 

--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -226,6 +226,33 @@ Example:
 - Use `npm run report:verify` after setup changes.
 - Use `npm run report:summarize` for a concise overview of recent captures.
 
-## 9) Compatibility note
+
+## 9) Report output (JSON)
+
+Validator reports include stable metadata fields for report envelope identity and reproducibility:
+
+- `validatorId`
+- `validatorVersion`
+- `sourceSnapshot`
+
+Tiny `sourceSnapshot` example shape:
+
+```json
+{
+  "sourceSnapshot": {
+    "source": "fs",
+    "gitRef": "HEAD",
+    "gitHeadSha": "abc123def456",
+    "diagnostics": {
+      "dirty": false,
+      "untrackedCount": 0
+    }
+  }
+}
+```
+
+`gitRef`, `gitHeadSha`, and `diagnostics` are optional and may vary by environment and capture mode.
+
+## 10) Compatibility note
 
 Legacy imports from `src/validators/naming-validator.logic.mjs` remain supported via a thin re-export shim to the canonical naming validator host entrypoint.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -80,11 +80,11 @@ This contract is intentionally shape-level so slices can add deterministic detai
 Canonical envelope is the stable suite contract; some slices currently emit equivalent fields under different names until runner unification.
 
 - `validatorVersion` → `toolVersion`
-- `validatorId` → not yet emitted by the naming report (deferred; currently not present in naming output)
+- `validatorId` → `validatorId`
 - `configFingerprint` → `configDigest`
 - `summary` → `counts` + `codeCounts` (plus deterministic naming-specific breakdowns such as `specialCaseTypeCounts` and warning-category/status counts)
 - `findings[]` → `findings[]`
-- `sourceSnapshot` → not yet emitted by the naming report (deferred)
+- `sourceSnapshot` → `sourceSnapshot`
 
 ## 7) Shared Determinism Rules (Canonical)
 

--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -5,7 +5,7 @@ Purpose: quick routing map for validator documentation so readers can distinguis
 ## 1) Canonical suite contracts
 
 - `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`  
-  Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes, with `validatorId` currently deferred in naming output. Read this first when interpreting validator behavior.
+  Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes. Read this first when interpreting validator behavior.
 
 ## 2) Naming
 


### PR DESCRIPTION
### Motivation

- Update canonical validator docs to reflect that the naming slice now emits `validatorId` and `sourceSnapshot` in reports instead of marking them as deferred. 
- Ensure the validator README documents the new report metadata fields and provides a tiny `sourceSnapshot` example for reproducibility guidance.
- Make it easier for consumers to find and run validator workflows from the repo root by adding the validator scripts to the root `README.md` scripts list and linking to the validator README.

### Description

- In `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` the naming-slice mapping was updated so `validatorId` maps to `validatorId` and `sourceSnapshot` maps to `sourceSnapshot` (removed the “deferred” wording) while keeping the rest of the mapping intact. 
- In `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` the outdated “`validatorId` currently deferred in naming output” wording was removed from the suite-contract entry. 
- Added a `Report output (JSON)` section to `calculogic-validator/README.md` documenting `validatorId`, `validatorVersion`, and `sourceSnapshot` and included a minimal `sourceSnapshot` example showing `source: "fs"` and optional `gitRef`, `gitHeadSha`, and `diagnostics`. 
- Expanded the root `README.md` “Current Scripts” block to list validator workflows (`npm run validate:naming`, `npm run validate:all`, `npm run health:validator`) and added a pointer to `calculogic-validator/README.md` for details.

### Testing

- Ran a repository search using `rg` to confirm there are no remaining canonical docs claiming `validatorId` or `sourceSnapshot` are deferred, and the search returned no matches for the deferred phrases (success). 
- Inspected diffs with `git status`/`git diff` and committed the changes with `git commit -m "docs: update validator report envelope documentation"` which succeeded. 
- No unit or integration tests were modified or required for these docs-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5103c38788331b89fec0c3c581dc9)