### PR TITLE
Retire naming-scope-profiles re-export seam

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -9,6 +9,7 @@ This note is a lightweight map for the later hardening/removal pass.
 - `BUILTIN_SPECIAL_CASE_RULES` retired after runtime/test import audit confirmed no internal consumers; runtime path remains `getBuiltinSpecialCaseRules()`.
 - `src/naming/registries/naming-roles.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
 - `src/naming/registries/naming-extensions.knowledge.mjs` removed after runtime/test import audit confirmed no internal consumers.
+- `src/naming/registries/naming-scope-profiles.knowledge.mjs` removed after runtime/test import audit + consumer repointing to `src/validator-scopes.knowledge.mjs`.
 
 ## Compatibility exports retained
 - None.
@@ -17,7 +18,6 @@ This note is a lightweight map for the later hardening/removal pass.
 - `naming-special-cases.knowledge.mjs` retained-path registry loader seam for builtin special-cases + walk-exclusions with getter-backed runtime accessors (not a standalone policy source).
 - `naming-case-rules.knowledge.mjs` retained-path registry loader seam (assertions + style resolver + `getSemanticNameCaseRule()` getter); filename kept intentionally to avoid broad import churn during seam cleanup pilot.
 - `validator-scopes.knowledge.mjs` retained-path validator-owned registry/runtime seam for builtin scope profiles; primary runtime access is getter-backed (`getBuiltinScopeProfiles`, `listValidatorScopes`, `getValidatorScopeProfile`) and the `.knowledge` filename is intentionally kept to avoid broad import churn.
-- `naming-scope-profiles.knowledge.mjs` retained-path naming-owned registry/re-export seam over validator-scopes getter-backed runtime APIs (not a standalone policy source).
 
 ## Primary runtime paths
 - Getter-backed registry accessors (`getBuiltin*`, `getSemanticNameCaseRule`).

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -9,7 +9,7 @@ import { getBuiltinWalkExclusions } from './registries/naming-special-cases.know
 import {
   listValidatorScopes,
   getValidatorScopeProfile,
-} from './registries/naming-scope-profiles.knowledge.mjs';
+} from '../validator-scopes.knowledge.mjs';
 import { parseCanonicalName } from './rules/naming-rule-parse-canonical.logic.mjs';
 import {
   getSpecialCaseType,

--- a/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
+++ b/calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs
@@ -1,9 +1,0 @@
-// Transitional naming note:
-// - This retained `.knowledge` path is intentionally preserved to avoid broad-churn import rewrites.
-// - Runtime ownership is validator-scopes getter-backed scope profile access.
-// - This module is a thin naming-owned registry/re-export seam, not a standalone policy source.
-export {
-  cloneScopeProfile,
-  listValidatorScopes,
-  getValidatorScopeProfile,
-} from '../../validator-scopes.knowledge.mjs';


### PR DESCRIPTION
### Motivation
- Remove a thin naming-facing re-export seam that duplicates validator-owned runtime APIs to reduce import churn and clarify primary runtime ownership. 
- Ensure runtime behavior remains unchanged by repointing consumers to the validator-owned getter-backed APIs (`getBuiltinScopeProfiles`, `listValidatorScopes`, `getValidatorScopeProfile`).

### Description
- Deleted `calculogic-validator/src/naming/registries/naming-scope-profiles.knowledge.mjs` because it was only a thin re-export seam. 
- Repointed imports in `calculogic-validator/src/naming/naming-validator.logic.mjs` to `calculogic-validator/src/validator-scopes.knowledge.mjs` to use the primary runtime accessors. 
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to record the seam as retired and reflect the new state. 
- No public APIs or runtime behavior were changed; callers continue to use the same functions (`listValidatorScopes`, `getValidatorScopeProfile`) via the validator-owned module. 

### Testing
- Ran a project-wide search with `rg` to confirm internal consumers were repointed and no remaining internal imports of the retired seam were present, and it returned only the expected references. 
- Executed `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and all tests passed. 
- Executed `node --test calculogic-validator/test/naming-validator.test.mjs` and all tests passed. 
- All automated checks completed successfully with no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa8d86f3748331be708e5851d7d8fc)