### PR TITLE
docs: remove V0.1.6 narrative drift in NamingValidatorSpec

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -8,14 +8,14 @@ This document defines the V0.1.7 filename naming validator slice for determinist
 
 This naming slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md): Calculogic Validator is modular, configurable, policy-driven, and report-first by default. Mode policy changes exit behavior and optional fix execution, not detection.
 
-V0.1.6 scope is intentionally narrow:
+V0.1.7 scope is intentionally narrow:
 - filename validation only
 - report mode only
 - deterministic findings output
 - deterministic scope profiles for migration planning
 - no rename enforcement
 
-Out of scope for V0.1.6:
+Out of scope for V0.1.7:
 - structural addressing validation
 - NL↔Code numbering/parity validation
 - provenance token consistency checks
@@ -277,7 +277,7 @@ When a canonical-like parse resolves to a known deprecated role (currently `view
 
 Mode semantics are centralized in the suite-wide matrix in [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md).
 
-Naming V0.1.6 currently implements:
+Naming V0.1.7 currently implements:
 - `report` only (slice behavior)
   - emits findings and summary deterministically before any enforcement/fix behavior
   - exit code is policy-driven in current implementation:


### PR DESCRIPTION
### Motivation
- Fix a small version-drift in the Naming validator spec where narrative prose still referenced `V0.1.6` while the document header is `V0.1.7`, and preserve the document's subsection "last-changed" tagging convention.

### Description
- Updated three narrative occurrences in `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` by replacing `V0.1.6` with `V0.1.7` in the prose lines `V0.1.6 scope is intentionally narrow:`, `Out of scope for V0.1.6:`, and `Naming V0.1.6 currently implements:`, while leaving subsection tags such as `Targeted runs (developer convenience, V0.1.6)` intact; only this single markdown file was modified.

### Testing
- Ran `rg -n "V0\.1\.6|# Naming Validator Spec \(V0\.1\.7\)|Validator Config Input \(Report-only, V0\.1\.7\)|## Targeted runs \(developer convenience, V0\.1\.6\)" calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` to confirm the narrative `V0.1.6` references were removed and the only remaining `V0.1.6` occurrence is the intentional subsection tag, and committed the change with `git commit` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b30677d48331a7232f2afb0fad66)