### PR TITLE
refactor(tree): move scoped/target selection to wiring and enforce tree target contract

### DIFF
--- a/calculogic-validator/src/core/scoped-target-paths.logic.mjs
+++ b/calculogic-validator/src/core/scoped-target-paths.logic.mjs
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const normalizePath = (relativePath) => relativePath.split(path.sep).join('/');
+
+const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
+
+const isPathOutsideRoot = (relativePath) =>
+  relativePath.startsWith('..') || path.isAbsolute(relativePath);
+
+export const resolveScopedTargets = (repositoryRoot, targets = []) => {
+  if (!targets?.length) {
+    return [];
+  }
+
+  const rootRealPath = fs.realpathSync(repositoryRoot);
+  const resolvedTargets = [];
+  const dedupeByAbsolutePath = new Set();
+
+  for (const rawTarget of targets) {
+    const trimmedTarget = String(rawTarget ?? '').trim();
+    const normalizedInput = trimmedTarget.replaceAll('\\', '/');
+
+    if (!normalizedInput) {
+      throw new Error('Target path must be a non-empty string.');
+    }
+
+    const absoluteCandidatePath = path.isAbsolute(trimmedTarget)
+      ? path.resolve(trimmedTarget)
+      : path.resolve(repositoryRoot, normalizedInput);
+
+    if (!fs.existsSync(absoluteCandidatePath)) {
+      throw new Error(`Target path does not exist: ${normalizedInput}`);
+    }
+
+    const absoluteRealPath = fs.realpathSync(absoluteCandidatePath);
+    const relativeToRoot = path.relative(rootRealPath, absoluteRealPath);
+    if (isPathOutsideRoot(relativeToRoot)) {
+      throw new Error(`Target path escapes repository root: ${normalizedInput}`);
+    }
+
+    if (dedupeByAbsolutePath.has(absoluteRealPath)) {
+      continue;
+    }
+
+    const targetStat = fs.statSync(absoluteRealPath);
+    const kind = targetStat.isDirectory() ? 'dir' : targetStat.isFile() ? 'file' : null;
+    if (!kind) {
+      throw new Error(`Target path must be a file or directory: ${normalizedInput}`);
+    }
+
+    dedupeByAbsolutePath.add(absoluteRealPath);
+    resolvedTargets.push({
+      absPath: absoluteRealPath,
+      relPath: relativeToRoot ? normalizePath(relativeToRoot) : '.',
+      kind,
+    });
+  }
+
+  return resolvedTargets.sort((left, right) => left.relPath.localeCompare(right.relPath));
+};
+
+export const filterScopedPathsByTargets = (
+  repositoryRoot,
+  relativePaths,
+  resolvedTargets = [],
+) => {
+  if (!resolvedTargets.length) {
+    return sortPaths(new Set(relativePaths));
+  }
+
+  const selectedPaths = relativePaths.filter((relativePath) => {
+    const absolutePath = path.resolve(repositoryRoot, relativePath);
+
+    return resolvedTargets.some((target) => {
+      if (target.kind === 'file') {
+        return absolutePath === target.absPath;
+      }
+
+      return absolutePath === target.absPath || absolutePath.startsWith(`${target.absPath}${path.sep}`);
+    });
+  });
+
+  return sortPaths(new Set(selectedPaths));
+};

--- a/calculogic-validator/src/core/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/core/validator-registry.knowledge.mjs
@@ -42,12 +42,21 @@ const runTreeStructureAdvisorHook = (repositoryRoot, options = {}) => {
     targets,
   });
   const summary = summarizeTreeStructureAdvisorFindings(treeStructureAdvisorResult.findings);
+  const meta = {};
+
+  if (treeStructureAdvisorResult.filters?.isFiltered) {
+    meta.filters = {
+      isFiltered: true,
+      targets: treeStructureAdvisorResult.filters.targets,
+    };
+  }
 
   return {
     scope: treeStructureAdvisorResult.scope,
     totalFilesScanned: treeStructureAdvisorResult.totalFilesScanned,
     findings: treeStructureAdvisorResult.findings,
     summary,
+    ...(Object.keys(meta).length > 0 ? { meta } : {}),
   };
 };
 

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -4,6 +4,10 @@ import {
   listValidatorScopes,
   getValidatorScopeProfile,
 } from '../core/validator-scopes.runtime.mjs';
+import {
+  resolveScopedTargets,
+  filterScopedPathsByTargets,
+} from '../core/scoped-target-paths.logic.mjs';
 import { parseCanonicalName } from './rules/naming-rule-parse-canonical.logic.mjs';
 import {
   getSpecialCaseType,
@@ -75,9 +79,6 @@ const assertPreparedWalkExclusions = (walkExclusions) => {
 };
 
 const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
-
-const isPathOutsideRoot = (relativePath) =>
-  relativePath.startsWith('..') || path.isAbsolute(relativePath);
 
 const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {}) => {
   const normalizedRoot = normalizePath(rootRelativePath);
@@ -187,83 +188,14 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   return sortPaths(new Set(scopedPaths));
 };
 
-export const resolveNamingValidatorTargets = (rootDirectory, targets = []) => {
-  if (!targets?.length) {
-    return [];
-  }
-
-  const repositoryRoot = fs.realpathSync(rootDirectory);
-  const resolvedTargets = [];
-  const dedupeByAbsolutePath = new Set();
-
-  for (const rawTarget of targets) {
-    const trimmedTarget = String(rawTarget ?? '').trim();
-    const normalizedInput = trimmedTarget.replaceAll('\\', '/');
-
-    if (!normalizedInput) {
-      throw new Error('Target path must be a non-empty string.');
-    }
-
-    const absoluteCandidatePath = path.isAbsolute(trimmedTarget)
-      ? path.resolve(trimmedTarget)
-      : path.resolve(rootDirectory, normalizedInput);
-
-    if (!fs.existsSync(absoluteCandidatePath)) {
-      throw new Error(`Target path does not exist: ${normalizedInput}`);
-    }
-
-    const absoluteRealPath = fs.realpathSync(absoluteCandidatePath);
-    const relativeToRoot = path.relative(repositoryRoot, absoluteRealPath);
-    if (isPathOutsideRoot(relativeToRoot)) {
-      throw new Error(`Target path escapes repository root: ${normalizedInput}`);
-    }
-
-    if (dedupeByAbsolutePath.has(absoluteRealPath)) {
-      continue;
-    }
-
-    const targetStat = fs.statSync(absoluteRealPath);
-    const kind = targetStat.isDirectory() ? 'dir' : targetStat.isFile() ? 'file' : null;
-    if (!kind) {
-      throw new Error(`Target path must be a file or directory: ${normalizedInput}`);
-    }
-
-    dedupeByAbsolutePath.add(absoluteRealPath);
-    resolvedTargets.push({
-      absPath: absoluteRealPath,
-      relPath: relativeToRoot ? normalizePath(relativeToRoot) : '.',
-      kind,
-    });
-  }
-
-  return resolvedTargets.sort((left, right) => left.relPath.localeCompare(right.relPath));
-};
+export const resolveNamingValidatorTargets = (rootDirectory, targets = []) =>
+  resolveScopedTargets(rootDirectory, targets);
 
 export const filterRepositoryPathsByTargets = (
   rootDirectory,
   relativePaths,
   resolvedTargets = [],
-) => {
-  if (!resolvedTargets.length) {
-    return sortPaths(new Set(relativePaths));
-  }
-
-  const selectedPaths = relativePaths.filter((relativePath) => {
-    const absolutePath = path.resolve(rootDirectory, relativePath);
-
-    return resolvedTargets.some((target) => {
-      if (target.kind === 'file') {
-        return absolutePath === target.absPath;
-      }
-
-      return (
-        absolutePath === target.absPath || absolutePath.startsWith(`${target.absPath}${path.sep}`)
-      );
-    });
-  });
-
-  return sortPaths(new Set(selectedPaths));
-};
+) => filterScopedPathsByTargets(rootDirectory, relativePaths, resolvedTargets);
 
 export const classifyPath = (relativePath, namingRolesRuntime) => {
   const runtime = assertPreparedNamingRolesRuntime(namingRolesRuntime);

--- a/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
@@ -1,6 +1,4 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import { getValidatorScopeProfile } from '../core/validator-scopes.runtime.mjs';
 
 const KNOWN_TOP_LEVEL_DIRECTORIES = new Set([
   'bin',
@@ -14,18 +12,6 @@ const KNOWN_TOP_LEVEL_DIRECTORIES = new Set([
   'tools',
 ]);
 
-const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
-const WALK_EXCLUDED_DIRECTORIES = new Set([
-  '.git',
-  '.next',
-  '.reports',
-  '.turbo',
-  '.yarn',
-  'coverage',
-  'dist',
-  'node_modules',
-]);
-
 const VALIDATOR_OWNED_BASENAME_PATTERNS = [
   /^naming-validator\.(logic|host|wiring|contracts)\.mjs$/u,
   /^tree-structure-advisor\.(logic|host|wiring|contracts)\.mjs$/u,
@@ -35,8 +21,6 @@ const VALIDATOR_OWNED_BASENAME_PATTERNS = [
   /^validator-.+\.test\.mjs$/u,
   /^naming-.+\.test\.mjs$/u,
 ];
-
-export const normalizePath = (relativePath) => relativePath.split(path.sep).join('/');
 
 const sortByPathThenCode = (left, right) => {
   const byPath = left.path.localeCompare(right.path);
@@ -50,69 +34,12 @@ const sortByPathThenCode = (left, right) => {
 const isValidatorOwnedBasenameSignal = (basename) =>
   VALIDATOR_OWNED_BASENAME_PATTERNS.some((pattern) => pattern.test(basename));
 
-const getScopeRoots = (scope) => {
-  const normalizedScope = scope ?? 'repo';
-  const profile = getValidatorScopeProfile(normalizedScope);
-
-  if (!profile) {
-    throw new Error(`Invalid scope profile: ${normalizedScope}`);
-  }
-
-  if (normalizedScope === 'repo') {
-    return ['.'];
-  }
-
-  return profile.includeRoots;
-};
-
-const collectPathsFromRoot = (repositoryRoot, rootRelativePath) => {
-  const absoluteRoot = path.resolve(repositoryRoot, rootRelativePath);
-  if (!fs.existsSync(absoluteRoot)) {
-    return [];
-  }
-
-  const rootStat = fs.statSync(absoluteRoot);
-  if (!rootStat.isDirectory()) {
-    return [];
-  }
-
-  const collected = [];
-
-  const walk = (absoluteDirectoryPath) => {
-    const entries = fs
-      .readdirSync(absoluteDirectoryPath, { withFileTypes: true })
-      .sort((left, right) => left.name.localeCompare(right.name));
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        if (WALK_EXCLUDED_DIRECTORIES.has(entry.name) || entry.name.startsWith('.')) {
-          continue;
-        }
-
-        walk(path.join(absoluteDirectoryPath, entry.name));
-        continue;
-      }
-
-      const relativeFilePath = normalizePath(path.relative(repositoryRoot, path.join(absoluteDirectoryPath, entry.name)));
-      collected.push(relativeFilePath);
-    }
-  };
-
-  walk(absoluteRoot);
-  return collected;
-};
-
-const collectTopLevelUnexpectedFolderFindings = (repositoryRoot, scope) => {
+const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope) => {
   if ((scope ?? 'repo') !== 'repo') {
     return [];
   }
 
-  return fs
-    .readdirSync(repositoryRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((directoryName) => !TOP_LEVEL_SCAN_EXCLUSIONS.has(directoryName))
-    .filter((directoryName) => !directoryName.startsWith('.'))
+  return topLevelDirectoryNames
     .filter((directoryName) => !KNOWN_TOP_LEVEL_DIRECTORIES.has(directoryName))
     .sort((left, right) => left.localeCompare(right))
     .map((directoryName) => ({
@@ -171,19 +98,37 @@ export const summarizeFindings = (findings) => {
   };
 };
 
-export const runTreeStructureAdvisor = (repositoryRoot, options = {}) => {
-  const selectedScope = options.scope ?? 'repo';
-  const scopeRoots = getScopeRoots(selectedScope);
-  const scopedPaths = scopeRoots.flatMap((scopeRoot) => collectPathsFromRoot(repositoryRoot, scopeRoot));
+const assertPreparedTreeInputs = (preparedInputs) => {
+  if (
+    preparedInputs &&
+    Array.isArray(preparedInputs.selectedPaths) &&
+    Array.isArray(preparedInputs.topLevelDirectoryNames)
+  ) {
+    return preparedInputs;
+  }
+
+  throw new Error('Tree runtime requires prepared inputs from wiring/runtime adapter.');
+};
+
+export const runTreeStructureAdvisor = (preparedInputs = {}) => {
+  const prepared = assertPreparedTreeInputs(preparedInputs);
 
   const findings = [
-    ...collectTopLevelUnexpectedFolderFindings(repositoryRoot, selectedScope),
-    ...collectValidatorOwnedOutsideTreeFindings(scopedPaths),
+    ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
+    ...collectValidatorOwnedOutsideTreeFindings(prepared.selectedPaths),
   ].sort(sortByPathThenCode);
 
   return {
     findings,
-    totalFilesScanned: Array.from(new Set(scopedPaths)).length,
-    scope: selectedScope,
+    totalFilesScanned: prepared.selectedPaths.length,
+    scope: prepared.scope ?? 'repo',
+    filters: {
+      isFiltered: prepared.targets.length > 0,
+      ...(prepared.targets.length > 0
+        ? {
+            targets: prepared.targets,
+          }
+        : {}),
+    },
   };
 };

--- a/calculogic-validator/src/tree/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.wiring.mjs
@@ -1,9 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   runTreeStructureAdvisor as runTreeStructureAdvisorRuntime,
   summarizeFindings,
 } from './tree-structure-advisor.logic.mjs';
+import { getValidatorScopeProfile } from '../core/validator-scopes.runtime.mjs';
+import {
+  normalizePath,
+  resolveScopedTargets,
+  filterScopedPathsByTargets,
+} from '../core/scoped-target-paths.logic.mjs';
 
-export const runTreeStructureAdvisor = (repositoryRoot, { scope, config, targets } = {}) =>
-  runTreeStructureAdvisorRuntime(repositoryRoot, { scope, config, targets });
+const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
+const WALK_EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  '.reports',
+  '.turbo',
+  '.yarn',
+  'coverage',
+  'dist',
+  'node_modules',
+]);
+
+const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
+
+const getScopeRoots = (scope) => {
+  const selectedScope = scope ?? 'repo';
+  const profile = getValidatorScopeProfile(selectedScope);
+
+  if (!profile) {
+    throw new Error(`Invalid scope profile: ${selectedScope}`);
+  }
+
+  if (selectedScope === 'repo') {
+    return ['.'];
+  }
+
+  return profile.includeRoots;
+};
+
+const collectPathsFromScopeRoot = (repositoryRoot, scopeRoot) => {
+  const absoluteRoot = path.resolve(repositoryRoot, scopeRoot);
+  if (!fs.existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  const rootStat = fs.statSync(absoluteRoot);
+  if (!rootStat.isDirectory()) {
+    return [];
+  }
+
+  const collected = [];
+
+  const walk = (absoluteDirectoryPath) => {
+    const entries = fs
+      .readdirSync(absoluteDirectoryPath, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (WALK_EXCLUDED_DIRECTORIES.has(entry.name) || entry.name.startsWith('.')) {
+          continue;
+        }
+
+        walk(path.join(absoluteDirectoryPath, entry.name));
+        continue;
+      }
+
+      const relativeFilePath = normalizePath(
+        path.relative(repositoryRoot, path.join(absoluteDirectoryPath, entry.name)),
+      );
+      collected.push(relativeFilePath);
+    }
+  };
+
+  walk(absoluteRoot);
+  return collected;
+};
+
+const collectTopLevelDirectoryNames = (repositoryRoot) =>
+  fs
+    .readdirSync(repositoryRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((directoryName) => !TOP_LEVEL_SCAN_EXCLUSIONS.has(directoryName))
+    .filter((directoryName) => !directoryName.startsWith('.'))
+    .sort((left, right) => left.localeCompare(right));
+
+export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targets } = {}) => {
+  const selectedScope = scope ?? 'repo';
+  const scopeRoots = getScopeRoots(selectedScope);
+  const scopedPaths = scopeRoots.flatMap((scopeRoot) =>
+    collectPathsFromScopeRoot(repositoryRoot, scopeRoot),
+  );
+  const inScopePaths = sortPaths(new Set(scopedPaths));
+  const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
+  const selectedPaths = filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets);
+
+  return {
+    scope: selectedScope,
+    selectedPaths,
+    topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
+    targets: resolvedTargets.map((target) => target.relPath),
+  };
+};
+
+export const runTreeStructureAdvisor = (repositoryRoot, { scope, targets } = {}) => {
+  const preparedInputs = prepareTreeStructureAdvisorInputs(repositoryRoot, { scope, targets });
+  return runTreeStructureAdvisorRuntime(preparedInputs);
+};
 
 export { summarizeFindings };

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -46,6 +46,7 @@ test('tree-structure-advisor is conservative for normal known repository shape',
     assert.equal(result.scope, 'repo');
     assert.equal(result.findings.length, 0);
     assert.equal(typeof result.totalFilesScanned, 'number');
+    assert.equal(result.filters.isFiltered, false);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
@@ -103,6 +104,115 @@ test('tree-structure-advisor flags validator-owned-looking file outside validato
     assert.equal(advisory.severity, 'info');
     assert.equal(advisory.classification, 'advisory-structure');
     assert.equal(advisory.path, 'src/naming-validator.wiring.mjs');
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor directory target narrows analyzed paths/findings', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-target-dir-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'validator-runner.logic.mjs'),
+      'export const misplaced = true\n',
+      'utf8',
+    );
+
+    const unfiltered = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const filtered = runTreeStructureAdvisor(fixtureDir, {
+      scope: 'repo',
+      targets: ['calculogic-validator'],
+    });
+
+    assert.equal(filtered.filters.isFiltered, true);
+    assert.deepEqual(filtered.filters.targets, ['calculogic-validator']);
+    assert.equal(
+      unfiltered.findings.some((finding) => finding.path === 'src/validator-runner.logic.mjs'),
+      true,
+    );
+    assert.equal(filtered.findings.some((finding) => finding.path === 'src/validator-runner.logic.mjs'), false);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor file target narrows analyzed paths/findings', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-target-file-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'naming-validator.wiring.mjs'),
+      'export const misplaced = true\n',
+      'utf8',
+    );
+
+    const filtered = runTreeStructureAdvisor(fixtureDir, {
+      scope: 'repo',
+      targets: ['src/app-shell.logic.ts'],
+    });
+
+    assert.equal(filtered.filters.isFiltered, true);
+    assert.deepEqual(filtered.filters.targets, ['src/app-shell.logic.ts']);
+    assert.equal(
+      filtered.findings.some((finding) => finding.code === 'TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE'),
+      false,
+    );
+    assert.equal(filtered.totalFilesScanned, 1);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor throws for invalid target path', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-target-invalid-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    assert.throws(
+      () => runTreeStructureAdvisor(fixtureDir, { scope: 'repo', targets: ['does-not-exist'] }),
+      /Target path does not exist: does-not-exist/u,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor throws for target path escaping repository root', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-target-escape-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    assert.throws(
+      () => runTreeStructureAdvisor(fixtureDir, { scope: 'repo', targets: ['..'] }),
+      /Target path escapes repository root: ../u,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor no-target behavior remains unchanged for findings', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-target-compat-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'validator-runner.logic.mjs'),
+      'export const misplaced = true\n',
+      'utf8',
+    );
+
+    const withoutTargets = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const explicitEmptyTargets = runTreeStructureAdvisor(fixtureDir, { scope: 'repo', targets: [] });
+
+    assert.deepEqual(withoutTargets.findings, explicitEmptyTargets.findings);
+    assert.equal(withoutTargets.filters.isFiltered, false);
+    assert.equal(explicitEmptyTargets.filters.isFiltered, false);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }

--- a/calculogic-validator/test/validate-all.targets.integration.test.mjs
+++ b/calculogic-validator/test/validate-all.targets.integration.test.mjs
@@ -87,3 +87,38 @@ test('validate-all returns deterministic error for nonexistent --target', async 
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
 });
+
+
+test('validate-all forwards target filtering contract to tree-structure-advisor', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-all-targets-tree-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'naming-validator.logic.mjs'),
+      'export const misplaced = true\n',
+      'utf8',
+    );
+
+    const result = runValidateAll(fixtureDir, [
+      '--validators=tree-structure-advisor',
+      '--scope=repo',
+      '--target',
+      'calculogic-validator',
+    ]);
+
+    assert.equal(result.status, 0);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.validators[0].id, 'tree-structure-advisor');
+    assert.equal(report.validators[0].meta.filters.isFiltered, true);
+    assert.deepEqual(report.validators[0].meta.filters.targets, ['calculogic-validator']);
+    assert.equal(
+      report.validators[0].findings.some((finding) => finding.code === 'TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -2,7 +2,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.1** (canonical slice-boundary convergence over existing advisory heuristics).
+Current implementation target: **V0.1.2** (wiring-owned scoped/target input preparation and runtime prepared-input consumption).
 
 ## 1.0 Purpose
 
@@ -15,7 +15,7 @@ V0.1.1 converges this slice to a canonical owned boundary under `calculogic-vali
 ### 2.1 Scope and targets
 
 - Uses validator suite scope resolution (`repo|app|docs|validator|system`).
-- Supports optional runner-forwarded `targets` when selected through `validate-all`.
+- Supports optional runner-forwarded `targets` when selected through `validate-all` with deterministic validation and selection parity to suite target semantics.
 - Default scope remains `repo` via existing runner behavior.
 
 ### 2.2 Repository signals
@@ -32,6 +32,22 @@ V0.1.x uses deterministic path-based signals only:
    - Emit info advisory for clearly unusual non-hidden top-level folders outside known repo shape.
 2. **Validator-owned-looking file outside validator tree**
    - Emit info advisory when filename/path signal strongly indicates validator ownership but file is outside `calculogic-validator/**`.
+
+
+### 2.4 Input ownership split (V0.1.2)
+
+V0.1.2 aligns tree with naming input ownership discipline:
+
+- wiring resolves scope profile and validates target paths
+- wiring prepares scoped path inventory and target-filtered selected paths
+- wiring prepares top-level directory inventory used by repo-scope top-level advisory checks
+- runtime consumes prepared inputs only and emits deterministic findings/summary-compatible output
+
+Target behaviors in V0.1.2:
+
+- no targets: analyze all scoped selected paths
+- file/directory targets: analyze only selected in-scope paths under target union
+- invalid/nonexistent/escaping targets: deterministic failures aligned with suite target contract
 
 ## 3.0 Output Contract
 


### PR DESCRIPTION
### Motivation
- Align the tree advisor with the naming slice input-ownership discipline so wiring prepares scoped/target inputs and runtime consumes prepared inputs only. 
- Ensure the validator-suite `--target` contract is honored by tree so target filtering behaves the same across slices. 
- Remove duplicated target-resolution logic by extracting a deterministic shared helper into core for reuse.

### Description
- Moved scope resolution, repo walking, target validation/resolution, in-scope path collection, and top-level directory inventory into `src/tree/tree-structure-advisor.wiring.mjs` so wiring prepares `selectedPaths`, `topLevelDirectoryNames`, `scope`, and `targets` before runtime. 
- Refactored runtime to accept prepared inputs only in `src/tree/tree-structure-advisor.logic.mjs` and made it report-only, deterministic, and unchanged in finding semantics while emitting filter metadata in the runner hook. 
- Added shared helpers `src/core/scoped-target-paths.logic.mjs` and switched `naming` to reuse them to avoid duplication (`resolveScopedTargets` and `filterScopedPathsByTargets`). 
- Added/updated tests exercising target parity and runner propagation in `calculogic-validator/test/tree-structure-advisor.test.mjs` and `calculogic-validator/test/validate-all.targets.integration.test.mjs`, and updated the NL skeleton `doc/nl-config/cfg-treeStructureAdvisor.md` to V0.1.2 before code changes.

### Testing
- Ran the full suite with `npm test` and all tests passed. 
- Ran focused validator tests with `node --test --experimental-strip-types calculogic-validator/test/tree-structure-advisor.test.mjs calculogic-validator/test/validate-all.targets.integration.test.mjs` and they passed. 
- Exercised the CLI runner with `npm run validate:all -- --validators=tree-structure-advisor --scope=repo` and with `--target src` and `--target calculogic-validator`, and all runs produced expected reports with target-filter metadata (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8bbe66548331a46c0248a824b5eb)