### PR TITLE
Retire EXCLUDED_DIRECTORIES compatibility export

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -3,6 +3,7 @@
 This note is a lightweight map for the later hardening/removal pass.
 
 ## Retired legacy modules
+- `EXCLUDED_DIRECTORIES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinWalkExclusions().excludedDirectories`.
 - `src/naming/registries/naming-roles.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 - `src/naming/registries/naming-extensions.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 
@@ -10,7 +11,6 @@ This note is a lightweight map for the later hardening/removal pass.
 - `SCOPE_PROFILES` (snapshot compatibility export; primary runtime path is `getBuiltinScopeProfiles()`).
 - `BUILTIN_SPECIAL_CASE_RULES` (snapshot compatibility export; primary runtime path is `getBuiltinSpecialCaseRules()`).
 - `BUILTIN_WALK_EXCLUSIONS` (snapshot compatibility export; primary runtime path is `getBuiltinWalkExclusions()`).
-- `EXCLUDED_DIRECTORIES` (legacy data export retained temporarily; primary runtime path is `getBuiltinWalkExclusions().excludedDirectories`).
 - `CANONICAL_SEMANTIC_PATTERN` (compatibility export; primary runtime path is `getSemanticNameCaseRule().pattern`).
 
 ## Registry loader seams

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -127,10 +127,6 @@ export const BUILTIN_WALK_EXCLUSIONS_REGISTRY_PATH = WALK_EXCLUSIONS_REGISTRY_PA
 // Primary runtime path is getBuiltinWalkExclusions().
 export const BUILTIN_WALK_EXCLUSIONS = getBuiltinWalkExclusions();
 
-// Legacy data export retained temporarily for compatibility.
-// Primary runtime path is getBuiltinWalkExclusions().excludedDirectories.
-export const EXCLUDED_DIRECTORIES = BUILTIN_WALK_EXCLUSIONS.excludedDirectories;
-
 // Primary runtime path: getter-backed access for special-case rule matchers.
 export const getBuiltinSpecialCaseRules = () => {
   if (cachedBuiltinSpecialCaseRules === null) {


### PR DESCRIPTION
### Motivation
- `EXCLUDED_DIRECTORIES` was a legacy snapshot alias while the primary runtime access is `getBuiltinWalkExclusions().excludedDirectories`, and an internal audit showed no remaining runtime/test consumers, so it can be retired to avoid a separately-maintained source of truth.

### Description
- Removed the legacy export `EXCLUDED_DIRECTORIES` from `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs` so it no longer exposes a separate data snapshot.
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to mark `EXCLUDED_DIRECTORIES` as retired and removed it from the list of retained compatibility exports.
- Left the getter-backed runtime access `getBuiltinWalkExclusions()` and the `BUILTIN_WALK_EXCLUSIONS` snapshot unchanged so runtime behavior remains identical.
- Files changed: `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`, `calculogic-validator/doc/naming-compatibility-inventory.md`.

### Testing
- Verified no internal consumers with `rg "EXCLUDED_DIRECTORIES" -n`, which showed only the inventory entry prior to the update and no runtime/test imports after the change.
- Ran `node --test calculogic-validator/test/naming-walk-exclusions-registry.test.mjs`, which passed.
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs`, which passed.
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa805d3c808331adcc6848f6ffd834)