### PR TITLE
Retire BUILTIN_WALK_EXCLUSIONS compatibility snapshot export

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -4,13 +4,13 @@ This note is a lightweight map for the later hardening/removal pass.
 
 ## Retired legacy modules
 - `EXCLUDED_DIRECTORIES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinWalkExclusions().excludedDirectories`.
+- `BUILTIN_WALK_EXCLUSIONS` retired after runtime/test import audit and consumer repointing to `getBuiltinWalkExclusions()` completed.
 - `src/naming/registries/naming-roles.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 - `src/naming/registries/naming-extensions.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 
 ## Compatibility exports retained
 - `SCOPE_PROFILES` (snapshot compatibility export; primary runtime path is `getBuiltinScopeProfiles()`).
 - `BUILTIN_SPECIAL_CASE_RULES` (snapshot compatibility export; primary runtime path is `getBuiltinSpecialCaseRules()`).
-- `BUILTIN_WALK_EXCLUSIONS` (snapshot compatibility export; primary runtime path is `getBuiltinWalkExclusions()`).
 - `CANONICAL_SEMANTIC_PATTERN` (compatibility export; primary runtime path is `getSemanticNameCaseRule().pattern`).
 
 ## Registry loader seams

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -5,7 +5,7 @@ import {
   toNamingRolesRuntime,
   toReportableExtensionsSet,
 } from './naming-runtime-converters.logic.mjs';
-import { BUILTIN_WALK_EXCLUSIONS } from './registries/naming-special-cases.knowledge.mjs';
+import { getBuiltinWalkExclusions } from './registries/naming-special-cases.knowledge.mjs';
 import {
   listValidatorScopes,
   getValidatorScopeProfile,
@@ -67,7 +67,7 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
   }
 
   const reportableExtensions = options.reportableExtensions ?? DEFAULT_REPORTABLE_EXTENSIONS;
-  const walkExclusions = options.walkExclusions ?? BUILTIN_WALK_EXCLUSIONS;
+  const walkExclusions = options.walkExclusions ?? getBuiltinWalkExclusions();
   const collected = [];
 
   const walk = (absoluteDirectoryPath) => {

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -123,9 +123,6 @@ export const getBuiltinWalkExclusions = () => {
 
 export const BUILTIN_WALK_EXCLUSIONS_REGISTRY_PATH = WALK_EXCLUSIONS_REGISTRY_PATH;
 
-// Compatibility export: eager snapshot retained for legacy imports.
-// Primary runtime path is getBuiltinWalkExclusions().
-export const BUILTIN_WALK_EXCLUSIONS = getBuiltinWalkExclusions();
 
 // Primary runtime path: getter-backed access for special-case rule matchers.
 export const getBuiltinSpecialCaseRules = () => {

--- a/calculogic-validator/test/naming-walk-exclusions-registry.test.mjs
+++ b/calculogic-validator/test/naming-walk-exclusions-registry.test.mjs
@@ -5,7 +5,6 @@ import os from 'node:os';
 import path from 'node:path';
 import { collectRepositoryPaths } from '../src/validators/naming-validator.logic.mjs';
 import {
-  BUILTIN_WALK_EXCLUSIONS,
   BUILTIN_WALK_EXCLUSIONS_REGISTRY_PATH,
   getBuiltinWalkExclusions,
 } from '../src/naming/registries/naming-special-cases.knowledge.mjs';
@@ -26,7 +25,6 @@ test('runtime walk exclusions are loaded from builtin registry json', () => {
   );
   assert.equal(runtime.skipDotDirectories, registryJson.skipDotDirectories);
   assert.deepEqual(Array.from(runtime.allowDotFiles).sort(), [...registryJson.allowDotFiles].sort());
-  assert.equal(BUILTIN_WALK_EXCLUSIONS, runtime);
 });
 
 test('collectRepositoryPaths preserves excluded-directories and dot-directory behavior while allowing reportable dot-files', () => {
@@ -39,7 +37,7 @@ test('collectRepositoryPaths preserves excluded-directories and dot-directory be
     writeFile(tempRoot, '.config/inside.logic.ts');
     writeFile(tempRoot, '.lintstagedrc.js');
 
-    for (const excludedDirectory of BUILTIN_WALK_EXCLUSIONS.excludedDirectories) {
+    for (const excludedDirectory of getBuiltinWalkExclusions().excludedDirectories) {
       writeFile(tempRoot, `${excludedDirectory}/ignored.logic.ts`);
     }
 
@@ -54,7 +52,7 @@ test('collectRepositoryPaths preserves excluded-directories and dot-directory be
     assert.equal(collected.includes('.lintstagedrc.js'), true);
     assert.equal(collected.includes('.config/inside.logic.ts'), false);
 
-    for (const excludedDirectory of BUILTIN_WALK_EXCLUSIONS.excludedDirectories) {
+    for (const excludedDirectory of getBuiltinWalkExclusions().excludedDirectories) {
       assert.equal(collected.includes(`${excludedDirectory}/ignored.logic.ts`), false);
     }
   } finally {


### PR DESCRIPTION
### Motivation
- `BUILTIN_WALK_EXCLUSIONS` is a legacy snapshot compatibility export while the primary runtime accessor is the getter `getBuiltinWalkExclusions()`. 
- The change aims to remove the redundant snapshot export where internal consumers are repointed to the getter to keep a single source of truth and avoid divergence. 

### Description
- Removed the `BUILTIN_WALK_EXCLUSIONS` eager snapshot compatibility export from `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`. 
- Repointed the runtime consumer in `calculogic-validator/src/naming/naming-validator.logic.mjs` to call `getBuiltinWalkExclusions()` as the default walk-exclusions source. 
- Updated `calculogic-validator/test/naming-walk-exclusions-registry.test.mjs` to stop importing the retired snapshot and to validate behavior via `getBuiltinWalkExclusions()` only, removing the identity assertion. 
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to mark `BUILTIN_WALK_EXCLUSIONS` as retired and removed it from the retained compatibility exports list. 

### Testing
- Ran a repo search for remaining references: `rg "BUILTIN_WALK_EXCLUSIONS" -n` and confirmed the export was removed from runtime/test imports; this succeeded. 
- Executed `node --test calculogic-validator/test/naming-walk-exclusions-registry.test.mjs` and the test suite passed. 
- Executed `node --test calculogic-validator/test/naming-validator.test.mjs` and `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and both suites passed. 
- All automated checks above passed, and runtime walk-exclusions behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa826db56c8331802af087db59c6dd)