### PR TITLE
Restore reportable dot-file collection in naming walk traversal

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -75,7 +75,6 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
 
     for (const entry of entries) {
       const isDotEntry = entry.name.startsWith('.');
-      const isAllowedDotFile = walkExclusions.allowDotFiles.has(entry.name);
 
       if (entry.isDirectory()) {
         if (walkExclusions.excludedDirectories.has(entry.name)) {
@@ -87,10 +86,6 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
         }
 
         walk(path.join(absoluteDirectoryPath, entry.name));
-        continue;
-      }
-
-      if (isDotEntry && !isAllowedDotFile) {
         continue;
       }
 

--- a/calculogic-validator/test/naming-walk-exclusions-registry.test.mjs
+++ b/calculogic-validator/test/naming-walk-exclusions-registry.test.mjs
@@ -29,7 +29,7 @@ test('runtime walk exclusions are loaded from builtin registry json', () => {
   assert.equal(BUILTIN_WALK_EXCLUSIONS, runtime);
 });
 
-test('collectRepositoryPaths preserves excluded-directories and dot-entry behavior from builtin walk exclusions', () => {
+test('collectRepositoryPaths preserves excluded-directories and dot-directory behavior while allowing reportable dot-files', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-walk-exclusions-'));
 
   try {
@@ -37,6 +37,7 @@ test('collectRepositoryPaths preserves excluded-directories and dot-entry behavi
     writeFile(tempRoot, '.eslintrc');
     writeFile(tempRoot, '.hidden.ts');
     writeFile(tempRoot, '.config/inside.logic.ts');
+    writeFile(tempRoot, '.lintstagedrc.js');
 
     for (const excludedDirectory of BUILTIN_WALK_EXCLUSIONS.excludedDirectories) {
       writeFile(tempRoot, `${excludedDirectory}/ignored.logic.ts`);
@@ -44,12 +45,13 @@ test('collectRepositoryPaths preserves excluded-directories and dot-entry behavi
 
     const collected = collectRepositoryPaths(tempRoot, {
       scope: 'repo',
-      reportableExtensions: new Set(['', '.ts']),
+      reportableExtensions: new Set(['', '.ts', '.js']),
     });
 
     assert.equal(collected.includes('src/visible.logic.ts'), true);
     assert.equal(collected.includes('.eslintrc'), true);
-    assert.equal(collected.includes('.hidden.ts'), false);
+    assert.equal(collected.includes('.hidden.ts'), true);
+    assert.equal(collected.includes('.lintstagedrc.js'), true);
     assert.equal(collected.includes('.config/inside.logic.ts'), false);
 
     for (const excludedDirectory of BUILTIN_WALK_EXCLUSIONS.excludedDirectories) {


### PR DESCRIPTION
### Motivation
- Fix a regression where dot-prefixed files were being broadly skipped during repository walk, restoring the pre-cutover behavior that only skipped dot-directories while keeping registry-backed walk exclusions as the source of truth.
- Keep the change small and compatibility-safe so `collectRepositoryPaths(...)` and public validator APIs are unchanged.

### Description
- Removed the broad deny-by-default dot-file gate from `collectPathsFromRoot(...)` in `calculogic-validator/src/naming/naming-validator.logic.mjs` so dot-files now fall through to normal `isReportableFile(...)` evaluation again.
- Preserved registry-backed walk exclusions by continuing to load `excludedDirectories`, `skipDotDirectories`, and `allowDotFiles` from `_builtin/walk-exclusions.registry.json` via `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`.
- Updated `calculogic-validator/test/naming-walk-exclusions-registry.test.mjs` to assert that reportable dot-files (e.g. `.hidden.ts`, `.lintstagedrc.js`) are collected while dot-directories and excluded directories remain skipped.
- Did not change schema or public runtime APIs, and left `allowDotFiles` present for compatibility/metadata continuity (it is still loaded at runtime but no longer acts as a global deny-by-default switch for dot-files).

### Testing
- Ran `node --test calculogic-validator/test/naming-walk-exclusions-registry.test.mjs` and it passed, verifying the walk-exclusions runtime load and restored dot-file collection behavior.
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs` and it passed, ensuring existing naming validations remain green.
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and it passed, ensuring scope/profile behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5aa7cf00833188fdd32fd517ea3c)