### PR TITLE
feat(tree): add deterministic shim/compat advisory detection

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -286,9 +286,15 @@ Example:
 
 Shim/compat detection is a tree-health diagnostic layer in report-first mode:
 
-- detect shim-like files via folder signals (`compat/`, `shims/`, `adapters/`) and/or naming needles (`shim`, `compat`, `adapter`, `bridge`, `migration`)
-- detect scatter when shim-like entries appear across many unrelated folders
+- detect shim-like files via folder signals (`compat/`, `shims/`, `adapters/`, `bridges/`) and/or naming needles (`shim`, `compat`, `adapter`, `bridge`, `migration`)
+- treat thin flat re-export files (`export * from ...` / `export { ... } from ...` only) as a strong shim-like signal
 - recommend a discoverable surface (for example `src/compat/` or `src/compat/shims/`) only when shim-like files already exist
+
+V0.0.1 implemented subset:
+
+- `TREE_SHIM_SURFACE_PRESENT` (`info`): emitted for deterministic shim-like paths with signal details
+- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`): emitted when shim-like paths are not under a discoverable compat/shims surface
+- `TREE_SHIM_SCATTERED`: reserved for a later deterministic slice
 
 Constraints:
 
@@ -361,9 +367,9 @@ Suggested codes (V0.0.1):
 - `TREE_MISSING_NAMESPACE_ROOT`
 - `TREE_SUBSYSTEM_SCAFFOLD_ASYMMETRY`
 - `TREE_TOOL_SURFACE_MIX`
-- `TREE_SHIM_SURFACE_PRESENT` (`info`)
-- `TREE_SHIM_SCATTERED` (`warn`/`info`)
-- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`/`info`)
+- `TREE_SHIM_SURFACE_PRESENT` (`info`) — implemented
+- `TREE_SHIM_SCATTERED` (`warn`/`info`) — planned
+- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`) — implemented
 - `TREE_SHARED_LANE_FIRST_PARTITION_PRESENT` (`info`)
 - `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` (`warn`/`info`)
 - `TREE_SHARED_SEMANTIC_ROOT_RECOMMENDED` (`warn`/`info`)

--- a/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
@@ -22,6 +22,11 @@ const VALIDATOR_OWNED_BASENAME_PATTERNS = [
   /^naming-.+\.test\.mjs$/u,
 ];
 
+const SHIM_FOLDER_SIGNALS = new Set(['compat', 'shims', 'adapters', 'bridges']);
+const SHIM_NAME_TOKEN_SIGNALS = new Set(['shim', 'compat', 'adapter', 'bridge', 'migration']);
+const SHIM_SURFACE_SEGMENT_SIGNALS = new Set(['compat', 'shims']);
+const SHIM_RELEVANT_FILE_EXTENSIONS = new Set(['.mjs', '.js', '.cjs', '.ts', '.tsx', '.jsx']);
+
 const sortByPathThenCode = (left, right) => {
   const byPath = left.path.localeCompare(right.path);
   if (byPath !== 0) {
@@ -33,6 +38,133 @@ const sortByPathThenCode = (left, right) => {
 
 const isValidatorOwnedBasenameSignal = (basename) =>
   VALIDATOR_OWNED_BASENAME_PATTERNS.some((pattern) => pattern.test(basename));
+
+const tokenizeBasename = (basename) =>
+  basename
+    .toLowerCase()
+    .replace(/\.[^.]+$/u, '')
+    .split(/[^a-z0-9]+/u)
+    .filter(Boolean);
+
+const collectPathShimSignals = (relativePath) => {
+  const segments = relativePath.split('/').filter(Boolean);
+  const directorySegments = segments.slice(0, -1);
+  const basename = segments.at(-1) ?? '';
+  const normalizedDirectories = directorySegments.map((segment) => segment.toLowerCase());
+
+  const folderSignals = normalizedDirectories.filter((segment) => SHIM_FOLDER_SIGNALS.has(segment));
+  const basenameTokens = tokenizeBasename(basename).filter((token) => SHIM_NAME_TOKEN_SIGNALS.has(token));
+
+  return {
+    folderSignals,
+    basenameTokens,
+    insideCompatSurface: normalizedDirectories.some((segment) => SHIM_SURFACE_SEGMENT_SIGNALS.has(segment)),
+  };
+};
+
+const parseThinReexportShim = (rawContent) => {
+  if (typeof rawContent !== 'string') {
+    return null;
+  }
+
+  const lines = rawContent
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('//'));
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const reexportTargets = [];
+  for (const line of lines) {
+    const match = line.match(/^export\s+(?:\*|\{[^}]+\})\s+from\s+['"]([^'"]+)['"];?$/u);
+    if (!match) {
+      return null;
+    }
+
+    reexportTargets.push(match[1]);
+  }
+
+  const canonicalTargetPath = reexportTargets[0];
+  const hasCanonicalSegmentSignal = /(?:^|\/)(?:core|tree|naming|validators)\//u.test(canonicalTargetPath);
+  if (!hasCanonicalSegmentSignal) {
+    return null;
+  }
+
+  return {
+    isThinReexportShim: true,
+    canonicalTargetPath,
+    reexportTargetCount: reexportTargets.length,
+  };
+};
+
+const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
+  const findings = [];
+
+  for (const relativePath of paths) {
+    const extension = path.posix.extname(relativePath).toLowerCase();
+    if (!SHIM_RELEVANT_FILE_EXTENSIONS.has(extension)) {
+      continue;
+    }
+
+    const shimSignals = collectPathShimSignals(relativePath);
+    const thinReexportSignal = parseThinReexportShim(fileContentsByPath[relativePath]);
+    const isShimLike =
+      shimSignals.folderSignals.length > 0 ||
+      shimSignals.basenameTokens.length > 0 ||
+      thinReexportSignal !== null;
+
+    if (!isShimLike) {
+      continue;
+    }
+
+    findings.push({
+      code: 'TREE_SHIM_SURFACE_PRESENT',
+      severity: 'info',
+      path: relativePath,
+      classification: 'advisory-structure',
+      message:
+        'Shim/compat signals are present for this path; maintain a discoverable and deterministic compatibility surface while cleanup is pending.',
+      ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
+      details: {
+        matchedShimSignals: {
+          folderSignals: shimSignals.folderSignals,
+          nameTokenSignals: shimSignals.basenameTokens,
+          thinReexportShim: thinReexportSignal?.isThinReexportShim ?? false,
+        },
+        canonicalTargetPath: thinReexportSignal?.canonicalTargetPath,
+        reexportTargetCount: thinReexportSignal?.reexportTargetCount,
+        insideCompatSurface: shimSignals.insideCompatSurface,
+      },
+    });
+
+    if (shimSignals.insideCompatSurface) {
+      continue;
+    }
+
+    findings.push({
+      code: 'TREE_SHIM_OUTSIDE_COMPAT',
+      severity: 'warn',
+      path: relativePath,
+      classification: 'advisory-structure',
+      message:
+        'Shim-like path is outside a discoverable compat/shims surface; consider consolidating compat entries to support later cleanup work.',
+      ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
+      details: {
+        matchedShimSignals: {
+          folderSignals: shimSignals.folderSignals,
+          nameTokenSignals: shimSignals.basenameTokens,
+          thinReexportShim: thinReexportSignal?.isThinReexportShim ?? false,
+        },
+        canonicalTargetPath: thinReexportSignal?.canonicalTargetPath,
+        insideCompatSurface: shimSignals.insideCompatSurface,
+      },
+    });
+  }
+
+  return findings;
+};
 
 const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope) => {
   if ((scope ?? 'repo') !== 'repo') {
@@ -116,6 +248,7 @@ export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const findings = [
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
     ...collectValidatorOwnedOutsideTreeFindings(prepared.selectedPaths),
+    ...collectShimCompatFindings(prepared.selectedPaths, prepared.fileContentsByPath),
   ].sort(sortByPathThenCode);
 
   return {

--- a/calculogic-validator/src/tree/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.wiring.mjs
@@ -97,12 +97,19 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
   const inScopePaths = sortPaths(new Set(scopedPaths));
   const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
   const selectedPaths = filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets);
+  const fileContentsByPath = Object.fromEntries(
+    selectedPaths.map((relativePath) => [
+      relativePath,
+      fs.readFileSync(path.resolve(repositoryRoot, relativePath), 'utf8'),
+    ]),
+  );
 
   return {
     scope: selectedScope,
     selectedPaths,
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: resolvedTargets.map((target) => target.relPath),
+    fileContentsByPath,
   };
 };
 

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -84,6 +84,87 @@ test('tree-structure-advisor findings are deterministic and summary-stable', asy
   }
 });
 
+
+test('tree-structure-advisor detects flat thin re-export shim deterministically', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-reexport-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'validator-runner.logic.mjs'),
+      "export * from '../calculogic-validator/src/core/validator-runner.logic.mjs';\n",
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const findings = result.findings.filter(
+      (finding) => finding.path === 'src/validator-runner.logic.mjs' && finding.code.startsWith('TREE_SHIM_'),
+    );
+
+    assert.deepEqual(
+      findings.map((finding) => finding.code),
+      ['TREE_SHIM_OUTSIDE_COMPAT', 'TREE_SHIM_SURFACE_PRESENT'],
+    );
+    const shimSurface = findings.find((finding) => finding.code === 'TREE_SHIM_SURFACE_PRESENT');
+    assert.ok(shimSurface);
+    assert.equal(shimSurface.details.matchedShimSignals.thinReexportShim, true);
+    assert.equal(
+      shimSurface.details.canonicalTargetPath,
+      '../calculogic-validator/src/core/validator-runner.logic.mjs',
+    );
+    assert.equal(shimSurface.details.insideCompatSurface, false);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor detects shim-like path inside compat surface without outside warning', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-compat-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'src', 'compat'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'compat', 'legacy-api.logic.mjs'),
+      "export * from '../../calculogic-validator/src/core/validator-runner.logic.mjs';\n",
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some(
+        (finding) =>
+          finding.path === 'src/compat/legacy-api.logic.mjs' && finding.code === 'TREE_SHIM_SURFACE_PRESENT',
+      ),
+      true,
+    );
+    assert.equal(
+      result.findings.some(
+        (finding) =>
+          finding.path === 'src/compat/legacy-api.logic.mjs' && finding.code === 'TREE_SHIM_OUTSIDE_COMPAT',
+      ),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor does not flag normal non-shim files for shim findings', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-non-shim-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(result.findings.some((finding) => finding.code.startsWith('TREE_SHIM_')), false);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor flags validator-owned-looking file outside validator tree', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-misplaced-'));
 

--- a/calculogic-validator/test/validate-all.targets.integration.test.mjs
+++ b/calculogic-validator/test/validate-all.targets.integration.test.mjs
@@ -122,3 +122,53 @@ test('validate-all forwards target filtering contract to tree-structure-advisor'
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
 });
+
+
+test('validate-all target filtering suppresses shim findings outside selected target', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-all-targets-tree-shim-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'core'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'validator-runner.logic.mjs'),
+      'export const core = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'validator-runner.logic.mjs'),
+      "export * from '../calculogic-validator/src/core/validator-runner.logic.mjs';\n",
+      'utf8',
+    );
+
+    const unfiltered = runValidateAll(fixtureDir, [
+      '--validators=tree-structure-advisor',
+      '--scope=repo',
+    ]);
+    assert.equal(unfiltered.status, 2);
+    const unfilteredReport = JSON.parse(unfiltered.stdout);
+    assert.equal(
+      unfilteredReport.validators[0].findings.some((finding) => finding.code === 'TREE_SHIM_SURFACE_PRESENT'),
+      true,
+    );
+
+    const filtered = runValidateAll(fixtureDir, [
+      '--validators=tree-structure-advisor',
+      '--scope=repo',
+      '--target',
+      'calculogic-validator',
+    ]);
+
+    assert.equal(filtered.status, 0);
+
+    const filteredReport = JSON.parse(filtered.stdout);
+    assert.equal(filteredReport.validators[0].meta.filters.isFiltered, true);
+    assert.deepEqual(filteredReport.validators[0].meta.filters.targets, ['calculogic-validator']);
+    assert.equal(
+      filteredReport.validators[0].findings.some((finding) => finding.code === 'TREE_SHIM_SURFACE_PRESENT'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
### Motivation
- Surface conservative, deterministic shim/compat signals in the tree advisor so existing shim surfaces are discoverable and can drive a later cleanup pass.
- Use the validator’s own flat re-export shims as dogfood examples and keep findings advisory-only to avoid introducing enforcement or automatic fixes.

### Description
- Added deterministic shim heuristics including folder signals (`compat`, `shims`, `adapters`, `bridges`), basename token signals (`shim`, `compat`, `adapter`, `bridge`, `migration`), and a strong thin flat re-export detection for `export * from ...` / `export { ... } from ...` with canonical-target segment checks.
- Gated detection to common code extensions (`.mjs`, `.js`, `.cjs`, `.ts`, `.tsx`, `.jsx`) and added deterministic detail fields (matched signals, `insideCompatSurface`, `canonicalTargetPath`, `reexportTargetCount`) to make findings actionable for later cleanup.
- Implemented two finding codes: `TREE_SHIM_SURFACE_PRESENT` (`info`) and `TREE_SHIM_OUTSIDE_COMPAT` (`warn`), and left `TREE_SHIM_SCATTERED` reserved for a later slice. 
- Wired the advisor to include `fileContentsByPath` from `prepareTreeStructureAdvisorInputs` so thin re-export detection is deterministic, and updated a small subset of tests plus the validator spec doc to document the implemented subset. 

### Testing
- Ran the full test suite with `npm test` and all tests passed. 
- Ran the focused validator tests with `node --test --experimental-strip-types calculogic-validator/test/tree-structure-advisor.test.mjs calculogic-validator/test/validate-all.targets.integration.test.mjs` and they passed. 
- Executed `npm run validate:all -- --validators=tree-structure-advisor --scope=validator` and `npm run validate:all -- --validators=tree-structure-advisor --scope=repo` to verify report-mode behavior and shim findings, and verified `--target` filtering with `npm run validate:all -- --validators=tree-structure-advisor --scope=repo --target calculogic-validator/src/core` which confirmed filtered runs suppress out-of-target shim findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab99d58734833196df1e39b6b73cf0)