### PR TITLE
Clarify retained-path seam role of naming-special-cases registry module

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -14,7 +14,7 @@ This note is a lightweight map for the later hardening/removal pass.
 - None.
 
 ## Registry loader seams
-- `naming-special-cases.knowledge.mjs` loaders for special-cases and walk-exclusions registries.
+- `naming-special-cases.knowledge.mjs` retained-path registry loader seam for builtin special-cases + walk-exclusions with getter-backed runtime accessors (not a standalone policy source).
 - `naming-case-rules.knowledge.mjs` retained-path registry loader seam (assertions + style resolver + `getSemanticNameCaseRule()` getter); filename kept intentionally to avoid broad import churn during seam cleanup pilot.
 - `validator-scopes.knowledge.mjs` builtin scope profile registry loading/normalization.
 - `naming-scope-profiles.knowledge.mjs` retained-path naming-owned registry/re-export seam over validator-scopes getter-backed runtime APIs (not a standalone policy source).

--- a/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs
@@ -2,6 +2,11 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { ROOT_APP_FILES } from '../../validator-root-files.knowledge.mjs';
 
+// Retained-path registry seam:
+// - Loads builtin naming registry JSON payloads for special-cases + walk-exclusions.
+// - Exposes getter-backed runtime access used by naming logic.
+// - Kept at the legacy `.knowledge` path to avoid broad import churn during seam cleanup.
+// - Not an independently maintained policy source.
 export { ROOT_APP_FILES };
 
 const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
@@ -133,4 +138,5 @@ export const getBuiltinSpecialCaseRules = () => {
   return cachedBuiltinSpecialCaseRules;
 };
 
+// Retained for compatibility/debug surfaces; runtime callers should use getter-backed accessors.
 export const BUILTIN_SPECIAL_CASES_REGISTRY_PATH = SPECIAL_CASES_REGISTRY_PATH;


### PR DESCRIPTION
### Motivation
- Reduce conceptual mismatch by making it explicit that `naming-special-cases.knowledge.mjs` is a retained-path registry loader seam rather than an independently maintained policy source.
- Keep the change narrow and low-risk so imports and runtime behavior remain stable while improving clarity for future seam-cleanup work.

### Description
- Added concise in-file comments to `calculogic-validator/src/naming/registries/naming-special-cases.knowledge.mjs` documenting that it is a retained-path registry loader seam, exposes getter-backed runtime accessors, and is intentionally kept at the legacy `.knowledge` path.
- Annotated the exported registry path with a compatibility note that runtime callers should prefer the getter-backed accessors, while retaining the path export for compatibility/debug surfaces.
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to reclassify `naming-special-cases.knowledge.mjs` as a retained-path registry seam and align wording with prior seam-cleanup pilots.

### Testing
- Ran `node --test calculogic-validator/test/naming-special-cases-registry.test.mjs` and it passed (all tests green).
- Ran `node --test calculogic-validator/test/naming-walk-exclusions-registry.test.mjs` and it passed (all tests green).
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs` and it passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8af4a3ec8331bf22ae19a3eeeca4)