### PR TITLE
Restore builtin reportable-extension parity and thread category allowlist into resolver flow

### DIFF
--- a/calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json
@@ -1,9 +1,11 @@
 {
   "version": "1",
   "reportableExtensions": [
+    ".cjs",
     ".css",
     ".js",
     ".json",
+    ".jsx",
     ".md",
     ".mjs",
     ".ts",

--- a/calculogic-validator/src/naming/registries/registry-state.logic.mjs
+++ b/calculogic-validator/src/naming/registries/registry-state.logic.mjs
@@ -42,9 +42,7 @@ const loadBuiltinCategorySet = () => {
   return categorySet;
 };
 
-const ALLOWED_ROLE_CATEGORIES = loadBuiltinCategorySet();
-
-const canonicalizeRole = (roleEntry) => {
+const canonicalizeRole = (roleEntry, { allowedCategories }) => {
   if (!roleEntry || typeof roleEntry !== 'object' || Array.isArray(roleEntry)) {
     throw new Error('Invalid custom roles registry: each entry must be an object.');
   }
@@ -59,8 +57,8 @@ const canonicalizeRole = (roleEntry) => {
     );
   }
 
-  if (!ALLOWED_ROLE_CATEGORIES.has(category)) {
-    const allowedCategoriesLabel = [...ALLOWED_ROLE_CATEGORIES].sort((a, b) => a.localeCompare(b));
+  if (!allowedCategories.has(category)) {
+    const allowedCategoriesLabel = [...allowedCategories].sort((a, b) => a.localeCompare(b));
     throw new Error(
       `Invalid custom roles registry: category must be one of ${allowedCategoriesLabel.join(', ')}.`,
     );
@@ -86,11 +84,11 @@ const canonicalizeRole = (roleEntry) => {
   return canonicalRole;
 };
 
-const canonicalizeRoles = (roles) => {
+const canonicalizeRoles = (roles, { allowedCategories }) => {
   const dedupedByRole = new Map();
 
   for (const roleEntry of roles) {
-    const canonicalRole = canonicalizeRole(roleEntry);
+    const canonicalRole = canonicalizeRole(roleEntry, { allowedCategories });
     if (!dedupedByRole.has(canonicalRole.role)) {
       dedupedByRole.set(canonicalRole.role, canonicalRole);
     }
@@ -160,7 +158,8 @@ const loadBuiltinRolesPayload = () => {
     }
   }
 
-  return canonicalizeRoles(flattenedRoles);
+  const allowedCategories = loadBuiltinCategorySet();
+  return canonicalizeRoles(flattenedRoles, { allowedCategories });
 };
 
 const loadBuiltinReportableExtensions = () => {
@@ -221,7 +220,7 @@ const loadCustomPayload = (registryRootDir) => {
   const extensionsRaw = loadJsonFile(customExtensionsPath);
 
   return {
-    roles: canonicalizeRoles(rolesRaw),
+    roles: canonicalizeRoles(rolesRaw, { allowedCategories: loadBuiltinCategorySet() }),
     reportableExtensions: canonicalizeExtensions(extensionsRaw),
   };
 };
@@ -234,6 +233,7 @@ const buildBuiltinPayload = () => ({
 const applyConfigOverlay = (builtinPayload, config) => {
   const extensionAdds = config?.naming?.reportableExtensions?.add ?? [];
   const roleAdds = config?.naming?.roles?.add ?? [];
+  const allowedCategories = loadBuiltinCategorySet();
 
   const mergedExtensions = canonicalizeExtensions([
     ...builtinPayload.reportableExtensions,
@@ -244,7 +244,7 @@ const applyConfigOverlay = (builtinPayload, config) => {
   const rolesToAppend = [];
 
   for (const roleEntry of roleAdds) {
-    const canonicalRole = canonicalizeRole(roleEntry);
+    const canonicalRole = canonicalizeRole(roleEntry, { allowedCategories });
     if (!existingRoles.has(canonicalRole.role)) {
       existingRoles.add(canonicalRole.role);
       rolesToAppend.push(canonicalRole);
@@ -252,7 +252,7 @@ const applyConfigOverlay = (builtinPayload, config) => {
   }
 
   return {
-    roles: canonicalizeRoles([...builtinPayload.roles, ...rolesToAppend]),
+    roles: canonicalizeRoles([...builtinPayload.roles, ...rolesToAppend], { allowedCategories }),
     reportableExtensions: mergedExtensions,
   };
 };

--- a/calculogic-validator/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/test/registry-state.logic.test.mjs
@@ -7,6 +7,18 @@ import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-s
 
 const REGISTRY_MODULE_ROOT = path.resolve('calculogic-validator/src/naming/registries');
 
+const INTENDED_BUILTIN_REPORTABLE_EXTENSIONS = [
+  '.cjs',
+  '.css',
+  '.js',
+  '.json',
+  '.jsx',
+  '.md',
+  '.mjs',
+  '.ts',
+  '.tsx',
+];
+
 const makeTempRegistryRoot = () => fs.mkdtempSync(path.join(os.tmpdir(), 'registry-state-test-'));
 
 const writeJson = (filePath, value) => {
@@ -34,6 +46,23 @@ test('defaults to builtin when registry-state.json is missing', () => {
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test('resolver contract shape remains stable', () => {
+  const result = resolveNamingRegistryInputs();
+
+  assert.deepEqual(Object.keys(result).sort((a, b) => a.localeCompare(b)), [
+    'registryDigests',
+    'registrySource',
+    'registryState',
+    'reportableExtensions',
+    'roles',
+  ]);
+  assert.deepEqual(Object.keys(result.registryDigests).sort((a, b) => a.localeCompare(b)), [
+    'builtin',
+    'custom',
+    'resolved',
+  ]);
 });
 
 test('builtin state selects builtin and digests stay stable across calls', () => {
@@ -94,6 +123,14 @@ test('builtin resolution loads roles and reportable extensions from _builtin JSO
 
   assert.deepEqual(result.roles, expectedRoles);
   assert.deepEqual(result.reportableExtensions, expectedExtensions);
+});
+
+test('builtin resolved reportable extensions preserve intended parity, including .jsx and .cjs', () => {
+  const result = resolveNamingRegistryInputs();
+
+  assert.deepEqual(result.reportableExtensions, INTENDED_BUILTIN_REPORTABLE_EXTENSIONS);
+  assert.ok(result.reportableExtensions.includes('.jsx'));
+  assert.ok(result.reportableExtensions.includes('.cjs'));
 });
 
 test('custom state selects custom and digests diverge from builtin when payload differs', () => {

--- a/doc/nl-config/cfg-validator-naming-registry-report-metadata.md
+++ b/doc/nl-config/cfg-validator-naming-registry-report-metadata.md
@@ -3,7 +3,7 @@
 Project: Calculogic Validator (calculogic-validator)
 Type: Configuration
 Scope: validator CLI + runner metadata plumbing
-Passes: 1
+Passes: 2
 
 ## 1. Purpose and Scope
 
@@ -42,10 +42,14 @@ N/A (non-visual).
 
 - Preserve existing exit-code behavior.
 - Add `sourceSnapshot` and `validatorVersion` parity in bin envelope.
+- Keep naming registry resolver behavior deterministic while validating custom role
+  categories from `_builtin/categories.registry.json` during resolver flow (not module init).
 
 ## 6. Knowledge Concern
 
 - Update schema and registry-state docs for optional registry metadata fields and runner placement.
+- Maintain `_builtin/reportable-extensions.registry.json` parity with intended built-in
+  reportable extension coverage.
 
 ## 7. Results Concern
 
@@ -64,3 +68,5 @@ N/A (non-visual).
 1. Update docs and code envelopes/meta plumbing.
 2. Add integration-ish tests.
 3. Run full test suite.
+4. Follow-up nits: restore intended built-in reportable extension parity and thread
+   builtin category allowlist through resolver validation flow.


### PR DESCRIPTION
### Motivation

- A cutover moved builtin naming registries to `_builtin/*.registry.json` and unintentionally dropped `.jsx` and `.cjs` from the builtin reportable extensions, causing behavior drift from the prior runtime set.
- Category validation was implemented by loading the allowed-category set at module init, which decouples validation from the resolver flow and makes later refactors awkward.

### Description

- Restored the intended builtin reportable-extension parity by adding `.cjs` and `.jsx` to `calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json`. 
- Refactored `calculogic-validator/src/naming/registries/registry-state.logic.mjs` so `canonicalizeRole` and `canonicalizeRoles` accept an `allowedCategories` parameter, and `loadBuiltinCategorySet()` is invoked during builtin/custom/config payload assembly and threaded into canonicalization rather than held on module init. 
- Kept the public resolver contract unchanged: `resolveNamingRegistryInputs()` still returns `registryState`, `registrySource`, `registryDigests`, `roles`, and `reportableExtensions`. 
- Updated tests in `calculogic-validator/test/registry-state.logic.test.mjs` and the NL skeleton `doc/nl-config/cfg-validator-naming-registry-report-metadata.md` to explicitly assert the intended builtin extension set and to add a resolver contract-shape guard.

### Testing

- Ran `node --test calculogic-validator/test/registry-state.logic.test.mjs` and all tests passed (12/12). 
- The test additions assert builtin extension parity (including `.jsx` and `.cjs`), digest determinism, category accept/reject behavior, and resolver contract shape, and they succeeded. 
- No changes were made to the external `resolveNamingRegistryInputs()` return shape, and digest outputs remain deterministic under the updated flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1eb2b4888331b83fdfed1c73d54b)