### PR TITLE
Audit validator scopes ownership and record retained-path decision

### DIFF
--- a/calculogic-validator/doc/naming-compatibility-inventory.md
+++ b/calculogic-validator/doc/naming-compatibility-inventory.md
@@ -17,7 +17,7 @@ This note is a lightweight map for the later hardening/removal pass.
 ## Registry loader seams
 - `src/naming/registries/naming-special-cases.knowledge.mjs` removed after runtime/test import audit + consumer repointing to dedicated runtime-owner loader modules (`naming-special-case-rules.registry.logic.mjs`, `naming-walk-exclusions.registry.logic.mjs`).
 - `src/naming/registries/naming-case-rules.knowledge.mjs` removed after runtime/test import audit + consumer repointing to `src/naming/rules/naming-rule-check-semantic-case.logic.mjs`.
-- `validator-scopes.knowledge.mjs` retained-path validator-owned registry/runtime seam for builtin scope profiles; primary runtime access is getter-backed (`getBuiltinScopeProfiles`, `listValidatorScopes`, `getValidatorScopeProfile`) and the `.knowledge` filename is intentionally kept to avoid broad import churn.
+- `validator-scopes.knowledge.mjs` is kept as the canonical validator-owned runtime owner for builtin scope profiles; getter-backed runtime APIs (`getBuiltinScopeProfiles`, `listValidatorScopes`, `getValidatorScopeProfile`) are the primary contract. The current `.knowledge` filename/path is retained for stability and explicitly marked as a later churn-managed rename candidate (no behavior change in this slice).
 
 ## Primary runtime paths
 - Getter-backed registry accessors (`getBuiltin*`, `getSemanticNameCaseRule`).

--- a/calculogic-validator/src/validator-scopes.knowledge.mjs
+++ b/calculogic-validator/src/validator-scopes.knowledge.mjs
@@ -3,10 +3,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ROOT_APP_FILES } from './validator-root-files.knowledge.mjs';
 
-// Retained-path seam note:
-// - This module remains at the historical `.knowledge` path to avoid broad-churn import rewrites.
-// - Runtime ownership is validator-owned builtin scope-profile registry loading + getter-backed access.
-// - Policy source-of-truth lives in the builtin registry payload, not in this file as standalone static knowledge.
+// Ownership decision (2026-03 narrow audit slice):
+// - Keep this module as the canonical validator-owned runtime owner for builtin scope profiles.
+// - Keep the existing `validator-scopes.knowledge.mjs` path for now to avoid churn across CLI, scripts,
+//   runtime, tests, and package export wiring.
+// - Mark filename as a rename candidate for a later churn-managed pass (`*.knowledge` -> runtime-focused
+//   name), with no behavior change in this slice.
+// - Policy source-of-truth remains the builtin registry payload, not ad hoc static data in this module.
 
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const BUILTIN_SCOPE_PROFILES_REGISTRY_PATH = path.join(
@@ -77,8 +80,8 @@ const canonicalizeScopeProfile = (scope, profile) => {
   };
 };
 
-// Validator-owned retained-path registry/runtime seam:
-// validates and normalizes builtin scope-profile registry payload at load time.
+// Canonical runtime-owner behavior in this module:
+// validates + normalizes builtin scope-profile registry payload at load time.
 const loadBuiltinScopeProfiles = () => {
   const parsedRegistry = loadJsonFile(BUILTIN_SCOPE_PROFILES_REGISTRY_PATH);
 


### PR DESCRIPTION
### Motivation
- Determine the correct short-term ownership posture for `calculogic-validator/src/validator-scopes.knowledge.mjs` before any further hardening or removal work. 
- The module appears to be a real runtime owner (registry loading, getter-backed APIs) rather than a thin retained-path seam because it is imported by runtime, CLI/bin, scripts, tests, and package exports. 
- The audit must record an explicit decision with minimal code/docs changes while preserving existing runtime behavior.

### Description
- Ownership decision: **Keep, but mark as rename candidate** — this module remains the canonical validator-owned runtime owner for builtin scope profiles; the current `.knowledge` filename/path is retained for stability and explicitly marked as a later churn-managed rename candidate. 
- Added a concise top-level ownership comment to `calculogic-validator/src/validator-scopes.knowledge.mjs` documenting the decision and rationale without changing any runtime logic. 
- Updated `calculogic-validator/doc/naming-compatibility-inventory.md` to unambiguously reflect that the module is the canonical owner and is a rename candidate (no behavior change). 
- No implementation or API behavior changes were made; getters, normalization, caching, and cloning semantics remain unchanged.

### Testing
- Audited import/usage surface with `rg "validator-scopes\.knowledge\.mjs|getBuiltinScopeProfiles|listValidatorScopes|getValidatorScopeProfile" -n` and confirmed active consumers in runtime, CLI, scripts, tests, and `package.json` exports; command succeeded. 
- Ran `node --test calculogic-validator/test/naming-validator-scope-contract.test.mjs` and all tests passed. 
- Ran `node --test calculogic-validator/test/naming-validator.test.mjs` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa92a2c1f08331ae065a0c94817dce)