### PR TITLE
Use builtin special-cases registry for naming classification runtime

### DIFF
--- a/calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json
+++ b/calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json
@@ -1,12 +1,52 @@
 {
   "version": "1",
   "specialCases": [
-    { "type": "ambient-declaration", "match": { "suffixEquals": [".d.ts"] } },
-    { "type": "barrel", "match": { "basenameEquals": ["index.ts", "index.tsx"] } },
-    { "type": "conventional-doc", "match": { "basenameEquals": ["README.md"] } },
+    {
+      "type": "ambient-declaration",
+      "match": {
+        "suffixEquals": [
+          ".d.ts"
+        ]
+      }
+    },
+    {
+      "type": "barrel",
+      "match": {
+        "basenameEquals": [
+          "index.ts",
+          "index.tsx"
+        ]
+      }
+    },
+    {
+      "type": "conventional-doc",
+      "match": {
+        "basenameEquals": [
+          "README.md"
+        ]
+      }
+    },
     {
       "type": "ecosystem-required",
-      "match": { "regex": "^tsconfig(\\..+)?\\.json$" }
+      "match": {
+        "basenameEquals": [
+          "package.json"
+        ]
+      }
+    },
+    {
+      "type": "ecosystem-required",
+      "match": {
+        "basenameEquals": [
+          "package-lock.json"
+        ]
+      }
+    },
+    {
+      "type": "ecosystem-required",
+      "match": {
+        "regex": "^tsconfig(\\..+)?\\.json$"
+      }
     },
     {
       "type": "ecosystem-required",
@@ -16,7 +56,9 @@
     },
     {
       "type": "test-convention",
-      "match": { "regex": "\\.(?:test|spec)\\.(?:[cm]?[jt]sx?)$" }
+      "match": {
+        "regex": "\\.(?:test|spec)\\.(?:[cm]?[jt]sx?)$"
+      }
     }
   ]
 }

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -1,11 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ROOT_APP_FILES } from '../../validator-root-files.knowledge.mjs';
 
 export const EXCLUDED_DIRECTORIES = new Set(['.git', 'node_modules', 'dist', 'coverage', '.vite']);
 
 export { ROOT_APP_FILES };
 
-export const TEST_CONVENTION_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/u;
-export const AMBIENT_DECLARATION_PATTERN = /\.d\.ts$/u;
-export const TSCONFIG_PATTERN = /^tsconfig(\..+)?\.json$/u;
-export const TOOLING_CONFIG_PATTERN =
-  /^vite\.config\.[^.]+$|^eslint\.config\.[^.]+$|^prettier\.config\.[^.]+$/u;
+const SPECIAL_CASES_REGISTRY_PATH = fileURLToPath(
+  new URL('./_builtin/special-cases.registry.json', import.meta.url),
+);
+
+const loadBuiltinSpecialCases = () => {
+  const payload = JSON.parse(fs.readFileSync(SPECIAL_CASES_REGISTRY_PATH, 'utf8'));
+
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.specialCases)) {
+    throw new Error('Invalid builtin special-cases registry: missing specialCases array.');
+  }
+
+  return payload.specialCases.map((specialCase, index) => {
+    const entryPrefix = `Invalid builtin special-cases registry entry at index ${index}`;
+
+    if (!specialCase || typeof specialCase !== 'object') {
+      throw new Error(`${entryPrefix}: expected object.`);
+    }
+
+    if (typeof specialCase.type !== 'string' || specialCase.type.length === 0) {
+      throw new Error(`${entryPrefix}: expected non-empty string type.`);
+    }
+
+    const match = specialCase.match;
+    if (!match || typeof match !== 'object') {
+      throw new Error(`${entryPrefix}: missing match object.`);
+    }
+
+    if (Array.isArray(match.basenameEquals)) {
+      return {
+        type: specialCase.type,
+        matches: ({ basename }) => match.basenameEquals.includes(basename),
+      };
+    }
+
+    if (Array.isArray(match.suffixEquals)) {
+      return {
+        type: specialCase.type,
+        matches: ({ basename }) => match.suffixEquals.some((suffix) => basename.endsWith(suffix)),
+      };
+    }
+
+    if (typeof match.regex === 'string') {
+      const regex = new RegExp(match.regex, 'u');
+      return {
+        type: specialCase.type,
+        matches: ({ basename }) => regex.test(basename),
+      };
+    }
+
+    throw new Error(`${entryPrefix}: unsupported match form.`);
+  });
+};
+
+export const BUILTIN_SPECIAL_CASES_REGISTRY_PATH = path.relative(process.cwd(), SPECIAL_CASES_REGISTRY_PATH);
+
+export const BUILTIN_SPECIAL_CASE_RULES = loadBuiltinSpecialCases();

--- a/calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs
+++ b/calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs
@@ -1,40 +1,13 @@
 import path from 'node:path';
-import {
-  TEST_CONVENTION_PATTERN,
-  AMBIENT_DECLARATION_PATTERN,
-  TSCONFIG_PATTERN,
-  TOOLING_CONFIG_PATTERN,
-} from '../registries/naming-special-cases.knowledge.mjs';
+import { BUILTIN_SPECIAL_CASE_RULES } from '../registries/naming-special-cases.knowledge.mjs';
 
 export const getSpecialCaseType = (normalizedPath) => {
   const basename = path.posix.basename(normalizedPath);
 
-  if (basename === 'README.md') {
-    return 'conventional-doc';
-  }
-
-  if (basename === 'index.ts' || basename === 'index.tsx') {
-    return 'barrel';
-  }
-
-  if (TEST_CONVENTION_PATTERN.test(basename)) {
-    return 'test-convention';
-  }
-
-  if (AMBIENT_DECLARATION_PATTERN.test(basename)) {
-    return 'ambient-declaration';
-  }
-
-  if (normalizedPath === 'package.json' || normalizedPath === 'package-lock.json') {
-    return 'ecosystem-required';
-  }
-
-  if (TSCONFIG_PATTERN.test(basename)) {
-    return 'ecosystem-required';
-  }
-
-  if (TOOLING_CONFIG_PATTERN.test(basename)) {
-    return 'ecosystem-required';
+  for (const rule of BUILTIN_SPECIAL_CASE_RULES) {
+    if (rule.matches({ normalizedPath, basename })) {
+      return rule.type;
+    }
   }
 
   return null;

--- a/calculogic-validator/test/naming-special-cases-registry.test.mjs
+++ b/calculogic-validator/test/naming-special-cases-registry.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  BUILTIN_SPECIAL_CASE_RULES,
+  BUILTIN_SPECIAL_CASES_REGISTRY_PATH,
+} from '../src/naming/registries/naming-special-cases.knowledge.mjs';
+import {
+  getSpecialCaseType,
+  isAllowedSpecialCase,
+} from '../src/naming/rules/naming-rule-classify-special-case.logic.mjs';
+
+test('special-case classification stays behavior-preserving with builtin registry rules', () => {
+  assert.equal(getSpecialCaseType('README.md'), 'conventional-doc');
+  assert.equal(getSpecialCaseType('src/tabs/index.ts'), 'barrel');
+  assert.equal(getSpecialCaseType('src/tabs/index.tsx'), 'barrel');
+  assert.equal(getSpecialCaseType('test/example.test.ts'), 'test-convention');
+  assert.equal(getSpecialCaseType('test/example.spec.tsx'), 'test-convention');
+  assert.equal(getSpecialCaseType('types/global.d.ts'), 'ambient-declaration');
+  assert.equal(getSpecialCaseType('tsconfig.json'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('tsconfig.app.json'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('vite.config.ts'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('eslint.config.js'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('prettier.config.cjs'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('package.json'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('package-lock.json'), 'ecosystem-required');
+  assert.equal(getSpecialCaseType('src/not-special.logic.ts'), null);
+});
+
+test('isAllowedSpecialCase remains aligned with getSpecialCaseType', () => {
+  assert.equal(isAllowedSpecialCase('README.md'), true);
+  assert.equal(isAllowedSpecialCase('package.json'), true);
+  assert.equal(isAllowedSpecialCase('src/leftpanel.logic.ts'), false);
+});
+
+test('runtime builtin special-case rules are loaded from builtin registry json', () => {
+  const registryPath = path.join(process.cwd(), BUILTIN_SPECIAL_CASES_REGISTRY_PATH);
+  const registryJson = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+  assert.ok(Array.isArray(registryJson.specialCases));
+  assert.ok(BUILTIN_SPECIAL_CASE_RULES.length > 0);
+
+  const hasPackageRule = registryJson.specialCases.some(
+    (entry) =>
+      entry.type === 'ecosystem-required' &&
+      Array.isArray(entry.match?.basenameEquals) &&
+      entry.match.basenameEquals.includes('package.json'),
+  );
+
+  assert.equal(hasPackageRule, true);
+  assert.equal(getSpecialCaseType('package.json'), 'ecosystem-required');
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -184,6 +184,8 @@ Classify as canonical when filename parses as `<semantic-name>.<role>.<ext>` (in
 
 Classify as allowed special case for reserved filenames and patterns including barrel files, framework-required names, test files (`*.test.<code-ext>` / `*.spec.<code-ext>`), ambient declaration files, and README convention docs.
 
+Runtime source of truth for builtin special-case classification is `calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json`, evaluated in stable first-match order with currently-supported match forms (`basenameEquals`, `suffixEquals`, `regex`).
+
 Allowed special-case findings include `details.specialCaseType` values:
 
 - `ecosystem-required`


### PR DESCRIPTION
### Motivation

- Replace hard-coded regex/constants as the runtime source of truth for naming special-case classification by reading the builtin JSON registry to keep runtime behavior centralized and maintainable.
- Preserve existing classification behavior (including `package.json` / `package-lock.json`) and keep the public functions `getSpecialCaseType()` and `isAllowedSpecialCase()` unchanged.

### Description

- Added a narrow builtin loader `loadBuiltinSpecialCases()` in `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs` that validates registry shape and compiles only the supported match forms `basenameEquals`, `suffixEquals`, and `regex` into predicate functions exported as `BUILTIN_SPECIAL_CASE_RULES`, and exported the registry path as `BUILTIN_SPECIAL_CASES_REGISTRY_PATH`.
- Switched `getSpecialCaseType(normalizedPath)` in `calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs` to iterate `BUILTIN_SPECIAL_CASE_RULES` (first-match wins) and kept `isAllowedSpecialCase(normalizedPath)` contract unchanged.
- Added `package.json` and `package-lock.json` as explicit `ecosystem-required` entries to `calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json` so existing package-file behavior is preserved via the builtin JSON.
- Added focused tests in `calculogic-validator/test/naming-special-cases-registry.test.mjs` that assert preserved classifications (README, barrel, tests/specs, `.d.ts`, tsconfig, tooling configs, package files) and verify the runtime reads the builtin JSON registry; also updated `doc/nl-config/cfg-namingValidator.md` to record the new source-of-truth behavior.
- Files changed: `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`, `calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs`, `calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json`, `calculogic-validator/test/naming-special-cases-registry.test.mjs`, and `doc/nl-config/cfg-namingValidator.md`.
- Legacy note: the `naming-special-cases.knowledge.mjs` module is intentionally retained and repurposed as the builtin registry loader for this slice rather than removed.

### Testing

- Ran the focused new test plus the existing naming validator tests with `node --test --experimental-strip-types calculogic-validator/test/naming-special-cases-registry.test.mjs calculogic-validator/test/naming-validator.test.mjs` and all tests passed (`23/23` passing in the run performed).
- The new tests assert both behavior-preserving classifications (README, barrel, test/spec, `.d.ts`, tsconfig, tooling configs, `package.json`, `package-lock.json`) and that runtime rules are loaded from `calculogic-validator/src/naming/registries/_builtin/special-cases.registry.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa3d9d70cc8331af98ca1c27e6e915)