### PR TITLE
docs: rename CSCS convention doc to CCS and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For validator workflow details and report commands, see `calculogic-validator/RE
 
 The CCS defines concern boundaries and dependency direction across Build / BuildStyle / Logic / Knowledge / Results.
 
-- Spec: `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- Spec: `calculogic-validator/doc/ConventionRoutines/CCS.md`
 - Doc-engine mapping: `doc/Architecture/DocEngine-CSCS-Mapping.md`
 
 Conventions are validator-owned so they can be reused across future repos by installing the validator suite. Host docs under `/doc/ConventionRoutines/` are entrypoint wrappers, not canonical rule sources.

--- a/calculogic-doc-engine/doc/Standards/Doc-Engine-Contribution-Checklist.md
+++ b/calculogic-doc-engine/doc/Standards/Doc-Engine-Contribution-Checklist.md
@@ -5,7 +5,7 @@ Use this checklist before opening or approving a doc-engine PR.
 ## Linked Standards (Required)
 
 - [ ] **CCPP** reviewed and applied: `calculogic-validator/doc/ConventionRoutines/CCPP.md`
-- [ ] **CSCS** reviewed and applied: `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- [ ] **CSCS** reviewed and applied: `calculogic-validator/doc/ConventionRoutines/CCS.md`
 - [ ] **General NL Skeletons** template/numbering followed: `doc/ConventionRoutines/General-NL-Skeletons.md`
 - [ ] **NL-First Workflow** enforced (NL updated before code): `doc/ConventionRoutines/NL-First-Workflow.md`
 

--- a/calculogic-doc-engine/doc/Standards/Doc-Engine-Standards-Summary.md
+++ b/calculogic-doc-engine/doc/Standards/Doc-Engine-Standards-Summary.md
@@ -1,6 +1,6 @@
 # Doc-Engine Standards Summary
 
-This summary restates required conventions for doc-engine implementation work. It is a local, practical restatement of the canonical standards in `calculogic-validator/doc/ConventionRoutines/CCPP.md`, `calculogic-validator/doc/ConventionRoutines/CSCS.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md`.
+This summary restates required conventions for doc-engine implementation work. It is a local, practical restatement of the canonical standards in `calculogic-validator/doc/ConventionRoutines/CCPP.md`, `calculogic-validator/doc/ConventionRoutines/CCS.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md`.
 
 ## 1) Required File Header (CCPP)
 

--- a/calculogic-doc-engine/doc/Standards/README.md
+++ b/calculogic-doc-engine/doc/Standards/README.md
@@ -5,7 +5,7 @@ This folder provides quick-start guidance for doc-engine work and points to the 
 ## Canonical Standards
 
 - **CCPP (Calculogic Comment & Provenance Protocol)**: `calculogic-validator/doc/ConventionRoutines/CCPP.md`
-- **CSCS (Calculogic Concern System, NL-Aligned)**: `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- **CSCS (Calculogic Concern System, NL-Aligned)**: `calculogic-validator/doc/ConventionRoutines/CCS.md`
 - **General NL Skeletons**: `doc/ConventionRoutines/General-NL-Skeletons.md`
 - **NL-First Workflow**: `doc/ConventionRoutines/NL-First-Workflow.md`
 

--- a/calculogic-validator/doc/ConventionRoutines/CCS.md
+++ b/calculogic-validator/doc/ConventionRoutines/CCS.md
@@ -1,6 +1,5 @@
 # Calculogic Concern System (CCS, NL-Aligned, Codebase-Level)
 
-> Note: This document filename remains `CSCS.md` for compatibility in this pass. In content, the canonical acronym is **CCS** (Calculogic Concern System).
 
 ## 1. First Principles
 

--- a/calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
+++ b/calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md
@@ -6,7 +6,7 @@
 - **Purpose:** Define a deterministic structural addressing grammar usable across Calculogic docs, NL skeletons, comments, and future JSON/engine representations.
 - **Scope:** Host-letter rules, no-host rules, concern-slot positioning, deep nesting extension, parse/sort assumptions, examples, and deferred decisions.
 - **Related docs:**
-  - `calculogic-validator/doc/ConventionRoutines/CSCS.md` (canonical concern model/order)
+  - `calculogic-validator/doc/ConventionRoutines/CCS.md` (canonical concern model/order)
   - `calculogic-validator/doc/ConventionRoutines/CCPP.md` (comment/provenance conventions)
   - `doc/ConventionRoutines/General-NL-Skeletons.md` (NL section structure/order)
   - `doc/ConventionRoutines/NL-First-Workflow.md` (workflow precedence)
@@ -326,7 +326,7 @@ This draft establishes grammar first. Later passes should synchronize wording/ex
 - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
 - `doc/ConventionRoutines/General-NL-Skeletons.md`
 - `doc/ConventionRoutines/NL-First-Workflow.md` (if workflow steps should explicitly reference structural address validation checkpoints)
-- `calculogic-validator/doc/ConventionRoutines/CSCS.md` (only if cross-reference section is needed; concern ordering itself remains canonical there)
+- `calculogic-validator/doc/ConventionRoutines/CCS.md` (only if cross-reference section is needed; concern ordering itself remains canonical there)
 - Relevant architecture docs where host/address references should be explicit (starting with `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`)
 
 ## 12. Change Control / Adoption Guidance (Draft)

--- a/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -18,7 +18,7 @@
 - **Validator Suite Contracts / Modes:** `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`
 - **Provenance Token Spec (NL/C):** Deferred as a separate spec; this document is currently the source for filename normalization rules.
 - **Architecture / Module Boundary Docs:**
-  - `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+  - `calculogic-validator/doc/ConventionRoutines/CCS.md`
   - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `doc/ConventionRoutines/NL-First-Workflow.md`

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -34,7 +34,7 @@ Primary naming authority:
 
 Supporting workflow alignment:
 - `doc/ConventionRoutines/NL-First-Workflow.md`
-- `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- `calculogic-validator/doc/ConventionRoutines/CCS.md`
 - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
 
 ## Canonical Filename Contract (V0.1.2)

--- a/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md
@@ -11,7 +11,7 @@
 - **Related Docs:**
   - `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`
   - `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
-  - `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+  - `calculogic-validator/doc/ConventionRoutines/CCS.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md`
   - `doc/ConventionRoutines/StatusVocabularyRegistry-V1.md`

--- a/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
+++ b/doc/Architecture/BuildSurfaceGlobalHostSliceExecutionPlaybook.md
@@ -12,7 +12,7 @@
   - `doc/Architecture/BuildSurfaceGlobalHostDraftInventoryPlan.md`
   - `doc/Architecture/BuildSurfaceGlobalHostSequencePlan.md`
   - `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
-  - `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+  - `calculogic-validator/doc/ConventionRoutines/CCS.md`
   - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `doc/ConventionRoutines/NL-First-Workflow.md`

--- a/doc/Architecture/ConfigurationArchitectureSummary.md
+++ b/doc/Architecture/ConfigurationArchitectureSummary.md
@@ -44,7 +44,7 @@ Calculogic transforms form building into a hands-on coding lesson. Each tab enfo
 
 ## Related Docs / Reading Order
 1. ConfigurationArchitectureSummary.md (this document)
-2. CSCS.md (Concern semantics and file mappings)
+2. CCS.md (Concern semantics and file mappings)
 3. General-NL-Skeletons.md (Canonical NL skeleton templates)
 4. NL-First-Workflow.md (Authoring workflow)
 5. CCPP.md (Comment and provenance protocol)

--- a/doc/ComplianceAudits/Alignment-Audit-2026-02-21.md
+++ b/doc/ComplianceAudits/Alignment-Audit-2026-02-21.md
@@ -1,7 +1,7 @@
 # Alignment Audit – 2026-02-21
 
 ## Scope and method
-- Binding routines reviewed first: `calculogic-validator/doc/ConventionRoutines/CCPP.md`, `calculogic-validator/doc/ConventionRoutines/CSCS.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md`.
+- Binding routines reviewed first: `calculogic-validator/doc/ConventionRoutines/CCPP.md`, `calculogic-validator/doc/ConventionRoutines/CCS.md`, `doc/ConventionRoutines/General-NL-Skeletons.md`, and `doc/ConventionRoutines/NL-First-Workflow.md`.
 - Recently changed configuration/shell surfaces were identified from git history focused on active config/shell paths.
 - Audited targets:
   - `cfg-buildSurface`

--- a/doc/ComplianceAudits/ComplianceAudit-2026-02-10.md
+++ b/doc/ComplianceAudits/ComplianceAudit-2026-02-10.md
@@ -4,7 +4,7 @@ Date: 2026-02-10
 Scope: recently changed configurations/shells identified from git history and mapped to current project paths.
 
 ## Inputs reviewed
-- `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- `calculogic-validator/doc/ConventionRoutines/CCS.md`
 - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
 - `doc/ConventionRoutines/General-NL-Skeletons.md`
 - `doc/ConventionRoutines/NL-First-Workflow.md`

--- a/doc/ConventionRoutines/CCS.md
+++ b/doc/ConventionRoutines/CCS.md
@@ -1,7 +1,6 @@
 # Calculogic Concern System (CCS, NL-aligned)
 
-> **Canonical source (validator-owned):** `calculogic-validator/doc/ConventionRoutines/CSCS.md`  
-> **Compatibility note:** the validator filename remains `CSCS.md` for compatibility, while the canonical acronym is **CCS**.
+> **Canonical source (validator-owned):** `calculogic-validator/doc/ConventionRoutines/CCS.md`  
 
 ## Repo usage
 

--- a/doc/ConventionRoutines/CSCS.md
+++ b/doc/ConventionRoutines/CSCS.md
@@ -1,6 +1,0 @@
-# Legacy Alias: CSCS → CCS
-
-This file is retained as a legacy alias for link stability.
-
-- Host canonical wrapper name: `doc/ConventionRoutines/CCS.md`
-- Canonical validator source: `calculogic-validator/doc/ConventionRoutines/CSCS.md`

--- a/doc/ConventionRoutines/General-NL-Skeletons.md
+++ b/doc/ConventionRoutines/General-NL-Skeletons.md
@@ -27,7 +27,7 @@ This doc defines the canonical NL skeleton templates used by all configuration (
 
 ## Changing This Doc
 
-If you change top-level sections or numbering here, you must also update `NL-First-Workflow.md`, `CSCS.md`, and `CCPP.md` to keep the system consistent.
+If you change top-level sections or numbering here, you must also update `NL-First-Workflow.md`, `CCS.md`, and `CCPP.md` to keep the system consistent.
 
 ---
 

--- a/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
+++ b/doc/ConventionRoutines/NL-SplitMigrationAndNumberingPolicy.md
@@ -61,4 +61,4 @@ A slice is considered done when all of the following are true:
 - `doc/ConventionRoutines/General-NL-Skeletons.md`
 - `doc/ConventionRoutines/NL-First-Workflow.md`
 - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
-- `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- `calculogic-validator/doc/ConventionRoutines/CCS.md`

--- a/doc/HealthChecks/ComplianceFindingsReconciliation-2026-02-22.md
+++ b/doc/HealthChecks/ComplianceFindingsReconciliation-2026-02-22.md
@@ -17,7 +17,7 @@
 ### 1.3 Current validation document locations
 - Convention routines used as binding validation baseline:
   - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
-  - `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+  - `calculogic-validator/doc/ConventionRoutines/CCS.md`
   - `doc/ConventionRoutines/General-NL-Skeletons.md`
   - `doc/ConventionRoutines/NL-First-Workflow.md`
 - Active NL skeleton references used during reconciliation checks:

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,6 @@
 ## Convention Routines
 - [CCPP](./ConventionRoutines/CCPP.md)
 - [CCS](./ConventionRoutines/CCS.md)
-- [CSCS (legacy alias)](./ConventionRoutines/CSCS.md)
 - [General NL Skeletons](./ConventionRoutines/General-NL-Skeletons.md)
 - [NL-First Workflow](./ConventionRoutines/NL-First-Workflow.md)
 

--- a/doc/doc-engine/README.md
+++ b/doc/doc-engine/README.md
@@ -12,7 +12,7 @@ Doc-engine package-owned docs live under `calculogic-doc-engine/doc/` (including
 
 ## Standards References
 - `calculogic-validator/doc/ConventionRoutines/CCPP.md`
-- `calculogic-validator/doc/ConventionRoutines/CSCS.md`
+- `calculogic-validator/doc/ConventionRoutines/CCS.md`
 - `doc/ConventionRoutines/General-NL-Skeletons.md`
 - `doc/ConventionRoutines/NL-First-Workflow.md`
 

--- a/doc/doc-engine/Standards-Pack-Links.md
+++ b/doc/doc-engine/Standards-Pack-Links.md
@@ -5,7 +5,7 @@ This page indexes standards documents used by the Doc Engine workstream.
 ## Current links
 
 - CCPP (Calculogic Core Principles Pack): [`calculogic-validator/doc/ConventionRoutines/CCPP.md`](../ConventionRoutines/CCPP.md)
-- CSCS (Calculogic Style and Conventions Set): [`calculogic-validator/doc/ConventionRoutines/CSCS.md`](../ConventionRoutines/CSCS.md)
+- CSCS (Calculogic Style and Conventions Set): [`calculogic-validator/doc/ConventionRoutines/CCS.md`](../ConventionRoutines/CCS.md)
 - Configuration architecture summary: [`doc/Architecture/ConfigurationArchitectureSummary.md`](../Architecture/ConfigurationArchitectureSummary.md)
 - NL-first workflow: [`doc/ConventionRoutines/NL-First-Workflow.md`](../ConventionRoutines/NL-First-Workflow.md)
 


### PR DESCRIPTION
### Motivation

- Normalize the canonical validator concern-system spec filename to the canonical acronym `CCS` and remove a legacy compatibility note that claimed the validator filename remained `CSCS.md`.
- Remove the host-side legacy alias and make all host/docs references point to the validator-owned canonical path to avoid link drift.

### Description

- Renamed the validator canonical spec from `calculogic-validator/doc/ConventionRoutines/CSCS.md` to `calculogic-validator/doc/ConventionRoutines/CCS.md`.
- Removed the in-file compatibility note that stated the validator filename remains `CSCS.md` from the canonical validator doc content.
- Deleted the host legacy alias `doc/ConventionRoutines/CSCS.md` and updated the host wrapper `doc/ConventionRoutines/CCS.md` to reference the validator `CCS.md` as the canonical source.
- Updated repository references to the new canonical path across README and docs (including `README.md`, `doc/doc-engine/Standards-Pack-Links.md`, `calculogic-doc-engine/doc/Standards/*`, multiple `doc/Architecture/*` and `calculogic-validator/doc/ConventionRoutines/*` files), and adjusted cross-reference wording where needed.
- Overall change set: 21 files touched with the validator file renamed and host alias removed.

### Testing

- Ran `npm test`, which completed successfully (all tests passed).
- Ran `npm run validate:naming -- --scope=docs`, which succeeded for the docs scope.
- Ran `npm run validate:naming -- --scope=validator`, which executed successfully but exited non-zero due to existing naming findings in the validator scope baseline (report contains validator naming findings unrelated to this docs rename).
- Verified no remaining references to the old `CSCS.md` canonical path with repository search (`rg` / scripted replacements), confirming host and validator references now point to `CCS.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a520f02fb88331badd8c8bd8c3a1ef)