### PR TITLE
Tighten scope-profile runtime loading and explicit system compatibility expansion

### DIFF
--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -19,20 +19,26 @@ const LEGACY_SCOPE_DESCRIPTIONS = {
   system: 'System/tooling files scan (root package/tsconfig/eslint/vite files).',
 };
 
-const ROOT_FILE_PATTERN_RESOLVERS = [
-  {
-    pattern: 'eslint.config.*',
-    resolve: () => [...ROOT_APP_FILES].filter((rootFile) => rootFile.startsWith('eslint.config.')),
-  },
-  {
-    pattern: 'vite.config.*',
-    resolve: () => [...ROOT_APP_FILES].filter((rootFile) => rootFile.startsWith('vite.config.')),
-  },
-  {
-    pattern: 'tsconfig*.json',
-    resolve: () => [...ROOT_APP_FILES].filter((rootFile) => rootFile.startsWith('tsconfig')),
-  },
+const SYSTEM_SCOPE_COMPATIBILITY_PATTERNS = [
+  'eslint.config.*',
+  'vite.config.*',
+  'tsconfig*.json',
 ];
+
+const SYSTEM_SCOPE_COMPATIBILITY_PATTERN_EXPANSIONS = {
+  'eslint.config.*': [...ROOT_APP_FILES]
+    .filter((rootFile) => rootFile.startsWith('eslint.config.'))
+    .sort((left, right) => left.localeCompare(right)),
+  'vite.config.*': [...ROOT_APP_FILES]
+    .filter((rootFile) => rootFile.startsWith('vite.config.'))
+    .sort((left, right) => left.localeCompare(right)),
+  'tsconfig*.json': [...ROOT_APP_FILES]
+    .filter((rootFile) => rootFile.startsWith('tsconfig'))
+    .sort((left, right) => left.localeCompare(right)),
+};
+
+const isKnownSystemScopeCompatibilityPattern = (rootFileToken) =>
+  SYSTEM_SCOPE_COMPATIBILITY_PATTERNS.includes(rootFileToken);
 
 function loadJsonFile(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -42,12 +48,8 @@ const normalizeIncludeRootFiles = (includeRootFiles = []) => {
   const expandedRootFiles = [];
 
   for (const rootFile of includeRootFiles) {
-    const matchingResolver = ROOT_FILE_PATTERN_RESOLVERS.find(
-      (resolver) => resolver.pattern === rootFile,
-    );
-
-    if (matchingResolver) {
-      expandedRootFiles.push(...matchingResolver.resolve());
+    if (isKnownSystemScopeCompatibilityPattern(rootFile)) {
+      expandedRootFiles.push(...SYSTEM_SCOPE_COMPATIBILITY_PATTERN_EXPANSIONS[rootFile]);
       continue;
     }
 
@@ -85,7 +87,17 @@ const loadBuiltinScopeProfiles = () => {
   );
 };
 
-export const SCOPE_PROFILES = loadBuiltinScopeProfiles();
+let cachedBuiltinScopeProfiles = null;
+
+export const getBuiltinScopeProfiles = () => {
+  if (!cachedBuiltinScopeProfiles) {
+    cachedBuiltinScopeProfiles = loadBuiltinScopeProfiles();
+  }
+
+  return cachedBuiltinScopeProfiles;
+};
+
+export const SCOPE_PROFILES = getBuiltinScopeProfiles();
 
 export const cloneScopeProfile = (profile) => ({
   description: profile.description,
@@ -94,10 +106,10 @@ export const cloneScopeProfile = (profile) => ({
 });
 
 export const listValidatorScopes = () =>
-  Array.from(new Set(Object.keys(SCOPE_PROFILES))).sort((a, b) => a.localeCompare(b));
+  Array.from(new Set(Object.keys(getBuiltinScopeProfiles()))).sort((a, b) => a.localeCompare(b));
 
 export const getValidatorScopeProfile = (scope) => {
   const normalizedScope = scope ?? 'repo';
-  const profile = SCOPE_PROFILES[normalizedScope];
+  const profile = getBuiltinScopeProfiles()[normalizedScope];
   return profile ? cloneScopeProfile(profile) : null;
 };

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -141,9 +141,32 @@ test('system scope profile keeps legacy explicit root-file behavior when builtin
   assert.equal(profile.includeRootFiles.includes('eslint.config.*'), false);
   assert.equal(profile.includeRootFiles.includes('tsconfig*.json'), false);
   assert.equal(profile.includeRootFiles.includes('vite.config.*'), false);
-  assert.ok(profile.includeRootFiles.includes('eslint.config.js'));
-  assert.ok(profile.includeRootFiles.includes('tsconfig.json'));
-  assert.ok(profile.includeRootFiles.includes('vite.config.ts'));
+  assert.deepEqual(profile.includeRootFiles, [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'package-lock.json',
+    'package.json',
+    'tsconfig.app.json',
+    'tsconfig.json',
+    'tsconfig.node.json',
+    'vite.config.js',
+    'vite.config.mjs',
+    'vite.config.ts',
+  ]);
+});
+
+test('scope profiles are cloned on lookup (mutations do not leak across reads)', () => {
+  const firstRead = getScopeProfile('docs');
+  assert.ok(firstRead);
+  firstRead.includeRoots.push('tmp');
+  firstRead.includeRootFiles.push('tmp.md');
+
+  const secondRead = getScopeProfile('docs');
+  assert.deepEqual(secondRead, {
+    description: 'Documentation-focused scan (doc/docs and root conventional docs: README.md).',
+    includeRoots: ['doc', 'docs'],
+    includeRootFiles: ['README.md'],
+  });
 });
 
 test('docs scope profile explicitly declares root conventional docs inclusion contract', () => {


### PR DESCRIPTION
### Motivation
- Remove module-init reliance for builtin scope profiles to make runtime loading explicit and easier to test and evolve.
- Make `system` scope wildcard-to-file compatibility expansion intentional and deterministic so future edits are less fragile while preserving current behavior.

### Description
- Files changed: `calculogic-validator/src/validator-scopes.knowledge.mjs` and `calculogic-validator/test/naming-validator-scope-contract.test.mjs`.
- Scope profile loading: introduced `getBuiltinScopeProfiles()` which lazily loads (with a tiny explicit cache) and canonicalizes the JSON-backed registry; public APIs (`listValidatorScopes()` and `getValidatorScopeProfile()`) now read through this getter and return cloned profiles.
- System compatibility normalization: replaced loose pattern-resolver lookup with an explicit list of supported tokens (`eslint.config.*`, `vite.config.*`, `tsconfig*.json`) and deterministic precomputed expansions derived from `ROOT_APP_FILES`, preserving sorting and deduplication.
- Legacy export: `SCOPE_PROFILES` is retained as a compatibility export but now sources through the new getter flow.
- Tests updated: strengthened the `system` scope test to assert the exact expanded `includeRootFiles` ordering and added a cloning-guard test to ensure returned profiles are copies and mutations do not leak.

### Testing
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and all tests passed (20 tests, 0 failures).
- The updated tests specifically verify deterministic scope listing, `system` compatibility expansion (no wildcard tokens leaked), cloning behavior on lookup, and no regressions in scope-based path collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa34302b1c8331b65f46cccd001bcc)