### PR TITLE
docs: draft validator registry customization state system (report-only)

### DIFF
--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -4,28 +4,33 @@ Purpose: quick routing map for validator documentation so readers can distinguis
 
 ## 1) Canonical suite contracts
 
-- `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`  
+- `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`
   Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes. Read this first when interpreting validator behavior.
 
 ## 2) Naming
 
-- `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`  
+- `doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
   Canonical naming authority (roles, grammar, exception policy, rollout guidance). Read when defining or reviewing naming rules.
 
-- `doc/ConventionRoutines/NamingValidatorSpec.md`  
+- `doc/ConventionRoutines/NamingValidatorSpec.md`
   Naming-slice validator spec (scope profiles, classification contract, report details, current report/strict exit behavior), including the current runtime category vocabulary for naming role metadata. Read when implementing or validating naming checks.
 
 ## 3) Tree advisor
 
-- `doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`  
+- `doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`
   Tree-structure advisor validator spec. Read when working on tree diagnostics and snapshot-driven structure checks.
 
 ## 4) Structural addressing
 
-- `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md`  
+- `doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md`
   Draft structural-addressing spec. Read for addressing model details; treat as draft/governance-in-progress, not naming authority.
 
 ## 5) Implementation notes (non-canonical / external)
 
-- `doc/nl-config/cfg-namingValidator.md`  
+- `doc/nl-config/cfg-namingValidator.md`
   Non-canonical implementation notes for NL/config context in this repo. Use for implementation context only; defer normative behavior to canonical validator-owned docs under `calculogic-validator/doc/...`.
+
+## 6) Drafts / ValidatorSpecs
+
+- `doc/ValidatorSpecs/registry-customization-state-system-draft.md`
+  Draft spec for built-in vs custom registry state, customization commands, and digest-based default/custom switching (report-only).

--- a/calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md
@@ -1,0 +1,261 @@
+# Registry Customization State System (Built-in vs Custom) — Draft
+
+- **Status:** Draft / document-plan
+- **Applies to:** Validator suite registry state handling (starting with naming registries)
+- **Report-only note:** This proposal changes registry input selection and report metadata transparency only. It does **not** add enforcement mode behavior or fix execution.
+
+## 1) Purpose and scope
+
+### Why this exists
+
+Current validator workflows often require passing `--config` repeatedly to test alternative registry content. This draft proposes a validator-owned registry-state UX that:
+
+- keeps an immutable built-in baseline;
+- supports controlled customization through explicit commands;
+- allows predictable default/custom switching without requiring `--config` every run.
+
+### What this covers
+
+- Registry state selection (`builtin` vs `custom`) and active-state resolution.
+- Customization command semantics for writing custom registry state.
+- Deterministic equality detection via canonicalization + stable stringify + SHA-256 digest.
+- Report metadata additions that disclose which registry state was used.
+
+### What this does not cover
+
+- No enforcement-mode introduction.
+- No fix/auto-remediation execution.
+- No validator algorithm changes beyond selecting registry inputs and reporting metadata.
+
+## 2) Core concepts and vocabulary
+
+- **Built-in registry**: Immutable canonical baseline shipped with validator source. Customization commands never mutate it.
+- **Custom registry**: Mutable registry payload under validator-owned custom paths; changed only by dedicated customization commands.
+- **Resolved registry**: Effective registry loaded at validation runtime after applying active-state selection.
+- **Active registry switch**: Single mutually exclusive state flag: `activeRegistry: "builtin" | "custom"`.
+- **Canonicalization**: Normalization step producing deterministic plain-JSON registry representation before digesting/comparison.
+- **Stable stringify**: Deterministic recursive JSON serialization with stable object-key ordering and defined array normalization rules.
+- **Digest**: `sha256(stableStringify(canonicalRegistry))`.
+
+## 3) Data model (draft minimal state)
+
+Proposed registry-state meta model (single state file):
+
+```json
+{
+  "activeRegistry": "builtin",
+  "builtinDigest": "<sha256-hex>",
+  "customDigest": "<sha256-hex>",
+  "lastUpdatedAt": "2026-01-01T00:00:00.000Z",
+  "schemaVersion": "1"
+}
+```
+
+### Field definitions
+
+- `activeRegistry` (required): enum `"builtin" | "custom"`; runtime selector.
+- `builtinDigest` (required): digest of canonical built-in resolved registry.
+- `customDigest` (required): digest of canonical custom resolved registry.
+- `lastUpdatedAt` (optional): ISO timestamp set by customization operations.
+- `schemaVersion` (optional): state schema version string/number.
+
+### Mutation policy
+
+- Customization commands update state meta.
+- Normal validation runs read state meta and registry payloads only.
+- Optional guard behavior (draft decision): validation run may recompute+warn on stale digest mismatch but should not silently rewrite state unless explicitly configured.
+
+## 4) File layout proposal (under `calculogic-validator/src/...`)
+
+```text
+calculogic-validator/src/
+  naming/
+    registries/
+      _builtin/
+        roles.registry.json
+        categories.registry.json
+        ...
+      _custom/
+        roles.registry.custom.json
+        categories.registry.custom.json
+        ...
+      registry-state.json
+      resolved/
+        current-registry.ts
+        current-roles.ts
+        current-categories.ts
+```
+
+### Responsibilities
+
+- `_builtin/**`: canonical immutable shipped registries.
+- `_custom/**`: mutable custom payloads written by customization commands.
+- `registry-state.json`: active switch + digest metadata.
+- `resolved/current-*`: import/export adapters that read `activeRegistry` and route to built-in or custom payload.
+
+### Edit constraints
+
+- Customization commands may edit only:
+  - `_custom/**`
+  - `registry-state.json`
+- Customization commands must never edit `_builtin/**`.
+
+## 5) Canonicalization rules (for digest/equality)
+
+### Object normalization
+
+- Recursively normalize to plain JSON values only (`object`, `array`, `string`, `number`, `boolean`, `null`).
+- Reject/strip non-JSON values (`undefined`, functions, `Map`, `Set`, symbols, BigInt) via deterministic policy (draft decision: hard error vs drop-with-warning).
+- Sort object keys lexicographically at every depth.
+
+### Array normalization
+
+Arrays must be classified by schema as one of:
+
+1. **Ordered arrays** (sequence is semantic): preserve order exactly.
+2. **Set-like arrays** (membership is semantic): sort deterministically.
+
+For naming registry initial scope:
+
+- Roles list is set-like → canonical sort key: `role` ascending, tie-breaker by full stable-stringified item.
+- Category identifier lists (if treated as set-like) sort ascending by identifier.
+- Rule pipelines/priority lists (if sequence semantics exist) remain ordered arrays.
+
+### Optional/default fields
+
+- Normalize empty optional notes/comments by omission (`"notes": ""` => field omitted).
+- Normalize absent optional booleans/flags to explicit defaults only if schema mandates defaults.
+- Maintain a single canonical rule per field in schema notes to prevent digest drift.
+
+### Serialization rule
+
+- Canonical output must be plain JSON and then stable-stringified deterministically.
+
+## 6) State transition algorithm (post-customization)
+
+After **every** customization operation:
+
+1. Build canonical built-in resolved registry `B*`.
+2. Build canonical custom resolved registry `C*`.
+3. Compute digests:
+   - `B = sha256(stableStringify(B*))`
+   - `C = sha256(stableStringify(C*))`
+4. If `C === B`:
+   - set `activeRegistry = "builtin"`
+   - optional cleanup decision: clear/reset `_custom/**` payloads to empty canonical no-op state.
+5. Else (`C !== B`):
+   - set `activeRegistry = "custom"`
+6. Persist `builtinDigest`, `customDigest`, and optionally `lastUpdatedAt`.
+
+Validation commands then only:
+
+- read `activeRegistry`;
+- load resolved registry from corresponding source;
+- include report metadata fields (see Section 8).
+
+## 7) Customization command UX (draft command surface)
+
+> Draft behavior contract only; no implementation commitment implied by this document.
+
+### `customize:init`
+
+- **Inputs:** optional scaffold mode/target slice.
+- **Effects:** ensure `_custom/**` exists with canonical empty/seed payloads; compute digests; update meta.
+- **Editable files:** `_custom/**`, `registry-state.json`.
+- **Determinism:** same built-in + same init options => identical custom payload and digests.
+
+### `customize:add-role`
+
+- **Inputs:** role identifier + optional metadata fields.
+- **Effects:** add/merge role in custom payload, canonicalize, recompute digests + active state.
+- **Editable files:** `_custom/**`, `registry-state.json`.
+- **Determinism:** idempotent insert/merge semantics; repeated same command yields identical payload.
+
+### `customize:disable-role`
+
+- **Inputs:** role identifier.
+- **Effects:** mark role disabled (or remove, per schema decision), canonicalize, recompute digests/state.
+- **Editable files:** `_custom/**`, `registry-state.json`.
+- **Determinism:** same input always yields same normalized representation.
+
+### `customize:disable-category`
+
+- **Inputs:** category identifier.
+- **Effects:** disable category in custom payload, canonicalize, recompute digests/state.
+- **Editable files:** `_custom/**`, `registry-state.json`.
+- **Determinism:** deterministic category targeting and sorted derived lists.
+
+### `customize:reset`
+
+- **Inputs:** optional scope (`all` default; or by registry slice).
+- **Effects:** clear selected custom payloads back to canonical no-op state; recompute digests/state.
+- **Editable files:** `_custom/**`, `registry-state.json`.
+- **Determinism:** equivalent scope + baseline always returns same resulting payload.
+
+### `customize:status`
+
+- **Inputs:** optional verbosity.
+- **Effects:** read-only status output (`activeRegistry`, digest pair, divergence summary).
+- **Editable files:** none (read-only).
+- **Determinism:** same on-disk state => byte-equivalent machine-readable output (if offered).
+
+### `customize:sync`
+
+- **Inputs:** none (or optional `--strict`).
+- **Effects:** force recompute canonical forms, digests, and active state from current files.
+- **Editable files:** `registry-state.json` (and optionally canonical rewrite of `_custom/**` if command defines formatting normalization).
+- **Determinism:** same inputs always converge to same digests and state.
+
+## 8) Report metadata additions (report-only transparency)
+
+Proposed additive fields in validator report envelope:
+
+- `registryState`: `"builtin" | "custom"`
+- `registrySource`: `"builtin" | "custom"` (explicit selected source for this run)
+- `registryDigests`: `{ "builtin": "...", "custom": "...", "resolved": "..." }`
+
+Notes:
+
+- `resolved` may equal `builtin` or `custom` digest based on active selection.
+- These fields are metadata-only and do not alter finding semantics or enforcement behavior.
+
+## 9) Relationship to existing `--config` system (draft decisions)
+
+This draft treats registry-state UX as potentially layered with CLI config overrides.
+
+### Candidate priority model (draft)
+
+1. If `--config` is provided, explicit CLI config has top priority for that run.
+2. Else, validator resolves via `activeRegistry` state.
+3. Built-in remains fallback if custom payload is absent/invalid per chosen failure mode.
+
+### Open decision points
+
+- Should `--config` fully bypass persisted registry state or compose with it?
+- Should digest metadata in reports include both persisted state digests and effective `--config` digest?
+- Should registry-state commands be limited to vendored/local repos only?
+
+## 10) Determinism and safety constraints
+
+- Built-in sources are immutable under customization workflow.
+- No network calls during customization or validation registry selection.
+- No nondeterministic ordering in canonicalization or serialization.
+- All derived lists sorted via explicit rules.
+- Digest algorithm fixed to SHA-256 over stable-stringified canonical JSON.
+- Malformed custom payload handling must be explicit (draft decision):
+  - **Option A:** hard error and abort validation.
+  - **Option B:** report-friendly fallback to built-in + structured warning.
+  - Chosen behavior should be stable and documented before implementation.
+
+## 11) Non-goals and deferred items
+
+- Enforcement mode or fix execution workflows.
+- Profile marketplace/sharing/distribution features.
+- Multi-slice generic registry framework beyond naming (possible future extension, out of scope for this draft).
+
+## 12) Rollout notes (draft planning aid)
+
+- Start with naming registries only.
+- Land read-path + report metadata first (still report-only).
+- Add customization commands in incremental phases.
+- Gate future expansion to other validator slices behind explicit follow-up specs.


### PR DESCRIPTION
### Motivation
- Provide a validator-owned, report-only UX for selecting between immutable built-in registries and mutable custom registries to avoid passing `--config` on every run.
- Specify deterministic equality via canonicalization + stable stringify + SHA-256 to make default/custom switching reliable and auditable.
- Describe a controlled customization command surface and the minimal on-disk state required so customization is explicit and confined to validator-owned artifacts.

### Description
- Add a new draft spec at `calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md` that includes purpose/scope, vocabulary, data model, file layout proposal, canonicalization rules, state transition algorithm, customization command UX, report metadata, `--config` relationship, determinism constraints, non-goals, and rollout notes.
- Introduce a minimal meta/state model that includes `activeRegistry`, `builtinDigest`, `customDigest`, optional `lastUpdatedAt`, and `schemaVersion` and document that customization commands update meta while validation runs read it.
- Propose a file layout under `calculogic-validator/src/...` with `_builtin/`, `_custom/`, a single `registry-state.json` meta file, and `resolved/` adapters, and clearly state edit constraints so only `_custom/**` and the meta file are modified by customization commands.
- Update `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to add a `Drafts / ValidatorSpecs` entry pointing to the new draft spec and emphasize the report-only framing.

### Testing
- Ran `git diff --check` to detect and fix trailing-whitespace issues and the check completed successfully. 
- Ran `git status --short` to verify working-tree changes and confirm the new draft file and index update before committing. 
- Committed the changes with a descriptive message which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a795d30cd48331a5e24be74090acdc)