### PR TITLE
docs(validator): clarify report-only config invocation in README

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -199,6 +199,17 @@ Validator config schema:
 
 Runtime behavior is strict and rejects unknown keys where the schema disallows them. Root-level `$schema` is allowed as an editor hint.
 
+**Report-only note (current CLI behavior):** Config currently affects report classification/metadata only. Enforcement/fix modes are not implemented in naming CLI behavior yet.
+
+Use `--config=<path>` to pass a config file explicitly:
+
+```bash
+npm run validate:naming -- --scope=app --config=./.calculogic/validator/config.json
+node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=docs --config=./.calculogic/validator/config.json
+```
+
+Canonical config spec: `doc/ValidatorSpecs/validator-config-spec.md`.
+
 Example:
 
 ```json


### PR DESCRIPTION
### Motivation
- Make it obvious how to pass an explicit validator config to the current (report-only) CLIs and to state that config is used for report classification/metadata today rather than enforcement/fix behavior.

### Description
- Updated `calculogic-validator/README.md` under `7) Strict config and schema` to add a `Report-only note`, example invocations showing `--config=<path>` (both npm script and direct `node` binary), and a pointer to `doc/ValidatorSpecs/validator-config-spec.md`, while keeping the JSON example strictly within the current schema keys.

### Testing
- Confirmed changes and formatting via `git diff` and `git status`, and committed the updated `calculogic-validator/README.md` successfully (docs-only change, no runtime tests required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a784b9f28083319d3253339264d856)