### PR TITLE
Add stage-1 _builtin policy registry JSON scaffolds for validator

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md
@@ -74,6 +74,10 @@ calculogic-validator/src/
       _builtin/
         roles.registry.json
         categories.registry.json
+        reportable-extensions.registry.json
+        case-rules.registry.json
+        special-cases.registry.json
+        walk-exclusions.registry.json
         ...
       _custom/
         roles.registry.custom.json
@@ -84,6 +88,9 @@ calculogic-validator/src/
         current-registry.ts
         current-roles.ts
         current-categories.ts
+  registries/
+    _builtin/
+      scope-profiles.registry.json
 ```
 
 ### Responsibilities

--- a/calculogic-validator/src/naming/registries/_builtin/case-rules.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/case-rules.registry.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "semanticName": {
+    "style": "kebab-case"
+  }
+}

--- a/calculogic-validator/src/naming/registries/_builtin/categories.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/categories.registry.json
@@ -1,0 +1,31 @@
+{
+  "version": "1",
+  "categories": [
+    { "category": "architecture-support", "status": "active" },
+    { "category": "build-system", "status": "active" },
+    { "category": "concern-core", "status": "active" },
+    { "category": "concern-style", "status": "active" },
+    { "category": "concurrency", "status": "active" },
+    { "category": "configuration", "status": "active" },
+    { "category": "data-model", "status": "active" },
+    { "category": "deprecated", "status": "active" },
+    { "category": "documentation", "status": "active" },
+    { "category": "examples", "status": "active" },
+    { "category": "experimental", "status": "active" },
+    { "category": "generated", "status": "active" },
+    { "category": "indexing-registry", "status": "active" },
+    { "category": "integration-adapter", "status": "active" },
+    { "category": "localization", "status": "active" },
+    { "category": "migration", "status": "active" },
+    { "category": "networking", "status": "active" },
+    { "category": "observability", "status": "active" },
+    { "category": "operations-support", "status": "active" },
+    { "category": "performance", "status": "active" },
+    { "category": "persistence", "status": "active" },
+    { "category": "quality-support", "status": "active" },
+    { "category": "security", "status": "active" },
+    { "category": "surface-system", "status": "active" },
+    { "category": "tooling", "status": "active" },
+    { "category": "vendor", "status": "active" }
+  ]
+}

--- a/calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json
@@ -1,0 +1,12 @@
+{
+  "version": "1",
+  "reportableExtensions": [
+    ".css",
+    ".js",
+    ".json",
+    ".md",
+    ".mjs",
+    ".ts",
+    ".tsx"
+  ]
+}

--- a/calculogic-validator/src/naming/registries/_builtin/roles.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/roles.registry.json
@@ -1,0 +1,68 @@
+{
+  "version": "1",
+  "rolesByCategory": {
+    "architecture-support": [
+      { "role": "boundary", "status": "active" },
+      { "role": "cli", "status": "active" },
+      { "role": "contracts", "status": "active" },
+      { "role": "wiring", "status": "active" }
+    ],
+    "concern-core": [
+      { "role": "build", "status": "active" },
+      { "role": "knowledge", "status": "active" },
+      { "role": "logic", "status": "active" },
+      { "role": "results", "status": "active" }
+    ],
+    "concern-style": [
+      { "role": "build-style", "status": "active" },
+      { "role": "results-style", "status": "active" }
+    ],
+    "data-model": [
+      { "role": "dto", "status": "active" },
+      { "role": "schema", "status": "active" },
+      { "role": "types", "status": "active" }
+    ],
+    "deprecated": [
+      {
+        "role": "view",
+        "status": "deprecated",
+        "notes": "Historical role from pre-current concern split; manual migration required."
+      }
+    ],
+    "documentation": [
+      { "role": "audit", "status": "active" },
+      { "role": "healthcheck", "status": "active" },
+      { "role": "plan", "status": "active" },
+      { "role": "policy", "status": "active" },
+      { "role": "spec", "status": "active" },
+      { "role": "workflow", "status": "active" }
+    ],
+    "indexing-registry": [
+      { "role": "anchor", "status": "active" },
+      { "role": "catalog", "status": "active" },
+      { "role": "ids", "status": "active" },
+      { "role": "index", "status": "active" },
+      { "role": "manifest", "status": "active" },
+      { "role": "registry", "status": "active" },
+      { "role": "tokens", "status": "active" }
+    ],
+    "integration-adapter": [
+      { "role": "adapter", "status": "active" },
+      { "role": "client", "status": "active" },
+      { "role": "gateway", "status": "active" },
+      { "role": "mapper", "status": "active" },
+      { "role": "resolver", "status": "active" }
+    ],
+    "quality-support": [
+      { "role": "benchmark", "status": "active" },
+      { "role": "fixture", "status": "active" },
+      { "role": "mock", "status": "active" },
+      { "role": "test", "status": "active" }
+    ],
+    "surface-system": [
+      { "role": "entry", "status": "active" },
+      { "role": "host", "status": "active" },
+      { "role": "router", "status": "active" }
+    ]
+  }
+}

--- a/calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json
@@ -1,0 +1,22 @@
+{
+  "version": "1",
+  "specialCases": [
+    { "type": "ambient-declaration", "match": { "suffixEquals": [".d.ts"] } },
+    { "type": "barrel", "match": { "basenameEquals": ["index.ts", "index.tsx"] } },
+    { "type": "conventional-doc", "match": { "basenameEquals": ["README.md"] } },
+    {
+      "type": "ecosystem-required",
+      "match": { "regex": "^tsconfig(\\..+)?\\.json$" }
+    },
+    {
+      "type": "ecosystem-required",
+      "match": {
+        "regex": "^vite\\.config\\.[^.]+$|^eslint\\.config\\.[^.]+$|^prettier\\.config\\.[^.]+$"
+      }
+    },
+    {
+      "type": "test-convention",
+      "match": { "regex": "\\.(?:test|spec)\\.(?:[cm]?[jt]sx?)$" }
+    }
+  ]
+}

--- a/calculogic-validator/src/naming/registries/_builtin/walk-exclusions.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/walk-exclusions.registry.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "excludedDirectories": [".git", ".vite", "coverage", "dist", "node_modules"],
+  "skipDotDirectories": true,
+  "allowDotFiles": [".eslintrc"]
+}

--- a/calculogic-validator/src/registries/_builtin/scope-profiles.registry.json
+++ b/calculogic-validator/src/registries/_builtin/scope-profiles.registry.json
@@ -1,0 +1,31 @@
+{
+  "version": "1",
+  "profiles": {
+    "app": {
+      "includeRoots": ["src", "test"],
+      "includeRootFiles": []
+    },
+    "docs": {
+      "includeRoots": ["doc", "docs"],
+      "includeRootFiles": ["README.md"]
+    },
+    "repo": {
+      "includeRoots": ["."],
+      "includeRootFiles": []
+    },
+    "system": {
+      "includeRoots": [],
+      "includeRootFiles": [
+        "eslint.config.*",
+        "package-lock.json",
+        "package.json",
+        "tsconfig*.json",
+        "vite.config.*"
+      ]
+    },
+    "validator": {
+      "includeRoots": ["calculogic-validator"],
+      "includeRootFiles": []
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an immutable, deterministic set of built-in policy registries so the validator can later be refactored to load policy from registry payloads. 
- Stage-1 change is data-only: add registry payloads without changing runtime imports, wiring, or existing `.knowledge.mjs` rule files. 
- Keep registry JSON canonical and deterministic to support later canonicalization and digest-based active-state resolution.

### Description

- Added naming-level built-in registry JSON files under `calculogic-validator/src/naming/registries/_builtin/`: `categories.registry.json`, `roles.registry.json`, `reportable-extensions.registry.json`, `case-rules.registry.json`, `special-cases.registry.json`, and `walk-exclusions.registry.json`. 
- Added suite-level built-in scope profiles at `calculogic-validator/src/registries/_builtin/scope-profiles.registry.json`. 
- Updated the registry customization draft at `calculogic-validator/doc/ValidatorSpecs/registry-customization-state-system-draft.md` to include the new `_builtin` file layout breadcrumb. 
- No existing runtime behavior, imports, `.knowledge.mjs`, or rule files were modified, and all new JSON payloads were authored with deterministic key ordering and sorted arrays.

### Testing

- Verified all added JSON files parse cleanly and are stable with `jq -S .` which returned success for every new file. 
- Performed repository status verification steps to ensure no existing validator runtime files were changed and the change set was limited to the new scaffolding and a single doc breadcrumb update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90c9d5810833191c833c4f2890be9)