### PR TITLE
Tighten builtin naming registry root selection for incomplete _builtin dirs

### DIFF
--- a/calculogic-validator/src/naming/registries/registry-state.logic.mjs
+++ b/calculogic-validator/src/naming/registries/registry-state.logic.mjs
@@ -6,12 +6,24 @@ import { stableStringify, sha256Hex } from '../../validator-report-meta.logic.mj
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const BUILTIN_REGISTRY_DIR = path.join(MODULE_DIR, '_builtin');
+const REQUIRED_BUILTIN_REGISTRY_FILES = [
+  'categories.registry.json',
+  'roles.registry.json',
+  'reportable-extensions.registry.json',
+];
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
 
+const hasRequiredBuiltinRegistryFiles = ({ builtinRegistryDir }) =>
+  REQUIRED_BUILTIN_REGISTRY_FILES.every((registryFile) =>
+    fs.existsSync(path.join(builtinRegistryDir, registryFile)),
+  );
+
 const resolveBuiltinRegistryDir = ({ resolvedRegistryRootDir }) => {
   const candidateBuiltinRegistryDir = path.join(resolvedRegistryRootDir, '_builtin');
-  return fs.existsSync(candidateBuiltinRegistryDir) ? candidateBuiltinRegistryDir : BUILTIN_REGISTRY_DIR;
+  return hasRequiredBuiltinRegistryFiles({ builtinRegistryDir: candidateBuiltinRegistryDir })
+    ? candidateBuiltinRegistryDir
+    : BUILTIN_REGISTRY_DIR;
 };
 
 const loadBuiltinCategorySet = ({ builtinRegistryDir }) => {

--- a/calculogic-validator/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/test/registry-state.logic.test.mjs
@@ -164,6 +164,37 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
+
+
+test('registryRootDir falls back to module _builtin when temp _builtin is incomplete', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'from-incomplete-temp-root' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      rolesByCategory: {
+        'from-incomplete-temp-root': [{ role: 'incomplete-temp-role', status: 'active' }],
+      },
+    });
+
+    const moduleBuiltinResult = resolveNamingRegistryInputs();
+    const incompleteBuiltinResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+
+    assert.deepEqual(incompleteBuiltinResult.roles, moduleBuiltinResult.roles);
+    assert.deepEqual(
+      incompleteBuiltinResult.reportableExtensions,
+      moduleBuiltinResult.reportableExtensions,
+    );
+    assert.ok(
+      !incompleteBuiltinResult.roles.some((entry) => entry.role === 'incomplete-temp-role'),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
 test('builtin resolved reportable extensions preserve intended parity, including .jsx and .cjs', () => {
   const result = resolveNamingRegistryInputs();
 


### PR DESCRIPTION
### Motivation
- The resolver currently prefers a provided `<registryRootDir>/_builtin` directory if it exists, even when that directory is only partially populated, which can cause ambiguous or avoidable failure modes when temp fixtures are incomplete.
- Make builtin-root selection explicit and deterministic by requiring the presence of the specific naming registry files this resolver slice needs before selecting a candidate `_builtin` directory.

### Description
- Added an explicit required-files list `REQUIRED_BUILTIN_REGISTRY_FILES` containing `categories.registry.json`, `roles.registry.json`, and `reportable-extensions.registry.json` in `registry-state.logic.mjs`.
- Implemented a small helper `hasRequiredBuiltinRegistryFiles({ builtinRegistryDir })` and updated `resolveBuiltinRegistryDir({ resolvedRegistryRootDir })` to prefer the candidate `<registryRootDir>/_builtin` only when that helper returns true, otherwise falling back to the module `_builtin` root.
- Added a focused regression test `registryRootDir falls back to module _builtin when temp _builtin is incomplete` to `calculogic-validator/test/registry-state.logic.test.mjs` that verifies an incomplete temp `_builtin` does not win and resolver output matches the module builtin.
- Files changed: `calculogic-validator/src/naming/registries/registry-state.logic.mjs` and `calculogic-validator/test/registry-state.logic.test.mjs`.

### Testing
- Ran the naming registry test suite with `node --test calculogic-validator/test/registry-state.logic.test.mjs` and all tests passed (14/14), including the new incomplete-`_builtin` fallback test.
- Existing tests that validate complete temp `_builtin` behavior remain and passed, confirming no behavioral regressions to resolver contract or payload canonicalization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2718eda8833193503f8f78125a17)