### PR TITLE
docs(naming): document --config as report-only input in NamingValidatorSpec v0.1.7

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -1,8 +1,8 @@
-# Naming Validator Spec (V0.1.6)
+# Naming Validator Spec (V0.1.7)
 
 ## Purpose and Scope
 
-This document defines the V0.1.6 filename naming validator slice for deterministic automation.
+This document defines the V0.1.7 filename naming validator slice for deterministic automation.
 
 ## Suite Contract Alignment
 
@@ -153,6 +153,18 @@ Inclusion/exclusion summary:
 Invalid scope behavior:
 - Unknown scope values are usage errors with non-zero exit and valid-scope usage text.
 
+## Validator Config Input (Report-only, V0.1.7)
+
+Config reference: [`validator-config-spec.md`](../ValidatorSpecs/validator-config-spec.md).
+
+Current naming behavior remains report-only in implementation. Passing `--config=<path>` does **not** enable enforcement or fix execution in the naming slice.
+
+When provided, config only affects naming report inputs for:
+- reportable extension set (defaults ∪ additions)
+- naming role registry runtime (defaults + add-only role additions)
+
+Config does not change detection mode/scope semantics and does not introduce enforcement/fix execution. Current exit policy remains policy-driven as documented in this spec.
+
 ## CLI Usage (V0.1.6)
 
 - `npm run validate:naming` (defaults to `--scope=repo`)
@@ -163,6 +175,8 @@ Invalid scope behavior:
 - `npm run validate:naming -- --scope=system`
 - `npm run validate:naming -- --scope=app --target src/buildsurface`
 - `npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared`
+- `npm run validate:naming -- --scope=app --config=./path/to/validator-config.json`
+- `node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app --config=./path/to/validator-config.json`
 
 
 npm argument forwarding note:
@@ -222,6 +236,9 @@ Report object includes:
 - `totalFilesScanned`
 - summary count objects
 - `findings`
+
+When `--config=<path>` is supplied, report metadata may also include:
+- `configDigest`
 
 ### Special-case subtype metadata
 


### PR DESCRIPTION
### Motivation

- Make the naming validator spec accurately reflect current runtime behavior for `--config=<path>` by explicitly labeling it as a report-only input and bumping the doc version. 
- Provide clear developer-facing CLI examples and report metadata notes so users know `--config` affects only classification/report inputs and not enforcement or fix execution.

### Description

- Bumped document version and header from `V0.1.6` to `V0.1.7` in `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md`. 
- Added a new section `Validator Config Input (Report-only, V0.1.7)` that links to `calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md` and explicitly states that naming remains report-only and that `--config=<path>` does not enable enforcement or fixes. 
- Clarified exactly what the config may change at runtime, namely the `reportable extension set` (defaults ∪ additions) and the `naming role registry runtime` (defaults + add-only role additions), and stated that detection modes/scope and exit policy remain unchanged. 
- Updated CLI usage examples to include the exact `--config` flag forms: `npm run validate:naming -- --scope=app --config=./path/to/validator-config.json` and `node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app --config=./path/to/validator-config.json`, and added a note that reports may include a `configDigest` when config is supplied.

### Testing

- Verified the four required Calculogic convention files were present before editing. 
- Confirmed the new version tag, the `Validator Config Input` section text, the exact CLI example lines, and the `configDigest` report note via pattern search using `rg` which returned the expected matches. 
- Inspected the updated spec file content directly (`sed`/`nl`) and reviewed the file diff to ensure the inserted section and CLI examples are correct and that no runtime code was modified; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77d70b41c8331a7c5d855afcf0581)