### PR TITLE
feat(validator): add advisory tree-structure-advisor slice

### DIFF
--- a/calculogic-validator/src/index.mjs
+++ b/calculogic-validator/src/index.mjs
@@ -2,3 +2,5 @@ export * from './validator-runner.logic.mjs';
 export * from './validator-registry.knowledge.mjs';
 export * from './validator-report.contracts.mjs';
 export * as naming from './naming/naming-validator.host.mjs';
+
+export * as treeStructureAdvisor from './tree-structure-advisor.host.mjs';

--- a/calculogic-validator/src/tree-structure-advisor.host.mjs
+++ b/calculogic-validator/src/tree-structure-advisor.host.mjs
@@ -1,0 +1,9 @@
+import {
+  runTreeStructureAdvisor as runTreeStructureAdvisorRuntime,
+  summarizeFindings,
+} from './tree-structure-advisor.logic.mjs';
+
+export const runTreeStructureAdvisor = (repositoryRoot, { scope, config, targets } = {}) =>
+  runTreeStructureAdvisorRuntime(repositoryRoot, { scope, config, targets });
+
+export { summarizeFindings };

--- a/calculogic-validator/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/src/tree-structure-advisor.logic.mjs
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getValidatorScopeProfile } from './validator-scopes.runtime.mjs';
+
+const KNOWN_TOP_LEVEL_DIRECTORIES = new Set([
+  'bin',
+  'calculogic-validator',
+  'doc',
+  'docs',
+  'public',
+  'scripts',
+  'src',
+  'test',
+  'tools',
+]);
+
+const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
+const WALK_EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  '.reports',
+  '.turbo',
+  '.yarn',
+  'coverage',
+  'dist',
+  'node_modules',
+]);
+
+const VALIDATOR_OWNED_BASENAME_PATTERNS = [
+  /^naming-validator\.(logic|host|wiring|contracts)\.mjs$/u,
+  /^tree-structure-advisor\.(logic|host|wiring|contracts)\.mjs$/u,
+  /^validator-(?:runner|registry|config|exit-code|report|scopes|health-check).+\.mjs$/u,
+  /^validate-(?:all|naming)\.mjs$/u,
+  /^calculogic-validate(?:-naming|-validator-health)?\.mjs$/u,
+  /^validator-.+\.test\.mjs$/u,
+  /^naming-.+\.test\.mjs$/u,
+];
+
+export const normalizePath = (relativePath) => relativePath.split(path.sep).join('/');
+
+const sortByPathThenCode = (left, right) => {
+  const byPath = left.path.localeCompare(right.path);
+  if (byPath !== 0) {
+    return byPath;
+  }
+
+  return left.code.localeCompare(right.code);
+};
+
+const isValidatorOwnedBasenameSignal = (basename) =>
+  VALIDATOR_OWNED_BASENAME_PATTERNS.some((pattern) => pattern.test(basename));
+
+const getScopeRoots = (scope) => {
+  const normalizedScope = scope ?? 'repo';
+  const profile = getValidatorScopeProfile(normalizedScope);
+
+  if (!profile) {
+    throw new Error(`Invalid scope profile: ${normalizedScope}`);
+  }
+
+  if (normalizedScope === 'repo') {
+    return ['.'];
+  }
+
+  return profile.includeRoots;
+};
+
+const collectPathsFromRoot = (repositoryRoot, rootRelativePath) => {
+  const absoluteRoot = path.resolve(repositoryRoot, rootRelativePath);
+  if (!fs.existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  const rootStat = fs.statSync(absoluteRoot);
+  if (!rootStat.isDirectory()) {
+    return [];
+  }
+
+  const collected = [];
+
+  const walk = (absoluteDirectoryPath) => {
+    const entries = fs
+      .readdirSync(absoluteDirectoryPath, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (WALK_EXCLUDED_DIRECTORIES.has(entry.name) || entry.name.startsWith('.')) {
+          continue;
+        }
+
+        walk(path.join(absoluteDirectoryPath, entry.name));
+        continue;
+      }
+
+      const relativeFilePath = normalizePath(path.relative(repositoryRoot, path.join(absoluteDirectoryPath, entry.name)));
+      collected.push(relativeFilePath);
+    }
+  };
+
+  walk(absoluteRoot);
+  return collected;
+};
+
+const collectTopLevelUnexpectedFolderFindings = (repositoryRoot, scope) => {
+  if ((scope ?? 'repo') !== 'repo') {
+    return [];
+  }
+
+  return fs
+    .readdirSync(repositoryRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((directoryName) => !TOP_LEVEL_SCAN_EXCLUSIONS.has(directoryName))
+    .filter((directoryName) => !directoryName.startsWith('.'))
+    .filter((directoryName) => !KNOWN_TOP_LEVEL_DIRECTORIES.has(directoryName))
+    .sort((left, right) => left.localeCompare(right))
+    .map((directoryName) => ({
+      code: 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER',
+      severity: 'info',
+      path: directoryName,
+      classification: 'advisory-structure',
+      message:
+        'Top-level folder is outside the known project shape for this repository and may indicate structural drift.',
+      ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
+      details: {
+        knownRoots: Array.from(KNOWN_TOP_LEVEL_DIRECTORIES).sort((a, b) => a.localeCompare(b)),
+      },
+    }));
+};
+
+const collectValidatorOwnedOutsideTreeFindings = (paths) =>
+  paths
+    .filter((relativePath) => !relativePath.startsWith('calculogic-validator/'))
+    .filter((relativePath) => isValidatorOwnedBasenameSignal(path.posix.basename(relativePath)))
+    .sort((left, right) => left.localeCompare(right))
+    .map((relativePath) => ({
+      code: 'TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE',
+      severity: 'info',
+      path: relativePath,
+      classification: 'advisory-structure',
+      message:
+        'Path appears validator-owned by basename signal but is located outside calculogic-validator/**.',
+      ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
+      details: {
+        expectedRoot: 'calculogic-validator/',
+      },
+    }));
+
+const incrementCounter = (counts, key) => {
+  counts[key] = (counts[key] ?? 0) + 1;
+};
+
+const sortCountObject = (counts) =>
+  Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+
+export const summarizeFindings = (findings) => {
+  const counts = {
+    'advisory-structure': 0,
+  };
+  const codeCounts = {};
+
+  for (const finding of findings) {
+    incrementCounter(counts, finding.classification);
+    incrementCounter(codeCounts, finding.code);
+  }
+
+  return {
+    counts,
+    codeCounts: sortCountObject(codeCounts),
+  };
+};
+
+export const runTreeStructureAdvisor = (repositoryRoot, options = {}) => {
+  const selectedScope = options.scope ?? 'repo';
+  const scopeRoots = getScopeRoots(selectedScope);
+  const scopedPaths = scopeRoots.flatMap((scopeRoot) => collectPathsFromRoot(repositoryRoot, scopeRoot));
+
+  const findings = [
+    ...collectTopLevelUnexpectedFolderFindings(repositoryRoot, selectedScope),
+    ...collectValidatorOwnedOutsideTreeFindings(scopedPaths),
+  ].sort(sortByPathThenCode);
+
+  return {
+    findings,
+    totalFilesScanned: Array.from(new Set(scopedPaths)).length,
+    scope: selectedScope,
+  };
+};

--- a/calculogic-validator/src/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/validator-registry.knowledge.mjs
@@ -1,4 +1,8 @@
 import { runNamingValidator, summarizeFindings } from './naming/naming-validator.host.mjs';
+import {
+  runTreeStructureAdvisor,
+  summarizeFindings as summarizeTreeStructureAdvisorFindings,
+} from './tree-structure-advisor.host.mjs';
 
 const runNamingValidatorHook = (repositoryRoot, options = {}) => {
   const scope = options.scope;
@@ -28,11 +32,35 @@ const runNamingValidatorHook = (repositoryRoot, options = {}) => {
   };
 };
 
+const runTreeStructureAdvisorHook = (repositoryRoot, options = {}) => {
+  const scope = options.scope;
+  const config = options.config;
+  const targets = options.targets;
+  const treeStructureAdvisorResult = runTreeStructureAdvisor(repositoryRoot, {
+    scope,
+    config,
+    targets,
+  });
+  const summary = summarizeTreeStructureAdvisorFindings(treeStructureAdvisorResult.findings);
+
+  return {
+    scope: treeStructureAdvisorResult.scope,
+    totalFilesScanned: treeStructureAdvisorResult.totalFilesScanned,
+    findings: treeStructureAdvisorResult.findings,
+    summary,
+  };
+};
+
 export const VALIDATOR_REGISTRY = [
   {
     id: 'naming',
     description: 'Filename naming validator (report-mode).',
     run: runNamingValidatorHook,
+  },
+  {
+    id: 'tree-structure-advisor',
+    description: 'Repository tree structure advisory validator (report-only).',
+    run: runTreeStructureAdvisorHook,
   },
 ];
 

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import {
+  runTreeStructureAdvisor,
+  summarizeFindings,
+} from '../src/tree-structure-advisor.host.mjs';
+import { listRegisteredValidators } from '../src/validator-registry.knowledge.mjs';
+
+const writeJson = async (filePath, value) => {
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
+};
+
+const writeBaseFixtureRepo = async (fixtureDir) => {
+  await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
+  await fs.mkdir(path.join(fixtureDir, 'doc'), { recursive: true });
+  await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src'), { recursive: true });
+
+  await writeJson(path.join(fixtureDir, 'package.json'), {
+    name: 'tree-structure-advisor-fixture',
+    version: '1.0.0',
+  });
+  await fs.writeFile(path.join(fixtureDir, 'src', 'app-shell.logic.ts'), 'export const app = true\n', 'utf8');
+  await fs.writeFile(path.join(fixtureDir, 'doc', 'README.md'), '# fixture\n', 'utf8');
+  await fs.writeFile(
+    path.join(fixtureDir, 'calculogic-validator', 'src', 'naming-validator.logic.mjs'),
+    'export const fixture = true\n',
+    'utf8',
+  );
+};
+
+test('tree-structure-advisor is registered as a validator slice', () => {
+  assert.deepEqual(listRegisteredValidators(), ['naming', 'tree-structure-advisor']);
+});
+
+test('tree-structure-advisor is conservative for normal known repository shape', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-safe-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(result.scope, 'repo');
+    assert.equal(result.findings.length, 0);
+    assert.equal(typeof result.totalFilesScanned, 'number');
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor findings are deterministic and summary-stable', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-deterministic-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'experiments'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'validator-runner.logic.mjs'),
+      'export const misplaced = true\n',
+      'utf8',
+    );
+
+    const first = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const second = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.deepEqual(first.findings, second.findings);
+
+    const findingKeys = first.findings.map((finding) => `${finding.path}|${finding.code}`);
+    const sortedFindingKeys = [...findingKeys].sort((left, right) => left.localeCompare(right));
+    assert.deepEqual(findingKeys, sortedFindingKeys);
+
+    const summary = summarizeFindings(first.findings);
+    assert.deepEqual(summary.counts, { 'advisory-structure': 2 });
+    assert.deepEqual(summary.codeCounts, {
+      TREE_UNEXPECTED_TOP_LEVEL_FOLDER: 1,
+      TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE: 1,
+    });
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor flags validator-owned-looking file outside validator tree', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-misplaced-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'naming-validator.wiring.mjs'),
+      'export const misplaced = true\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const advisory = result.findings.find(
+      (finding) => finding.code === 'TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE',
+    );
+
+    assert.ok(advisory);
+    assert.equal(advisory.severity, 'info');
+    assert.equal(advisory.classification, 'advisory-structure');
+    assert.equal(advisory.path, 'src/naming-validator.wiring.mjs');
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/validator-runner.test.mjs
+++ b/calculogic-validator/test/validator-runner.test.mjs
@@ -5,7 +5,7 @@ import { listRegisteredValidators } from '../src/validator-registry.knowledge.mj
 import { runValidatorRunner } from '../src/validator-runner.logic.mjs';
 
 test('registry lists validators deterministically', () => {
-  assert.deepEqual(listRegisteredValidators(), ['naming']);
+  assert.deepEqual(listRegisteredValidators(), ['naming', 'tree-structure-advisor']);
 });
 
 test('runner report includes naming validator in deterministic order', () => {
@@ -15,12 +15,25 @@ test('runner report includes naming validator in deterministic order', () => {
   assert.equal(report.validatorId, 'runner');
   assert.equal(report.sourceSnapshot?.source, 'fs');
   assert.ok(Array.isArray(report.validators));
-  assert.equal(report.validators.length, 1);
-  assert.equal(report.validators[0].id, 'naming');
-  assert.equal(report.validators[0].validatorId, 'naming');
-  assert.equal(report.validators[0].scope, 'app');
-  assert.equal(typeof report.validators[0].totalFilesScanned, 'number');
-  assert.ok(Array.isArray(report.validators[0].findings));
+  assert.equal(report.validators.length, 2);
+  assert.deepEqual(
+    report.validators.map((validator) => validator.id),
+    ['naming', 'tree-structure-advisor'],
+  );
+
+  const namingValidator = report.validators.find((validator) => validator.id === 'naming');
+  const treeValidator = report.validators.find((validator) => validator.id === 'tree-structure-advisor');
+
+  assert.ok(namingValidator);
+  assert.ok(treeValidator);
+  assert.equal(namingValidator.validatorId, 'naming');
+  assert.equal(treeValidator.validatorId, 'tree-structure-advisor');
+  assert.equal(namingValidator.scope, 'app');
+  assert.equal(treeValidator.scope, 'app');
+  assert.equal(typeof namingValidator.totalFilesScanned, 'number');
+  assert.equal(typeof treeValidator.totalFilesScanned, 'number');
+  assert.ok(Array.isArray(namingValidator.findings));
+  assert.ok(Array.isArray(treeValidator.findings));
 });
 
 test('validate-all CLI runs and returns naming validator report', () => {
@@ -32,9 +45,11 @@ test('validate-all CLI runs and returns naming validator report', () => {
 
   assert.equal(result.status, 0);
   const report = JSON.parse(result.stdout);
-  assert.equal(report.validators[0].id, 'naming');
-  assert.equal(report.validators[0].validatorId, 'naming');
-  assert.equal(report.validators[0].scope, 'docs');
+  const namingValidator = report.validators.find((validator) => validator.id === 'naming');
+  assert.ok(namingValidator);
+  assert.equal(namingValidator.id, 'naming');
+  assert.equal(namingValidator.validatorId, 'naming');
+  assert.equal(namingValidator.scope, 'docs');
 });
 
 test('runner forwards targets and includes naming filter meta when filtering is active', () => {

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -1,0 +1,75 @@
+# cfg-treeStructureAdvisor
+
+## 0.0 Version
+
+Current implementation target: **V0.1.0** (first real advisory-only validator slice).
+
+## 1.0 Purpose
+
+Add a conservative tree-structure advisor validator slice that proves validator-suite multi-slice execution while remaining report-only and non-destructive.
+
+## 2.0 Inputs and Source of Truth
+
+### 2.1 Scope and targets
+
+- Uses validator suite scope resolution (`repo|app|docs|validator|system`).
+- Supports optional runner-forwarded `targets` when selected through `validate-all`.
+- Default scope remains `repo` via existing runner behavior.
+
+### 2.2 Repository signals
+
+V0.1.0 uses deterministic path-based signals only:
+
+- top-level directory names in repository root
+- repository-relative file paths
+- filename basename patterns that strongly indicate validator ownership
+
+### 2.3 Initial advisory heuristics (narrow slice)
+
+1. **Top-level unexpected-folder advisory**
+   - Emit info advisory for clearly unusual non-hidden top-level folders outside known repo shape.
+2. **Validator-owned-looking file outside validator tree**
+   - Emit info advisory when filename/path signal strongly indicates validator ownership but file is outside `calculogic-validator/**`.
+
+## 3.0 Output Contract
+
+### 3.1 Report shape alignment
+
+Findings flow through the existing suite validator entry shape:
+
+- `id = tree-structure-advisor`
+- `summary.counts`
+- `findings[]`
+
+### 3.2 Finding shape (advisory-only)
+
+Each finding follows existing report conventions:
+
+- `code`
+- `severity` (`info` only in this slice)
+- `path`
+- `classification = advisory-structure`
+- `message`
+- optional `details`
+- optional `ruleRef`
+
+### 3.3 Determinism requirements
+
+- normalize separators to `/`
+- stable sorting by `path` then `code`
+- deterministic message text and codes
+
+## 4.0 Registration and Execution
+
+- Registered in validator registry alongside naming validator.
+- Default runner execution includes both `naming` and `tree-structure-advisor` in deterministic registry order.
+- No fix mode, no move/rename behavior.
+
+## 5.0 Deferred Behavior
+
+Deferred to later slices:
+
+- docs/runtime/test co-location drift heuristics
+- mixed concern folder smell heuristics
+- structural recommendation planning and move proposals
+- any mutating or fix-mode behavior

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -21,9 +21,11 @@ The runner reads validator definitions from a deterministic registry in `calculo
 - `config` (optional loaded validator config object from JSON contract V0.1)
 - `targets` (optional repeatable path filters forwarded to validators that implement target-aware filtering)
 
-### 2.3 Initial validator set
+### 2.3 Validator set
 
-V0.1.0 includes the naming validator only, wrapped through the registry run hook without changing naming-validator internals.
+- V0.1.0 started with naming validator registration only.
+- V0.1.6 adds the second real slice: `tree-structure-advisor` (advisory-only/report-first).
+- Runner continues to preserve deterministic registry declaration ordering when executing multiple slices.
 
 ### 2.4 Metadata injections
 


### PR DESCRIPTION
### Motivation

- Prove the validator suite is multi-slice (not naming-only) by adding a conservative, report-first second slice that exercises registry/runner/report plumbing. 
- Provide a non-destructive, low-risk advisor that surfaces obvious repo tree drift without any automatic file changes. 

### Description

- Registered a new validator slice `tree-structure-advisor` in the runner registry and exported it from the package index so the runner can execute both `naming` and `tree-structure-advisor`. 
- Added a conservative advisory runtime in `calculogic-validator/src/tree-structure-advisor.logic.mjs` and a thin host wrapper `calculogic-validator/src/tree-structure-advisor.host.mjs` that returns `{ scope, totalFilesScanned, findings, summary }`. 
- Implemented two deterministic, low-noise heuristics: `TREE_UNEXPECTED_TOP_LEVEL_FOLDER` (detects clearly unexpected top-level folders in repo scope) and `TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE` (flags validator-looking basenames found outside `calculogic-validator/**`), with findings normalized to `/`, deterministically sorted by `path` then `code`, and classified as `advisory-structure` with `severity: info`. 
- Added NL-first documentation `doc/nl-config/cfg-treeStructureAdvisor.md` and updated `doc/nl-config/cfg-validatorRunner.md` to record the new slice; updated tests and runner wiring (`calculogic-validator/src/validator-registry.knowledge.mjs`, `calculogic-validator/src/index.mjs`). 

### Testing

- Added `calculogic-validator/test/tree-structure-advisor.test.mjs` and updated `calculogic-validator/test/validator-runner.test.mjs` to assert registration and runner behavior. 
- Ran the new and existing automated tests with: `node --test calculogic-validator/test/tree-structure-advisor.test.mjs calculogic-validator/test/validator-runner.test.mjs calculogic-validator/test/naming-validator.test.mjs` and `node --test calculogic-validator/test/validate-runner-registry-meta.test.mjs calculogic-validator/test/validator-package-bins.test.mjs`, and all ran and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab4767e95c8331b96dd5a9e52e7e49)