### PR TITLE
refactor(naming): make runtime consume prepared inputs from wiring

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -1,10 +1,5 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { resolveNamingRegistryInputs } from './registries/registry-state.logic.mjs';
-import {
-  toNamingRolesRuntime,
-  toReportableExtensionsSet,
-} from './naming-runtime-converters.logic.mjs';
 import { getBuiltinWalkExclusions } from './registries/naming-walk-exclusions.registry.logic.mjs';
 import {
   listValidatorScopes,
@@ -27,17 +22,7 @@ export const normalizePath = (relativePath) => relativePath.split(path.sep).join
 
 export { parseCanonicalName, getSpecialCaseType, isAllowedSpecialCase };
 
-
-const BUILTIN_NAMING_REGISTRY_INPUTS = resolveNamingRegistryInputs({ config: {} });
-const DEFAULT_NAMING_ROLES_RUNTIME = toNamingRolesRuntime(BUILTIN_NAMING_REGISTRY_INPUTS.roles);
-const DEFAULT_REPORTABLE_EXTENSIONS = toReportableExtensionsSet(
-  BUILTIN_NAMING_REGISTRY_INPUTS.reportableExtensions,
-);
-
-const resolveNamingRolesRuntime = (namingRolesRuntime) =>
-  namingRolesRuntime ?? DEFAULT_NAMING_ROLES_RUNTIME;
-
-const isReportableFile = (relativePath, reportableExtensions = DEFAULT_REPORTABLE_EXTENSIONS) => {
+const isReportableFile = (relativePath, reportableExtensions) => {
   const extension = path.extname(relativePath);
   if (reportableExtensions.has(extension)) {
     return true;
@@ -46,6 +31,31 @@ const isReportableFile = (relativePath, reportableExtensions = DEFAULT_REPORTABL
   return (
     path.basename(relativePath) === 'package-lock.json' ||
     path.basename(relativePath) === 'package.json'
+  );
+};
+
+const assertPreparedReportableExtensions = (reportableExtensions) => {
+  if (reportableExtensions instanceof Set) {
+    return reportableExtensions;
+  }
+
+  throw new Error(
+    'Naming runtime requires prepared reportableExtensions (Set) from wiring/runtime adapter.',
+  );
+};
+
+const assertPreparedNamingRolesRuntime = (namingRolesRuntime) => {
+  if (
+    namingRolesRuntime &&
+    namingRolesRuntime.roleMetadata instanceof Map &&
+    namingRolesRuntime.activeRoles instanceof Set &&
+    Array.isArray(namingRolesRuntime.roleSuffixes)
+  ) {
+    return namingRolesRuntime;
+  }
+
+  throw new Error(
+    'Naming runtime requires prepared namingRolesRuntime from wiring/runtime adapter.',
   );
 };
 
@@ -66,7 +76,7 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
     return [];
   }
 
-  const reportableExtensions = options.reportableExtensions ?? DEFAULT_REPORTABLE_EXTENSIONS;
+  const reportableExtensions = assertPreparedReportableExtensions(options.reportableExtensions);
   const walkExclusions = options.walkExclusions ?? getBuiltinWalkExclusions();
   const collected = [];
 
@@ -240,7 +250,7 @@ export const filterRepositoryPathsByTargets = (
 };
 
 export const classifyPath = (relativePath, namingRolesRuntime) => {
-  const runtime = resolveNamingRolesRuntime(namingRolesRuntime);
+  const runtime = assertPreparedNamingRolesRuntime(namingRolesRuntime);
   const normalizedPath = normalizePath(relativePath);
   const basename = path.posix.basename(normalizedPath);
 

--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -10,32 +10,54 @@ import {
   normalizePath,
   listNamingValidatorScopes,
   getScopeProfile,
-  collectRepositoryPaths,
-  classifyPath,
+  collectRepositoryPaths as collectRepositoryPathsRuntime,
+  classifyPath as classifyPathRuntime,
   runNamingValidator as runNamingValidatorRuntime,
   summarizeFindings,
 } from './naming-validator.logic.mjs';
 
-export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) => {
+export const prepareNamingRuntimeInputs = (config) => {
   const registryInputs = resolveNamingRegistryInputs({ config });
-  const reportableExtensions = toReportableExtensionsSet(registryInputs.reportableExtensions);
-  const namingRolesRuntime = toNamingRolesRuntime(registryInputs.roles);
-
-  const result = runNamingValidatorRuntime(repositoryRoot, {
-    scope,
-    targets,
-    reportableExtensions,
-    namingRolesRuntime,
-  });
 
   return {
-    ...result,
+    reportableExtensions: toReportableExtensionsSet(registryInputs.reportableExtensions),
+    namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
     registry: {
       registryState: registryInputs.registryState,
       registrySource: registryInputs.registrySource,
       registryDigests: registryInputs.registryDigests,
     },
   };
+};
+
+export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) => {
+  const runtimeInputs = prepareNamingRuntimeInputs(config);
+
+  const result = runNamingValidatorRuntime(repositoryRoot, {
+    scope,
+    targets,
+    reportableExtensions: runtimeInputs.reportableExtensions,
+    namingRolesRuntime: runtimeInputs.namingRolesRuntime,
+  });
+
+  return {
+    ...result,
+    registry: runtimeInputs.registry,
+  };
+};
+
+export const collectRepositoryPaths = (rootDirectory, options = {}) => {
+  const runtimeInputs = prepareNamingRuntimeInputs(options.config);
+
+  return collectRepositoryPathsRuntime(rootDirectory, {
+    ...options,
+    reportableExtensions: options.reportableExtensions ?? runtimeInputs.reportableExtensions,
+  });
+};
+
+export const classifyPath = (relativePath, namingRolesRuntime, options = {}) => {
+  const runtimeInputs = prepareNamingRuntimeInputs(options.config);
+  return classifyPathRuntime(relativePath, namingRolesRuntime ?? runtimeInputs.namingRolesRuntime);
 };
 
 export {
@@ -45,7 +67,5 @@ export {
   normalizePath,
   listNamingValidatorScopes,
   getScopeProfile,
-  collectRepositoryPaths,
-  classifyPath,
   summarizeFindings,
 };

--- a/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
@@ -4,14 +4,14 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  classifyPath as classifyPathRuntime,
+  collectRepositoryPaths as collectRepositoryPathsRuntime,
+} from '../src/naming/naming-validator.logic.mjs';
+import {
   classifyPath,
   collectRepositoryPaths,
+  prepareNamingRuntimeInputs,
 } from '../src/validators/naming-validator.logic.mjs';
-import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-state.logic.mjs';
-import {
-  toNamingRolesRuntime,
-  toReportableExtensionsSet,
-} from '../src/naming/naming-runtime-converters.logic.mjs';
 
 const writeFile = (rootDirectory, relativePath) => {
   const absolutePath = path.join(rootDirectory, relativePath);
@@ -19,20 +19,25 @@ const writeFile = (rootDirectory, relativePath) => {
   fs.writeFileSync(absolutePath, 'x', 'utf8');
 };
 
-test('default direct classifyPath runtime aligns with builtin registry resolver payload', () => {
-  const registryInputs = resolveNamingRegistryInputs({ config: {} });
-  const explicitRuntime = toNamingRolesRuntime(registryInputs.roles);
+test('wiring-injected classifyPath aligns with runtime when using prepared registry payload', () => {
+  const prepared = prepareNamingRuntimeInputs({});
 
-  const canonicalDefault = classifyPath('src/rightpanel.results-style.css');
-  const canonicalExplicit = classifyPath('src/rightpanel.results-style.css', explicitRuntime);
-  assert.deepEqual(canonicalDefault, canonicalExplicit);
+  const wiringCanonical = classifyPath('src/rightpanel.results-style.css');
+  const runtimeCanonical = classifyPathRuntime(
+    'src/rightpanel.results-style.css',
+    prepared.namingRolesRuntime,
+  );
+  assert.deepEqual(wiringCanonical, runtimeCanonical);
 
-  const deprecatedDefault = classifyPath('src/tabs/build/BuildSurface.view.css');
-  const deprecatedExplicit = classifyPath('src/tabs/build/BuildSurface.view.css', explicitRuntime);
-  assert.deepEqual(deprecatedDefault, deprecatedExplicit);
+  const wiringDeprecated = classifyPath('src/tabs/build/BuildSurface.view.css');
+  const runtimeDeprecated = classifyPathRuntime(
+    'src/tabs/build/BuildSurface.view.css',
+    prepared.namingRolesRuntime,
+  );
+  assert.deepEqual(wiringDeprecated, runtimeDeprecated);
 });
 
-test('default direct collectRepositoryPaths reportable extension behavior aligns with builtin registry resolver payload', () => {
+test('wiring-injected collectRepositoryPaths aligns with runtime when using prepared reportable extensions', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-default-runtime-'));
 
   try {
@@ -40,24 +45,21 @@ test('default direct collectRepositoryPaths reportable extension behavior aligns
     writeFile(tempRoot, 'doc/readme.spec.md');
     writeFile(tempRoot, 'src/skip.tmp');
 
-    const registryInputs = resolveNamingRegistryInputs({ config: {} });
-    const explicitReportableExtensions = toReportableExtensionsSet(
-      registryInputs.reportableExtensions,
-    );
+    const prepared = prepareNamingRuntimeInputs({});
 
-    const collectedDefault = collectRepositoryPaths(tempRoot, { scope: 'repo' });
-    const collectedExplicit = collectRepositoryPaths(tempRoot, {
+    const collectedWiring = collectRepositoryPaths(tempRoot, { scope: 'repo' });
+    const collectedRuntime = collectRepositoryPathsRuntime(tempRoot, {
       scope: 'repo',
-      reportableExtensions: explicitReportableExtensions,
+      reportableExtensions: prepared.reportableExtensions,
     });
 
-    assert.deepEqual(collectedDefault, collectedExplicit);
+    assert.deepEqual(collectedWiring, collectedRuntime);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
 
-test('direct runtime overrides still win over default registry-backed runtime', () => {
+test('wiring helper overrides still win over prepared defaults', () => {
   const runtimeWithoutHost = {
     roleMetadata: new Map([
       ['logic', { role: 'logic', category: 'concern-core', status: 'active' }],
@@ -73,7 +75,7 @@ test('direct runtime overrides still win over default registry-backed runtime', 
   assert.equal(overrideFinding.code, 'NAMING_UNKNOWN_ROLE');
 });
 
-test('direct reportableExtensions override still wins over default registry-backed extensions', () => {
+test('wiring helper reportableExtensions override still wins over prepared defaults', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-default-ext-'));
 
   try {
@@ -89,37 +91,6 @@ test('direct reportableExtensions override still wins over default registry-back
     assert.equal(defaultCollected.includes('src/notes.tmp'), false);
     assert.equal(overrideCollected.includes('src/notes.tmp'), true);
     assert.equal(overrideCollected.includes('src/visible.logic.ts'), false);
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-});
-
-
-test('default direct helper behavior matches explicit builtin resolver runtime bundle', () => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-default-bundle-'));
-
-  try {
-    writeFile(tempRoot, 'src/panel.host.tsx');
-    writeFile(tempRoot, 'src/panel.logic.ts');
-    writeFile(tempRoot, 'src/not-reportable.tmp');
-
-    const registryInputs = resolveNamingRegistryInputs({ config: {} });
-    const explicitRuntime = toNamingRolesRuntime(registryInputs.roles);
-    const explicitReportableExtensions = toReportableExtensionsSet(
-      registryInputs.reportableExtensions,
-    );
-
-    const defaultClassification = classifyPath('src/panel.host.tsx');
-    const explicitClassification = classifyPath('src/panel.host.tsx', explicitRuntime);
-
-    const defaultCollected = collectRepositoryPaths(tempRoot, { scope: 'repo' });
-    const explicitCollected = collectRepositoryPaths(tempRoot, {
-      scope: 'repo',
-      reportableExtensions: explicitReportableExtensions,
-    });
-
-    assert.deepEqual(defaultClassification, explicitClassification);
-    assert.deepEqual(defaultCollected, explicitCollected);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/calculogic-validator/test/naming-registry-metadata.test.mjs
+++ b/calculogic-validator/test/naming-registry-metadata.test.mjs
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { runNamingValidator } from '../src/naming/naming-validator.host.mjs';
+import {
+  prepareNamingRuntimeInputs,
+  runNamingValidator,
+} from '../src/naming/naming-validator.host.mjs';
 
 const assertDigestShape = (digest) => {
   assert.equal(typeof digest, 'string');
@@ -16,4 +19,16 @@ test('runNamingValidator returns registry metadata envelope', () => {
   assertDigestShape(result.registry.registryDigests?.builtin);
   assertDigestShape(result.registry.registryDigests?.custom);
   assertDigestShape(result.registry.registryDigests?.resolved);
+});
+
+test('prepareNamingRuntimeInputs exposes prepared dependencies and stable registry metadata', () => {
+  const prepared = prepareNamingRuntimeInputs({});
+  assert.ok(prepared.reportableExtensions instanceof Set);
+  assert.ok(prepared.namingRolesRuntime.roleMetadata instanceof Map);
+  assert.ok(prepared.namingRolesRuntime.activeRoles instanceof Set);
+  assert.ok(Array.isArray(prepared.namingRolesRuntime.roleSuffixes));
+  assert.ok(prepared.registry);
+
+  const result = runNamingValidator(process.cwd(), { scope: 'system', config: {} });
+  assert.deepEqual(result.registry, prepared.registry);
 });

--- a/calculogic-validator/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/test/naming-runtime-input-boundary.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  classifyPath,
+  collectRepositoryPaths,
+  runNamingValidator,
+} from '../src/naming/naming-validator.logic.mjs';
+import { resolveNamingRegistryInputs } from '../src/naming/registries/registry-state.logic.mjs';
+import {
+  toNamingRolesRuntime,
+  toReportableExtensionsSet,
+} from '../src/naming/naming-runtime-converters.logic.mjs';
+
+const writeFile = (rootDirectory, relativePath) => {
+  const absolutePath = path.join(rootDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, 'x', 'utf8');
+};
+
+test('runtime accepts externally prepared naming runtime dependencies', () => {
+  const registryInputs = resolveNamingRegistryInputs({ config: {} });
+  const namingRolesRuntime = toNamingRolesRuntime(registryInputs.roles);
+  const reportableExtensions = toReportableExtensionsSet(registryInputs.reportableExtensions);
+
+  const canonicalFinding = classifyPath('src/rightpanel.results-style.css', namingRolesRuntime);
+  assert.equal(canonicalFinding.code, 'NAMING_CANONICAL');
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-runtime-inputs-'));
+
+  try {
+    writeFile(tempRoot, 'src/panel.logic.ts');
+    writeFile(tempRoot, 'src/skip.tmp');
+
+    const result = runNamingValidator(tempRoot, {
+      scope: 'repo',
+      reportableExtensions,
+      namingRolesRuntime,
+    });
+
+    assert.equal(result.totalFilesScanned, 1);
+    assert.deepEqual(
+      result.findings.map((finding) => finding.path),
+      ['src/panel.logic.ts'],
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('runtime enforces prepared dependency injection contract', () => {
+  assert.throws(
+    () => classifyPath('src/rightpanel.results-style.css'),
+    /requires prepared namingRolesRuntime/u,
+  );
+
+  assert.throws(
+    () => collectRepositoryPaths(process.cwd(), { scope: 'repo' }),
+    /requires prepared reportableExtensions/u,
+  );
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -10,7 +10,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.22** (registry-backed naming payload conversion consolidated through shared runtime converters for direct defaults and wiring).
+Current implementation target: **V0.1.23** (naming runtime dependencies are wiring-provided; runtime no longer composes builtin registry defaults internally).
 
 ## 1.0 Purpose
 
@@ -196,25 +196,27 @@ Semantic-name case validation is sourced from builtin registry JSON at:
 
 Runtime currently supports the builtin `semanticName.style` value `kebab-case` only for this slice. The runtime maps that style to the existing canonical kebab-case semantic-name predicate behavior.
 
-### 2.10 Shared naming runtime converter path (V0.1.22)
+### 2.10 Naming runtime input ownership boundary (V0.1.23)
 
-Direct runtime defaults and wiring now share one helper conversion seam for registry-backed naming payloads.
+Wiring owns registry/default/config composition and prepares runtime-ready dependencies before invoking runtime behavior.
 
-Default runtime source path:
+Prepared runtime dependency source path:
 
-- shared converter module: `calculogic-validator/src/naming/naming-runtime-converters.logic.mjs`
-- `resolveNamingRegistryInputs({ config: {} })` (builtin payload path)
-- roles payload converted via `toNamingRolesRuntime(roles)` to runtime shape:
-  - `roleMetadata: Map`
-  - `activeRoles: Set`
-  - `roleSuffixes: string[]` (length-desc sorting)
-- reportable extensions payload converted via `toReportableExtensionsSet(reportableExtensions)` to runtime `Set`
+- registry resolver: `calculogic-validator/src/naming/registries/registry-state.logic.mjs`
+- converter module: `calculogic-validator/src/naming/naming-runtime-converters.logic.mjs`
+- wiring composition entrypoint: `calculogic-validator/src/naming/naming-validator.wiring.mjs`
+- runtime consumer: `calculogic-validator/src/naming/naming-validator.logic.mjs`
 
-Injection precedence remains unchanged:
+Prepared runtime dependency contract:
 
-- explicit `options.namingRolesRuntime` and `options.reportableExtensions` continue to override defaults.
-- direct runtime defaults (`naming-validator.logic.mjs`) and wiring runtime assembly (`naming-validator.wiring.mjs`) both consume the shared converter helper path.
-- alignment tests for direct runtime defaults must be isolation-safe and must not mutate repo-owned registry state files in-place.
+- `namingRolesRuntime` supplied by wiring (shape: `roleMetadata`, `activeRoles`, `roleSuffixes`)
+- `reportableExtensions` supplied by wiring as runtime `Set`
+
+Ownership and precedence requirements:
+
+- runtime does not resolve registry state and does not build builtin runtime defaults at module scope.
+- runtime behavior remains responsible for scanning, scope filtering, target filtering, classification, and summarization.
+- host/wiring public behavior remains unchanged; config continues to override builtin defaults via resolver + converter flow before runtime execution.
 
 ## 3.0 Classification Contract
 


### PR DESCRIPTION
### Motivation
- Finish the ownership split between wiring and runtime for the naming validator so the runtime becomes input-pure and wiring is the single place that composes registry/default/config inputs.
- Avoid hidden module-scope defaults in the runtime so runtime responsibilities remain scanning, filtering, classification, and summarization only.

### Description
- Removed registry-resolution and builtin/default runtime construction from `src/naming/naming-validator.logic.mjs` and added strict assertions so the runtime requires prepared `reportableExtensions` (`Set`) and `namingRolesRuntime` (`{ roleMetadata, activeRoles, roleSuffixes }`).
- Added `prepareNamingRuntimeInputs(config)` to `src/naming/naming-validator.wiring.mjs` and wired `runNamingValidator(...)` to pass `reportableExtensions` and `namingRolesRuntime` into the runtime while preserving the registry metadata envelope (state/source/digests) in the returned report.
- Kept ergonomic wiring helpers by exposing compatibility helpers `collectRepositoryPaths` and `classifyPath` from wiring that inject prepared defaults when callers omit explicit runtime inputs, avoiding scattering ad-hoc fallbacks across runtime functions.
- Updated NL-first documentation `doc/nl-config/cfg-namingValidator.md` to record the V0.1.23 ownership boundary and added/updated tests to make the boundary explicit rather than implicit.

### Testing
- Added test `calculogic-validator/test/naming-runtime-input-boundary.test.mjs` and updated `naming-default-runtime-registry-alignment.test.mjs` and `naming-registry-metadata.test.mjs` to validate wiring→runtime parity and the prepared-input contract, and these tests passed.
- Ran validator-focused commands and automation: `npm test` (full suite), `npm run validate:naming -- --scope=app`, `npm run validate:naming -- --scope=repo`, `npm run validate:all -- --validators=naming --scope=docs`, and `npm run health:validator`, and all completed successfully with behavior unchanged.
- Verified that host/wiring public behavior and report contracts (including `registry.registryState`, `registry.registrySource`, and `registry.registryDigests`) remain identical to prior behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab71f3e1388331be9ed8c6a490b40f)