### PR TITLE
Retire CANONICAL_SEMANTIC_PATTERN compatibility export

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -11,11 +11,11 @@ This note is a lightweight map for the later hardening/removal pass.
 - `src/naming/registries/naming-extensions.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 
 ## Compatibility exports retained
-- `CANONICAL_SEMANTIC_PATTERN` (compatibility export; primary runtime path is `getSemanticNameCaseRule().pattern`).
+- None.
 
 ## Registry loader seams
 - `naming-special-cases.knowledge.mjs` loaders for special-cases and walk-exclusions registries.
-- `naming-case-rules.knowledge.mjs` builtin registry assertions.
+- `naming-case-rules.knowledge.mjs` builtin registry assertions and semantic-name case-rule getter.
 - `validator-scopes.knowledge.mjs` builtin scope profile registry loading/normalization.
 - `naming-scope-profiles.knowledge.mjs` re-export seam to validator-scope APIs.
 

--- a/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
@@ -31,10 +31,6 @@ assertBuiltinCaseRulesRegistry(builtinCaseRulesRegistry);
 const semanticNameStyle = builtinCaseRulesRegistry.semanticName.style;
 const canonicalSemanticPattern = resolveSemanticNamePatternByStyle(semanticNameStyle);
 
-// Compatibility export: concrete pattern retained for legacy imports.
-// Primary runtime path is getSemanticNameCaseRule().pattern.
-export const CANONICAL_SEMANTIC_PATTERN = canonicalSemanticPattern;
-
 // Primary runtime path: getter-backed semantic-name case rule for runtime and tests.
 export const getSemanticNameCaseRule = () => ({
   style: semanticNameStyle,

--- a/calculogic-validator/test/naming-case-rules-registry.test.mjs
+++ b/calculogic-validator/test/naming-case-rules-registry.test.mjs
@@ -1,10 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import caseRulesRegistry from '../src/naming/registries/_builtin/case-rules.registry.json' with { type: 'json' };
-import {
-  CANONICAL_SEMANTIC_PATTERN,
-  getSemanticNameCaseRule,
-} from '../src/naming/registries/naming-case-rules.knowledge.mjs';
+import { getSemanticNameCaseRule } from '../src/naming/registries/naming-case-rules.knowledge.mjs';
 import { isCanonicalSemanticName } from '../src/naming/rules/naming-rule-check-semantic-case.logic.mjs';
 
 test('semantic-name case rule runtime is sourced from builtin registry style', () => {
@@ -12,7 +9,8 @@ test('semantic-name case rule runtime is sourced from builtin registry style', (
 
   assert.equal(semanticCaseRule.style, caseRulesRegistry.semanticName.style);
   assert.equal(semanticCaseRule.style, 'kebab-case');
-  assert.equal(semanticCaseRule.pattern, CANONICAL_SEMANTIC_PATTERN);
+  assert.equal(semanticCaseRule.pattern.test('left-panel'), true);
+  assert.equal(semanticCaseRule.pattern.test('leftPanel'), false);
 });
 
 test('kebab-case semantic names are canonical', () => {


### PR DESCRIPTION
### Motivation
- The canonical semantic-name matcher is already served by the getter-backed runtime path `getSemanticNameCaseRule()`, so the concrete `CANONICAL_SEMANTIC_PATTERN` compatibility export is redundant and safe to remove if no internal consumers remain. 
- This change is a narrow retirement slice to remove the legacy compatibility surface while keeping runtime behavior unchanged. 

### Description
- Removed the `CANONICAL_SEMANTIC_PATTERN` export from `calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs` and left `getSemanticNameCaseRule()` as the primary runtime access point. 
- Repointed the internal test in `calculogic-validator/test/naming-case-rules-registry.test.mjs` to use `getSemanticNameCaseRule().pattern` and replaced the direct constant assertion with positive and negative `RegExp.test` checks. 
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to mark that there are no retained compatibility exports and to document the semantic-name case-rule getter as the primary seam. 
- Files changed: `naming-case-rules.knowledge.mjs`, `naming-case-rules-registry.test.mjs`, and `naming-compatibility-inventory.md`.

### Testing
- Searched the repo for remaining references with `rg "CANONICAL_SEMANTIC_PATTERN" -n` and found none, confirming removal. (succeeded)
- Ran `node --test calculogic-validator/test/naming-case-rules-registry.test.mjs` and it passed. (ok)
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs` and it passed. (ok)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa878bbcb88331896b840dbffd9723)