### PR TITLE
feat(tree): add dedicated validate:tree command and report presets

### DIFF
--- a/calculogic-validator/scripts/validate-tree.mjs
+++ b/calculogic-validator/scripts/validate-tree.mjs
@@ -1,0 +1,139 @@
+import {
+  getValidatorScopeProfile,
+  listValidatorScopes,
+} from '../src/core/validator-scopes.runtime.mjs';
+import { runValidatorRunner } from '../src/core/validator-runner.logic.mjs';
+import { resolveRepositoryRoot } from '../src/core/repository-root.logic.mjs';
+import {
+  computeConfigDigest,
+  getValidatorToolVersion,
+} from '../src/core/validator-report-meta.logic.mjs';
+import { loadValidatorConfigFromFile } from '../src/core/config/validator-config.logic.mjs';
+import { deriveExitCodeFromRunnerReport } from '../src/core/validator-exit-code.logic.mjs';
+import { detectNpmArgForwardingFootgun } from '../src/core/npm-arg-forwarding-guard.logic.mjs';
+
+const repositoryRoot = resolveRepositoryRoot();
+
+const supportedScopes = listValidatorScopes();
+const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
+const supportedScopesToken = preferredScopeOrder
+  .filter((scope) => supportedScopes.includes(scope))
+  .join('|');
+
+const usageLines = [
+  `Usage: npm run validate:tree -- [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>]`,
+  'Scopes:',
+  ...supportedScopes.map((scope) => {
+    const profile = getValidatorScopeProfile(scope);
+    return `  - ${scope}: ${profile?.description ?? ''}`;
+  }),
+  'Default scope: validator default (repo for tree-structure-advisor)',
+  'Validator: tree-structure-advisor',
+  'Examples:',
+  '  ✅ npm run validate:tree -- --scope=repo',
+  '  ✅ npm run validate:tree -- --scope=app --target src/tree',
+  '  ✅ npm run validate:tree -- --target calculogic-validator/src/tree',
+  '  ✅ npm run validate:all -- --validators=tree-structure-advisor --scope=repo',
+];
+
+const parseCliArgs = (argv) => {
+  let selectedScope;
+  let configPath;
+  const targets = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--help' || argument === '-h') {
+      return { helpRequested: true, selectedScope, configPath, targets };
+    }
+
+    if (argument.startsWith('--scope=')) {
+      selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    if (argument === '--target') {
+      const rawTarget = argv[index + 1];
+      if (!rawTarget || rawTarget.startsWith('--')) {
+        throw new Error('Missing required value for --target');
+      }
+
+      targets.push(rawTarget.trim().replaceAll('\\', '/'));
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--target=')) {
+      targets.push(argument.slice('--target='.length).trim().replaceAll('\\', '/'));
+      continue;
+    }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
+      continue;
+    }
+
+    throw new Error(`Invalid argument: ${argument}`);
+  }
+
+  return { helpRequested: false, selectedScope, configPath, targets };
+};
+
+const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
+  argv: process.argv.slice(2),
+  npmConfigArgvJson: process.env.npm_config_argv,
+  lifecycleEvent: process.env.npm_lifecycle_event,
+  expectedLifecycleEvent: 'validate:tree',
+  supportedFlagNames: ['scope', 'target', 'config'],
+});
+
+if (npmArgForwardingMessage) {
+  console.error(npmArgForwardingMessage);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = parseCliArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+if (parsed.helpRequested) {
+  console.log(usageLines.join('\n'));
+  process.exit(0);
+}
+
+if (parsed.selectedScope && !getValidatorScopeProfile(parsed.selectedScope)) {
+  console.error(`Invalid scope: ${parsed.selectedScope}`);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}
+
+try {
+  const config = parsed.configPath
+    ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
+    : undefined;
+
+  const toolVersion = getValidatorToolVersion();
+
+  const report = runValidatorRunner(repositoryRoot, {
+    scope: parsed.selectedScope,
+    validators: ['tree-structure-advisor'],
+    config,
+    targets: parsed.targets,
+    toolVersion,
+    ...(config ? { configDigest: computeConfigDigest(config) } : {}),
+  });
+
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(deriveExitCodeFromRunnerReport(report));
+} catch (error) {
+  console.error(error.message);
+  console.error(usageLines.join('\n'));
+  process.exit(1);
+}

--- a/calculogic-validator/test/report-capture.scopes.integration.test.mjs
+++ b/calculogic-validator/test/report-capture.scopes.integration.test.mjs
@@ -105,3 +105,36 @@ test('report-capture host emits validate-all reports for repo/app/docs/validator
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+
+test('report-capture host emits validate-tree reports for repo/app/docs/validator/system scopes', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-scopes-tree-'));
+
+  try {
+    for (const scope of scopes) {
+      const prefix = `validate-tree-${scope}`;
+      const before = reportFilesForPrefix(tempDir, prefix);
+
+      const exitCode = await runReportCapture(
+        prefix,
+        'calculogic-validator/scripts/validate-tree.mjs',
+        scope,
+        tempDir,
+      );
+      assert.ok([0, 1, 2].includes(exitCode));
+
+      const after = reportFilesForPrefix(tempDir, prefix);
+      assert.equal(after.length, before.length + 1);
+
+      const newest = after.at(-1);
+      assert.ok(newest, `missing report file for ${prefix}`);
+
+      const reportContent = fs.readFileSync(path.join(tempDir, newest), 'utf8');
+      assert.ok(reportContent.includes(`"scope": "${scope}"`));
+      assert.ok(reportContent.includes('"mode": "report"'));
+      assert.ok(reportContent.includes('"id": "tree-structure-advisor"'));
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/validate-tree.script.integration.test.mjs
+++ b/calculogic-validator/test/validate-tree.script.integration.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const repositoryRoot = process.cwd();
+const validateTreeScriptPath = path.resolve(
+  repositoryRoot,
+  'calculogic-validator/scripts/validate-tree.mjs',
+);
+
+const runValidateTree = (cwd, args, extraEnv = {}) =>
+  spawnSync(process.execPath, ['--experimental-strip-types', validateTreeScriptPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...extraEnv },
+  });
+
+const writeFixtureRepo = async (fixtureDir) => {
+  await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
+  await fs.writeFile(
+    path.join(fixtureDir, 'package.json'),
+    JSON.stringify({ name: 'validate-tree-script-fixture', version: '1.0.0' }, null, 2),
+    'utf8',
+  );
+  await fs.writeFile(path.join(fixtureDir, 'src', 'App.tsx'), 'export const App = () => null;\n', 'utf8');
+};
+
+test('validate-tree runs tree-structure-advisor only and preserves target filter metadata', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-tree-script-'));
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'core'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'validator-runner.logic.mjs'),
+      'export const runner = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'validator-runner.logic.mjs'),
+      "export * from '../calculogic-validator/src/core/validator-runner.logic.mjs';\n",
+      'utf8',
+    );
+
+    const result = runValidateTree(fixtureDir, ['--scope=repo', '--target', 'calculogic-validator']);
+    assert.equal(result.status, 0);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(Array.isArray(report.validators), true);
+    assert.equal(report.validators.length, 1);
+    assert.equal(report.validators[0].id, 'tree-structure-advisor');
+    assert.equal(report.validators[0].meta.filters.isFiltered, true);
+    assert.deepEqual(report.validators[0].meta.filters.targets, ['calculogic-validator']);
+    assert.equal(
+      report.validators[0].findings.some((finding) => finding.code === 'TREE_SHIM_SURFACE_PRESENT'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('validate-tree prints usage when npm args are not forwarded', () => {
+  const result = runValidateTree(repositoryRoot, [], {
+    npm_lifecycle_event: 'validate:tree',
+    npm_config_argv: JSON.stringify({
+      original: ['run', 'validate:tree', '--scope=app'],
+      cooked: [],
+      remain: [],
+    }),
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Detected npm argument forwarding issue/);
+  assert.match(result.stderr, /Usage: npm run validate:tree --/);
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -94,7 +94,7 @@ Validator implementation assets live under top-level `calculogic-validator/`:
 - package export barrel: `calculogic-validator/src/index.mjs`
 - stable repository-root resolver shared by CLIs: `calculogic-validator/src/repository-root.logic.mjs`
 - temporary compatibility shim (legacy imports): `calculogic-validator/src/validators/naming-validator.logic.mjs`
-- repo-local script entrypoints remain supported: `calculogic-validator/scripts/{validate-naming.mjs,validate-all.mjs,validator-health-check.host.mjs}`
+- repo-local script entrypoints remain supported: `calculogic-validator/scripts/{validate-naming.mjs,validate-tree.mjs,validate-all.mjs,validator-health-check.host.mjs}`
 - stable installable bin entrypoints: `calculogic-validator/bin/{calculogic-validate.mjs,calculogic-validate-naming.mjs,calculogic-validator-health.mjs}`
 - validator tests: `calculogic-validator/test/*.test.mjs`
 

--- a/doc/nl-config/cfg-reportCapture.md
+++ b/doc/nl-config/cfg-reportCapture.md
@@ -2,7 +2,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.0** (capture wrapper plus compact latest-report summarizer).
+Current implementation target: **V0.1.1** (add tree-validator report-capture presets alongside naming and validate-all).
 
 ## 1.0 Purpose
 
@@ -34,7 +34,7 @@ Report filenames are deterministic and filesystem-safe:
 
 ### 2.4 Scope capture presets
 
-Root package scripts provide deterministic capture presets for naming and validate-all across `repo`, `app`, `docs`, `validator`, and `system` scopes, writing files to repo-local `./.reports/` for safe exclusion from validator walking behavior.
+Root package scripts provide deterministic capture presets for naming, validate-all, and validate-tree across `repo`, `app`, `docs`, `validator`, and `system` scopes, writing files to repo-local `./.reports/` for safe exclusion from validator walking behavior.
 
 ### 2.5 Verifier workflow contract
 

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -2,7 +2,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.2** (wiring-owned scoped/target input preparation and runtime prepared-input consumption).
+Current implementation target: **V0.1.3** (dedicated `validate:tree` CLI surface with scope/target parity to suite semantics).
 
 ## 1.0 Purpose
 
@@ -16,7 +16,21 @@ V0.1.1 converges this slice to a canonical owned boundary under `calculogic-vali
 
 - Uses validator suite scope resolution (`repo|app|docs|validator|system`).
 - Supports optional runner-forwarded `targets` when selected through `validate-all` with deterministic validation and selection parity to suite target semantics.
+- Supports the same optional repeatable target filtering when selected through dedicated `validate-tree` CLI (`--target <path>` and `--target=<path>`).
 - Default scope remains `repo` via existing runner behavior.
+
+### 2.5 Dedicated CLI surface (`validate-tree`) (V0.1.3)
+
+`validate-tree` is a thin report-mode CLI wrapper over the validator runner with a fixed validator set containing only `tree-structure-advisor`.
+
+Contract:
+
+- accepts `--help`
+- accepts optional `--scope=<repo|app|docs|validator|system>`
+- accepts optional repeatable targets via `--target <path>` and `--target=<path>`
+- preserves npm argument-forwarding guard behavior used by validator script surfaces
+- emits JSON report envelope aligned with runner report conventions
+- remains report-only (no fix/mutate behavior)
 
 ### 2.2 Repository signals
 
@@ -87,6 +101,7 @@ Each finding follows existing report conventions:
 - Registry/index/package exports target the canonical `src/tree/` host boundary.
 - Flat legacy paths under `calculogic-validator/src/tree-structure-advisor.*.mjs` remain compatibility shims only (re-export wrappers) during migration.
 - Default runner execution includes both `naming` and `tree-structure-advisor` in deterministic registry order.
+- Dedicated `validate-tree` execution includes only `tree-structure-advisor` while preserving shared runner scope/target semantics.
 - No fix mode, no move/rename behavior.
 
 ## 5.0 Deferred Behavior

--- a/package.json
+++ b/package.json
@@ -26,7 +26,13 @@
     "report:summarize": "node calculogic-validator/scripts/report-capture-summarize.mjs",
     "lint:fix": "eslint . --fix",
     "format:check": "prettier . --check",
-    "format:write": "prettier . --write"
+    "format:write": "prettier . --write",
+    "validate:tree": "node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs",
+    "report:tree:repo": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-repo -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=repo",
+    "report:tree:app": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-app -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=app",
+    "report:tree:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=docs",
+    "report:tree:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=validator",
+    "report:tree:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-system -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=system"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- The tree validator is now a first-class slice under `src/tree/` but there was no dedicated root command, forcing runs via `validate:all`; a thin direct CLI improves discoverability and developer ergonomics. 
- The new surface should preserve the same scope/target semantics, npm-arg forwarding guard, and JSON report envelope used by other validator scripts.

### Description
- Add a thin dedicated CLI wrapper at `calculogic-validator/scripts/validate-tree.mjs` that delegates to the existing runner with `validators: ['tree-structure-advisor']` and supports `--help`, `--scope=<...>`, repeatable `--target <path>` / `--target=<path>`, `--config=<path>`, and npm arg-forwarding guard semantics. 
- Add root npm scripts in `package.json`: `validate:tree` plus `report:tree:{repo,app,docs,validator,system}` report-capture presets. 
- Add integration tests: `calculogic-validator/test/validate-tree.script.integration.test.mjs` and extend `report-capture.scopes.integration.test.mjs` to include `validate-tree` runs across scopes. 
- Update NL-first docs to reflect the new CLI and presets in `doc/nl-config/cfg-treeStructureAdvisor.md`, `doc/nl-config/cfg-reportCapture.md`, and `doc/nl-config/cfg-namingValidator.md` (noting the new V0.1.3 target and report presets). 

### Testing
- Ran `node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --help` which printed usage successfully. (passed)
- Ran the integration test suite: `node --test --experimental-strip-types calculogic-validator/test/validate-tree.script.integration.test.mjs calculogic-validator/test/report-capture.scopes.integration.test.mjs calculogic-validator/test/validate-all.targets.integration.test.mjs` and all tests passed (9/9). (passed)
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/src/tree` and observed a valid JSON report envelope for `tree-structure-advisor` with expected `meta.filters` populated. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aba184e04c8331a385bbfff55769e6)