### PR TITLE
Retire SCOPE_PROFILES snapshot compatibility export

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -3,6 +3,7 @@
 This note is a lightweight map for the later hardening/removal pass.
 
 ## Retired legacy modules
+- `SCOPE_PROFILES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinScopeProfiles()`.
 - `EXCLUDED_DIRECTORIES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinWalkExclusions().excludedDirectories`.
 - `BUILTIN_WALK_EXCLUSIONS` retired after runtime/test import audit and consumer repointing to `getBuiltinWalkExclusions()` completed.
 - `BUILTIN_SPECIAL_CASE_RULES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinSpecialCaseRules()`.
@@ -10,7 +11,6 @@ This note is a lightweight map for the later hardening/removal pass.
 - `src/naming/registries/naming-extensions.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 
 ## Compatibility exports retained
-- `SCOPE_PROFILES` (snapshot compatibility export; primary runtime path is `getBuiltinScopeProfiles()`).
 - `CANONICAL_SEMANTIC_PATTERN` (compatibility export; primary runtime path is `getSemanticNameCaseRule().pattern`).
 
 ## Registry loader seams

--- a/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
@@ -1,6 +1,5 @@
 // Registry loader seam: naming scope profiles are sourced from validator-level scope APIs.
 export {
-  SCOPE_PROFILES,
   cloneScopeProfile,
   listValidatorScopes,
   getValidatorScopeProfile,

--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -99,11 +99,6 @@ export const getBuiltinScopeProfiles = () => {
   return cachedBuiltinScopeProfiles;
 };
 
-// Compatibility export: snapshot retained for legacy imports.
-// Runtime access must use getter-backed APIs: getBuiltinScopeProfiles(),
-// listValidatorScopes(), and getValidatorScopeProfile().
-export const SCOPE_PROFILES = getBuiltinScopeProfiles();
-
 // Primary runtime path helper: immutable copy for callers and compatibility shims.
 export const cloneScopeProfile = (profile) => ({
   description: profile.description,

--- a/calculogic-validator/test/naming-validator-scope-contract.test.mjs
+++ b/calculogic-validator/test/naming-validator-scope-contract.test.mjs
@@ -7,10 +7,7 @@ import {
   getScopeProfile,
   listNamingValidatorScopes,
 } from '../src/validators/naming-validator.logic.mjs';
-import {
-  SCOPE_PROFILES,
-  getBuiltinScopeProfiles,
-} from '../src/validator-scopes.knowledge.mjs';
+import { getBuiltinScopeProfiles } from '../src/validator-scopes.knowledge.mjs';
 
 const runValidatorCli = (args) =>
   spawnSync(
@@ -160,10 +157,6 @@ test('system scope profile keeps legacy explicit root-file behavior when builtin
 });
 
 
-
-test('compatibility scope profiles export stays aligned with getter-backed builtin profiles', () => {
-  assert.deepEqual(SCOPE_PROFILES, getBuiltinScopeProfiles());
-});
 
 test('scope profiles are cloned on lookup (mutations do not leak across reads)', () => {
   const firstRead = getScopeProfile('docs');


### PR DESCRIPTION
### Motivation
- `SCOPE_PROFILES` is a retained snapshot compatibility export while the primary runtime path is already getter-backed via `getBuiltinScopeProfiles()`, so it should be retired if no internal consumers remain. 
- The change is a narrow retirement slice intended to remove only this one compatibility export while keeping runtime behavior unchanged.

### Description
- Removed the `SCOPE_PROFILES` export from `calculogic-validator/src/validator-scopes.knowledge.mjs` so runtime access uses `getBuiltinScopeProfiles()` only. 
- Stopped re-exporting `SCOPE_PROFILES` from `calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs` and left `cloneScopeProfile`, `listValidatorScopes`, and `getValidatorScopeProfile` in place. 
- Updated `calculogic-validator/test/naming-validator-scope-contract.test.mjs` to import the getter-backed API only and removed the compatibility-export alignment assertion that referenced `SCOPE_PROFILES`. 
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to mark `SCOPE_PROFILES` as retired and removed it from the retained compatibility exports list. 
- Files changed: `validator-scopes.knowledge.mjs`, `naming-scope-profiles.knowledge.mjs`, `naming-validator-scope-contract.test.mjs`, and `doc/naming-compatibility-inventory.md`.

### Testing
- Ran `rg "SCOPE_PROFILES" -n` to confirm internal references were removed, and it showed no runtime/test consumers remaining. (OK) 
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and all tests passed. (20/20 passing) 
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs` and all tests passed. (20/20 passing) 
- Next best retirement candidate after this slice: `CANONICAL_SEMANTIC_PATTERN` (still listed as a retained compatibility export in the inventory).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa85b2d3a8833186db4f3b1caa9e26)