### PR TITLE
docs(naming): add Surface Registry and Category↔Surface governance; align NamingValidatorSpec

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md
@@ -76,9 +76,13 @@ This spec is intentionally explicit and semantic (no guessing/inference required
   - [Use `.` for role suffix separation](#use--for-role-suffix-separation)
 - [Role Registry Master List V1](#role-registry-master-list-v1)
   - [Role Category Registry](#role-category-registry)
+    - [Surface Registry (deterministic set)](#surface-registry-deterministic-set)
     - [Role Categories (deterministic set)](#role-categories-deterministic-set)
+    - [Category ↔ Surface Allowance Matrix (governance)](#category--surface-allowance-matrix-governance)
     - [Role Status Values (deterministic vocabulary)](#role-status-values-deterministic-vocabulary)
     - [Role Change-Control Rules](#role-change-control-rules)
+    - [Validator taxonomy compatibility (naming slice)](#validator-taxonomy-compatibility-naming-slice)
+    - [Governance validity rule (taxonomy)](#governance-validity-rule-taxonomy)
   - [Role Semantics Definitions](#role-semantics-definitions)
     - [Active Roles](#active-roles)
     - [Deprecated Roles](#deprecated-roles)
@@ -384,17 +388,82 @@ This is the canonical role list for filenames.
 
 ### Role Category Registry
 
+### Surface Registry (deterministic set)
+
+Surface is a taxonomy class for how an artifact is consumed. Surface is governance metadata in this master list; it is not yet enforced by the naming validator runtime.
+
+All taxonomy entries that declare surface constraints MUST use one or more values from the bounded list below.
+
+- `runtime`: shipped/executed product code.
+- `tooling`: developer automation (build/lint/codegen/CLIs/migrations).
+- `quality`: tests/fixtures/mocks/benchmarks.
+- `docs`: human-facing documentation artifacts.
+- `data`: structured payload artifacts consumed by runtime/tooling/quality.
+- `config`: configuration artifacts.
+- `ops`: operational/infrastructure artifacts.
+- `generated`: machine-generated outputs.
+- `vendor`: third-party/vendored code/assets.
+- `experimental`: prototypes/spikes with relaxed rules.
+- `examples`: demos/tutorial sample code.
+- `assets`: non-code static assets.
+
+Surface change-control notes:
+
+- Surface additions/removals MUST be documented in this section before use in policy/validator logic.
+- `generated`, `vendor`, `experimental`, and `examples` are governance-important for exception policy but are not role-assignment targets by default.
+- Surface-aware validity remains governance-first until naming runtime adds explicit surface classification inputs.
+
 #### Role Categories (deterministic set)
 
 All role registry entries MUST declare one category from the bounded list below.
 
 - `concern-core`: core Calculogic concern roles that represent primary concern responsibilities.
 - `concern-style`: style-partner concern roles dedicated to visual/layout styling concerns.
+- `surface-system`: runtime system surface composition/entry routing roles.
 - `architecture-support`: architecture support/wiring/composition/contract boundary roles.
+- `data-model`: shape/model boundary roles.
+- `configuration`: configuration/settings/environment roles.
+- `operations-support`: operational/deploy/infra support roles.
+- `observability`: logging/telemetry roles.
+- `security`: auth/crypto/secrets-loader boundary roles.
+- `localization`: i18n/locale roles.
+- `build-system`: build/packaging system roles.
+- `migration`: migration roles.
+- `performance`: performance-focused roles.
+- `concurrency`: worker/concurrency roles.
+- `persistence`: storage/cache roles.
+- `networking`: transport/network boundary roles.
 - `documentation`: documentation-only filename roles (spec/policy/workflow/plan/audit/healthcheck).
 - `indexing-registry`: stable indexing/catalog/inventory/anchor/identifier-style roles.
 - `integration-adapter`: adapter/mapper/resolver boundary translation roles (defined now for deterministic future use).
+- `quality-support`: quality artifact roles (test/fixture/mock/benchmark).
 - `deprecated`: historical role segments retained for detection and migration guidance.
+
+#### Category ↔ Surface Allowance Matrix (governance)
+
+The table below is canonical taxonomy policy for allowed category/surface pairings. Runtime validation of this matrix is deferred.
+
+- `concern-core` → `runtime`
+- `concern-style` → `runtime`
+- `surface-system` → `runtime`
+- `architecture-support` → `runtime`, `tooling`, `quality`
+- `indexing-registry` → `runtime`, `tooling`, `quality`, `data`
+- `integration-adapter` → `runtime`, `tooling`, `quality`
+- `data-model` → `runtime`, `tooling`, `quality`, `data`
+- `configuration` → `runtime`, `tooling`, `config`
+- `operations-support` → `ops`, `tooling`
+- `observability` → `runtime`, `tooling`, `ops`
+- `security` → `runtime`, `tooling`, `ops`
+- `localization` → `runtime`, `data`
+- `build-system` → `tooling`, `ops`, `config`
+- `migration` → `tooling`, `ops`, `quality`
+- `performance` → `runtime`, `tooling`, `quality`
+- `concurrency` → `runtime`, `tooling`
+- `persistence` → `runtime`, `tooling`, `quality`
+- `networking` → `runtime`, `tooling`, `quality`
+- `documentation` → `docs`
+- `quality-support` → `quality`
+- `deprecated` → all surfaces (detection/migration only)
 
 #### Role Status Values (deterministic vocabulary)
 
@@ -413,12 +482,22 @@ All role registry entries MUST declare one status from the bounded list below.
 
 #### Validator taxonomy compatibility (naming slice)
 
-- This master list defines the full intended taxonomy, including richer categories such as `concern-style`, `indexing-registry`, and `integration-adapter`.
+- This master list defines the full intended taxonomy, including richer categories and explicit category↔surface policy.
 - The current naming validator runtime uses a bounded subset of category values for deterministic checks (`concern-core`, `architecture-support`, `documentation`, `deprecated`).
+- Surface-aware validation is not runtime-enforced in the naming slice yet.
 - Adoption path for runtime compatibility:
   - use config to add roles and map them to currently supported runtime categories where needed
-  - treat richer master-list categories as governance/semantic intent until validator category handling expands
+  - treat richer master-list categories and category↔surface rules as governance/semantic intent until runtime handling expands
 - Current slice taxonomy constraint note: runtime currently treats `build-style` and `results-style` as concern-aligned roles under `concern-core` for deterministic naming checks. This is an implementation taxonomy constraint in the naming slice today, not a semantic redefinition of those roles in this master list.
+
+#### Governance validity rule (taxonomy)
+
+A role usage is taxonomy-valid iff:
+
+1. the role exists in this registry with `status: active`; and
+2. the role's category allows the file surface according to the category↔surface matrix above.
+
+Runtime note: V0.1.7 naming validation currently enforces role recognition/status via runtime registry rules and does not yet enforce surface-based validity.
 
 ### Role Semantics Definitions
 
@@ -673,6 +752,29 @@ Each role below has an explicit deterministic definition: meaning, purpose/use-c
 - **Category:** `integration-adapter` _(provisional category assignment pending final meaning lock)_
 - **Status:** `provisional`
 - **Finalization plan note:** before activation, this document MUST define a single intended meaning and boundary; if no single meaning converges, remove/rename instead of activating.
+
+#### Planned role lanes (documented for future expansion, not active)
+
+The roles below are documented as planned taxonomy lanes but are intentionally **not** activated in this version. They remain governance candidates until role semantics, usage evidence, and runtime checks are mature enough for deterministic activation.
+
+- `surface-system`: `entry`, `router`
+- `indexing-registry`: `manifest`, `index`, `tokens`
+- `integration-adapter`: `mapper`, `resolver`, `client`, `gateway`
+- `data-model`: `types`, `schema`, `dto`
+- `configuration`: `config`, `settings`, `env`
+- `operations-support`: `deploy`, `infra`, `monitoring`
+- `observability`: `logging`, `telemetry`
+- `security`: `auth`, `crypto`, `secrets` (loaders/placeholders only; no secret material)
+- `localization`: `i18n`, `locale`
+- `build-system`: `buildsys`, `packaging`
+- `migration`: `migration`
+- `performance`: `perf`
+- `concurrency`: `worker`
+- `persistence`: `storage`, `cache`
+- `networking`: `transport`
+- `quality-support`: `test`, `fixture`, `mock`, `benchmark`
+
+Activation rule for this set: each role must receive a full semantics block (meaning/use-cases/non-goals/category/status), plus validator compatibility updates, before it can move from planned candidate to `active` or `provisional`.
 
 ### Role Decision Rubric
 

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -33,7 +33,7 @@ Subsection version tags (for example `(V0.1.2)`) reflect the last material chang
 Primary naming authority:
 
 - `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`
-- Role categories, role status values, role semantics, and provisional-role policy are authoritative in the `Role Registry Master List V1` section of `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`.
+- Role categories, role status values, role semantics, provisional-role policy, and category↔surface governance policy are authoritative in the `Role Registry Master List V1` section of `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md`.
 
 Supporting workflow alignment:
 
@@ -59,8 +59,8 @@ V0.1.2 uses a structured role registry with metadata:
 The role registry source-of-truth is `FileNamingMasterList-V1_1.md`.
 
 - `role`
-- `category` (`concern-core` | `architecture-support` | `documentation` | `deprecated`)
-- `status` (`active` | `deprecated`)
+- `category` (runtime-bounded: `concern-core` | `architecture-support` | `documentation` | `deprecated`)
+- `status` (runtime-bounded: `active` | `deprecated`)
 - `notes` (optional)
 
 Default runtime registry roles in the naming slice:
@@ -87,6 +87,13 @@ Registry vocabulary vs config additions:
 - Config can add roles (add-only).
 - `FileNamingMasterList-V1_1.md` remains the source-of-truth taxonomy, while the naming slice currently uses a bounded category vocabulary for deterministic checks.
 - If runtime-supported category values expand beyond the bounded set listed here, update this section and the master-list compatibility note accordingly.
+
+Governance taxonomy vs runtime subset (explicit boundary):
+
+- The master list includes additional governance categories (for example `concern-style`, `surface-system`, `indexing-registry`, `integration-adapter`, and other planned categories) plus category↔surface allowance policy.
+- V0.1.7 runtime does **not** enforce category↔surface validity yet and does not require/support the full governance category vocabulary in this slice.
+- Governance status vocabulary includes `provisional`; runtime role classification in this slice remains bounded to active/deprecated handling for deterministic report behavior.
+- Runtime currently keeps `build-style` and `results-style` under `concern-core` as an implementation taxonomy constraint for deterministic checks; this is not a governance semantic redefinition.
 
 Deprecated historical roles:
 
@@ -386,3 +393,4 @@ A file is `invalid-ambiguous` instead of `legacy-exception` when it presents can
 - no automatic suppression generation
 - no cross-file semantic validation
 - no role taxonomy expansion for `provider`/`catalog`/`ids`/`anchor` in this slice
+- no surface-aware role validity enforcement yet (category↔surface matrix remains governance-only in this slice)


### PR DESCRIPTION
### Motivation
- Bring the canonical master list into alignment with the newer role/category direction and explicit surface-aware governance without overclaiming runtime enforcement.
- Preserve deterministic ownership (role vs category vs status vs surface) and keep incremental-adoption framing so validators and contributors can evolve taxonomy safely.
- Provide a clear, auditable governance-to-runtime boundary so future validator expansions are deterministic and reversible.

### Description
- Updated `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` to add a bounded `Surface Registry`, a `Category ↔ Surface Allowance Matrix` (governance), and a `Governance validity rule` that defines taxonomy-valid usage as `role.status=active` plus allowed category↔surface pairing. 
- Expanded the category vocabulary in the master list to capture planned lanes (for example `data-model`, `configuration`, `observability`, `security`, `quality-support`, etc.) and added a compact `Planned role lanes` section that documents intended roles without activating them. 
- Preserved strict guardrails for provisional roles (notably `provider` remains `provisional` and requires a single-meaning lock before activation) and explicitly documented that the new surface rules are governance-only until runtime support is added. 
- Reconciled `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` to state the governance-vs-runtime boundary, mark category/status vocabulary as runtime-bounded for V0.1.7, and add explicit non-goal language that surface-aware validation is not enforced in the current naming slice. 
- No runtime code or enforcement behavior was changed; the change is documentation-only and preserves the naming-slice deterministic subset used by the validator today. 

### Testing
- Ran repository checks and textual validations including `rg` searches for the inserted anchors and phrases which returned the expected locations, and those scans succeeded. 
- Ran `git diff --check` to ensure no whitespace/index issues and it passed with no errors. 
- Committed the changes with `git commit` and created the PR record; the commit succeeded and the branch contains only documentation updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abaa95e0c883319609efbf45a949dd)