### PR TITLE
docs(naming-validator): update walk-exclusions NL to reflect restored dot-file discovery

### DIFF
--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -184,9 +184,9 @@ Runtime walk policy fields:
 
 - `excludedDirectories`: directory basenames skipped during recursive walk.
 - `skipDotDirectories`: when `true`, dot-directories are skipped.
-- `allowDotFiles`: explicit dot-file basename allowlist; other dot-files are skipped.
+- `allowDotFiles`: retained registry compatibility field (loaded at runtime) for explicit dot-file entries such as `.eslintrc`; it does **not** act as a deny-by-default switch for all other dot-files.
 
-This slice is behavior-preserving for the default builtin profile (`.git`, `.vite`, `coverage`, `dist`, `node_modules`; skip dot-directories; allow `.eslintrc` exception).
+This slice preserves default builtin walk behavior (`.git`, `.vite`, `coverage`, `dist`, `node_modules`; skip dot-directories) while allowing reportable dot-files to flow through standard reportable-file checks.
 
 ### 2.9 Semantic-name case rules runtime source (V0.1.18)
 


### PR DESCRIPTION
### Motivation
- Align the NL-config documentation with the runtime behavior that restores pre-cutover dot-file discovery (dot-directories and excluded directories remain skipped, but dot-files are not deny-by-default).

### Description
- Updated `doc/nl-config/cfg-namingValidator.md` to document that `allowDotFiles` is retained for registry compatibility (loaded from `_builtin/walk-exclusions.registry.json`) but does **not** act as a global deny-by-default switch and that reportable dot-files flow through normal reportable-file checks.

### Testing
- Ran the focused validator test suite with `node --test calculogic-validator/test/naming-walk-exclusions-registry.test.mjs calculogic-validator/test/naming-validator.test.mjs calculogic-validator/test/naming-validator-scope-contract.test.mjs` and all tests passed (43/43).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5e63ea688331b6b93b69866411ca)