### PR TITLE
Use builtin scope profiles registry for naming runtime

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -8,8 +8,8 @@ import {
 import { REPORTABLE_EXTENSIONS } from './registries/naming-extensions.knowledge.mjs';
 import { EXCLUDED_DIRECTORIES } from './registries/naming-special-cases.knowledge.mjs';
 import {
-  SCOPE_PROFILES,
-  cloneScopeProfile,
+  listValidatorScopes,
+  getValidatorScopeProfile,
 } from './registries/naming-scope-profiles.knowledge.mjs';
 import { parseCanonicalName } from './rules/naming-rule-parse-canonical.logic.mjs';
 import {
@@ -116,13 +116,9 @@ const buildScopePathPredicate = (profile) => {
   };
 };
 
-export const listNamingValidatorScopes = () => sortPaths(new Set(Object.keys(SCOPE_PROFILES)));
+export const listNamingValidatorScopes = () => listValidatorScopes();
 
-export const getScopeProfile = (scope) => {
-  const normalizedScope = scope ?? 'repo';
-  const profile = SCOPE_PROFILES[normalizedScope];
-  return profile ? cloneScopeProfile(profile) : null;
-};
+export const getScopeProfile = (scope) => getValidatorScopeProfile(scope);
 
 const detectMissingRoleCandidate = (basename) => {
   const segments = basename.split('.');

--- a/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
@@ -1,1 +1,6 @@
-export { SCOPE_PROFILES, cloneScopeProfile } from '../../validator-scopes.knowledge.mjs';
+export {
+  SCOPE_PROFILES,
+  cloneScopeProfile,
+  listValidatorScopes,
+  getValidatorScopeProfile,
+} from '../../validator-scopes.knowledge.mjs';

--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -1,32 +1,91 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ROOT_APP_FILES } from './validator-root-files.knowledge.mjs';
 
-export const SCOPE_PROFILES = {
-  repo: {
-    description: 'Repository-wide scan of all reportable files.',
-    includeRoots: ['.'],
-    includeRootFiles: [],
-  },
-  app: {
-    description: 'Application-only scan (src/** and test/**).',
-    includeRoots: ['src', 'test'],
-    includeRootFiles: [],
-  },
-  docs: {
-    description: 'Documentation-focused scan (doc/docs and root conventional docs: README.md).',
-    includeRoots: ['doc', 'docs'],
-    includeRootFiles: ['README.md'],
-  },
-  validator: {
-    description: 'Validator-only scan (calculogic-validator/**).',
-    includeRoots: ['calculogic-validator'],
-    includeRootFiles: [],
-  },
-  system: {
-    description: 'System/tooling files scan (root package/tsconfig/eslint/vite files).',
-    includeRoots: [],
-    includeRootFiles: Array.from(ROOT_APP_FILES),
-  },
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const BUILTIN_SCOPE_PROFILES_REGISTRY_PATH = path.join(
+  MODULE_DIR,
+  'registries',
+  '_builtin',
+  'scope-profiles.registry.json',
+);
+
+const LEGACY_SCOPE_DESCRIPTIONS = {
+  repo: 'Repository-wide scan of all reportable files.',
+  app: 'Application-only scan (src/** and test/**).',
+  docs: 'Documentation-focused scan (doc/docs and root conventional docs: README.md).',
+  validator: 'Validator-only scan (calculogic-validator/**).',
+  system: 'System/tooling files scan (root package/tsconfig/eslint/vite files).',
 };
+
+const ROOT_FILE_PATTERN_RESOLVERS = [
+  {
+    pattern: 'eslint.config.*',
+    resolve: () => [...ROOT_APP_FILES].filter((rootFile) => rootFile.startsWith('eslint.config.')),
+  },
+  {
+    pattern: 'vite.config.*',
+    resolve: () => [...ROOT_APP_FILES].filter((rootFile) => rootFile.startsWith('vite.config.')),
+  },
+  {
+    pattern: 'tsconfig*.json',
+    resolve: () => [...ROOT_APP_FILES].filter((rootFile) => rootFile.startsWith('tsconfig')),
+  },
+];
+
+function loadJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const normalizeIncludeRootFiles = (includeRootFiles = []) => {
+  const expandedRootFiles = [];
+
+  for (const rootFile of includeRootFiles) {
+    const matchingResolver = ROOT_FILE_PATTERN_RESOLVERS.find(
+      (resolver) => resolver.pattern === rootFile,
+    );
+
+    if (matchingResolver) {
+      expandedRootFiles.push(...matchingResolver.resolve());
+      continue;
+    }
+
+    expandedRootFiles.push(rootFile);
+  }
+
+  return Array.from(new Set(expandedRootFiles)).sort((left, right) => left.localeCompare(right));
+};
+
+const canonicalizeScopeProfile = (scope, profile) => {
+  const includeRoots = Array.isArray(profile?.includeRoots) ? profile.includeRoots : [];
+  const includeRootFiles = normalizeIncludeRootFiles(
+    Array.isArray(profile?.includeRootFiles) ? profile.includeRootFiles : [],
+  );
+
+  return {
+    description: LEGACY_SCOPE_DESCRIPTIONS[scope],
+    includeRoots: [...includeRoots],
+    includeRootFiles,
+  };
+};
+
+const loadBuiltinScopeProfiles = () => {
+  const parsedRegistry = loadJsonFile(BUILTIN_SCOPE_PROFILES_REGISTRY_PATH);
+
+  if (!parsedRegistry?.profiles || typeof parsedRegistry.profiles !== 'object') {
+    throw new Error('Invalid builtin scope profiles registry: expected profiles object.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(parsedRegistry.profiles).map(([scope, profile]) => [
+      scope,
+      canonicalizeScopeProfile(scope, profile),
+    ]),
+  );
+};
+
+export const SCOPE_PROFILES = loadBuiltinScopeProfiles();
 
 export const cloneScopeProfile = (profile) => ({
   description: profile.description,

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import {
   collectRepositoryPaths,
   getScopeProfile,
@@ -17,8 +18,20 @@ const runValidatorCli = (args) =>
     },
   );
 
+const BUILTIN_SCOPE_PROFILES_REGISTRY_PATH =
+  'calculogic-validator/src/registries/_builtin/scope-profiles.registry.json';
+
 test('scope registry exposes deterministic supported scopes', () => {
   assert.deepEqual(listNamingValidatorScopes(), ['app', 'docs', 'repo', 'system', 'validator']);
+});
+
+test('scope registry is sourced from builtin JSON scope profile keys', () => {
+  const builtinRegistry = JSON.parse(fs.readFileSync(BUILTIN_SCOPE_PROFILES_REGISTRY_PATH, 'utf8'));
+  const expectedScopes = Object.keys(builtinRegistry.profiles).sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+  assert.deepEqual(listNamingValidatorScopes(), expectedScopes);
 });
 
 test('default/no-scope behavior resolves to repo', () => {
@@ -120,6 +133,17 @@ test('--scope=system includes root tooling files only and excludes all folders',
     systemPaths.some((pathname) => pathname.includes('/')),
     false,
   );
+});
+
+test('system scope profile keeps legacy explicit root-file behavior when builtin registry has wildcard patterns', () => {
+  const profile = getScopeProfile('system');
+  assert.ok(profile);
+  assert.equal(profile.includeRootFiles.includes('eslint.config.*'), false);
+  assert.equal(profile.includeRootFiles.includes('tsconfig*.json'), false);
+  assert.equal(profile.includeRootFiles.includes('vite.config.*'), false);
+  assert.ok(profile.includeRootFiles.includes('eslint.config.js'));
+  assert.ok(profile.includeRootFiles.includes('tsconfig.json'));
+  assert.ok(profile.includeRootFiles.includes('vite.config.ts'));
 });
 
 test('docs scope profile explicitly declares root conventional docs inclusion contract', () => {


### PR DESCRIPTION
### Motivation
- Move naming scope-profile resolution off the legacy knowledge export and make the builtin JSON registry the runtime source-of-truth to match recent naming registry cutover. 
- Keep the change narrow and safe by preserving public APIs and existing scope/profile shapes and behavior.

### Description
- Load builtin scope profiles from `calculogic-validator/src/registries/_builtin/scope-profiles.registry.json` via a loader implemented in `calculogic-validator/src/validator-scopes.knowledge.mjs`. 
- Wire naming helpers to the new validator-backed APIs by having `listNamingValidatorScopes()` and `getScopeProfile()` delegate to `listValidatorScopes()` and `getValidatorScopeProfile()` respectively, so `collectRepositoryPaths()` uses the JSON-backed profiles. 
- Add a small compatibility layer that preserves legacy `description` values and expands wildcard-style `system` root-file entries (e.g. `eslint.config.*`, `tsconfig*.json`, `vite.config.*`) into explicit filenames using `ROOT_APP_FILES` to keep existing root-file matching semantics deterministic. 
- Keep `naming-scope-profiles.knowledge.mjs` as a thin re-export seam to minimize cross-slice changes. 
- Files changed: `calculogic-validator/src/validator-scopes.knowledge.mjs`, `calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs`, `calculogic-validator/src/naming/naming-validator.logic.mjs`, and `calculogic-validator/test/naming-validator-scope-contract.test.mjs`.

### Testing
- Added assertions in `calculogic-validator/test/naming-validator-scope-contract.test.mjs` to assert the runtime scope list is sourced from the builtin JSON keys and that `system` scope wildcard entries are normalized to explicit root files; existing scope/path tests were left in place and exercised. 
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs calculogic-validator/test/naming-validator.test.mjs` and all tests passed (39 tests, 0 failures). 
- No other automated tests were modified and no legacy files were removed; `naming-scope-profiles.knowledge.mjs` remains a deliberate re-export seam.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2fc40184833183e88794f655908d)