### PR TITLE
Clarify naming case-rules knowledge module as retained-path registry seam

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -15,7 +15,7 @@ This note is a lightweight map for the later hardening/removal pass.
 
 ## Registry loader seams
 - `naming-special-cases.knowledge.mjs` loaders for special-cases and walk-exclusions registries.
-- `naming-case-rules.knowledge.mjs` builtin registry assertions and semantic-name case-rule getter.
+- `naming-case-rules.knowledge.mjs` retained-path registry loader seam (assertions + style resolver + `getSemanticNameCaseRule()` getter); filename kept intentionally to avoid broad import churn during seam cleanup pilot.
 - `validator-scopes.knowledge.mjs` builtin scope profile registry loading/normalization.
 - `naming-scope-profiles.knowledge.mjs` re-export seam to validator-scope APIs.
 

--- a/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs
@@ -1,5 +1,9 @@
 import builtinCaseRulesRegistry from './_builtin/case-rules.registry.json' with { type: 'json' };
 
+// Transitional naming note:
+// - The `.knowledge` filename is retained to avoid broad-churn import rewrites.
+// - Runtime ownership lives in builtin registry payloads plus getter-backed access.
+// - This module acts as a registry loader seam (assert + style resolver + getter export).
 const CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 // Registry loader seam: validates builtin case-rules registry payload shape.


### PR DESCRIPTION
### Motivation
- Tighten the conceptual model for naming modules now acting as registry-backed loader seams by making `naming-case-rules.knowledge.mjs` explicitly documented as a registry loader seam while avoiding broad rename churn.

### Description
- Kept `calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs` in place and added a short transitional module note clarifying it is a registry loader seam with getter-backed runtime ownership, and updated the inventory to classify the module as a retained-path registry seam; no runtime behavior or public API was changed.

### Testing
- Ran `node --test calculogic-validator/test/naming-case-rules-registry.test.mjs` and `node --test calculogic-validator/test/naming-validator.test.mjs`, and both test suites passed successfully; files changed: `calculogic-validator/src/naming/registries/naming-case-rules.knowledge.mjs` and `calculogic-validator/doc/naming-compatibility-inventory.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa88f499e48331a4932fdffed28c4c)