### PR TITLE
docs: point host convention docs to validator canon and adopt CCS naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A modular React + TypeScript builder shell for composing configuration-driven wo
 6. [Project Structure (Current)](#project-structure-current)
 7. [Roadmap (Planned)](#roadmap-planned)
 8. [Configuration Architecture](#configuration-architecture)
-9. [Calculogic-Style Concern System (CSCS)](#calculogic-style-concern-system-cscs)
+9. [Calculogic Concern System (CCS)](#calculogic-concern-system-ccs)
 10. [Comment & Provenance Protocol (CCPP)](#comment--provenance-protocol-ccpp)
 
 ---
@@ -160,15 +160,19 @@ For validator workflow details and report commands, see `calculogic-validator/RE
 - External architecture document: <https://docs.google.com/document/d/1UNlEDQTqWKbuq2QIFNIhYWxzMzj_opopgXu4QIScZKA/edit>
 - Local summary: `doc/Architecture/ConfigurationArchitectureSummary.md`
 
-## Calculogic-Style Concern System (CSCS)
+## Calculogic Concern System (CCS)
 
-The CSCS defines concern boundaries and dependency direction across Build / BuildStyle / Logic / Knowledge / Results.
+The CCS defines concern boundaries and dependency direction across Build / BuildStyle / Logic / Knowledge / Results.
 
 - Spec: `calculogic-validator/doc/ConventionRoutines/CSCS.md`
 - Doc-engine mapping: `doc/Architecture/DocEngine-CSCS-Mapping.md`
 
+Conventions are validator-owned so they can be reused across future repos by installing the validator suite. Host docs under `/doc/ConventionRoutines/` are entrypoint wrappers, not canonical rule sources.
+
 ## Comment & Provenance Protocol (CCPP)
 
 CCPP defines file headers, section/atomic comments, decision notes, and provenance annotations.
+
+Conventions are validator-owned so they can be reused across future repos by installing the validator suite. Host docs under `/doc/ConventionRoutines/` are entrypoint wrappers, not canonical rule sources.
 
 - Spec: `calculogic-validator/doc/ConventionRoutines/CCPP.md`

--- a/doc/ConventionRoutines/CCPP.md
+++ b/doc/ConventionRoutines/CCPP.md
@@ -1,11 +1,10 @@
-# CCPP (Concern/Code Provenance Policy)
+# Calculogic Comment & Provenance Protocol (CCPP)
 
-## Purpose
-Define lightweight provenance and comment rules for Calculogic repositories.
+> **Canonical source (validator-owned):** `calculogic-validator/doc/ConventionRoutines/CCPP.md`  
+> This host document is a convenience pointer. To change protocol rules, update the canonical validator source (not this wrapper).
 
-## Rules
-1. Keep comments focused on intent, constraints, and invariants.
-2. Avoid stale implementation comments; prefer self-descriptive names and tests.
-3. When behavior is governed by architecture/docs, reference the source doc in nearby comments or commit/PR notes.
-4. Preserve public behavior unless a task explicitly changes it.
-5. Keep changes minimal and scoped to the concern being modified.
+## What is this used for in this repo?
+
+- Quick entrypoint for contributors working in the host app repo.
+- Shared reference for comment/provenance expectations during local implementation and reviews.
+- Redirect to validator-owned canon so rule changes stay centralized.

--- a/doc/ConventionRoutines/CCS.md
+++ b/doc/ConventionRoutines/CCS.md
@@ -1,0 +1,10 @@
+# Calculogic Concern System (CCS, NL-aligned)
+
+> **Canonical source (validator-owned):** `calculogic-validator/doc/ConventionRoutines/CSCS.md`  
+> **Compatibility note:** the validator filename remains `CSCS.md` for compatibility, while the canonical acronym is **CCS**.
+
+## Repo usage
+
+- Host-repo entrypoint for concern boundaries and dependency direction.
+- Reference during architecture review and concern-split implementation work.
+- Pointer to validator-owned canon to prevent host-rule drift.

--- a/doc/ConventionRoutines/CSCS.md
+++ b/doc/ConventionRoutines/CSCS.md
@@ -1,11 +1,6 @@
-# CSCS (Concern Separation & Coupling Standard)
+# Legacy Alias: CSCS → CCS
 
-## Purpose
-Maintain clean dependency direction and concern purity.
+This file is retained as a legacy alias for link stability.
 
-## Rules
-1. Runtime/domain modules must not depend on feature UI modules.
-2. Feature UI modules may depend on runtime/domain modules.
-3. Shared primitives/types live in neutral modules; avoid circular dependencies.
-4. Side-effect wiring should be isolated at composition boundaries.
-5. Prefer explicit interfaces between concerns.
+- Host canonical wrapper name: `doc/ConventionRoutines/CCS.md`
+- Canonical validator source: `calculogic-validator/doc/ConventionRoutines/CSCS.md`

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,8 @@
 
 ## Convention Routines
 - [CCPP](./ConventionRoutines/CCPP.md)
-- [CSCS](./ConventionRoutines/CSCS.md)
+- [CCS](./ConventionRoutines/CCS.md)
+- [CSCS (legacy alias)](./ConventionRoutines/CSCS.md)
 - [General NL Skeletons](./ConventionRoutines/General-NL-Skeletons.md)
 - [NL-First Workflow](./ConventionRoutines/NL-First-Workflow.md)
 


### PR DESCRIPTION
### Motivation

- Ensure host repo convention docs are thin wrappers that point to validator-owned canonical specs to prevent drift and duplicate rule bodies.
- Adopt the canonical acronym **CCS** for host-facing documentation while preserving the validator filename `CSCS.md` for compatibility and link stability.
- Make it explicit in top-level docs that convention ownership lives in the validator suite so future repos reuse the same canonical sources.

### Description

- Converted `doc/ConventionRoutines/CCPP.md` into a wrapper that includes a canonical-source block pointing to `calculogic-validator/doc/ConventionRoutines/CCPP.md` and a short `What is this used for in this repo?` section. 
- Added `doc/ConventionRoutines/CCS.md` as the host canonical wrapper titled `# Calculogic Concern System (CCS, NL-aligned)` with a canonical-source pointer to `calculogic-validator/doc/ConventionRoutines/CSCS.md` and a compatibility note. 
- Replaced `doc/ConventionRoutines/CSCS.md` content with a legacy alias shim that points to host `CCS.md` and the validator `CSCS.md` and explains the alias is retained for link stability. 
- Updated `README.md` and `doc/README.md` to use the `CCS` terminology, preserve links to the validator canonical paths, and add a short note explaining why canon lives in the validator suite.

### Testing

- Verified the modified wrapper files exist and contain pointer-style content using file inspection commands (e.g. `sed -n` to print file heads), confirming no duplicated rule bodies. 
- Searched repository references with `rg` to confirm host-path references were updated to `doc/ConventionRoutines/CCS.md` where appropriate and validator-path links to `calculogic-validator/doc/ConventionRoutines/CSCS.md` were left intact. 
- Confirmed repository status reflected the expected file changes and that all targeted validation checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51b402f0c83318ca81d11ea95f467)