### PR TITLE
docs(tree-advisor): add shared-root semantic-first advisory pattern

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -117,7 +117,7 @@ This slice must preserve the existing concern slot semantics where applicable wh
 
 Notes:
 - This lane extension is permitted only because these Tree Addresses are report-only.
-- When a filename role is concern-core, it MUST map to its concern index (3–8).
+- When a filename role’s category is concern-core or concern-style, it MUST map to its concern index (3–8).
 - When a filename role is architecture-support, it MUST map to lane `2`.
 
 ---
@@ -192,6 +192,12 @@ Detect when subpackages (e.g., `tools/report-capture`) contain mixed surfaces th
 
 All scoring thresholds MUST be explicit constants in code and reported in `details`.
 
+### Explicit thresholds (V0.0.1 defaults)
+
+- `MIN_LANE_PARTITIONS_FOR_SCATTER = 2`
+- `MIN_FILES_IN_FAMILY_FOR_RECOMMENDATION = 2`
+- `LANE_FIRST_FOLDER_SIGNAL_SET = { build, build-style, logic, knowledge, results, results-style, tests, docs }`
+
 ## Recommendation Patterns (Advisory Only)
 
 The following outputs are advisory recommendation patterns only. They are not mandatory rules and should be emitted as explainable `suggested-reorg` findings.
@@ -213,8 +219,45 @@ When a semantic family has multi-file and multi-lane presence and is not already
 
 This recommendation should trigger only when it reduces lane entropy or improves navigation, and remains advisory-only.
 
+Constraint (shared-root):
+- Do not recommend creating or expanding lane-first folders directly under a shared root (for example, `src/shared/logic/`).
+- Lane/role subfolders are only recommended inside a semantic family folder (for example, `src/shared/<semantic-family>/logic/...`).
+
 Naming metadata reuse note:
 - Treat parsed naming metadata (`<semantic-name>.<role>.<ext>`) as a primary lane signal.
+
+### 3) Shared-root semantic-first grouping (advisory-only)
+
+Intent:
+- At shared-root level (default example: `src/shared/`), prefer semantic-first grouping.
+- Preferred target: `src/shared/<semantic-family>/...`
+- Avoid recommending: `src/shared/<lane>/...` as the target structure.
+
+Detect (deterministic):
+- A shared root is one of a configured set (V0.0.1 default example: `src/shared`).
+- The shared root contains lane-first partitions as immediate child folders (examples):
+  - `logic`, `knowledge`, `results`, `build`, `build-style`, `results-style`, `tests`, `docs`
+- A semantic family (derived from parsed `<semantic-name>`) appears under >= 2 distinct lane-first partitions within that shared root.
+- Guardrail: only recommend when the family has >= 2 files (reduces churn/noise).
+
+Recommend (advisory):
+- Consolidate to: `src/shared/<semantic-family>/...`
+- Within `src/shared/<semantic-family>/`, lane/role subfolders are allowed only when needed to reduce clutter/entropy:
+  - `src/shared/<semantic-family>/logic/...`
+  - `src/shared/<semantic-family>/knowledge/...`
+  - etc.
+
+No-inference constraint (V0.0.1):
+- The advisor must not require or assume folder-name case transforms (no kebab↔Pascal conversion).
+- Use the derived `familyKey` as-is for suggested target paths.
+
+Example:
+- Before:
+  - `src/shared/logic/selection.logic.ts`
+  - `src/shared/knowledge/selection.knowledge.ts`
+- Suggested target:
+  - `src/shared/selection/selection.logic.ts`
+  - `src/shared/selection/selection.knowledge.ts`
 
 ## Compat / Shim Health Signals (Advisory Diagnostics)
 
@@ -263,6 +306,11 @@ Each finding uses the same stable envelope shape used by existing validators:
   - `parsed.role` (string|null)
   - `parsed.roleCategory` (string|null)
   - `familyKey` (string|null)
+  - `sharedRoot` (string|null)
+  - `isSharedRootContext` (boolean)
+  - `isLaneFirstPartition` (boolean)
+  - `laneFirstFolderName` (string|null)
+  - `semanticFamilyKey` (string|null; `familyKey` when in shared-root context)
 - `metrics`
   - `familyScatterCount` (number)
   - `laneEntropy` (number)
@@ -287,6 +335,9 @@ Suggested codes (V0.0.1):
 - `TREE_SHIM_SURFACE_PRESENT` (`info`)
 - `TREE_SHIM_SCATTERED` (`warn`/`info`)
 - `TREE_SHIM_OUTSIDE_COMPAT` (`warn`/`info`)
+- `TREE_SHARED_LANE_FIRST_PARTITION_PRESENT` (`info`)
+- `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` (`warn`/`info`)
+- `TREE_SHARED_SEMANTIC_ROOT_RECOMMENDED` (`warn`/`info`)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Reduce scatter and lane-first noise under repository shared roots by preferring semantic-first grouping (e.g., `src/shared/<semantic-family>/...`) when a family appears across multiple lane folders.
- Align the lane-mapping note with the role registry by treating `concern-style` the same as `concern-core` for concern-index mapping.
- Provide deterministic, doc-only guardrails (signals, codes, and thresholds) so the advisor can make explainable suggestions without performing filesystem changes.

### Description
- Updated the lane index mapping note so that when a filename role’s category is `concern-core` or `concern-style`, it must map to its concern index (`3–8`) in the spec file `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`.
- Added explicit V0.0.1 threshold/constants: `MIN_LANE_PARTITIONS_FOR_SCATTER = 2`, `MIN_FILES_IN_FAMILY_FOR_RECOMMENDATION = 2`, and `LANE_FIRST_FOLDER_SIGNAL_SET = { build, build-style, logic, knowledge, results, results-style, tests, docs }`.
- Extended Pattern 2 with a shared-root constraint that forbids recommending creation/expansion of lane-first folders directly under shared roots and limits lane/role subfolders to inside semantic family folders.
- Introduced a new advisory Pattern 3: "Shared-root semantic-first grouping" with Intent, Deterministic Detect rules, Recommend guidance, No-inference constraint, and a concrete Before/After example targeted at `src/shared` style roots.
- Extended the finding `details.signals` with shared-root context fields (`sharedRoot`, `isSharedRootContext`, `isLaneFirstPartition`, `laneFirstFolderName`, `semanticFamilyKey`) and added three draft finding codes: `TREE_SHARED_LANE_FIRST_PARTITION_PRESENT`, `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES`, and `TREE_SHARED_SEMANTIC_ROOT_RECOMMENDED`.

### Testing
- Ran `rg -n "Shared-root semantic-first grouping" calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` and confirmed the new pattern section is present (match found).
- Ran `rg -n "TREE_SHARED_" calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` and confirmed the new `TREE_SHARED_*` codes are present (matches found).
- Ran `rg -n "concern-style" calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` and confirmed the updated lane-mapping note reflects `concern-style` (match found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5df73dfdc8331a91863f6d8eeb817)