### PR TITLE
Use _builtin JSON registries for naming resolver

### DIFF
--- a/calculogic-validator/src/naming/registries/registry-state.logic.mjs
+++ b/calculogic-validator/src/naming/registries/registry-state.logic.mjs
@@ -1,20 +1,48 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ROLE_REGISTRY } from './naming-roles.knowledge.mjs';
-import { REPORTABLE_EXTENSIONS } from './naming-extensions.knowledge.mjs';
 import { stableStringify, sha256Hex } from '../../validator-report-meta.logic.mjs';
 
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const BUILTIN_REGISTRY_DIR = path.join(MODULE_DIR, '_builtin');
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
-const ALLOWED_ROLE_CATEGORIES = new Set([
-  'concern-core',
-  'architecture-support',
-  'documentation',
-  'deprecated',
-]);
+const BUILTIN_CATEGORIES_PATH = path.join(BUILTIN_REGISTRY_DIR, 'categories.registry.json');
+
+
+const loadBuiltinCategorySet = () => {
+  const parsed = loadJsonFile(BUILTIN_CATEGORIES_PATH);
+  const categories = parsed?.categories;
+
+  if (!Array.isArray(categories)) {
+    throw new Error('Invalid builtin categories registry: expected a categories array.');
+  }
+
+  const categorySet = new Set();
+
+  for (const categoryEntry of categories) {
+    if (!categoryEntry || typeof categoryEntry !== 'object' || Array.isArray(categoryEntry)) {
+      throw new Error(
+        'Invalid builtin categories registry: each category entry must be an object.',
+      );
+    }
+
+    const category =
+      typeof categoryEntry.category === 'string' ? categoryEntry.category.trim() : '';
+    if (!category) {
+      throw new Error(
+        'Invalid builtin categories registry: each category entry must include a non-empty category string.',
+      );
+    }
+
+    categorySet.add(category);
+  }
+
+  return categorySet;
+};
+
+const ALLOWED_ROLE_CATEGORIES = loadBuiltinCategorySet();
 
 const canonicalizeRole = (roleEntry) => {
   if (!roleEntry || typeof roleEntry !== 'object' || Array.isArray(roleEntry)) {
@@ -32,8 +60,9 @@ const canonicalizeRole = (roleEntry) => {
   }
 
   if (!ALLOWED_ROLE_CATEGORIES.has(category)) {
+    const allowedCategoriesLabel = [...ALLOWED_ROLE_CATEGORIES].sort((a, b) => a.localeCompare(b));
     throw new Error(
-      'Invalid custom roles registry: category must be one of concern-core, architecture-support, documentation, deprecated.',
+      `Invalid custom roles registry: category must be one of ${allowedCategoriesLabel.join(', ')}.`,
     );
   }
 
@@ -105,7 +134,48 @@ const canonicalizeExtensions = (extensions) => {
 
 const digestPayload = (payload) => sha256Hex(stableStringify(payload));
 
-const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+function loadJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const loadBuiltinRolesPayload = () => {
+  const parsed = loadJsonFile(path.join(BUILTIN_REGISTRY_DIR, 'roles.registry.json'));
+  const rolesByCategory = parsed?.rolesByCategory;
+
+  if (!rolesByCategory || typeof rolesByCategory !== 'object' || Array.isArray(rolesByCategory)) {
+    throw new Error('Invalid builtin roles registry: expected rolesByCategory object.');
+  }
+
+  const flattenedRoles = [];
+
+  for (const [category, roles] of Object.entries(rolesByCategory)) {
+    if (!Array.isArray(roles)) {
+      throw new Error(
+        `Invalid builtin roles registry: category "${category}" must map to an array.`,
+      );
+    }
+
+    for (const roleEntry of roles) {
+      flattenedRoles.push({ ...roleEntry, category });
+    }
+  }
+
+  return canonicalizeRoles(flattenedRoles);
+};
+
+const loadBuiltinReportableExtensions = () => {
+  const parsed = loadJsonFile(
+    path.join(BUILTIN_REGISTRY_DIR, 'reportable-extensions.registry.json'),
+  );
+
+  if (!Array.isArray(parsed?.reportableExtensions)) {
+    throw new Error(
+      'Invalid builtin reportable extensions registry: expected reportableExtensions array.',
+    );
+  }
+
+  return canonicalizeExtensions(parsed.reportableExtensions);
+};
 
 const loadRegistryState = (registryRootDir) => {
   const statePath = path.join(registryRootDir, 'registry-state.json');
@@ -157,8 +227,8 @@ const loadCustomPayload = (registryRootDir) => {
 };
 
 const buildBuiltinPayload = () => ({
-  roles: canonicalizeRoles(ROLE_REGISTRY),
-  reportableExtensions: canonicalizeExtensions([...REPORTABLE_EXTENSIONS]),
+  roles: loadBuiltinRolesPayload(),
+  reportableExtensions: loadBuiltinReportableExtensions(),
 });
 
 const applyConfigOverlay = (builtinPayload, config) => {

--- a/calculogic-validator/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/test/registry-state.logic.test.mjs
@@ -5,6 +5,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-state.logic.mjs';
 
+const REGISTRY_MODULE_ROOT = path.resolve('calculogic-validator/src/naming/registries');
+
 const makeTempRegistryRoot = () => fs.mkdtempSync(path.join(os.tmpdir(), 'registry-state-test-'));
 
 const writeJson = (filePath, value) => {
@@ -54,6 +56,44 @@ test('builtin state selects builtin and digests stay stable across calls', () =>
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test('builtin resolution loads roles and reportable extensions from _builtin JSON registries', () => {
+  const result = resolveNamingRegistryInputs();
+
+  const builtinRolesRegistry = JSON.parse(
+    fs.readFileSync(path.join(REGISTRY_MODULE_ROOT, '_builtin', 'roles.registry.json'), 'utf8'),
+  );
+  const expectedRoles = Object.entries(builtinRolesRegistry.rolesByCategory)
+    .flatMap(([category, entries]) =>
+      entries.map((entry) => {
+        const normalized = {
+          role: entry.role.trim(),
+          category,
+          status: entry.status.trim(),
+        };
+
+        if (typeof entry.notes === 'string' && entry.notes.trim()) {
+          normalized.notes = entry.notes.trim();
+        }
+
+        return normalized;
+      }),
+    )
+    .sort((left, right) => left.role.localeCompare(right.role));
+
+  const builtinExtensionsRegistry = JSON.parse(
+    fs.readFileSync(
+      path.join(REGISTRY_MODULE_ROOT, '_builtin', 'reportable-extensions.registry.json'),
+      'utf8',
+    ),
+  );
+  const expectedExtensions = [...new Set(builtinExtensionsRegistry.reportableExtensions)]
+    .map((value) => value.trim())
+    .sort((left, right) => left.localeCompare(right));
+
+  assert.deepEqual(result.roles, expectedRoles);
+  assert.deepEqual(result.reportableExtensions, expectedExtensions);
 });
 
 test('custom state selects custom and digests diverge from builtin when payload differs', () => {
@@ -123,6 +163,30 @@ test('throws when custom is active and custom files are missing', () => {
       () => resolveNamingRegistryInputs({ registryRootDir: tempRoot }),
       /Custom registry file missing: _custom\/reportable-extensions\.registry\.custom\.json\./u,
     );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('accepts custom role category values that exist in _builtin/categories.registry.json', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'perf-role', category: 'performance', status: 'active' },
+    ]);
+
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), [
+      '.ts',
+    ]);
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.ok(result.roles.some((entry) => entry.role === 'perf-role'));
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -122,7 +122,7 @@ Naming validator supports optional runtime config input with deterministic JSON 
 - each extension entry must be a string starting with `.`
 - optional `naming.roles.add` array of role metadata objects:
   - required `role` string
-  - required `category` from `concern-core | architecture-support | documentation | deprecated`
+  - required `category` string, validated against `calculogic-validator/src/naming/registries/_builtin/categories.registry.json` `categories[].category`
   - required `status` from `active | deprecated`
   - optional `notes` string
 
@@ -130,11 +130,13 @@ Normalization and merge semantics for `naming.roles.add` are deterministic and a
 
 - role values are trimmed before validation and storage
 - duplicate role entries in config are dropped by first occurrence (input-order stable)
-- entries whose role already exists in default role registry are treated as no-op at runtime
+- entries whose role already exists in built-in role registry are treated as no-op at runtime
 
 Runtime behavior in this slice resolves naming registries via registry-state logic:
 
 - wiring resolves inputs through `resolveNamingRegistryInputs({ config })`
+- built-in roles are loaded from `calculogic-validator/src/naming/registries/_builtin/roles.registry.json` (`rolesByCategory` flattened into `{ role, category, status, notes? }`)
+- built-in reportable extensions are loaded from `calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json` (`reportableExtensions`)
 - resolver returns normalized arrays for `reportableExtensions` and `roles`
 - wiring converts arrays into runtime structures expected by naming runtime:
   - `reportableExtensions` → `Set`


### PR DESCRIPTION
### Motivation
- Move runtime built-in naming data off legacy `*.knowledge.mjs` sources and onto the new `_builtin/*.registry.json` files to centralize the source of truth.
- Keep this slice intentionally small and safe: preserve existing custom registry and config-overlay behavior while swapping only the built-in loading path and category validation source.

### Description
- Updated `resolveNamingRegistryInputs()` to load built-in roles from `calculogic-validator/src/naming/registries/_builtin/roles.registry.json`, flatten `rolesByCategory` into `{ role, category, status, notes? }`, and canonicalize deterministically via a new loader helper (`loadBuiltinRolesPayload`).
- Updated built-in reportable extension loading to read `calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json` and canonicalize via `loadBuiltinReportableExtensions`.
- Replaced hard-coded allowed role category list with a derived set read from `calculogic-validator/src/naming/registries/_builtin/categories.registry.json` (`loadBuiltinCategorySet`) and updated validation error messaging accordingly.
- Added focused tests in `calculogic-validator/test/registry-state.logic.test.mjs` and a small NL config note update in `doc/nl-config/cfg-namingValidator.md`; legacy `naming-roles.knowledge.mjs` and `naming-extensions.knowledge.mjs` were left in place intentionally.

### Testing
- Ran the focused registry tests with `node --test calculogic-validator/test/registry-state.logic.test.mjs` and they passed (built-in JSON resolution, digest determinism, category acceptance/rejection, custom selection covered).
- Ran the full validator test suite `node --test calculogic-validator/test/**/*.test.mjs` and all tests passed.
- Verified the public runtime contract from `resolveNamingRegistryInputs()` remains unchanged (`registryState`, `registrySource`, `registryDigests`, `roles`, `reportableExtensions`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa171ab7e48331a92804ce9665c2b5)