### PR TITLE
Clarify retained-path seam role for naming scope profiles registry module

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -17,7 +17,7 @@ This note is a lightweight map for the later hardening/removal pass.
 - `naming-special-cases.knowledge.mjs` loaders for special-cases and walk-exclusions registries.
 - `naming-case-rules.knowledge.mjs` retained-path registry loader seam (assertions + style resolver + `getSemanticNameCaseRule()` getter); filename kept intentionally to avoid broad import churn during seam cleanup pilot.
 - `validator-scopes.knowledge.mjs` builtin scope profile registry loading/normalization.
-- `naming-scope-profiles.knowledge.mjs` re-export seam to validator-scope APIs.
+- `naming-scope-profiles.knowledge.mjs` retained-path naming-owned registry/re-export seam over validator-scopes getter-backed runtime APIs (not a standalone policy source).
 
 ## Primary runtime paths
 - Getter-backed registry accessors (`getBuiltin*`, `getSemanticNameCaseRule`).

--- a/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
@@ -1,4 +1,7 @@
-// Registry loader seam: naming scope profiles are sourced from validator-level scope APIs.
+// Transitional naming note:
+// - This retained `.knowledge` path is intentionally preserved to avoid broad-churn import rewrites.
+// - Runtime ownership is validator-scopes getter-backed scope profile access.
+// - This module is a thin naming-owned registry/re-export seam, not a standalone policy source.
 export {
   cloneScopeProfile,
   listValidatorScopes,


### PR DESCRIPTION
### Motivation
- Clarify that `calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs` is a retained-path naming-owned registry/re-export seam and not a standalone policy source, following the case-rules pilot pattern to reduce conceptual mismatch while avoiding broad churn.

### Description
- Added concise transitional comments to `calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs` documenting that the `.knowledge` path is retained and runtime ownership lives in `validator-scopes.knowledge.mjs`, and updated `calculogic-validator/doc/naming-compatibility-inventory.md` to reflect the clearer seam classification, with no changes to re-exports or runtime behavior.

### Testing
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and `node --test calculogic-validator/test/naming-validator.test.mjs`, and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa89fd79508331ac4b544d2342221d)