### PR TITLE
Tighten registry-state validation for custom roles and extensions

### DIFF
--- a/calculogic-validator/src/naming/registries/registry-state.logic.mjs
+++ b/calculogic-validator/src/naming/registries/registry-state.logic.mjs
@@ -8,6 +8,14 @@ import { stableStringify, sha256Hex } from '../../validator-report-meta.logic.mj
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 
+const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
+const ALLOWED_ROLE_CATEGORIES = new Set([
+  'concern-core',
+  'architecture-support',
+  'documentation',
+  'deprecated',
+]);
+
 const canonicalizeRole = roleEntry => {
   if (!roleEntry || typeof roleEntry !== 'object' || Array.isArray(roleEntry)) {
     throw new Error('Invalid custom roles registry: each entry must be an object.');
@@ -19,6 +27,16 @@ const canonicalizeRole = roleEntry => {
 
   if (!role || !category || !status) {
     throw new Error('Invalid custom roles registry: role, category, and status must be non-empty strings.');
+  }
+
+  if (!ALLOWED_ROLE_CATEGORIES.has(category)) {
+    throw new Error(
+      'Invalid custom roles registry: category must be one of concern-core, architecture-support, documentation, deprecated.',
+    );
+  }
+
+  if (!ALLOWED_ROLE_STATUSES.has(status)) {
+    throw new Error('Invalid custom roles registry: status must be "active" or "deprecated".');
   }
 
   const canonicalRole = { role, category, status };
@@ -65,6 +83,10 @@ const canonicalizeExtensions = extensions => {
     const extension = extensionValue.trim();
     if (!extension) {
       throw new Error('Invalid custom reportable extensions registry: each extension must be a non-empty string.');
+    }
+
+    if (!extension.startsWith('.')) {
+      throw new Error('Invalid custom reportable extensions registry: each extension must start with ".".');
     }
 
     deduped.add(extension);

--- a/calculogic-validator/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/test/registry-state.logic.test.mjs
@@ -67,7 +67,7 @@ test('custom state selects custom and digests diverge from builtin when payload 
 
     writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
       { role: 'host', category: 'architecture-support', status: 'active' },
-      { role: 'custom-role', category: 'custom', status: 'active' },
+      { role: 'custom-role', category: 'architecture-support', status: 'active' },
     ]);
 
     writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts', '.abc']);
@@ -119,6 +119,79 @@ test('throws when custom is active and custom files are missing', () => {
     assert.throws(
       () => resolveNamingRegistryInputs({ registryRootDir: tempRoot }),
       /Custom registry file missing: _custom\/reportable-extensions\.registry\.custom\.json\./u,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+
+test('throws when custom roles include invalid category', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'x', category: 'nope', status: 'active' },
+    ]);
+
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
+
+    assert.throws(
+      () => resolveNamingRegistryInputs({ registryRootDir: tempRoot }),
+      /category must be one of/u,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('throws when custom roles include invalid status', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'x', category: 'architecture-support', status: 'provisional' },
+    ]);
+
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
+
+    assert.throws(
+      () => resolveNamingRegistryInputs({ registryRootDir: tempRoot }),
+      /status must be "active" or "deprecated"/u,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('throws when custom reportable extension omits leading dot', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'host', category: 'architecture-support', status: 'active' },
+    ]);
+
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['ts']);
+
+    assert.throws(
+      () => resolveNamingRegistryInputs({ registryRootDir: tempRoot }),
+      /must start with "\."|must start with "."/u,
     );
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
### Motivation
- Prevent malformed "custom registry" JSON from silently introducing values that break naming semantics later by enforcing strict, deterministic validation and canonicalization in the registry-state resolver. 
- Ensure role-driven logic (active vs deprecated) and category-driven semantics remain reliable by bounding accepted values.

### Description
- Added bounded enums for role `status` and `category` in `canonicalizeRole()` and return deterministic errors when values are outside the allowed sets (`status` must be `active` or `deprecated`; `category` must be one of `concern-core`, `architecture-support`, `documentation`, `deprecated`).
- Enforced leading-dot rule in `canonicalizeExtensions()` so every reportable extension must be a non-empty trimmed string that starts with `.` and throws a deterministic error otherwise.
- Adjusted the custom fixture in `calculogic-validator/test/registry-state.logic.test.mjs` to use a valid role category and added new tests asserting deterministic throws for invalid category, invalid status, and extensions missing the leading dot.
- Changes are confined to `calculogic-validator/src/naming/registries/registry-state.logic.mjs` and `calculogic-validator/test/registry-state.logic.test.mjs` (plus test updates), with no other functional wiring changes.

### Testing
- Ran `node --test calculogic-validator/test/registry-state.logic.test.mjs` and the registry-state unit tests completed successfully. 
- Ran full test suite via `npm test`; the registry-state tests pass but `npm test` reports a single pre-existing, unrelated failing assertion in `calculogic-validator/test/naming-validator.test.mjs` (expecting `doc/ConventionRoutines/CCS.spec.md` to classify as `canonical`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c4427d408331bfa9216668f9ab61)