### PR TITLE
Retire BUILTIN_SPECIAL_CASE_RULES snapshot compatibility export

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -5,12 +5,12 @@ This note is a lightweight map for the later hardening/removal pass.
 ## Retired legacy modules
 - `EXCLUDED_DIRECTORIES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinWalkExclusions().excludedDirectories`.
 - `BUILTIN_WALK_EXCLUSIONS` retired after runtime/test import audit and consumer repointing to `getBuiltinWalkExclusions()` completed.
+- `BUILTIN_SPECIAL_CASE_RULES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinSpecialCaseRules()`.
 - `src/naming/registries/naming-roles.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 - `src/naming/registries/naming-extensions.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 
 ## Compatibility exports retained
 - `SCOPE_PROFILES` (snapshot compatibility export; primary runtime path is `getBuiltinScopeProfiles()`).
-- `BUILTIN_SPECIAL_CASE_RULES` (snapshot compatibility export; primary runtime path is `getBuiltinSpecialCaseRules()`).
 - `CANONICAL_SEMANTIC_PATTERN` (compatibility export; primary runtime path is `getSemanticNameCaseRule().pattern`).
 
 ## Registry loader seams

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -134,7 +134,3 @@ export const getBuiltinSpecialCaseRules = () => {
 };
 
 export const BUILTIN_SPECIAL_CASES_REGISTRY_PATH = SPECIAL_CASES_REGISTRY_PATH;
-
-// Compatibility export: eager snapshot retained for legacy imports.
-// Primary runtime path is getBuiltinSpecialCaseRules().
-export const BUILTIN_SPECIAL_CASE_RULES = getBuiltinSpecialCaseRules();

--- a/calculogic-validator/test/naming-special-cases-registry.test.mjs
+++ b/calculogic-validator/test/naming-special-cases-registry.test.mjs
@@ -2,7 +2,6 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import {
-  BUILTIN_SPECIAL_CASE_RULES,
   BUILTIN_SPECIAL_CASES_REGISTRY_PATH,
   getBuiltinSpecialCaseRules,
 } from '../src/naming/registries/naming-special-cases.knowledge.mjs';
@@ -53,11 +52,4 @@ test('runtime builtin special-case rules are loaded from builtin registry json',
 
   assert.equal(hasPackageRule, true);
   assert.equal(getSpecialCaseType('package.json'), 'ecosystem-required');
-});
-
-test('builtin special-case rules compatibility export stays aligned with getter', () => {
-  const runtimeRules = getBuiltinSpecialCaseRules();
-
-  assert.equal(BUILTIN_SPECIAL_CASE_RULES, runtimeRules);
-  assert.deepEqual(BUILTIN_SPECIAL_CASE_RULES, runtimeRules);
 });


### PR DESCRIPTION
### Motivation
- Remove the retained eager snapshot-style export `BUILTIN_SPECIAL_CASE_RULES` now that the getter-backed runtime path `getBuiltinSpecialCaseRules()` is primary and no runtime consumers remain, advancing the incremental retirement of legacy snapshot exports.

### Description
- Deleted the `BUILTIN_SPECIAL_CASE_RULES` compatibility export from `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs` and removed the corresponding import/assertion from the affected test; updated the compatibility inventory to mark the symbol retired. Files changed: `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs`, `calculogic-validator/test/naming-special-cases-registry.test.mjs`, and `calculogic-validator/doc/naming-compatibility-inventory.md`.

### Testing
- Ran the targeted search and test suite commands `rg "BUILTIN_SPECIAL_CASE_RULES" -n`, `node --test calculogic-validator/test/naming-special-cases-registry.test.mjs`, `node --test calculogic-validator/test/naming-validator.test.mjs`, and `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs`, and all tests passed (special-cases registry tests passed; full validator tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa840192a88331b8811043f32130f1)