### PR TITLE
docs: note future walk-exclusions customization alignment in naming validator

### DIFF
--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -220,6 +220,13 @@ Ownership and precedence requirements:
 - runtime behavior remains responsible for scanning, scope filtering, target filtering, classification, and summarization.
 - host/wiring public behavior remains unchanged; config continues to override builtin defaults via resolver + converter flow before runtime execution.
 
+Future alignment note:
+
+- current runtime purity for naming runtime dependencies is complete.
+- `walkExclusions` are currently prepared in wiring from the builtin walk-exclusions loader path.
+- future customization may align `walkExclusions` with the same registry-state/config-driven composition path used for roles and reportable extensions.
+- this is an architecture alignment note only, not a current contract violation.
+
 ## 3.0 Classification Contract
 
 ### 3.1 Canonical


### PR DESCRIPTION
### Motivation

- Make the naming validator architecture docs more precise by calling out a small future-alignment point for how `walkExclusions` are prepared, so contributors can see the next likely customization path without implying a runtime contract change.

### Description

- Inserted a concise "Future alignment note" into `### 2.10 Naming runtime input ownership boundary (V0.1.24)` that states runtime purity for current naming runtime dependencies is complete, that `walkExclusions` are currently prepared in wiring from the builtin walk-exclusions loader path, and that future customization may align `walkExclusions` with the same registry-state/config-driven composition path used for roles and reportable extensions.
- Emphasized that this is an architecture-alignment note only and not a current contract violation.
- Exact subsection updated: `### 2.10 Naming runtime input ownership boundary (V0.1.24)`; one-sentence summary: the note clarifies runtime purity while documenting that `walkExclusions` are wiring-provided today and may be aligned with registry/config resolution in the future; no runtime behavior was changed.

### Testing

- No automated unit or integration tests were required for this documentation-only change.
- Quick validations run and succeeded: `git diff -- doc/nl-config/cfg-namingValidator.md` and `rg -n "^### 2.10|^Future alignment note:" doc/nl-config/cfg-namingValidator.md` confirming the new note is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7ac5bc4883319fe4dd7301f7da70)