### PR TITLE
docs(readme): relabel direct invocation section for accurate entrypoint terminology

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -175,9 +175,9 @@ npm run report:summarize
 - `report:verify`: checks report-capture wiring/outputs.
 - `report:summarize`: summarizes captured reports.
 
-## 5) Validator binaries (direct invocation)
+## 5) Validator entrypoints and direct invocation
 
-These binaries are defined in `calculogic-validator/package.json` and can be executed directly from repo root.
+This section includes package-defined validator entrypoints plus direct script invocation where useful, all executable from repo root.
 
 ```bash
 node calculogic-validator/bin/calculogic-validate.mjs
@@ -186,7 +186,7 @@ node calculogic-validator/bin/calculogic-validator-health.mjs
 node calculogic-validator/scripts/validate-tree.mjs --scope=repo
 ```
 
-What each binary does:
+What each entrypoint does:
 
 - `calculogic-validate.mjs`: full validator entrypoint.
 - `calculogic-validate-naming.mjs`: naming-only validator entrypoint.


### PR DESCRIPTION
### Motivation
- The README previously labeled the section "Validator binaries (direct invocation)" which became inaccurate after documenting direct invocation of `calculogic-validator/scripts/validate-tree.mjs`; the wording should cover both package `bin` entrypoints and direct script invocation without implying all listed items are package binaries.

### Description
- Rename the section heading to `Validator entrypoints and direct invocation`, revise the intro sentence to state the list includes package-defined validator entrypoints plus direct script invocation, and change the subheading from `What each binary does:` to `What each entrypoint does:`; this is a documentation-only wording correction and does not change any runtime behavior or scripts.

### Testing
- Inspected the README diff and ran a text search to confirm the old phrase "Validator binaries (direct invocation)" was replaced and the new wording appears as intended, with no other files modified and the check passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abad7d71648331abb8c92c29366775)