### PR TITLE
docs(validator): align sourceSnapshot diagnostics example

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -244,7 +244,8 @@ Tiny `sourceSnapshot` example shape:
     "gitRef": "HEAD",
     "gitHeadSha": "abc123def456",
     "diagnostics": {
-      "dirty": false,
+      "isDirty": false,
+      "changedCount": 0,
       "untrackedCount": 0
     }
   }


### PR DESCRIPTION
### Motivation
- Ensure the README `sourceSnapshot.diagnostics` JSON example matches the actual validator runtime/report contract fields (`isDirty`, `changedCount`, `untrackedCount`).

### Description
- Updated `calculogic-validator/README.md` to replace `dirty` with `isDirty` and add `changedCount` in the `sourceSnapshot.diagnostics` example so it matches `calculogic-validator/src/source-snapshot.logic.mjs` and `calculogic-validator/src/validator-report.contracts.mjs`.

### Testing
- No automated tests were added or modified for this docs-only change; verification was done by inspecting `src/source-snapshot.logic.mjs` and `src/validator-report.contracts.mjs` and confirming the README diff (`git diff` / `nl` outputs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a514863f1483319f7449e5858becd4)