### PR TITLE
refactor(naming): wire walk exclusions as prepared runtime input

### DIFF
--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { getBuiltinWalkExclusions } from './registries/naming-walk-exclusions.registry.logic.mjs';
 import {
   listValidatorScopes,
   getValidatorScopeProfile,
@@ -59,6 +58,22 @@ const assertPreparedNamingRolesRuntime = (namingRolesRuntime) => {
   );
 };
 
+
+const assertPreparedWalkExclusions = (walkExclusions) => {
+  if (
+    walkExclusions &&
+    walkExclusions.excludedDirectories instanceof Set &&
+    typeof walkExclusions.skipDotDirectories === 'boolean' &&
+    walkExclusions.allowDotFiles instanceof Set
+  ) {
+    return walkExclusions;
+  }
+
+  throw new Error(
+    'Naming runtime requires prepared walkExclusions from wiring/runtime adapter.',
+  );
+};
+
 const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
 
 const isPathOutsideRoot = (relativePath) =>
@@ -77,7 +92,7 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
   }
 
   const reportableExtensions = assertPreparedReportableExtensions(options.reportableExtensions);
-  const walkExclusions = options.walkExclusions ?? getBuiltinWalkExclusions();
+  const walkExclusions = assertPreparedWalkExclusions(options.walkExclusions);
   const collected = [];
 
   const walk = (absoluteDirectoryPath) => {
@@ -160,6 +175,7 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
 
   const allReportablePaths = collectPathsFromRoot(rootDirectory, '.', {
     reportableExtensions: options.reportableExtensions,
+    walkExclusions: options.walkExclusions,
   });
 
   if (selectedScope === 'repo') {
@@ -402,6 +418,7 @@ export const runNamingValidator = (rootDirectory, options = {}) => {
   const inScopePaths = collectRepositoryPaths(rootDirectory, {
     scope: selectedScope,
     reportableExtensions: options.reportableExtensions,
+    walkExclusions: options.walkExclusions,
   });
   const resolvedTargets = resolveNamingValidatorTargets(rootDirectory, options.targets ?? []);
   const paths = filterRepositoryPathsByTargets(rootDirectory, inScopePaths, resolvedTargets);

--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -1,4 +1,5 @@
 import { resolveNamingRegistryInputs } from './registries/registry-state.logic.mjs';
+import { getBuiltinWalkExclusions } from './registries/naming-walk-exclusions.registry.logic.mjs';
 import {
   toNamingRolesRuntime,
   toReportableExtensionsSet,
@@ -22,6 +23,7 @@ export const prepareNamingRuntimeInputs = (config) => {
   return {
     reportableExtensions: toReportableExtensionsSet(registryInputs.reportableExtensions),
     namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
+    walkExclusions: getBuiltinWalkExclusions(),
     registry: {
       registryState: registryInputs.registryState,
       registrySource: registryInputs.registrySource,
@@ -38,6 +40,7 @@ export const runNamingValidator = (repositoryRoot, { scope, config, targets } = 
     targets,
     reportableExtensions: runtimeInputs.reportableExtensions,
     namingRolesRuntime: runtimeInputs.namingRolesRuntime,
+    walkExclusions: runtimeInputs.walkExclusions,
   });
 
   return {
@@ -52,6 +55,7 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   return collectRepositoryPathsRuntime(rootDirectory, {
     ...options,
     reportableExtensions: options.reportableExtensions ?? runtimeInputs.reportableExtensions,
+    walkExclusions: options.walkExclusions ?? runtimeInputs.walkExclusions,
   });
 };
 

--- a/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
@@ -37,7 +37,7 @@ test('wiring-injected classifyPath aligns with runtime when using prepared regis
   assert.deepEqual(wiringDeprecated, runtimeDeprecated);
 });
 
-test('wiring-injected collectRepositoryPaths aligns with runtime when using prepared reportable extensions', () => {
+test('wiring-injected collectRepositoryPaths aligns with runtime when using prepared runtime inputs', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-default-runtime-'));
 
   try {
@@ -51,6 +51,7 @@ test('wiring-injected collectRepositoryPaths aligns with runtime when using prep
     const collectedRuntime = collectRepositoryPathsRuntime(tempRoot, {
       scope: 'repo',
       reportableExtensions: prepared.reportableExtensions,
+      walkExclusions: prepared.walkExclusions,
     });
 
     assert.deepEqual(collectedWiring, collectedRuntime);

--- a/calculogic-validator/test/naming-registry-metadata.test.mjs
+++ b/calculogic-validator/test/naming-registry-metadata.test.mjs
@@ -27,6 +27,9 @@ test('prepareNamingRuntimeInputs exposes prepared dependencies and stable regist
   assert.ok(prepared.namingRolesRuntime.roleMetadata instanceof Map);
   assert.ok(prepared.namingRolesRuntime.activeRoles instanceof Set);
   assert.ok(Array.isArray(prepared.namingRolesRuntime.roleSuffixes));
+  assert.ok(prepared.walkExclusions.excludedDirectories instanceof Set);
+  assert.equal(typeof prepared.walkExclusions.skipDotDirectories, 'boolean');
+  assert.ok(prepared.walkExclusions.allowDotFiles instanceof Set);
   assert.ok(prepared.registry);
 
   const result = runNamingValidator(process.cwd(), { scope: 'system', config: {} });

--- a/calculogic-validator/test/naming-runtime-converters.test.mjs
+++ b/calculogic-validator/test/naming-runtime-converters.test.mjs
@@ -9,6 +9,7 @@ import {
   toReportableExtensionsSet,
 } from '../src/naming/naming-runtime-converters.logic.mjs';
 import { runNamingValidator as runNamingValidatorRuntime } from '../src/naming/naming-validator.logic.mjs';
+import { getBuiltinWalkExclusions } from '../src/naming/registries/naming-walk-exclusions.registry.logic.mjs';
 import { runNamingValidator as runNamingValidatorWiring } from '../src/naming/naming-validator.wiring.mjs';
 
 const writeFile = (rootDirectory, relativePath) => {
@@ -54,6 +55,7 @@ test('direct runtime and wiring derive equivalent runtime validation output from
       scope: 'repo',
       namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
       reportableExtensions: toReportableExtensionsSet(registryInputs.reportableExtensions),
+      walkExclusions: getBuiltinWalkExclusions(),
     });
 
     const wiringResult = runNamingValidatorWiring(tempRoot, { scope: 'repo', config: {} });

--- a/calculogic-validator/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/test/naming-runtime-input-boundary.test.mjs
@@ -13,6 +13,7 @@ import {
   toNamingRolesRuntime,
   toReportableExtensionsSet,
 } from '../src/naming/naming-runtime-converters.logic.mjs';
+import { getBuiltinWalkExclusions } from '../src/naming/registries/naming-walk-exclusions.registry.logic.mjs';
 
 const writeFile = (rootDirectory, relativePath) => {
   const absolutePath = path.join(rootDirectory, relativePath);
@@ -38,6 +39,7 @@ test('runtime accepts externally prepared naming runtime dependencies', () => {
       scope: 'repo',
       reportableExtensions,
       namingRolesRuntime,
+      walkExclusions: getBuiltinWalkExclusions(),
     });
 
     assert.equal(result.totalFilesScanned, 1);
@@ -59,5 +61,13 @@ test('runtime enforces prepared dependency injection contract', () => {
   assert.throws(
     () => collectRepositoryPaths(process.cwd(), { scope: 'repo' }),
     /requires prepared reportableExtensions/u,
+  );
+
+  assert.throws(
+    () => collectRepositoryPaths(process.cwd(), {
+      scope: 'repo',
+      reportableExtensions: new Set(['.ts']),
+    }),
+    /requires prepared walkExclusions/u,
   );
 });

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -196,7 +196,7 @@ Semantic-name case validation is sourced from builtin registry JSON at:
 
 Runtime currently supports the builtin `semanticName.style` value `kebab-case` only for this slice. The runtime maps that style to the existing canonical kebab-case semantic-name predicate behavior.
 
-### 2.10 Naming runtime input ownership boundary (V0.1.23)
+### 2.10 Naming runtime input ownership boundary (V0.1.24)
 
 Wiring owns registry/default/config composition and prepares runtime-ready dependencies before invoking runtime behavior.
 
@@ -211,10 +211,12 @@ Prepared runtime dependency contract:
 
 - `namingRolesRuntime` supplied by wiring (shape: `roleMetadata`, `activeRoles`, `roleSuffixes`)
 - `reportableExtensions` supplied by wiring as runtime `Set`
+- `walkExclusions` supplied by wiring (shape: `excludedDirectories`, `skipDotDirectories`, `allowDotFiles`)
 
 Ownership and precedence requirements:
 
 - runtime does not resolve registry state and does not build builtin runtime defaults at module scope.
+- runtime does not import builtin walk-exclusions registry loaders and does not own builtin fallback seams.
 - runtime behavior remains responsible for scanning, scope filtering, target filtering, classification, and summarization.
 - host/wiring public behavior remains unchanged; config continues to override builtin defaults via resolver + converter flow before runtime execution.
 


### PR DESCRIPTION
### Motivation
- Finish removing runtime-owned registry fallbacks from the naming slice by eliminating the builtin walk-exclusions fallback seam so the runtime is fully driven by wiring-provided inputs. 
- Keep ownership clear: wiring should prepare and inject all runtime dependencies (`reportableExtensions`, `namingRolesRuntime`, `walkExclusions`) while the runtime remains responsible only for scanning, filtering, classification, and summarization.

### Description
- Remove direct import/use of the builtin walk-exclusions loader in the runtime and add `assertPreparedWalkExclusions(...)` so the runtime requires a prepared `walkExclusions` input; change path collection and run logic to consume that input. (changed: `calculogic-validator/src/naming/naming-validator.logic.mjs`)
- Extend `prepareNamingRuntimeInputs(config)` to include `walkExclusions` (sourced from the builtin registry resolver) and inject `walkExclusions` into `runNamingValidator(...)` and `collectRepositoryPaths(...)` calls while preserving helper override precedence. (changed: `calculogic-validator/src/naming/naming-validator.wiring.mjs`)
- Update wiring/runtime helper parity and boundary tests to pass `walkExclusions` where needed and to assert the prepared bundle shape; update the NL-config doc to document the new prepared-runtime contract. (changed tests: `naming-runtime-input-boundary.test.mjs`, `naming-default-runtime-registry-alignment.test.mjs`, `naming-runtime-converters.test.mjs`, `naming-registry-metadata.test.mjs`; doc: `doc/nl-config/cfg-namingValidator.md`)

### Testing
- Ran `npm test` and the full test suite completed successfully (all tests passed after the changes). 
- Ran `npm run validate:naming -- --scope=app` and `npm run validate:all -- --validators=naming --scope=docs` and both succeeded. 
- Ran `npm run validate:naming -- --scope=repo` which exits non-zero due to existing repository naming findings (this is an expected, pre-existing report output and not a regression from this change). 
- Ran `npm run health:validator` which reported OK for naming validator deterministic checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab76e9e5588331a39d067e3e4b09d2)