### PR TITLE
docs(validator): add canonical Validator report schema and Rule ID contract

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -240,6 +240,16 @@ Example:
 
 ## 9) Report output (JSON)
 
+Canonical report contracts:
+
+- `doc/ConventionRoutines/ValidatorReportSchema-V0_1.md` (canonical schema for slice and runner envelopes)
+- `doc/ConventionRoutines/ValidatorRuleIds-Contract.md` (canonical rule ID and `ruleRef` linkage contract)
+
+There are two report envelopes:
+
+- slice output (single-slice CLI, for example `validate:naming`)
+- runner output (multi-slice CLI, for example `validate:all`)
+
 Validator reports include stable metadata fields for report envelope identity and reproducibility:
 
 - `validatorId`

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -232,6 +232,11 @@ Each finding uses a stable object shape:
 - `suggestedFix` (optional)
 - `details` (optional object)
 
+Rule ID note (canonical linkage):
+- naming currently emits `code` values (`NAMING_*`) as the stable finding identifiers
+- map `code` to canonical `ruleId` for suite-wide contracts and future slice alignment
+- canonical contract reference: [`ValidatorRuleIds-Contract.md`](./ValidatorRuleIds-Contract.md)
+
 Report object includes:
 - `mode`
 - `scope`

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -1,0 +1,227 @@
+# Validator Report Schema (V0.1)
+
+## 1) Purpose and Scope (Canonical)
+
+This document is the **canonical** reference for Calculogic Validator report JSON structure.
+
+It explicitly defines both report envelopes used today:
+
+- **Slice Report** (single-slice CLI output, for example `validate:naming`)
+- **Runner Report** (multi-slice CLI output, for example `validate:all`)
+
+Where implementation-specific naming currently differs, this schema records current emitted keys and notes canonical alignment.
+
+## 2) Terms
+
+- **Report Envelope**: the top-level JSON object emitted by a validator command.
+- **Slice**: one validator domain/module (for example `naming`, later `tree`).
+- **Runner**: orchestrator that executes one or more slices and emits a multi-slice report.
+- **Finding**: one deterministic diagnostic record produced by a slice.
+- **Summary**: deterministic aggregate counts and rollups for findings.
+- **SourceSnapshot**: reproducibility metadata about the scanned source state.
+- **Config Digest / Fingerprint**: stable digest/fingerprint of resolved config used for the run.
+
+## 3) Canonical: Slice Report Envelope
+
+The slice report envelope is the canonical shape for single-slice output. Current naming CLI output must include these fields:
+
+### Required fields
+
+- `mode` (string; currently `"report"`)
+- `validatorId` (string; for naming slice: `"naming"`)
+- `toolVersion` (string when tool version is resolved)
+- `sourceSnapshot` (object)
+- `startedAt` (ISO-8601 datetime string)
+- `endedAt` (ISO-8601 datetime string)
+- `durationMs` (number)
+- `scope` (string)
+- `totalFilesScanned` (number)
+- `filters` (object)
+- `counts` (object)
+- `findings` (array of finding objects)
+
+### Optional / transitional fields
+
+- `validatorVersion` (string; currently emitted alongside `toolVersion` for compatibility)
+- `configDigest` (string; present when config is supplied)
+- `scopeSummary` (object; deterministic slice summary)
+- `scopeContract` (object; deterministic scope metadata)
+- `codeCounts` (object; naming transitional summary key)
+- `specialCaseTypeCounts` (object; naming-specific summary key)
+- `warningRoleStatusCounts` (object; naming-specific summary key)
+- `warningRoleCategoryCounts` (object; naming-specific summary key)
+
+## 4) Canonical: Runner Report Envelope
+
+The runner report envelope is the canonical shape for multi-slice output. Current runner output must include these fields:
+
+### Required fields
+
+- `version` (string; report contract version)
+- `mode` (string; currently `"report"`)
+- `validatorId` (string; `"runner"`)
+- `sourceSnapshot` (object)
+- `startedAt` (ISO-8601 datetime string)
+- `endedAt` (ISO-8601 datetime string)
+- `durationMs` (number)
+- `validators` (array of runner validator entries)
+
+### Optional fields
+
+- `scope` (string; when a scoped run is requested)
+- `toolVersion` (string)
+- `validatorVersion` (string; currently emitted alongside `toolVersion` for compatibility)
+- `configDigest` (string; when config is supplied)
+
+## 5) Canonical: Runner `validators[]` Entry
+
+Each `validators[]` entry must include:
+
+- `id` (string; runner registry id)
+- `validatorId` (string; slice id)
+- `description` (string)
+- `findings` (array; possibly empty)
+
+Entry-level optional fields:
+
+- `scope` (string)
+- `totalFilesScanned` (number)
+- `counts` (object)
+- `meta` (object)
+
+Pass-through summary keys are allowed (for example naming summary keys beyond `counts`), but they must be deterministic and documented by the corresponding slice spec.
+
+## 6) Canonical: Finding Object Shape (Suite-wide baseline)
+
+Suite-wide minimum finding shape:
+
+- `ruleId` (string; canonical stable identifier, see `ValidatorRuleIds-Contract.md`)
+- `severity` (`info` | `warn` | `error`)
+- `path` (normalized repo-relative path using `/`)
+- `message` (string)
+- `details` (optional object)
+- `ruleRef` (optional repo-local rule/spec pointer string)
+- `suggestedFix` (optional object; plan-only where applicable)
+
+Transitional note: naming currently emits `code`. Until migration is complete, treat `code` as the effective `ruleId`.
+
+## 7) Determinism Rules (Canonical)
+
+- Normalize all reported file paths to `/` separators.
+- Sort findings by:
+  1. `path` ascending,
+  2. `ruleId` ascending (or transitional `code`),
+  3. stable tie-breakers (for example deterministic message/details ordering).
+- Sort `targets` input lists before persistence/emission.
+- Keep count/summary object key order deterministic when serialized (stable stringify is recommended for digest/comparison workflows).
+- Same inputs + same resolved config => identical report payload.
+
+## 8) Examples (matching current implementation)
+
+### 8.1 Slice report example (`validate:naming`)
+
+```json
+{
+  "mode": "report",
+  "validatorId": "naming",
+  "toolVersion": "0.1.7",
+  "validatorVersion": "0.1.7",
+  "configDigest": "sha256:abc123",
+  "sourceSnapshot": {
+    "source": "fs",
+    "gitRef": "HEAD"
+  },
+  "startedAt": "2026-01-10T12:00:00.000Z",
+  "endedAt": "2026-01-10T12:00:00.120Z",
+  "durationMs": 120,
+  "scope": "app",
+  "totalFilesScanned": 42,
+  "filters": {
+    "isFiltered": true,
+    "targets": [
+      "src/buildsurface",
+      "src/shared"
+    ]
+  },
+  "scopeSummary": {
+    "scope": "app",
+    "reportableFilesInScope": 42,
+    "findingsGenerated": 2
+  },
+  "scopeContract": {
+    "description": "Application source files",
+    "includeRoots": [
+      "src"
+    ],
+    "includeRootFiles": []
+  },
+  "counts": {
+    "info": 1,
+    "warn": 1,
+    "total": 2
+  },
+  "codeCounts": {
+    "NAMING_CANONICAL": 1,
+    "NAMING_UNKNOWN_ROLE": 1
+  },
+  "specialCaseTypeCounts": {
+    "barrel": 0
+  },
+  "warningRoleStatusCounts": {
+    "active": 1
+  },
+  "warningRoleCategoryCounts": {
+    "architecture-support": 1
+  },
+  "findings": [
+    {
+      "code": "NAMING_UNKNOWN_ROLE",
+      "severity": "warn",
+      "path": "src/shared/user-widget.thing.ts",
+      "classification": "invalid-ambiguous",
+      "message": "Unknown role token 'thing'.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md#finding--error-codes"
+    }
+  ]
+}
+```
+
+### 8.2 Runner report example (`validate:all`)
+
+```json
+{
+  "version": "0.1",
+  "mode": "report",
+  "scope": "repo",
+  "validatorId": "runner",
+  "toolVersion": "0.1.7",
+  "validatorVersion": "0.1.7",
+  "configDigest": "sha256:abc123",
+  "sourceSnapshot": {
+    "source": "fs",
+    "gitRef": "HEAD"
+  },
+  "startedAt": "2026-01-10T12:00:00.000Z",
+  "endedAt": "2026-01-10T12:00:00.300Z",
+  "durationMs": 300,
+  "validators": [
+    {
+      "id": "naming",
+      "validatorId": "naming",
+      "description": "Filename naming validator",
+      "scope": "repo",
+      "totalFilesScanned": 420,
+      "counts": {
+        "info": 410,
+        "warn": 10,
+        "total": 420
+      },
+      "codeCounts": {
+        "NAMING_CANONICAL": 410,
+        "NAMING_UNKNOWN_ROLE": 10
+      },
+      "findings": []
+    }
+  ]
+}
+```

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorRuleIds-Contract.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorRuleIds-Contract.md
@@ -1,0 +1,60 @@
+# Validator Rule IDs Contract
+
+## 1) Purpose (Canonical)
+
+This document defines the canonical rule identifier contract for Calculogic Validator findings.
+
+A **rule ID** is the stable identifier for the rule that produced a finding. Rule IDs must remain stable across time so reports can be compared deterministically across runs, slices, tools, and CI systems.
+
+## 2) Canonical Rule ID Format
+
+Recommended canonical format:
+
+- `<slice>::<RULE_TOKEN>`
+
+Example:
+
+- `naming::NAMING_UNKNOWN_ROLE`
+
+Format requirements:
+
+- `<slice>`: lowercase alphanumeric plus hyphen (`[a-z0-9-]+`)
+- separator: literal `::`
+- `<RULE_TOKEN>`: uppercase alphanumeric plus underscore (`[A-Z0-9_]+`)
+- no whitespace
+- no environment-specific prefixes/suffixes
+
+## 3) Finding Fields and Mapping
+
+Canonical finding identifier field:
+
+- `ruleId`
+
+Transitional mapping rule:
+
+- If an implementation emits `code` today, treat `code` as that finding's effective `ruleId` until migration is complete.
+
+Field relationship contract:
+
+- `ruleId`: stable machine identifier (for diffing, policy, automation)
+- `message`: human-readable explanation (can evolve for clarity)
+- `ruleRef`: stable pointer to local spec text that defines or contextualizes the rule
+
+## 4) `ruleRef` Contract
+
+`ruleRef` should use a stable repo-local reference string format. Absolute URLs are not required.
+
+Recommended format:
+
+- `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md#finding--error-codes`
+- `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#role-registry-master-list-v1`
+
+Contract rules:
+
+- Reference strings should point to canonical docs for the slice/rule.
+- Anchors should exist in the referenced file whenever possible.
+- If an anchor changes, use a deterministic fallback section anchor in the same canonical document until the original anchor is restored or updated consistently.
+
+## 5) Non-goals
+
+This contract does **not** define fix execution behavior. It covers rule identification and documentation linkage only.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -57,6 +57,8 @@ Slices may implement scope-specific include/exclude details, but the scope vocab
 
 ## 6) Shared Report Envelope (Canonical)
 
+This document defines the suite-level shape contract. For the canonical full schema reference (including slice report vs runner report envelopes, finding baseline shape, and deterministic ordering rules), see [`ValidatorReportSchema-V0_1.md`](./ValidatorReportSchema-V0_1.md).
+
 Each validator slice should emit a stable high-level report envelope:
 
 - `validatorId`

--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -7,6 +7,12 @@ Purpose: quick routing map for validator documentation so readers can distinguis
 - `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`
   Canonical suite-wide contract for report-first semantics, mode vocabulary, report envelope, and exit-policy framing, including canonical-envelope-to-current naming-slice report mapping notes. Read this first when interpreting validator behavior.
 
+- `doc/ConventionRoutines/ValidatorReportSchema-V0_1.md`
+  Canonical schema reference for validator JSON output envelopes (slice report and runner report), including deterministic field and ordering expectations.
+
+- `doc/ConventionRoutines/ValidatorRuleIds-Contract.md`
+  Canonical rule ID contract for stable finding identifiers and rule-to-document linkage via `ruleRef`.
+
 ## 2) Canonical config contract
 
 - `doc/ValidatorSpecs/validator-config-spec.md`


### PR DESCRIPTION
### Motivation
- Provide an unambiguous, canonical JSON report schema so slices and the runner can interoperate deterministically across single-slice (`validate:naming`) and multi-slice (`validate:all`) runs.  
- Define a stable rule identifier contract and transitional mapping from existing `code` values to a canonical `ruleId` to enable consistent diffing, automation, and doc linkage.  

### Description
- Added the canonical report schema at `calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md`, covering purpose/scope, terms, canonical slice and runner envelopes, `validators[]` entry shape, baseline finding object shape, determinism rules, and realistic examples that match current naming and runner-emitted fields.  
- Added the canonical rule ID contract at `calculogic-validator/doc/ConventionRoutines/ValidatorRuleIds-Contract.md`, specifying the recommended `<slice>::<RULE_TOKEN>` format, allowed characters, `ruleRef` repo-local linkage rules, and the transitional `code -> ruleId` mapping.  
- Updated `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` to point to the full canonical schema and to use consistent "slice report" vs "runner report" terminology.  
- Updated `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` to add a short Rule ID note that maps current `NAMING_*` `code` values to the canonical `ruleId` contract.  
- Updated `calculogic-validator/README.md` (Section 9) to link the new canonical docs and clarify the two report envelopes, and updated `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to list both new canonical docs with one-line descriptions.  

### Testing
- Verified presence and references with ripgrep using `rg -n "ValidatorReportSchema-V0_1.md|ValidatorRuleIds-Contract.md|slice report|runner report"` and confirmed expected matches (succeeded).  
- Performed repository hygiene checks with `git diff --check` and `git status --short` and found no whitespace or patch issues (succeeded).  
- Committed changes and validated the committed files include the two new docs and the four updated files (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b8d0bf748331a3b9955973cd8e01)