### PR TITLE
Clarify retained-path seam role for validator scopes knowledge module

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -16,7 +16,7 @@ This note is a lightweight map for the later hardening/removal pass.
 ## Registry loader seams
 - `naming-special-cases.knowledge.mjs` retained-path registry loader seam for builtin special-cases + walk-exclusions with getter-backed runtime accessors (not a standalone policy source).
 - `naming-case-rules.knowledge.mjs` retained-path registry loader seam (assertions + style resolver + `getSemanticNameCaseRule()` getter); filename kept intentionally to avoid broad import churn during seam cleanup pilot.
-- `validator-scopes.knowledge.mjs` builtin scope profile registry loading/normalization.
+- `validator-scopes.knowledge.mjs` retained-path validator-owned registry/runtime seam for builtin scope profiles; primary runtime access is getter-backed (`getBuiltinScopeProfiles`, `listValidatorScopes`, `getValidatorScopeProfile`) and the `.knowledge` filename is intentionally kept to avoid broad import churn.
 - `naming-scope-profiles.knowledge.mjs` retained-path naming-owned registry/re-export seam over validator-scopes getter-backed runtime APIs (not a standalone policy source).
 
 ## Primary runtime paths

--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -3,6 +3,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ROOT_APP_FILES } from './validator-root-files.knowledge.mjs';
 
+// Retained-path seam note:
+// - This module remains at the historical `.knowledge` path to avoid broad-churn import rewrites.
+// - Runtime ownership is validator-owned builtin scope-profile registry loading + getter-backed access.
+// - Policy source-of-truth lives in the builtin registry payload, not in this file as standalone static knowledge.
+
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const BUILTIN_SCOPE_PROFILES_REGISTRY_PATH = path.join(
   MODULE_DIR,
@@ -72,7 +77,8 @@ const canonicalizeScopeProfile = (scope, profile) => {
   };
 };
 
-// Registry loader seam: validates and normalizes builtin scope-profile registry payload.
+// Validator-owned retained-path registry/runtime seam:
+// validates and normalizes builtin scope-profile registry payload at load time.
 const loadBuiltinScopeProfiles = () => {
   const parsedRegistry = loadJsonFile(BUILTIN_SCOPE_PROFILES_REGISTRY_PATH);
 


### PR DESCRIPTION
### Motivation
- Reduce conceptual mismatch by making it explicit that `validator-scopes.knowledge.mjs` is a retained-path, validator-owned registry/runtime seam rather than a standalone static knowledge source. 
- Keep changes narrow and low-risk so runtime behavior and imports remain unchanged while improving clarity for future seam-cleanups.

### Description
- Kept `calculogic-validator/src/validator-scopes.knowledge.mjs` in place and added concise top-level comments stating it is a retained-path, validator-owned registry/runtime seam with getter-backed runtime access. 
- Adjusted an inline loader comment to emphasize the validator-owned registry/runtime seam role and load-time normalization responsibility. 
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to classify `validator-scopes.knowledge.mjs` consistently as a retained-path seam and list its primary getter-backed APIs (`getBuiltinScopeProfiles`, `listValidatorScopes`, `getValidatorScopeProfile`). 
- No runtime behavior or public API changes were made; getters and cloning behavior remain the same.

### Testing
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and it passed (all subtests OK). 
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs` and it passed (all subtests OK). 
- No additional tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8c665918833197ce4f4abc080826)