### PR TITLE
Use builtin case-rules registry for semantic-name validation

### DIFF
--- a/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
@@ -1,1 +1,37 @@
-export const CANONICAL_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+import builtinCaseRulesRegistry from './_builtin/case-rules.registry.json' with { type: 'json' };
+
+const CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const assertBuiltinCaseRulesRegistry = (registry) => {
+  if (typeof registry !== 'object' || registry === null) {
+    throw new TypeError('Builtin case-rules registry must be an object.');
+  }
+
+  if (typeof registry.semanticName !== 'object' || registry.semanticName === null) {
+    throw new TypeError('Builtin case-rules registry semanticName must be an object.');
+  }
+
+  if (typeof registry.semanticName.style !== 'string') {
+    throw new TypeError('Builtin case-rules registry semanticName.style must be a string.');
+  }
+};
+
+const resolveSemanticNamePatternByStyle = (semanticNameStyle) => {
+  if (semanticNameStyle === 'kebab-case') {
+    return CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN;
+  }
+
+  throw new Error(`Unsupported builtin semantic-name style: ${semanticNameStyle}`);
+};
+
+assertBuiltinCaseRulesRegistry(builtinCaseRulesRegistry);
+
+const semanticNameStyle = builtinCaseRulesRegistry.semanticName.style;
+const canonicalSemanticPattern = resolveSemanticNamePatternByStyle(semanticNameStyle);
+
+export const CANONICAL_SEMANTIC_PATTERN = canonicalSemanticPattern;
+
+export const getSemanticNameCaseRule = () => ({
+  style: semanticNameStyle,
+  pattern: canonicalSemanticPattern,
+});

--- a/calculogic-validator/src/naming/rules/naming-rule-check-semantic-case.logic.mjs
+++ b/calculogic-validator/src/naming/rules/naming-rule-check-semantic-case.logic.mjs
@@ -1,4 +1,4 @@
-import { CANONICAL_SEMANTIC_PATTERN } from '../registries/naming-case-rules.knowledge.mjs';
+import { getSemanticNameCaseRule } from '../registries/naming-case-rules.knowledge.mjs';
 
 export const isCanonicalSemanticName = (semanticName) =>
-  CANONICAL_SEMANTIC_PATTERN.test(semanticName);
+  getSemanticNameCaseRule().pattern.test(semanticName);

--- a/calculogic-validator/test/naming-case-rules-registry.test.mjs
+++ b/calculogic-validator/test/naming-case-rules-registry.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import caseRulesRegistry from '../src/naming/registries/_builtin/case-rules.registry.json' with { type: 'json' };
+import {
+  CANONICAL_SEMANTIC_PATTERN,
+  getSemanticNameCaseRule,
+} from '../src/naming/registries/naming-case-rules.knowledge.mjs';
+import { isCanonicalSemanticName } from '../src/naming/rules/naming-rule-check-semantic-case.logic.mjs';
+
+test('semantic-name case rule runtime is sourced from builtin registry style', () => {
+  const semanticCaseRule = getSemanticNameCaseRule();
+
+  assert.equal(semanticCaseRule.style, caseRulesRegistry.semanticName.style);
+  assert.equal(semanticCaseRule.style, 'kebab-case');
+  assert.equal(semanticCaseRule.pattern, CANONICAL_SEMANTIC_PATTERN);
+});
+
+test('kebab-case semantic names are canonical', () => {
+  assert.equal(isCanonicalSemanticName('leftpanel'), true);
+  assert.equal(isCanonicalSemanticName('left-panel'), true);
+  assert.equal(isCanonicalSemanticName('left-panel-v2'), true);
+  assert.equal(isCanonicalSemanticName('v2-left-panel'), true);
+});
+
+test('non-kebab semantic names are non-canonical', () => {
+  assert.equal(isCanonicalSemanticName('LeftPanel'), false);
+  assert.equal(isCanonicalSemanticName('leftPanel'), false);
+  assert.equal(isCanonicalSemanticName('left_panel'), false);
+  assert.equal(isCanonicalSemanticName('left..panel'), false);
+  assert.equal(isCanonicalSemanticName('left--panel'), false);
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -188,6 +188,14 @@ Runtime walk policy fields:
 
 This slice is behavior-preserving for the default builtin profile (`.git`, `.vite`, `coverage`, `dist`, `node_modules`; skip dot-directories; allow `.eslintrc` exception).
 
+### 2.9 Semantic-name case rules runtime source (V0.1.18)
+
+Semantic-name case validation is sourced from builtin registry JSON at:
+
+- `calculogic-validator/src/naming/registries/_builtin/case-rules.registry.json`
+
+Runtime currently supports the builtin `semanticName.style` value `kebab-case` only for this slice. The runtime maps that style to the existing canonical kebab-case semantic-name predicate behavior.
+
 ## 3.0 Classification Contract
 
 ### 3.1 Canonical


### PR DESCRIPTION
### Motivation

- Make the builtin `_builtin/case-rules.registry.json` the runtime source-of-truth for semantic-name case validation instead of relying on a hard-coded regex constant.  
- Keep the slice small and behavior-preserving by supporting the existing `kebab-case` mapping only and not changing the public API contract.

### Description

- Load and shape-check the builtin registry from `src/naming/registries/_builtin/case-rules.registry.json` in `calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs` and map `semanticName.style = "kebab-case"` to the existing kebab-case regex.  
- Provide `getSemanticNameCaseRule()` (and still export `CANONICAL_SEMANTIC_PATTERN` for compatibility) so runtime consumers can derive the pattern from the registry.  
- Update `isCanonicalSemanticName(semanticName)` in `calculogic-validator/src/naming/rules/naming-rule-check-semantic-case.logic.mjs` to use the runtime getter-backed rule (`getSemanticNameCaseRule().pattern`) without changing the function contract.  
- Add focused tests `calculogic-validator/test/naming-case-rules-registry.test.mjs` and update NL docs `doc/nl-config/cfg-namingValidator.md` to record the runtime-source shift (V0.1.18).

### Testing

- Ran the new focused test plus the existing naming validator tests with: `node --test --experimental-strip-types calculogic-validator/test/naming-case-rules-registry.test.mjs calculogic-validator/test/naming-validator.test.mjs`.  
- All tests passed (23/23 passing across the validator naming suite and the new registry-backed tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa571ef6cc8331ae1f304c9b808dee)