### PR TITLE
Tighten builtin special-cases runtime follow-up nits

### DIFF
--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ROOT_APP_FILES } from '../../validator-root-files.knowledge.mjs';
 
@@ -10,6 +9,8 @@ export { ROOT_APP_FILES };
 const SPECIAL_CASES_REGISTRY_PATH = fileURLToPath(
   new URL('./_builtin/special-cases.registry.json', import.meta.url),
 );
+
+let cachedBuiltinSpecialCaseRules = null;
 
 const loadBuiltinSpecialCases = () => {
   const payload = JSON.parse(fs.readFileSync(SPECIAL_CASES_REGISTRY_PATH, 'utf8'));
@@ -60,6 +61,14 @@ const loadBuiltinSpecialCases = () => {
   });
 };
 
-export const BUILTIN_SPECIAL_CASES_REGISTRY_PATH = path.relative(process.cwd(), SPECIAL_CASES_REGISTRY_PATH);
+export const getBuiltinSpecialCaseRules = () => {
+  if (cachedBuiltinSpecialCaseRules === null) {
+    cachedBuiltinSpecialCaseRules = loadBuiltinSpecialCases();
+  }
 
-export const BUILTIN_SPECIAL_CASE_RULES = loadBuiltinSpecialCases();
+  return cachedBuiltinSpecialCaseRules;
+};
+
+export const BUILTIN_SPECIAL_CASES_REGISTRY_PATH = SPECIAL_CASES_REGISTRY_PATH;
+
+export const BUILTIN_SPECIAL_CASE_RULES = getBuiltinSpecialCaseRules();

--- a/calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs
+++ b/calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs
@@ -1,10 +1,10 @@
 import path from 'node:path';
-import { BUILTIN_SPECIAL_CASE_RULES } from '../registries/naming-special-cases.knowledge.mjs';
+import { getBuiltinSpecialCaseRules } from '../registries/naming-special-cases.knowledge.mjs';
 
 export const getSpecialCaseType = (normalizedPath) => {
   const basename = path.posix.basename(normalizedPath);
 
-  for (const rule of BUILTIN_SPECIAL_CASE_RULES) {
+  for (const rule of getBuiltinSpecialCaseRules()) {
     if (rule.matches({ normalizedPath, basename })) {
       return rule.type;
     }

--- a/calculogic-validator/test/naming-special-cases-registry.test.mjs
+++ b/calculogic-validator/test/naming-special-cases-registry.test.mjs
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import path from 'node:path';
 import {
   BUILTIN_SPECIAL_CASE_RULES,
   BUILTIN_SPECIAL_CASES_REGISTRY_PATH,
+  getBuiltinSpecialCaseRules,
 } from '../src/naming/registries/naming-special-cases.knowledge.mjs';
 import {
   getSpecialCaseType,
@@ -35,11 +35,11 @@ test('isAllowedSpecialCase remains aligned with getSpecialCaseType', () => {
 });
 
 test('runtime builtin special-case rules are loaded from builtin registry json', () => {
-  const registryPath = path.join(process.cwd(), BUILTIN_SPECIAL_CASES_REGISTRY_PATH);
-  const registryJson = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+  const registryJson = JSON.parse(fs.readFileSync(BUILTIN_SPECIAL_CASES_REGISTRY_PATH, 'utf8'));
+  const runtimeRules = getBuiltinSpecialCaseRules();
 
   assert.ok(Array.isArray(registryJson.specialCases));
-  assert.ok(BUILTIN_SPECIAL_CASE_RULES.length > 0);
+  assert.ok(runtimeRules.length > 0);
 
   const hasPackageRule = registryJson.specialCases.some(
     (entry) =>
@@ -48,6 +48,16 @@ test('runtime builtin special-case rules are loaded from builtin registry json',
       entry.match.basenameEquals.includes('package.json'),
   );
 
+
+  assert.equal(runtimeRules.length, registryJson.specialCases.length);
+
   assert.equal(hasPackageRule, true);
   assert.equal(getSpecialCaseType('package.json'), 'ecosystem-required');
+});
+
+test('builtin special-case rules compatibility export stays aligned with getter', () => {
+  const runtimeRules = getBuiltinSpecialCaseRules();
+
+  assert.equal(BUILTIN_SPECIAL_CASE_RULES, runtimeRules);
+  assert.deepEqual(BUILTIN_SPECIAL_CASE_RULES, runtimeRules);
 });


### PR DESCRIPTION
### Motivation

- Remove the remaining module-init snapshot as the primary runtime path and make the builtin registry export deterministic and module-local while preserving existing classification behavior.
- Keep the change small and surgical to align runtime access with the getter-based scope-profile cleanup without introducing a broader registry framework.

### Description

- Added a getter-backed runtime access function `getBuiltinSpecialCaseRules()` with a tiny module-local cache and kept `loadBuiltinSpecialCases()` as the loader in `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`.
- Exported `BUILTIN_SPECIAL_CASES_REGISTRY_PATH` as the module-local absolute `SPECIAL_CASES_REGISTRY_PATH` instead of deriving a `process.cwd()`-relative path, making the path deterministic and environment-independent.
- Updated runtime classification to iterate over `getBuiltinSpecialCaseRules()` in `calculogic-validator/src/naming/rules/naming-rule-classify-special-case.logic.mjs` so `getSpecialCaseType()` flows through the getter-backed path while preserving the public contract.
- Updated tests in `calculogic-validator/test/naming-special-cases-registry.test.mjs` to read the registry JSON directly from `BUILTIN_SPECIAL_CASES_REGISTRY_PATH`, assert the getter-backed rules match the JSON-backed source, and add a small compatibility assertion that `BUILTIN_SPECIAL_CASE_RULES` remains aligned with the getter.

### Testing

- Ran `node --test calculogic-validator/test/naming-special-cases-registry.test.mjs` and all tests passed (4 tests, 0 failures).
- The focused test assertions validated behavior-preserving classification for README/barrel/test/spec/`.d.ts`/tsconfig/vite/eslint/prettier/package cases and runtime alignment between the getter and the builtin JSON registry.
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa41b153e483318327e162f7fa7b7c)