### PR TITLE
Resolve built-in category loading via effective built-in registry root

### DIFF
--- a/calculogic-validator/src/naming/registries/registry-state.logic.mjs
+++ b/calculogic-validator/src/naming/registries/registry-state.logic.mjs
@@ -8,11 +8,14 @@ const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const BUILTIN_REGISTRY_DIR = path.join(MODULE_DIR, '_builtin');
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
-const BUILTIN_CATEGORIES_PATH = path.join(BUILTIN_REGISTRY_DIR, 'categories.registry.json');
 
+const resolveBuiltinRegistryDir = ({ resolvedRegistryRootDir }) => {
+  const candidateBuiltinRegistryDir = path.join(resolvedRegistryRootDir, '_builtin');
+  return fs.existsSync(candidateBuiltinRegistryDir) ? candidateBuiltinRegistryDir : BUILTIN_REGISTRY_DIR;
+};
 
-const loadBuiltinCategorySet = () => {
-  const parsed = loadJsonFile(BUILTIN_CATEGORIES_PATH);
+const loadBuiltinCategorySet = ({ builtinRegistryDir }) => {
+  const parsed = loadJsonFile(path.join(builtinRegistryDir, 'categories.registry.json'));
   const categories = parsed?.categories;
 
   if (!Array.isArray(categories)) {
@@ -136,8 +139,8 @@ function loadJsonFile(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
-const loadBuiltinRolesPayload = () => {
-  const parsed = loadJsonFile(path.join(BUILTIN_REGISTRY_DIR, 'roles.registry.json'));
+const loadBuiltinRolesPayload = ({ builtinRegistryDir }) => {
+  const parsed = loadJsonFile(path.join(builtinRegistryDir, 'roles.registry.json'));
   const rolesByCategory = parsed?.rolesByCategory;
 
   if (!rolesByCategory || typeof rolesByCategory !== 'object' || Array.isArray(rolesByCategory)) {
@@ -158,13 +161,13 @@ const loadBuiltinRolesPayload = () => {
     }
   }
 
-  const allowedCategories = loadBuiltinCategorySet();
+  const allowedCategories = loadBuiltinCategorySet({ builtinRegistryDir });
   return canonicalizeRoles(flattenedRoles, { allowedCategories });
 };
 
-const loadBuiltinReportableExtensions = () => {
+const loadBuiltinReportableExtensions = ({ builtinRegistryDir }) => {
   const parsed = loadJsonFile(
-    path.join(BUILTIN_REGISTRY_DIR, 'reportable-extensions.registry.json'),
+    path.join(builtinRegistryDir, 'reportable-extensions.registry.json'),
   );
 
   if (!Array.isArray(parsed?.reportableExtensions)) {
@@ -194,7 +197,7 @@ const loadRegistryState = (registryRootDir) => {
   return activeRegistry;
 };
 
-const loadCustomPayload = (registryRootDir) => {
+const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
   const customRolesPath = path.join(registryRootDir, '_custom', 'roles.registry.custom.json');
   const customExtensionsPath = path.join(
     registryRootDir,
@@ -220,20 +223,22 @@ const loadCustomPayload = (registryRootDir) => {
   const extensionsRaw = loadJsonFile(customExtensionsPath);
 
   return {
-    roles: canonicalizeRoles(rolesRaw, { allowedCategories: loadBuiltinCategorySet() }),
+    roles: canonicalizeRoles(rolesRaw, {
+      allowedCategories: loadBuiltinCategorySet({ builtinRegistryDir }),
+    }),
     reportableExtensions: canonicalizeExtensions(extensionsRaw),
   };
 };
 
-const buildBuiltinPayload = () => ({
-  roles: loadBuiltinRolesPayload(),
-  reportableExtensions: loadBuiltinReportableExtensions(),
+const buildBuiltinPayload = ({ builtinRegistryDir }) => ({
+  roles: loadBuiltinRolesPayload({ builtinRegistryDir }),
+  reportableExtensions: loadBuiltinReportableExtensions({ builtinRegistryDir }),
 });
 
-const applyConfigOverlay = (builtinPayload, config) => {
+const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
   const extensionAdds = config?.naming?.reportableExtensions?.add ?? [];
   const roleAdds = config?.naming?.roles?.add ?? [];
-  const allowedCategories = loadBuiltinCategorySet();
+  const allowedCategories = loadBuiltinCategorySet({ builtinRegistryDir });
 
   const mergedExtensions = canonicalizeExtensions([
     ...builtinPayload.reportableExtensions,
@@ -261,7 +266,8 @@ export const resolveNamingRegistryInputs = ({ config, registryRootDir } = {}) =>
   const resolvedRegistryRootDir = registryRootDir ?? MODULE_DIR;
   const registryState = loadRegistryState(resolvedRegistryRootDir);
 
-  const builtinPayload = buildBuiltinPayload();
+  const builtinRegistryDir = resolveBuiltinRegistryDir({ resolvedRegistryRootDir });
+  const builtinPayload = buildBuiltinPayload({ builtinRegistryDir });
   const builtinDigest = digestPayload(builtinPayload);
 
   const customRolesPath = path.join(
@@ -278,7 +284,7 @@ export const resolveNamingRegistryInputs = ({ config, registryRootDir } = {}) =>
   const hasCustomFiles = fs.existsSync(customRolesPath) && fs.existsSync(customExtensionsPath);
 
   const customPayload = hasCustomFiles
-    ? loadCustomPayload(resolvedRegistryRootDir)
+    ? loadCustomPayload({ registryRootDir: resolvedRegistryRootDir, builtinRegistryDir })
     : builtinPayload;
   const customDigest = digestPayload(customPayload);
 
@@ -296,7 +302,7 @@ export const resolveNamingRegistryInputs = ({ config, registryRootDir } = {}) =>
   const registrySource = hasConfigOverlay ? 'config' : registryState;
 
   const resolvedPayload = hasConfigOverlay
-    ? applyConfigOverlay(builtinPayload, config)
+    ? applyConfigOverlay({ builtinPayload, config, builtinRegistryDir })
     : registryState === 'custom'
       ? customPayload
       : builtinPayload;

--- a/calculogic-validator/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/test/registry-state.logic.test.mjs
@@ -125,6 +125,45 @@ test('builtin resolution loads roles and reportable extensions from _builtin JSO
   assert.deepEqual(result.reportableExtensions, expectedExtensions);
 });
 
+test('registryRootDir drives builtin roles, extensions, and categories from the same _builtin root', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'from-temp-root' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      rolesByCategory: {
+        'from-temp-root': [{ role: 'temp-builtin-role', status: 'active' }],
+      },
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
+      reportableExtensions: ['.tmp', '.tmp', '.alt'],
+    });
+
+    const builtinResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.deepEqual(builtinResult.roles, [
+      { role: 'temp-builtin-role', category: 'from-temp-root', status: 'active' },
+    ]);
+    assert.deepEqual(builtinResult.reportableExtensions, ['.alt', '.tmp']);
+
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'temp-custom-role', category: 'from-temp-root', status: 'active' },
+    ]);
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.tmp']);
+
+    const customResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.ok(customResult.roles.some((entry) => entry.role === 'temp-custom-role'));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
 test('builtin resolved reportable extensions preserve intended parity, including .jsx and .cjs', () => {
   const result = resolveNamingRegistryInputs();
 

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -135,8 +135,10 @@ Normalization and merge semantics for `naming.roles.add` are deterministic and a
 Runtime behavior in this slice resolves naming registries via registry-state logic:
 
 - wiring resolves inputs through `resolveNamingRegistryInputs({ config })`
-- built-in roles are loaded from `calculogic-validator/src/naming/registries/_builtin/roles.registry.json` (`rolesByCategory` flattened into `{ role, category, status, notes? }`)
-- built-in reportable extensions are loaded from `calculogic-validator/src/naming/registries/_builtin/reportable-extensions.registry.json` (`reportableExtensions`)
+- resolver computes one effective built-in registry root per call (defaulting to `calculogic-validator/src/naming/registries/_builtin`)
+- built-in roles are loaded from that effective root `roles.registry.json` (`rolesByCategory` flattened into `{ role, category, status, notes? }`)
+- built-in reportable extensions are loaded from that effective root `reportable-extensions.registry.json` (`reportableExtensions`)
+- built-in allowed categories for role validation are loaded from that same effective root `categories.registry.json`
 - resolver returns normalized arrays for `reportableExtensions` and `roles`
 - wiring converts arrays into runtime structures expected by naming runtime:
   - `reportableExtensions` → `Set`


### PR DESCRIPTION
### Motivation
- Remove the remaining module-global path coupling so built-in category reads come from the same effective built-in registry root used by roles and extensions, improving portability and coherence of the naming resolver. 

### Description
- Refactored `loadBuiltinCategorySet` to accept an explicit `builtinRegistryDir` and removed the module-global built-in categories path constant. 
- Added `resolveBuiltinRegistryDir({ resolvedRegistryRootDir })` that prefers `<registryRootDir>/_builtin` when present and falls back to the module `_builtin`, and threaded the resulting `builtinRegistryDir` through `buildBuiltinPayload`, `loadCustomPayload`, and `applyConfigOverlay`. 
- Updated helper signatures to accept `builtinRegistryDir` so `roles.registry.json`, `reportable-extensions.registry.json`, and `categories.registry.json` are all read from the same effective root per resolver call, while preserving the public return shape of `resolveNamingRegistryInputs()`. 
- Updated NL config doc `doc/nl-config/cfg-namingValidator.md` and added a focused test to `calculogic-validator/test/registry-state.logic.test.mjs` that asserts a temporary `registryRootDir` `_builtin` controls built-in roles/extensions/categories and custom category validation. 

### Testing
- Ran the naming registry unit tests with `node --test calculogic-validator/test/registry-state.logic.test.mjs` and all tests passed (13/13). 
- The updated tests include `registryRootDir drives builtin roles, extensions, and categories from the same _builtin root` which verifies the new single-root behavior and guards against regressions to module-global category loading.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa222aaa048331b9e9ec1904c3ac99)