### PR TITLE
Consolidate naming registry payload conversion through shared runtime helpers

### DIFF
--- a/calculogic-validator/src/naming/naming-runtime-converters.logic.mjs
+++ b/calculogic-validator/src/naming/naming-runtime-converters.logic.mjs
@@ -1,0 +1,27 @@
+export const toReportableExtensionsSet = (extensionArray) => new Set(extensionArray);
+
+export const toNamingRolesRuntime = (rolesArray) => {
+  const roleMetadata = new Map();
+
+  rolesArray.forEach((entry) => {
+    if (!roleMetadata.has(entry.role)) {
+      roleMetadata.set(entry.role, entry);
+    }
+  });
+
+  const activeRoles = new Set(
+    Array.from(roleMetadata.values())
+      .filter((entry) => entry.status === 'active')
+      .map((entry) => entry.role),
+  );
+
+  const roleSuffixes = Array.from(roleMetadata.keys()).sort(
+    (left, right) => right.length - left.length,
+  );
+
+  return {
+    roleMetadata,
+    activeRoles,
+    roleSuffixes,
+  };
+};

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -1,6 +1,10 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { resolveNamingRegistryInputs } from './registries/registry-state.logic.mjs';
+import {
+  toNamingRolesRuntime,
+  toReportableExtensionsSet,
+} from './naming-runtime-converters.logic.mjs';
 import { BUILTIN_WALK_EXCLUSIONS } from './registries/naming-special-cases.knowledge.mjs';
 import {
   listValidatorScopes,
@@ -23,34 +27,6 @@ export const normalizePath = (relativePath) => relativePath.split(path.sep).join
 
 export { parseCanonicalName, getSpecialCaseType, isAllowedSpecialCase };
 
-
-const toReportableExtensionsSet = (extensionArray) => new Set(extensionArray);
-
-const toNamingRolesRuntime = (rolesArray) => {
-  const roleMetadata = new Map();
-
-  rolesArray.forEach((entry) => {
-    if (!roleMetadata.has(entry.role)) {
-      roleMetadata.set(entry.role, entry);
-    }
-  });
-
-  const activeRoles = new Set(
-    Array.from(roleMetadata.values())
-      .filter((entry) => entry.status === 'active')
-      .map((entry) => entry.role),
-  );
-
-  const roleSuffixes = Array.from(roleMetadata.keys()).sort(
-    (left, right) => right.length - left.length,
-  );
-
-  return {
-    roleMetadata,
-    activeRoles,
-    roleSuffixes,
-  };
-};
 
 const BUILTIN_NAMING_REGISTRY_INPUTS = resolveNamingRegistryInputs({ config: {} });
 const DEFAULT_NAMING_ROLES_RUNTIME = toNamingRolesRuntime(BUILTIN_NAMING_REGISTRY_INPUTS.roles);

--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -1,5 +1,9 @@
 import { resolveNamingRegistryInputs } from './registries/registry-state.logic.mjs';
 import {
+  toNamingRolesRuntime,
+  toReportableExtensionsSet,
+} from './naming-runtime-converters.logic.mjs';
+import {
   parseCanonicalName,
   getSpecialCaseType,
   isAllowedSpecialCase,
@@ -11,34 +15,6 @@ import {
   runNamingValidator as runNamingValidatorRuntime,
   summarizeFindings,
 } from './naming-validator.logic.mjs';
-
-const toReportableExtensionsSet = (extensionArray) => new Set(extensionArray);
-
-const toNamingRolesRuntime = (rolesArray) => {
-  const roleMetadata = new Map();
-
-  rolesArray.forEach((entry) => {
-    if (!roleMetadata.has(entry.role)) {
-      roleMetadata.set(entry.role, entry);
-    }
-  });
-
-  const activeRoles = new Set(
-    Array.from(roleMetadata.values())
-      .filter((entry) => entry.status === 'active')
-      .map((entry) => entry.role),
-  );
-
-  const roleSuffixes = Array.from(roleMetadata.keys()).sort(
-    (left, right) => right.length - left.length,
-  );
-
-  return {
-    roleMetadata,
-    activeRoles,
-    roleSuffixes,
-  };
-};
 
 export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) => {
   const registryInputs = resolveNamingRegistryInputs({ config });

--- a/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
@@ -8,32 +8,10 @@ import {
   collectRepositoryPaths,
 } from '../src/validators/naming-validator.logic.mjs';
 import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-state.logic.mjs';
-
-const toNamingRolesRuntime = (rolesArray) => {
-  const roleMetadata = new Map();
-
-  rolesArray.forEach((entry) => {
-    if (!roleMetadata.has(entry.role)) {
-      roleMetadata.set(entry.role, entry);
-    }
-  });
-
-  const activeRoles = new Set(
-    Array.from(roleMetadata.values())
-      .filter((entry) => entry.status === 'active')
-      .map((entry) => entry.role),
-  );
-
-  const roleSuffixes = Array.from(roleMetadata.keys()).sort(
-    (left, right) => right.length - left.length,
-  );
-
-  return {
-    roleMetadata,
-    activeRoles,
-    roleSuffixes,
-  };
-};
+import {
+  toNamingRolesRuntime,
+  toReportableExtensionsSet,
+} from '../src/naming/naming-runtime-converters.logic.mjs';
 
 const writeFile = (rootDirectory, relativePath) => {
   const absolutePath = path.join(rootDirectory, relativePath);
@@ -63,7 +41,9 @@ test('default direct collectRepositoryPaths reportable extension behavior aligns
     writeFile(tempRoot, 'src/skip.tmp');
 
     const registryInputs = resolveNamingRegistryInputs({ config: {} });
-    const explicitReportableExtensions = new Set(registryInputs.reportableExtensions);
+    const explicitReportableExtensions = toReportableExtensionsSet(
+      registryInputs.reportableExtensions,
+    );
 
     const collectedDefault = collectRepositoryPaths(tempRoot, { scope: 'repo' });
     const collectedExplicit = collectRepositoryPaths(tempRoot, {
@@ -125,7 +105,9 @@ test('default direct helper behavior matches explicit builtin resolver runtime b
 
     const registryInputs = resolveNamingRegistryInputs({ config: {} });
     const explicitRuntime = toNamingRolesRuntime(registryInputs.roles);
-    const explicitReportableExtensions = new Set(registryInputs.reportableExtensions);
+    const explicitReportableExtensions = toReportableExtensionsSet(
+      registryInputs.reportableExtensions,
+    );
 
     const defaultClassification = classifyPath('src/panel.host.tsx');
     const explicitClassification = classifyPath('src/panel.host.tsx', explicitRuntime);

--- a/calculogic-validator/test/naming-runtime-converters.test.mjs
+++ b/calculogic-validator/test/naming-runtime-converters.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-state.logic.mjs';
+import {
+  toNamingRolesRuntime,
+  toReportableExtensionsSet,
+} from '../src/naming/naming-runtime-converters.logic.mjs';
+import { runNamingValidator as runNamingValidatorRuntime } from '../src/naming/naming-validator.logic.mjs';
+import { runNamingValidator as runNamingValidatorWiring } from '../src/naming/naming-validator.wiring.mjs';
+
+const writeFile = (rootDirectory, relativePath) => {
+  const absolutePath = path.join(rootDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, 'x', 'utf8');
+};
+
+test('shared naming roles converter keeps deterministic first-wins metadata and length-sorted suffixes', () => {
+  const runtime = toNamingRolesRuntime([
+    { role: 'logic', category: 'concern-core', status: 'active' },
+    { role: 'results-style', category: 'concern-core', status: 'active' },
+    { role: 'logic', category: 'deprecated', status: 'deprecated' },
+    { role: 'view', category: 'deprecated', status: 'deprecated' },
+  ]);
+
+  assert.equal(runtime.roleMetadata.get('logic')?.status, 'active');
+  assert.equal(runtime.activeRoles.has('logic'), true);
+  assert.equal(runtime.activeRoles.has('view'), false);
+  assert.deepEqual(runtime.roleSuffixes, ['results-style', 'logic', 'view']);
+});
+
+test('shared reportable extension converter returns a Set preserving extension membership semantics', () => {
+  const reportableExtensions = toReportableExtensionsSet(['.ts', '.tsx', '.ts']);
+
+  assert.equal(reportableExtensions instanceof Set, true);
+  assert.equal(reportableExtensions.has('.ts'), true);
+  assert.equal(reportableExtensions.has('.tsx'), true);
+  assert.equal(reportableExtensions.has('.tmp'), false);
+  assert.equal(reportableExtensions.size, 2);
+});
+
+test('direct runtime and wiring derive equivalent runtime validation output from the same resolver payload', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-runtime-converter-parity-'));
+
+  try {
+    writeFile(tempRoot, 'src/panel.logic.ts');
+    writeFile(tempRoot, 'src/panel.host.tsx');
+    writeFile(tempRoot, 'src/legacy.tmp');
+
+    const registryInputs = resolveNamingRegistryInputs({ config: {} });
+    const runtimeResult = runNamingValidatorRuntime(tempRoot, {
+      scope: 'repo',
+      namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
+      reportableExtensions: toReportableExtensionsSet(registryInputs.reportableExtensions),
+    });
+
+    const wiringResult = runNamingValidatorWiring(tempRoot, { scope: 'repo', config: {} });
+
+    assert.deepEqual(wiringResult.findings, runtimeResult.findings);
+    assert.equal(wiringResult.totalFilesScanned, runtimeResult.totalFilesScanned);
+    assert.equal(wiringResult.scope, runtimeResult.scope);
+    assert.deepEqual(wiringResult.filters, runtimeResult.filters);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -10,7 +10,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.21** (direct naming runtime defaults pinned to builtin registry payload with isolation-safe alignment tests).
+Current implementation target: **V0.1.22** (registry-backed naming payload conversion consolidated through shared runtime converters for direct defaults and wiring).
 
 ## 1.0 Purpose
 
@@ -196,22 +196,24 @@ Semantic-name case validation is sourced from builtin registry JSON at:
 
 Runtime currently supports the builtin `semanticName.style` value `kebab-case` only for this slice. The runtime maps that style to the existing canonical kebab-case semantic-name predicate behavior.
 
-### 2.10 Direct runtime default registry alignment (V0.1.21)
+### 2.10 Shared naming runtime converter path (V0.1.22)
 
-Direct helper entrypoints in `calculogic-validator/src/naming/naming-validator.logic.mjs` now source default runtime roles/extensions from registry resolver output instead of legacy static knowledge constants.
+Direct runtime defaults and wiring now share one helper conversion seam for registry-backed naming payloads.
 
 Default runtime source path:
 
+- shared converter module: `calculogic-validator/src/naming/naming-runtime-converters.logic.mjs`
 - `resolveNamingRegistryInputs({ config: {} })` (builtin payload path)
-- roles payload converted to runtime shape:
+- roles payload converted via `toNamingRolesRuntime(roles)` to runtime shape:
   - `roleMetadata: Map`
   - `activeRoles: Set`
   - `roleSuffixes: string[]` (length-desc sorting)
-- reportable extensions payload converted to runtime `Set`
+- reportable extensions payload converted via `toReportableExtensionsSet(reportableExtensions)` to runtime `Set`
 
 Injection precedence remains unchanged:
 
 - explicit `options.namingRolesRuntime` and `options.reportableExtensions` continue to override defaults.
+- direct runtime defaults (`naming-validator.logic.mjs`) and wiring runtime assembly (`naming-validator.wiring.mjs`) both consume the shared converter helper path.
 - alignment tests for direct runtime defaults must be isolation-safe and must not mutate repo-owned registry state files in-place.
 
 ## 3.0 Classification Contract


### PR DESCRIPTION
### Motivation
- Remove duplicated conversion logic that built runtime shapes from registry-backed naming payloads in both runtime (`naming-validator.logic.mjs`) and wiring (`naming-validator.wiring.mjs`) to reduce drift risk. 
- Keep runtime behavior, injection precedence, and deterministic runtime shapes (`Map`, `Set`, length-sorted `roleSuffixes`) unchanged while making both paths share one conversion seam.

### Description
- Added a small shared converter module `calculogic-validator/src/naming/naming-runtime-converters.logic.mjs` exporting `toNamingRolesRuntime(rolesArray)` and `toReportableExtensionsSet(extensionArray)`. 
- Updated `calculogic-validator/src/naming/naming-validator.logic.mjs` to import and use the shared `toNamingRolesRuntime`/`toReportableExtensionsSet` for direct builtin-backed defaults. 
- Updated `calculogic-validator/src/naming/naming-validator.wiring.mjs` to import and use the same shared converters and removed the duplicated conversion implementations from that file. 
- Replaced the local converter in `calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs` and added a focused parity test file `calculogic-validator/test/naming-runtime-converters.test.mjs` that asserts converter semantics and runtime vs wiring parity, and updated NL-config notes in `doc/nl-config/cfg-namingValidator.md` to document the shared seam.

### Testing
- Ran the new focused tests and the relevant naming test suite with: `node --test calculogic-validator/test/naming-runtime-converters.test.mjs calculogic-validator/test/naming-validator.test.mjs calculogic-validator/test/naming-validator-scope-contract.test.mjs calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs calculogic-validator/test/registry-state.logic.test.mjs`. 
- All executed tests passed (63 tests, 0 failures) confirming converter behavior and parity between direct runtime and wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa726591c08331a4e551762e4e7816)