### PR TITLE
Align naming-validator direct defaults with builtin registry resolver

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -1,11 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import {
-  ROLE_METADATA,
-  ACTIVE_ROLES,
-  ROLE_SUFFIXES,
-} from './registries/naming-roles.knowledge.mjs';
-import { REPORTABLE_EXTENSIONS } from './registries/naming-extensions.knowledge.mjs';
+import { resolveNamingRegistryInputs } from './registries/registry-state.logic.mjs';
 import { BUILTIN_WALK_EXCLUSIONS } from './registries/naming-special-cases.knowledge.mjs';
 import {
   listValidatorScopes,
@@ -28,16 +23,45 @@ export const normalizePath = (relativePath) => relativePath.split(path.sep).join
 
 export { parseCanonicalName, getSpecialCaseType, isAllowedSpecialCase };
 
-const buildDefaultNamingRolesRuntime = () => ({
-  roleMetadata: ROLE_METADATA,
-  activeRoles: ACTIVE_ROLES,
-  roleSuffixes: ROLE_SUFFIXES,
-});
+
+const toReportableExtensionsSet = (extensionArray) => new Set(extensionArray);
+
+const toNamingRolesRuntime = (rolesArray) => {
+  const roleMetadata = new Map();
+
+  rolesArray.forEach((entry) => {
+    if (!roleMetadata.has(entry.role)) {
+      roleMetadata.set(entry.role, entry);
+    }
+  });
+
+  const activeRoles = new Set(
+    Array.from(roleMetadata.values())
+      .filter((entry) => entry.status === 'active')
+      .map((entry) => entry.role),
+  );
+
+  const roleSuffixes = Array.from(roleMetadata.keys()).sort(
+    (left, right) => right.length - left.length,
+  );
+
+  return {
+    roleMetadata,
+    activeRoles,
+    roleSuffixes,
+  };
+};
+
+const BUILTIN_NAMING_REGISTRY_INPUTS = resolveNamingRegistryInputs();
+const DEFAULT_NAMING_ROLES_RUNTIME = toNamingRolesRuntime(BUILTIN_NAMING_REGISTRY_INPUTS.roles);
+const DEFAULT_REPORTABLE_EXTENSIONS = toReportableExtensionsSet(
+  BUILTIN_NAMING_REGISTRY_INPUTS.reportableExtensions,
+);
 
 const resolveNamingRolesRuntime = (namingRolesRuntime) =>
-  namingRolesRuntime ?? buildDefaultNamingRolesRuntime();
+  namingRolesRuntime ?? DEFAULT_NAMING_ROLES_RUNTIME;
 
-const isReportableFile = (relativePath, reportableExtensions = REPORTABLE_EXTENSIONS) => {
+const isReportableFile = (relativePath, reportableExtensions = DEFAULT_REPORTABLE_EXTENSIONS) => {
   const extension = path.extname(relativePath);
   if (reportableExtensions.has(extension)) {
     return true;
@@ -66,7 +90,7 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
     return [];
   }
 
-  const reportableExtensions = options.reportableExtensions ?? REPORTABLE_EXTENSIONS;
+  const reportableExtensions = options.reportableExtensions ?? DEFAULT_REPORTABLE_EXTENSIONS;
   const walkExclusions = options.walkExclusions ?? BUILTIN_WALK_EXCLUSIONS;
   const collected = [];
 

--- a/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  classifyPath,
+  collectRepositoryPaths,
+} from '../src/validators/naming-validator.logic.mjs';
+import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-state.logic.mjs';
+
+const toNamingRolesRuntime = (rolesArray) => {
+  const roleMetadata = new Map();
+
+  rolesArray.forEach((entry) => {
+    if (!roleMetadata.has(entry.role)) {
+      roleMetadata.set(entry.role, entry);
+    }
+  });
+
+  const activeRoles = new Set(
+    Array.from(roleMetadata.values())
+      .filter((entry) => entry.status === 'active')
+      .map((entry) => entry.role),
+  );
+
+  const roleSuffixes = Array.from(roleMetadata.keys()).sort(
+    (left, right) => right.length - left.length,
+  );
+
+  return {
+    roleMetadata,
+    activeRoles,
+    roleSuffixes,
+  };
+};
+
+const writeFile = (rootDirectory, relativePath) => {
+  const absolutePath = path.join(rootDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, 'x', 'utf8');
+};
+
+test('default direct classifyPath runtime aligns with builtin registry resolver payload', () => {
+  const registryInputs = resolveNamingRegistryInputs();
+  const explicitRuntime = toNamingRolesRuntime(registryInputs.roles);
+
+  const canonicalDefault = classifyPath('src/rightpanel.results-style.css');
+  const canonicalExplicit = classifyPath('src/rightpanel.results-style.css', explicitRuntime);
+  assert.deepEqual(canonicalDefault, canonicalExplicit);
+
+  const deprecatedDefault = classifyPath('src/tabs/build/BuildSurface.view.css');
+  const deprecatedExplicit = classifyPath('src/tabs/build/BuildSurface.view.css', explicitRuntime);
+  assert.deepEqual(deprecatedDefault, deprecatedExplicit);
+});
+
+test('default direct collectRepositoryPaths reportable extension behavior aligns with builtin registry resolver payload', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-default-runtime-'));
+
+  try {
+    writeFile(tempRoot, 'src/visible.logic.ts');
+    writeFile(tempRoot, 'doc/readme.spec.md');
+    writeFile(tempRoot, 'src/skip.tmp');
+
+    const registryInputs = resolveNamingRegistryInputs();
+    const explicitReportableExtensions = new Set(registryInputs.reportableExtensions);
+
+    const collectedDefault = collectRepositoryPaths(tempRoot, { scope: 'repo' });
+    const collectedExplicit = collectRepositoryPaths(tempRoot, {
+      scope: 'repo',
+      reportableExtensions: explicitReportableExtensions,
+    });
+
+    assert.deepEqual(collectedDefault, collectedExplicit);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('direct runtime overrides still win over default registry-backed runtime', () => {
+  const runtimeWithoutHost = {
+    roleMetadata: new Map([
+      ['logic', { role: 'logic', category: 'concern-core', status: 'active' }],
+    ]),
+    activeRoles: new Set(['logic']),
+    roleSuffixes: ['logic'],
+  };
+
+  const defaultFinding = classifyPath('src/panel.host.tsx');
+  const overrideFinding = classifyPath('src/panel.host.tsx', runtimeWithoutHost);
+
+  assert.equal(defaultFinding.code, 'NAMING_CANONICAL');
+  assert.equal(overrideFinding.code, 'NAMING_UNKNOWN_ROLE');
+});
+
+test('direct reportableExtensions override still wins over default registry-backed extensions', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-default-ext-'));
+
+  try {
+    writeFile(tempRoot, 'src/notes.tmp');
+    writeFile(tempRoot, 'src/visible.logic.ts');
+
+    const defaultCollected = collectRepositoryPaths(tempRoot, { scope: 'repo' });
+    const overrideCollected = collectRepositoryPaths(tempRoot, {
+      scope: 'repo',
+      reportableExtensions: new Set(['.tmp']),
+    });
+
+    assert.equal(defaultCollected.includes('src/notes.tmp'), false);
+    assert.equal(overrideCollected.includes('src/notes.tmp'), true);
+    assert.equal(overrideCollected.includes('src/visible.logic.ts'), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -10,7 +10,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.16** (canonical report-envelope aliases and source snapshot metadata).
+Current implementation target: **V0.1.19** (direct naming runtime defaults sourced from registry resolver).
 
 ## 1.0 Purpose
 
@@ -195,6 +195,23 @@ Semantic-name case validation is sourced from builtin registry JSON at:
 - `calculogic-validator/src/naming/registries/_builtin/case-rules.registry.json`
 
 Runtime currently supports the builtin `semanticName.style` value `kebab-case` only for this slice. The runtime maps that style to the existing canonical kebab-case semantic-name predicate behavior.
+
+### 2.10 Direct runtime default registry alignment (V0.1.19)
+
+Direct helper entrypoints in `calculogic-validator/src/naming/naming-validator.logic.mjs` now source default runtime roles/extensions from registry resolver output instead of legacy static knowledge constants.
+
+Default runtime source path:
+
+- `resolveNamingRegistryInputs()` (no explicit overrides)
+- roles payload converted to runtime shape:
+  - `roleMetadata: Map`
+  - `activeRoles: Set`
+  - `roleSuffixes: string[]` (length-desc sorting)
+- reportable extensions payload converted to runtime `Set`
+
+Injection precedence remains unchanged:
+
+- explicit `options.namingRolesRuntime` and `options.reportableExtensions` continue to override defaults.
 
 ## 3.0 Classification Contract
 


### PR DESCRIPTION
### Motivation
- Replace the last direct runtime dependency on legacy naming knowledge constants so default direct helpers source builtin registry-backed data. 
- Keep injection precedence and public helper contracts unchanged so existing callers/tests preserve behavior. 

### Description
- `calculogic-validator/src/naming/naming-validator.logic.mjs` now calls `resolveNamingRegistryInputs()` at module runtime and converts the resolver payload into the runtime shapes expected by the validator (`roleMetadata: Map`, `activeRoles: Set`, `roleSuffixes: string[]`) and reportable extensions (`Set`).
- Added local conversion helpers `toNamingRolesRuntime` and `toReportableExtensionsSet` inside `naming-validator.logic.mjs` to keep the change small and avoid cross-file refactors. 
- The default values are used only when callers do not provide overrides; explicit `options.namingRolesRuntime` and `options.reportableExtensions` continue to take precedence. 
- Updated NL-first notes in `doc/nl-config/cfg-namingValidator.md` to document the V0.1.19 direct-runtime default alignment. 
- Added focused test file `calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs` to assert default runtime alignment and override precedence.

### Testing
- Added and ran the focused alignment tests: `node --test calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs` (passed).
- Re-ran the main naming test suites to validate no regressions: `node --test calculogic-validator/test/naming-validator.test.mjs calculogic-validator/test/naming-validator-scope-contract.test.mjs` (passed).
- Re-ran registry metadata test: `node --test calculogic-validator/test/naming-registry-metadata.test.mjs` (passed).
- All automated tests executed during the rollout passed after the change; the added alignment test verifies parity between default direct runtime and explicit resolver-derived runtime, and other naming tests remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5f2e4cc88331ab89a62354a64e1b)