### PR TITLE
Expose naming registry metadata in CLI reports and runner; docs & tests

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -10,6 +10,7 @@ import { resolveRepositoryRoot } from '../src/repository-root.logic.mjs';
 import { loadValidatorConfigFromFile } from '../src/validator-config.logic.mjs';
 import { computeConfigDigest, getValidatorToolVersion } from '../src/validator-report-meta.logic.mjs';
 import { deriveExitCodeFromFindings } from '../src/validator-exit-code.logic.mjs';
+import { getSourceSnapshot } from '../src/source-snapshot.logic.mjs';
 
 const parseScopeFromCli = argv => {
   let selectedScope = 'repo';
@@ -129,13 +130,24 @@ try {
   process.exit(1);
 }
 const { findings, totalFilesScanned, scope, filters } = validatorResult;
+const registry = validatorResult.registry;
 const endedAtDate = new Date();
 const summary = summarizeFindings(findings);
 
 const report = {
   mode: 'report',
+  validatorId: 'naming',
   toolVersion,
+  ...(toolVersion ? { validatorVersion: toolVersion } : {}),
   ...(configDigest ? { configDigest } : {}),
+  sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot }),
+  ...(registry
+    ? {
+        registryState: registry.registryState,
+        registrySource: registry.registrySource,
+        registryDigests: registry.registryDigests,
+      }
+    : {}),
   startedAt: startedAtDate.toISOString(),
   endedAt: endedAtDate.toISOString(),
   durationMs: endedAtDate.getTime() - startedAtDate.getTime(),

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -50,6 +50,9 @@ The slice report envelope is the canonical shape for single-slice output. Curren
 - `specialCaseTypeCounts` (object; naming-specific summary key)
 - `warningRoleStatusCounts` (object; naming-specific summary key)
 - `warningRoleCategoryCounts` (object; naming-specific summary key)
+- `registryState` (`"builtin" | "custom"`; optional registry-state metadata)
+- `registrySource` (`"builtin" | "custom" | "config"`; optional resolved source metadata)
+- `registryDigests` (object `{ builtin, custom, resolved }`; optional digest transparency metadata)
 
 ## 4) Canonical: Runner Report Envelope
 
@@ -88,6 +91,8 @@ Entry-level optional fields:
 - `totalFilesScanned` (number)
 - `counts` (object)
 - `meta` (object)
+  - `meta.filters` (object; present when runner forwards active target filtering metadata)
+  - `meta.registry` (object; present when slice exposes registry-state metadata, e.g. naming)
 
 Pass-through summary keys are allowed (for example naming summary keys beyond `counts`), but they must be deterministic and documented by the corresponding slice spec.
 

--- a/calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md
@@ -256,6 +256,7 @@ This draft treats registry-state UX as potentially layered with CLI config overr
 ## 12) Rollout notes (draft planning aid)
 
 - Start with naming registries only.
-- Land read-path + report metadata first (still report-only).
+- **Phase 1 landed:** read-path-only registry resolution, digest computation, and report metadata emission (`registryState`, `registrySource`, `registryDigests`) are in place.
+- Phase 1 remains non-mutating: no customization mutation commands/UX are shipped yet.
 - Add customization commands in incremental phases.
 - Gate future expansion to other validator slices behind explicit follow-up specs.

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -144,6 +144,7 @@ try {
   process.exit(1);
 }
 const { findings, totalFilesScanned, scope, filters } = validatorResult;
+const registry = validatorResult.registry;
 const endedAtDate = new Date();
 const summary = summarizeFindings(findings);
 
@@ -154,6 +155,13 @@ const report = {
   ...(toolVersion ? { validatorVersion: toolVersion } : {}),
   ...(configDigest ? { configDigest } : {}),
   sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot }),
+  ...(registry
+    ? {
+        registryState: registry.registryState,
+        registrySource: registry.registrySource,
+        registryDigests: registry.registryDigests,
+      }
+    : {}),
   startedAt: startedAtDate.toISOString(),
   endedAt: endedAtDate.toISOString(),
   durationMs: endedAtDate.getTime() - startedAtDate.getTime(),

--- a/calculogic-validator/src/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/validator-registry.knowledge.mjs
@@ -9,23 +9,25 @@ const runNamingValidatorHook = (repositoryRoot, options = {}) => {
   const targets = options.targets;
   const namingResult = runNamingValidator(repositoryRoot, { scope, config, targets });
   const summary = summarizeFindings(namingResult.findings);
-  const hasFilterMetadata = Boolean(namingResult.filters?.isFiltered);
+  const meta = {};
+
+  if (namingResult.filters?.isFiltered) {
+    meta.filters = {
+      isFiltered: true,
+      targets: namingResult.filters.targets,
+    };
+  }
+
+  if (namingResult.registry) {
+    meta.registry = namingResult.registry;
+  }
 
   return {
     scope: namingResult.scope,
     totalFilesScanned: namingResult.totalFilesScanned,
     findings: namingResult.findings,
     summary,
-    ...(hasFilterMetadata
-      ? {
-          meta: {
-            filters: {
-              isFiltered: true,
-              targets: namingResult.filters.targets,
-            },
-          },
-        }
-      : {}),
+    ...(Object.keys(meta).length > 0 ? { meta } : {}),
   };
 };
 

--- a/calculogic-validator/test/validate-naming-report-registry-meta.test.mjs
+++ b/calculogic-validator/test/validate-naming-report-registry-meta.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+const digestPattern = /^[a-f0-9]{64}$/u;
+
+const assertRegistryDigestShape = registryDigests => {
+  assert.ok(registryDigests);
+  assert.match(registryDigests.builtin, digestPattern);
+  assert.match(registryDigests.custom, digestPattern);
+  assert.match(registryDigests.resolved, digestPattern);
+};
+
+test('validate-naming script report includes registry metadata fields', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', 'calculogic-validator/scripts/validate-naming.mjs', '--scope=system'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.validatorId, 'naming');
+  assert.ok(report.sourceSnapshot);
+  assert.match(report.registryState, /^(builtin|custom)$/u);
+  assert.match(report.registrySource, /^(builtin|custom|config)$/u);
+  assertRegistryDigestShape(report.registryDigests);
+});
+
+test('validate-naming bin report aligns envelope and includes registry metadata fields', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['calculogic-validator/bin/calculogic-validate-naming.mjs', '--scope=system'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.validatorId, 'naming');
+  assert.ok(report.sourceSnapshot);
+
+  if (report.toolVersion) {
+    assert.equal(typeof report.validatorVersion, 'string');
+    assert.ok(report.validatorVersion.length > 0);
+  }
+
+  assert.match(report.registryState, /^(builtin|custom)$/u);
+  assert.match(report.registrySource, /^(builtin|custom|config)$/u);
+  assertRegistryDigestShape(report.registryDigests);
+});

--- a/calculogic-validator/test/validate-runner-registry-meta.test.mjs
+++ b/calculogic-validator/test/validate-runner-registry-meta.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+test('validate runner includes naming meta.registry with digest metadata', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['calculogic-validator/bin/calculogic-validate.mjs', '--scope=system', '--validators=naming'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+  const namingEntry = report.validators.find(entry => entry.id === 'naming' || entry.validatorId === 'naming');
+
+  assert.ok(namingEntry);
+  assert.ok(namingEntry.meta?.registry);
+  assert.match(namingEntry.meta.registry.registryDigests?.resolved, /^[a-f0-9]{64}$/u);
+});

--- a/doc/nl-config/cfg-validator-naming-registry-report-metadata.md
+++ b/doc/nl-config/cfg-validator-naming-registry-report-metadata.md
@@ -1,0 +1,52 @@
+# Configuration: Validator Naming Registry Report Metadata (cfg-validator-naming-registry-report-metadata)
+Project: Calculogic Validator (calculogic-validator)
+Type: Configuration
+Scope: validator CLI + runner metadata plumbing
+Passes: 1
+
+## 1. Purpose and Scope
+Add read-path registry-state metadata from naming validator results into script/bin report envelopes and runner validator meta.
+
+## 2. Configuration Contracts
+- Naming validator already returns `result.registry`.
+- Script/bin envelopes should include registry metadata when present.
+- Runner validator entries should expose `meta.registry` without losing `meta.filters`.
+
+## 3. Build Concern
+### 3.1 Containers
+- Script report builder in `scripts/validate-naming.mjs`.
+- Bin report builder in `bin/calculogic-validate-naming.mjs`.
+- Runner hook metadata assembler in `src/validator-registry.knowledge.mjs`.
+
+### 3.2 Subcontainers
+- Conditional spread of registry fields in top-level report objects.
+- Conditional assembly of runner `meta` object from filters + registry.
+
+### 3.3 Primitives
+- `registryState`
+- `registrySource`
+- `registryDigests`
+
+## 4. BuildStyle Concern
+N/A (non-visual).
+
+## 5. Logic Concern
+- Preserve existing exit-code behavior.
+- Add `sourceSnapshot` and `validatorVersion` parity in bin envelope.
+
+## 6. Knowledge Concern
+- Update schema and registry-state docs for optional registry metadata fields and runner placement.
+
+## 7. Results Concern
+- JSON report payloads include registry metadata fields when `result.registry` exists.
+
+## 8. ResultsStyle Concern
+N/A (non-visual).
+
+## 9. Assembly and Integration
+- Integration-ish tests invoke script, bin, and runner CLIs via `spawnSync` and verify metadata presence + digest shape.
+
+## 10. Implementation Passes
+1) Update docs and code envelopes/meta plumbing.
+2) Add integration-ish tests.
+3) Run full test suite.


### PR DESCRIPTION
### Motivation

- Surface registry-state metadata emitted by `runNamingValidator(...)` into the single-slice CLI outputs and the runner so consumers can see which registry source and digests were used. 
- Fix envelope drift between the npm script and the direct bin for the naming validator so both emit the same identity/metadata keys. 
- Record the read-path rollout milestone in docs and add integration-ish tests to validate the plumbing.

### Description

- Added conditional inclusion of `registryState`, `registrySource`, and `registryDigests` (from `validatorResult.registry`) into the naming script report at `calculogic-validator/scripts/validate-naming.mjs`. 
- Brought the bin `calculogic-validator/bin/calculogic-validate-naming.mjs` into parity with the script by adding `validatorId: 'naming'`, conditional `validatorVersion`, `sourceSnapshot`, and the same conditional registry metadata. 
- Updated the runner hook in `calculogic-validator/src/validator-registry.knowledge.mjs` to assemble a `meta` object that preserves `meta.filters` and also includes `meta.registry` when present, and only attaches `meta` when it has keys. 
- Updated documentation to record the optional registry metadata in the report schema (`calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md`) and to mark Phase 1 as landed in the registry customization draft (`calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md`). 
- Added an NL-first configuration skeleton `doc/nl-config/cfg-validator-naming-registry-report-metadata.md` describing the change, and added integration-ish tests: `calculogic-validator/test/validate-naming-report-registry-meta.test.mjs` and `calculogic-validator/test/validate-runner-registry-meta.test.mjs` to validate script/bin/runner outputs.

### Testing

- Ran focused node tests: `node --test calculogic-validator/test/validate-naming-report-registry-meta.test.mjs calculogic-validator/test/validate-runner-registry-meta.test.mjs calculogic-validator/test/validator-runner.test.mjs`, and those subtests passed. 
- Ran full test suite via `npm test` (which runs `node --test` across test folders) and all tests passed (135 tests, 0 failures). 
- The new integration-ish tests assert presence and shape of `registryState`, `registrySource`, and `registryDigests` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8cd0172408331832d2f8ca33d4b32)