### PR TITLE
Label naming compatibility exports and registry loader seams

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -1,0 +1,20 @@
+# Naming runtime compatibility inventory (transitional)
+
+This note is a lightweight map for the later hardening/removal pass.
+
+## Compatibility exports retained
+- `SCOPE_PROFILES` (snapshot compatibility export; primary runtime path is `getBuiltinScopeProfiles()`).
+- `BUILTIN_SPECIAL_CASE_RULES` (snapshot compatibility export; primary runtime path is `getBuiltinSpecialCaseRules()`).
+- `BUILTIN_WALK_EXCLUSIONS` (snapshot compatibility export; primary runtime path is `getBuiltinWalkExclusions()`).
+- `EXCLUDED_DIRECTORIES` (legacy data export retained temporarily; primary runtime path is `getBuiltinWalkExclusions().excludedDirectories`).
+- `CANONICAL_SEMANTIC_PATTERN` (compatibility export; primary runtime path is `getSemanticNameCaseRule().pattern`).
+
+## Registry loader seams
+- `naming-special-cases.knowledge.mjs` loaders for special-cases and walk-exclusions registries.
+- `naming-case-rules.knowledge.mjs` builtin registry assertions.
+- `validator-scopes.knowledge.mjs` builtin scope profile registry loading/normalization.
+- `naming-scope-profiles.knowledge.mjs` re-export seam to validator-scope APIs.
+
+## Primary runtime paths
+- Getter-backed registry accessors (`getBuiltin*`, `getSemanticNameCaseRule`).
+- `ROLE_REGISTRY` and `REPORTABLE_EXTENSIONS` as direct runtime policy defaults.

--- a/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
@@ -2,6 +2,7 @@ import builtinCaseRulesRegistry from './_builtin/case-rules.registry.json' with 
 
 const CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+// Registry loader seam: validates builtin case-rules registry payload shape.
 const assertBuiltinCaseRulesRegistry = (registry) => {
   if (typeof registry !== 'object' || registry === null) {
     throw new TypeError('Builtin case-rules registry must be an object.');
@@ -16,6 +17,7 @@ const assertBuiltinCaseRulesRegistry = (registry) => {
   }
 };
 
+// Primary runtime path: canonical semantic-name matcher selection by declared builtin style.
 const resolveSemanticNamePatternByStyle = (semanticNameStyle) => {
   if (semanticNameStyle === 'kebab-case') {
     return CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN;
@@ -29,8 +31,11 @@ assertBuiltinCaseRulesRegistry(builtinCaseRulesRegistry);
 const semanticNameStyle = builtinCaseRulesRegistry.semanticName.style;
 const canonicalSemanticPattern = resolveSemanticNamePatternByStyle(semanticNameStyle);
 
+// Compatibility export: concrete pattern retained for legacy imports.
+// Primary runtime path is getSemanticNameCaseRule().pattern.
 export const CANONICAL_SEMANTIC_PATTERN = canonicalSemanticPattern;
 
+// Primary runtime path: getter-backed semantic-name case rule for runtime and tests.
 export const getSemanticNameCaseRule = () => ({
   style: semanticNameStyle,
   pattern: canonicalSemanticPattern,

--- a/calculogic-validator/src/naming/registries/naming-extensions.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-extensions.knowledge.mjs
@@ -1,3 +1,4 @@
+// Primary runtime path: builtin reportable-extension defaults used by naming runtime.
 export const REPORTABLE_EXTENSIONS = new Set([
   '.ts',
   '.tsx',

--- a/calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs
@@ -1,3 +1,4 @@
+// Primary runtime path: naming role policy source loaded directly by validator runtime.
 export const ROLE_REGISTRY = [
   { role: 'host', category: 'architecture-support', status: 'active' },
   { role: 'wiring', category: 'architecture-support', status: 'active' },

--- a/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
@@ -1,3 +1,4 @@
+// Registry loader seam: naming scope profiles are sourced from validator-level scope APIs.
 export {
   SCOPE_PROFILES,
   cloneScopeProfile,

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -17,6 +17,7 @@ const WALK_EXCLUSIONS_REGISTRY_PATH = fileURLToPath(
 let cachedBuiltinSpecialCaseRules = null;
 let cachedBuiltinWalkExclusions = null;
 
+// Registry loader seam: validates builtin JSON and adapts it into runtime matchers.
 const loadBuiltinSpecialCases = () => {
   const payload = JSON.parse(fs.readFileSync(SPECIAL_CASES_REGISTRY_PATH, 'utf8'));
 
@@ -67,6 +68,7 @@ const loadBuiltinSpecialCases = () => {
 };
 
 
+// Registry loader seam: validates builtin JSON and adapts it into runtime walk exclusions.
 const loadBuiltinWalkExclusions = () => {
   const payload = JSON.parse(fs.readFileSync(WALK_EXCLUSIONS_REGISTRY_PATH, 'utf8'));
 
@@ -110,6 +112,7 @@ const loadBuiltinWalkExclusions = () => {
   };
 };
 
+// Primary runtime path: getter-backed access for naming walk exclusions.
 export const getBuiltinWalkExclusions = () => {
   if (cachedBuiltinWalkExclusions === null) {
     cachedBuiltinWalkExclusions = loadBuiltinWalkExclusions();
@@ -120,10 +123,15 @@ export const getBuiltinWalkExclusions = () => {
 
 export const BUILTIN_WALK_EXCLUSIONS_REGISTRY_PATH = WALK_EXCLUSIONS_REGISTRY_PATH;
 
+// Compatibility export: eager snapshot retained for legacy imports.
+// Primary runtime path is getBuiltinWalkExclusions().
 export const BUILTIN_WALK_EXCLUSIONS = getBuiltinWalkExclusions();
 
+// Legacy data export retained temporarily for compatibility.
+// Primary runtime path is getBuiltinWalkExclusions().excludedDirectories.
 export const EXCLUDED_DIRECTORIES = BUILTIN_WALK_EXCLUSIONS.excludedDirectories;
 
+// Primary runtime path: getter-backed access for special-case rule matchers.
 export const getBuiltinSpecialCaseRules = () => {
   if (cachedBuiltinSpecialCaseRules === null) {
     cachedBuiltinSpecialCaseRules = loadBuiltinSpecialCases();
@@ -134,4 +142,6 @@ export const getBuiltinSpecialCaseRules = () => {
 
 export const BUILTIN_SPECIAL_CASES_REGISTRY_PATH = SPECIAL_CASES_REGISTRY_PATH;
 
+// Compatibility export: eager snapshot retained for legacy imports.
+// Primary runtime path is getBuiltinSpecialCaseRules().
 export const BUILTIN_SPECIAL_CASE_RULES = getBuiltinSpecialCaseRules();

--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -72,6 +72,7 @@ const canonicalizeScopeProfile = (scope, profile) => {
   };
 };
 
+// Registry loader seam: validates and normalizes builtin scope-profile registry payload.
 const loadBuiltinScopeProfiles = () => {
   const parsedRegistry = loadJsonFile(BUILTIN_SCOPE_PROFILES_REGISTRY_PATH);
 
@@ -89,6 +90,7 @@ const loadBuiltinScopeProfiles = () => {
 
 let cachedBuiltinScopeProfiles = null;
 
+// Primary runtime path: getter-backed scope profile access for validator runtime.
 export const getBuiltinScopeProfiles = () => {
   if (!cachedBuiltinScopeProfiles) {
     cachedBuiltinScopeProfiles = loadBuiltinScopeProfiles();
@@ -97,11 +99,12 @@ export const getBuiltinScopeProfiles = () => {
   return cachedBuiltinScopeProfiles;
 };
 
-// Compatibility snapshot export for legacy imports.
+// Compatibility export: snapshot retained for legacy imports.
 // Runtime access must use getter-backed APIs: getBuiltinScopeProfiles(),
 // listValidatorScopes(), and getValidatorScopeProfile().
 export const SCOPE_PROFILES = getBuiltinScopeProfiles();
 
+// Primary runtime path helper: immutable copy for callers and compatibility shims.
 export const cloneScopeProfile = (profile) => ({
   description: profile.description,
   includeRoots: [...profile.includeRoots],


### PR DESCRIPTION
### Motivation
- Make remaining legacy naming exports and registry loader seams explicit so ownership and intent are clear for a later hardening/removal pass.
- Reduce future confusion by classifying transitional pieces as primary runtime paths, compatibility exports, or registry loader seams without changing behavior.
- Provide a small validator-owned inventory to guide the later cleanup pass.

### Description
- Added concise comment labels (`Primary runtime path`, `Compatibility export`, `Registry loader seam`, `Legacy data export retained temporarily`) across naming-related files to make intent explicit in-place. 
- Files changed: `calculogic-validator/src/naming/registries/naming-roles.knowledge.mjs`, `calculogic-validator/src/naming/registries/naming-extensions.knowledge.mjs`, `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`, `calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs`, `calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs`, `calculogic-validator/src/validator-scopes.knowledge.mjs`, and added `calculogic-validator/doc/naming-compatibility-inventory.md`.
- Marked specific exports and paths: compatibility/legacy snapshots (`SCOPE_PROFILES`, `BUILTIN_SPECIAL_CASE_RULES`, `BUILTIN_WALK_EXCLUSIONS`, `EXCLUDED_DIRECTORIES`, `CANONICAL_SEMANTIC_PATTERN`) now include comments pointing consumers to getter-backed primary runtime APIs (`getBuiltinScopeProfiles`, `getBuiltinSpecialCaseRules`, `getBuiltinWalkExclusions`, `getSemanticNameCaseRule`), and loader seams around builtin JSON registry loaders were labeled.
- No API renames or removals were performed and no runtime logic was changed; changes are documentation/comment-only and a small inventory file for follow-up work.

### Testing
- Re-ran the suggested naming-focused suites with `node --test calculogic-validator/test/naming-validator.test.mjs calculogic-validator/test/naming-validator-scope-contract.test.mjs calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs calculogic-validator/test/naming-runtime-converters.test.mjs calculogic-validator/test/registry-state.logic.test.mjs`.
- Result: all tests passed (63 tests, 0 failures), confirming no behavioral regressions were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa757adeb88331ba667cebca811697)