### PR TITLE
refactor(naming): move scoped path preparation into wiring and align runtime ownership

### DIFF
--- a/calculogic-validator/src/core/scoped-target-paths.logic.mjs
+++ b/calculogic-validator/src/core/scoped-target-paths.logic.mjs
@@ -83,3 +83,24 @@ export const filterScopedPathsByTargets = (
 
   return sortPaths(new Set(selectedPaths));
 };
+
+export const buildScopePathPredicate = (scopeProfile) => {
+  const includeRootSet = new Set((scopeProfile?.includeRoots ?? []).map(normalizePath));
+  const includeRootFileSet = new Set((scopeProfile?.includeRootFiles ?? []).map(normalizePath));
+
+  return (relativePath) => {
+    const normalizedPath = normalizePath(relativePath);
+    if (normalizedPath.includes('/')) {
+      const firstSegment = normalizedPath.split('/')[0];
+      return includeRootSet.has(firstSegment);
+    }
+
+    return includeRootFileSet.has(normalizedPath);
+  };
+};
+
+export const filterScopedPathsByProfile = (relativePaths, scopeProfile) => {
+  const scopePathPredicate = buildScopePathPredicate(scopeProfile);
+  const scopedPaths = relativePaths.filter(scopePathPredicate);
+  return sortPaths(new Set(scopedPaths));
+};

--- a/calculogic-validator/src/naming/naming-validator.logic.mjs
+++ b/calculogic-validator/src/naming/naming-validator.logic.mjs
@@ -1,12 +1,9 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import { listValidatorScopes, getValidatorScopeProfile } from '../core/validator-scopes.runtime.mjs';
 import {
-  listValidatorScopes,
-  getValidatorScopeProfile,
-} from '../core/validator-scopes.runtime.mjs';
-import {
-  resolveScopedTargets,
-  filterScopedPathsByTargets,
+  normalizePath,
+  filterScopedPathsByProfile,
 } from '../core/scoped-target-paths.logic.mjs';
 import { parseCanonicalName } from './rules/naming-rule-parse-canonical.logic.mjs';
 import {
@@ -20,8 +17,6 @@ import {
   isDeprecatedRole,
   isUnknownOrInactiveRole,
 } from './rules/naming-rule-check-role.logic.mjs';
-
-export const normalizePath = (relativePath) => relativePath.split(path.sep).join('/');
 
 export { parseCanonicalName, getSpecialCaseType, isAllowedSpecialCase };
 
@@ -128,21 +123,6 @@ const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {
   return collected;
 };
 
-const buildScopePathPredicate = (profile) => {
-  const includeRootSet = new Set(profile.includeRoots.map(normalizePath));
-  const includeRootFileSet = new Set(profile.includeRootFiles.map(normalizePath));
-
-  return (relativePath) => {
-    const normalizedPath = normalizePath(relativePath);
-    if (normalizedPath.includes('/')) {
-      const firstSegment = normalizedPath.split('/')[0];
-      return includeRootSet.has(firstSegment);
-    }
-
-    return includeRootFileSet.has(normalizedPath);
-  };
-};
-
 export const listNamingValidatorScopes = () => listValidatorScopes();
 
 export const getScopeProfile = (scope) => getValidatorScopeProfile(scope);
@@ -183,19 +163,8 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
     return sortPaths(new Set(allReportablePaths));
   }
 
-  const scopePathPredicate = buildScopePathPredicate(profile);
-  const scopedPaths = allReportablePaths.filter(scopePathPredicate);
-  return sortPaths(new Set(scopedPaths));
+  return filterScopedPathsByProfile(allReportablePaths, profile);
 };
-
-export const resolveNamingValidatorTargets = (rootDirectory, targets = []) =>
-  resolveScopedTargets(rootDirectory, targets);
-
-export const filterRepositoryPathsByTargets = (
-  rootDirectory,
-  relativePaths,
-  resolvedTargets = [],
-) => filterScopedPathsByTargets(rootDirectory, relativePaths, resolvedTargets);
 
 export const classifyPath = (relativePath, namingRolesRuntime) => {
   const runtime = assertPreparedNamingRolesRuntime(namingRolesRuntime);
@@ -345,30 +314,33 @@ export const classifyPath = (relativePath, namingRolesRuntime) => {
   };
 };
 
-export const runNamingValidator = (rootDirectory, options = {}) => {
-  const selectedScope = options.scope ?? 'repo';
-  const inScopePaths = collectRepositoryPaths(rootDirectory, {
-    scope: selectedScope,
-    reportableExtensions: options.reportableExtensions,
-    walkExclusions: options.walkExclusions,
-  });
-  const resolvedTargets = resolveNamingValidatorTargets(rootDirectory, options.targets ?? []);
-  const paths = filterRepositoryPathsByTargets(rootDirectory, inScopePaths, resolvedTargets);
-  const findings = paths.map((pathname) => classifyPath(pathname, options.namingRolesRuntime));
+export const runNamingValidator = (preparedInputs = {}) => {
+  const selectedPaths = assertPreparedSelectedPaths(preparedInputs.selectedPaths);
+  const namingRolesRuntime = assertPreparedNamingRolesRuntime(preparedInputs.namingRolesRuntime);
+  const resolvedTargets = Array.isArray(preparedInputs.targets) ? preparedInputs.targets : [];
+  const findings = selectedPaths.map((pathname) => classifyPath(pathname, namingRolesRuntime));
 
   return {
     findings,
-    totalFilesScanned: paths.length,
-    scope: selectedScope,
+    totalFilesScanned: selectedPaths.length,
+    scope: preparedInputs.scope ?? 'repo',
     filters: {
       isFiltered: resolvedTargets.length > 0,
       ...(resolvedTargets.length > 0
         ? {
-            targets: resolvedTargets.map((target) => target.relPath),
+            targets: resolvedTargets,
           }
         : {}),
     },
   };
+};
+
+const assertPreparedSelectedPaths = (selectedPaths) => {
+  if (Array.isArray(selectedPaths)) {
+    return selectedPaths;
+  }
+
+  throw new Error('Naming runtime requires prepared selectedPaths from wiring/runtime adapter.');
 };
 
 const incrementCounter = (counts, key) => {

--- a/calculogic-validator/src/naming/naming-validator.wiring.mjs
+++ b/calculogic-validator/src/naming/naming-validator.wiring.mjs
@@ -8,14 +8,18 @@ import {
   parseCanonicalName,
   getSpecialCaseType,
   isAllowedSpecialCase,
-  normalizePath,
-  listNamingValidatorScopes,
-  getScopeProfile,
   collectRepositoryPaths as collectRepositoryPathsRuntime,
   classifyPath as classifyPathRuntime,
   runNamingValidator as runNamingValidatorRuntime,
+  listNamingValidatorScopes,
+  getScopeProfile,
   summarizeFindings,
 } from './naming-validator.logic.mjs';
+import {
+  normalizePath,
+  resolveScopedTargets,
+  filterScopedPathsByTargets,
+} from '../core/scoped-target-paths.logic.mjs';
 
 export const prepareNamingRuntimeInputs = (config) => {
   const registryInputs = resolveNamingRegistryInputs({ config });
@@ -32,20 +36,35 @@ export const prepareNamingRuntimeInputs = (config) => {
   };
 };
 
-export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) => {
+export const prepareNamingValidatorInputs = (
+  repositoryRoot,
+  { scope, config, targets } = {},
+) => {
   const runtimeInputs = prepareNamingRuntimeInputs(config);
-
-  const result = runNamingValidatorRuntime(repositoryRoot, {
-    scope,
-    targets,
+  const selectedScope = scope ?? 'repo';
+  const inScopePaths = collectRepositoryPathsRuntime(repositoryRoot, {
+    scope: selectedScope,
     reportableExtensions: runtimeInputs.reportableExtensions,
-    namingRolesRuntime: runtimeInputs.namingRolesRuntime,
     walkExclusions: runtimeInputs.walkExclusions,
   });
+  const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
+
+  return {
+    ...runtimeInputs,
+    scope: selectedScope,
+    selectedPaths: filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets),
+    targets: resolvedTargets.map((target) => target.relPath),
+  };
+};
+
+export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) => {
+  const preparedInputs = prepareNamingValidatorInputs(repositoryRoot, { scope, config, targets });
+
+  const result = runNamingValidatorRuntime(preparedInputs);
 
   return {
     ...result,
-    registry: runtimeInputs.registry,
+    registry: preparedInputs.registry,
   };
 };
 

--- a/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs
@@ -10,8 +10,10 @@ import {
 import {
   classifyPath,
   collectRepositoryPaths,
+  prepareNamingValidatorInputs,
   prepareNamingRuntimeInputs,
 } from '../src/validators/naming-validator.logic.mjs';
+import { runNamingValidator as runNamingValidatorRuntime } from '../src/naming/naming-validator.logic.mjs';
 
 const writeFile = (rootDirectory, relativePath) => {
   const absolutePath = path.join(rootDirectory, relativePath);
@@ -55,6 +57,27 @@ test('wiring-injected collectRepositoryPaths aligns with runtime when using prep
     });
 
     assert.deepEqual(collectedWiring, collectedRuntime);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('wiring prepares selected naming paths and runtime consumes prepared inputs unchanged', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-wiring-prepared-inputs-'));
+
+  try {
+    writeFile(tempRoot, 'src/visible.logic.ts');
+    writeFile(tempRoot, 'src/skip.tmp');
+
+    const prepared = prepareNamingValidatorInputs(tempRoot, { scope: 'app', targets: ['src'] });
+    const runtimeResult = runNamingValidatorRuntime(prepared);
+
+    assert.deepEqual(
+      runtimeResult.findings.map((finding) => finding.path),
+      ['src/visible.logic.ts'],
+    );
+    assert.equal(runtimeResult.scope, 'app');
+    assert.deepEqual(runtimeResult.filters, { isFiltered: true, targets: ['src'] });
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/calculogic-validator/test/naming-runtime-converters.test.mjs
+++ b/calculogic-validator/test/naming-runtime-converters.test.mjs
@@ -11,6 +11,7 @@ import {
 import { runNamingValidator as runNamingValidatorRuntime } from '../src/naming/naming-validator.logic.mjs';
 import { getBuiltinWalkExclusions } from '../src/naming/registries/naming-walk-exclusions.registry.logic.mjs';
 import { runNamingValidator as runNamingValidatorWiring } from '../src/naming/naming-validator.wiring.mjs';
+import { collectRepositoryPaths } from '../src/naming/naming-validator.wiring.mjs';
 
 const writeFile = (rootDirectory, relativePath) => {
   const absolutePath = path.join(rootDirectory, relativePath);
@@ -51,11 +52,15 @@ test('direct runtime and wiring derive equivalent runtime validation output from
     writeFile(tempRoot, 'src/legacy.tmp');
 
     const registryInputs = resolveNamingRegistryInputs({ config: {} });
-    const runtimeResult = runNamingValidatorRuntime(tempRoot, {
+    const runtimeResult = runNamingValidatorRuntime({
       scope: 'repo',
+      selectedPaths: collectRepositoryPaths(tempRoot, {
+        scope: 'repo',
+        reportableExtensions: toReportableExtensionsSet(registryInputs.reportableExtensions),
+        walkExclusions: getBuiltinWalkExclusions(),
+      }),
+      targets: [],
       namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
-      reportableExtensions: toReportableExtensionsSet(registryInputs.reportableExtensions),
-      walkExclusions: getBuiltinWalkExclusions(),
     });
 
     const wiringResult = runNamingValidatorWiring(tempRoot, { scope: 'repo', config: {} });

--- a/calculogic-validator/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/test/naming-runtime-input-boundary.test.mjs
@@ -35,11 +35,15 @@ test('runtime accepts externally prepared naming runtime dependencies', () => {
     writeFile(tempRoot, 'src/panel.logic.ts');
     writeFile(tempRoot, 'src/skip.tmp');
 
-    const result = runNamingValidator(tempRoot, {
+    const result = runNamingValidator({
       scope: 'repo',
-      reportableExtensions,
+      selectedPaths: collectRepositoryPaths(tempRoot, {
+        scope: 'repo',
+        reportableExtensions,
+        walkExclusions: getBuiltinWalkExclusions(),
+      }),
       namingRolesRuntime,
-      walkExclusions: getBuiltinWalkExclusions(),
+      targets: [],
     });
 
     assert.equal(result.totalFilesScanned, 1);
@@ -56,6 +60,15 @@ test('runtime enforces prepared dependency injection contract', () => {
   assert.throws(
     () => classifyPath('src/rightpanel.results-style.css'),
     /requires prepared namingRolesRuntime/u,
+  );
+
+  assert.throws(
+    () => runNamingValidator({
+      scope: 'repo',
+      namingRolesRuntime: toNamingRolesRuntime(resolveNamingRegistryInputs({ config: {} }).roles),
+      targets: [],
+    }),
+    /requires prepared selectedPaths/u,
   );
 
   assert.throws(


### PR DESCRIPTION
### Motivation
- Align the naming slice with the tree ownership model so wiring prepares scoped/targeted path inputs and runtime consumes only prepared inputs for classification and summarization. 
- Share small scoped-path selection logic in `core` to avoid duplication and keep naming/tree consistent. 

### Description
- Moved scoped path selection from naming runtime into wiring by adding `prepareNamingValidatorInputs(repositoryRoot, { scope, config, targets })` and updated `runNamingValidator(...)` in wiring to call runtime with a prepared bundle containing `scope`, `selectedPaths`, `targets`, prepared naming dependencies, and registry envelope. 
- Narrowed naming runtime (`src/naming/naming-validator.logic.mjs`) to consume prepared inputs only (classification, summarization, deterministic ordering, and report shaping) and to reject missing `selectedPaths` as a prepared-input contract. 
- Extracted small reusable helpers into core: added `buildScopePathPredicate` and `filterScopedPathsByProfile` in `src/core/scoped-target-paths.logic.mjs` and re-used them from naming to apply scope profiles deterministically. 
- Kept ergonomic wiring helpers (`collectRepositoryPaths`, `classifyPath`, `prepareNamingRuntimeInputs`) and preserved registry metadata envelope, finding codes/severities/classifications, target semantics, and deterministic ordering. 
- Updated tests to reflect the new prepared-input contract and wiring/runtime parity (see updated tests below). 

### Testing
- Ran full test suite: `npm test` — all tests passed. 
- Ran validator and CLI checks: `npm run validate:naming -- --scope=app`, `npm run validate:naming -- --scope=app --target src`, and `npm run validate:all -- --validators=naming --scope=app --target src` — all succeeded and outputs matched prior semantics. 
- Ran focused naming tests: `calculogic-validator/test/naming-runtime-input-boundary.test.mjs`, `calculogic-validator/test/naming-default-runtime-registry-alignment.test.mjs`, `calculogic-validator/test/naming-registry-metadata.test.mjs` — all passed. 

Files changed (high level): `src/naming/naming-validator.wiring.mjs`, `src/naming/naming-validator.logic.mjs`, `src/core/scoped-target-paths.logic.mjs`, and updated naming tests to assert the new prepared-input contract.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab917e11408331a07c26f8d466cddb)