### PR TITLE
Harden tree advisor shim detection: artifact-surface inference, structured evidence, and pass-through carveouts

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -284,16 +284,34 @@ Example:
 
 ## Compat / Shim Health Signals (Advisory Diagnostics)
 
-Shim/compat detection is a tree-health diagnostic layer in report-first mode:
+Shim/compat detection is a tree-health diagnostic layer in report-first mode.
 
-- detect shim-like files via folder signals (`compat/`, `shims/`, `adapters/`, `bridges/`) and/or naming needles (`shim`, `compat`, `adapter`, `bridge`, `migration`)
-- treat thin flat re-export files (`export * from ...` / `export { ... } from ...` only) as a strong shim-like signal
-- recommend a discoverable surface (for example `src/compat/` or `src/compat/shims/`) only when shim-like files already exist
+V0.1.4 hardened subset:
 
-V0.0.1 implemented subset:
+- infer bounded artifact surface from path/basename only:
+  - `quality`, `docs`, `examples`, `fixtures`, `runtimeish`
+- collect structured evidence fields (do not flatten to `isShimLike` early):
+  - `artifactSurface`
+  - `matchedShimSignals.folderSignals`
+  - `matchedShimSignals.nameTokenSignals`
+  - `matchedShimSignals.thinReexportShim`
+  - `insideCompatSurface`
+  - `canonicalTargetPath`
+  - `reexportTargetCount`
+  - intentional pass-through booleans (canonical host pass-through / public entrypoint pass-through)
+- thin flat re-export files (`export * from ...` / `export { ... } from ...` only) remain the strongest/high-confidence shim signal
+- intentional pass-through entrypoints are excluded from shim debt findings:
+  - canonical `*.host.* -> sibling *.wiring.*` pass-through in owned slices
+  - `calculogic-validator/src/index.mjs` package/public entrypoint barrel
+- weak token/path-only shim signals on non-runtime surfaces (`quality/docs/examples/fixtures`) are suppressed from shim-debt output
+- runtimeish token/path-only shim signals remain info-only observability
 
-- `TREE_SHIM_SURFACE_PRESENT` (`info`): emitted for deterministic shim-like paths with signal details
-- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`): emitted when shim-like paths are not under a discoverable compat/shims surface
+Implemented codes:
+
+- `TREE_SHIM_SURFACE_PRESENT` (`info`):
+  - emitted for thin re-export shim evidence
+  - emitted for runtimeish token/path-only signals as low-confidence observability
+- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`): emitted only when thin re-export shim evidence exists and the path is outside a compat/shims surface
 - `TREE_SHIM_SCATTERED`: reserved for a later deterministic slice
 
 Constraints:
@@ -367,9 +385,9 @@ Suggested codes (V0.0.1):
 - `TREE_MISSING_NAMESPACE_ROOT`
 - `TREE_SUBSYSTEM_SCAFFOLD_ASYMMETRY`
 - `TREE_TOOL_SURFACE_MIX`
-- `TREE_SHIM_SURFACE_PRESENT` (`info`) — implemented
+- `TREE_SHIM_SURFACE_PRESENT` (`info`) — implemented (thin-reexport high-confidence + runtimeish token-only info)
 - `TREE_SHIM_SCATTERED` (`warn`/`info`) — planned
-- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`) — implemented
+- `TREE_SHIM_OUTSIDE_COMPAT` (`warn`) — implemented (thin re-export evidence only)
 - `TREE_SHARED_LANE_FIRST_PARTITION_PRESENT` (`info`)
 - `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` (`warn`/`info`)
 - `TREE_SHARED_SEMANTIC_ROOT_RECOMMENDED` (`warn`/`info`)

--- a/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
@@ -26,6 +26,7 @@ const SHIM_FOLDER_SIGNALS = new Set(['compat', 'shims', 'adapters', 'bridges']);
 const SHIM_NAME_TOKEN_SIGNALS = new Set(['shim', 'compat', 'adapter', 'bridge', 'migration']);
 const SHIM_SURFACE_SEGMENT_SIGNALS = new Set(['compat', 'shims']);
 const SHIM_RELEVANT_FILE_EXTENSIONS = new Set(['.mjs', '.js', '.cjs', '.ts', '.tsx', '.jsx']);
+const NON_RUNTIME_SHIM_SUPPRESSED_SURFACES = new Set(['quality', 'docs', 'examples', 'fixtures']);
 
 const sortByPathThenCode = (left, right) => {
   const byPath = left.path.localeCompare(right.path);
@@ -45,6 +46,39 @@ const tokenizeBasename = (basename) =>
     .replace(/\.[^.]+$/u, '')
     .split(/[^a-z0-9]+/u)
     .filter(Boolean);
+
+const inferArtifactSurface = (relativePath) => {
+  const normalizedPath = relativePath.toLowerCase();
+  const segments = normalizedPath.split('/').filter(Boolean);
+  const basename = segments.at(-1) ?? '';
+
+  if (
+    segments.includes('test') ||
+    segments.includes('tests') ||
+    segments.includes('__tests__') ||
+    /\.(?:test|spec)\.[^.]+$/u.test(basename)
+  ) {
+    return 'quality';
+  }
+
+  if (segments.includes('doc') || segments.includes('docs') || basename.endsWith('.md')) {
+    return 'docs';
+  }
+
+  if (segments.includes('examples') || segments.includes('demo')) {
+    return 'examples';
+  }
+
+  if (
+    segments.includes('fixtures') ||
+    segments.includes('mocks') ||
+    segments.includes('benchmarks')
+  ) {
+    return 'fixtures';
+  }
+
+  return 'runtimeish';
+};
 
 const collectPathShimSignals = (relativePath) => {
   const segments = relativePath.split('/').filter(Boolean);
@@ -99,6 +133,43 @@ const parseThinReexportShim = (rawContent) => {
   };
 };
 
+const detectCanonicalHostPassThrough = (relativePath, thinReexportSignal) => {
+  if (!thinReexportSignal || thinReexportSignal.reexportTargetCount !== 1) {
+    return false;
+  }
+
+  const basename = path.posix.basename(relativePath);
+  if (!basename.includes('.host.')) {
+    return false;
+  }
+
+  const expectedSiblingWiringTarget = `./${basename.replace('.host.', '.wiring.')}`;
+  return thinReexportSignal.canonicalTargetPath === expectedSiblingWiringTarget;
+};
+
+const detectPublicEntrypointPassThrough = (relativePath, thinReexportSignal) =>
+  relativePath === 'calculogic-validator/src/index.mjs' && thinReexportSignal !== null;
+
+const collectShimEvidence = (relativePath, rawContent) => {
+  const shimSignals = collectPathShimSignals(relativePath);
+  const thinReexportSignal = parseThinReexportShim(rawContent);
+  const surface = inferArtifactSurface(relativePath);
+  const isCanonicalHostPassThrough = detectCanonicalHostPassThrough(relativePath, thinReexportSignal);
+  const isPublicEntryPointPassThrough = detectPublicEntrypointPassThrough(relativePath, thinReexportSignal);
+
+  return {
+    surface,
+    folderSignals: shimSignals.folderSignals,
+    nameTokenSignals: shimSignals.basenameTokens,
+    insideCompatSurface: shimSignals.insideCompatSurface,
+    thinReexportShim: thinReexportSignal !== null,
+    canonicalTargetPath: thinReexportSignal?.canonicalTargetPath,
+    reexportTargetCount: thinReexportSignal?.reexportTargetCount ?? 0,
+    isCanonicalHostPassThrough,
+    isPublicEntryPointPassThrough,
+  };
+};
+
 const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
   const findings = [];
 
@@ -108,38 +179,53 @@ const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
       continue;
     }
 
-    const shimSignals = collectPathShimSignals(relativePath);
-    const thinReexportSignal = parseThinReexportShim(fileContentsByPath[relativePath]);
-    const isShimLike =
-      shimSignals.folderSignals.length > 0 ||
-      shimSignals.basenameTokens.length > 0 ||
-      thinReexportSignal !== null;
+    const evidence = collectShimEvidence(relativePath, fileContentsByPath[relativePath]);
+    const hasWeakSignalOnly =
+      !evidence.thinReexportShim &&
+      (evidence.folderSignals.length > 0 || evidence.nameTokenSignals.length > 0);
+    const isIntentionalPassThrough =
+      evidence.isCanonicalHostPassThrough || evidence.isPublicEntryPointPassThrough;
+    const isShimLike = evidence.thinReexportShim || hasWeakSignalOnly;
 
     if (!isShimLike) {
       continue;
     }
+
+    if (isIntentionalPassThrough) {
+      continue;
+    }
+
+    if (hasWeakSignalOnly && NON_RUNTIME_SHIM_SUPPRESSED_SURFACES.has(evidence.surface)) {
+      continue;
+    }
+
+    const matchedShimSignals = {
+      folderSignals: evidence.folderSignals,
+      nameTokenSignals: evidence.nameTokenSignals,
+      thinReexportShim: evidence.thinReexportShim,
+    };
 
     findings.push({
       code: 'TREE_SHIM_SURFACE_PRESENT',
       severity: 'info',
       path: relativePath,
       classification: 'advisory-structure',
-      message:
-        'Shim/compat signals are present for this path; maintain a discoverable and deterministic compatibility surface while cleanup is pending.',
+      message: evidence.thinReexportShim
+        ? 'Thin re-export shim signal detected; maintain a discoverable and deterministic compatibility surface while cleanup is pending.'
+        : 'Shim/compat naming/path signals are present with no thin re-export evidence; treat this as low-confidence observability, not immediate shim debt.',
       ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
       details: {
-        matchedShimSignals: {
-          folderSignals: shimSignals.folderSignals,
-          nameTokenSignals: shimSignals.basenameTokens,
-          thinReexportShim: thinReexportSignal?.isThinReexportShim ?? false,
-        },
-        canonicalTargetPath: thinReexportSignal?.canonicalTargetPath,
-        reexportTargetCount: thinReexportSignal?.reexportTargetCount,
-        insideCompatSurface: shimSignals.insideCompatSurface,
+        artifactSurface: evidence.surface,
+        matchedShimSignals,
+        insideCompatSurface: evidence.insideCompatSurface,
+        canonicalTargetPath: evidence.canonicalTargetPath,
+        reexportTargetCount: evidence.reexportTargetCount,
+        suppressedAsIntentionalPassThrough: false,
+        suppressedBySurfaceContext: false,
       },
     });
 
-    if (shimSignals.insideCompatSurface) {
+    if (!evidence.thinReexportShim || evidence.insideCompatSurface) {
       continue;
     }
 
@@ -152,13 +238,13 @@ const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
         'Shim-like path is outside a discoverable compat/shims surface; consider consolidating compat entries to support later cleanup work.',
       ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
       details: {
-        matchedShimSignals: {
-          folderSignals: shimSignals.folderSignals,
-          nameTokenSignals: shimSignals.basenameTokens,
-          thinReexportShim: thinReexportSignal?.isThinReexportShim ?? false,
-        },
-        canonicalTargetPath: thinReexportSignal?.canonicalTargetPath,
-        insideCompatSurface: shimSignals.insideCompatSurface,
+        artifactSurface: evidence.surface,
+        matchedShimSignals,
+        insideCompatSurface: evidence.insideCompatSurface,
+        canonicalTargetPath: evidence.canonicalTargetPath,
+        reexportTargetCount: evidence.reexportTargetCount,
+        suppressedAsIntentionalPassThrough: false,
+        suppressedBySurfaceContext: false,
       },
     });
   }

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -151,6 +151,115 @@ test('tree-structure-advisor detects shim-like path inside compat surface withou
   }
 });
 
+test('tree-structure-advisor suppresses token-only shim signals on quality surfaces', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-quality-suppressed-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'test'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'test', 'core-compat-shims.test.mjs'),
+      'export const testCase = true\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some(
+        (finding) => finding.path === 'calculogic-validator/test/core-compat-shims.test.mjs',
+      ),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor keeps runtime token-only shim path as informational signal only', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-runtime-token-only-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'src', 'bridges'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'bridges', 'legacy-api.logic.mjs'),
+      'export const maybeBridge = true\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const shimFindings = result.findings.filter((finding) => finding.path === 'src/bridges/legacy-api.logic.mjs');
+
+    assert.deepEqual(
+      shimFindings.map((finding) => finding.code),
+      ['TREE_SHIM_SURFACE_PRESENT'],
+    );
+    assert.equal(shimFindings[0].details.artifactSurface, 'runtimeish');
+    assert.equal(shimFindings[0].details.matchedShimSignals.thinReexportShim, false);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor does not treat canonical host-to-wiring pass-through as shim debt', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-host-wiring-pass-through-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'tree'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'tree', 'tree-structure-advisor.host.mjs'),
+      "export * from './tree-structure-advisor.wiring.mjs';\n",
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'tree', 'tree-structure-advisor.wiring.mjs'),
+      'export const treeAdvisor = true\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some(
+        (finding) => finding.path === 'calculogic-validator/src/tree/tree-structure-advisor.host.mjs',
+      ),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor does not treat public index entrypoint barrel as shim debt', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-public-entrypoint-pass-through-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'index.mjs'),
+      "export * from './core/validator-runner.logic.mjs';\n",
+      'utf8',
+    );
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'core'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'validator-runner.logic.mjs'),
+      'export const validatorRunner = true\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some((finding) => finding.path === 'calculogic-validator/src/index.mjs'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor does not flag normal non-shim files for shim findings', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-non-shim-'));
 

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -2,7 +2,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.3** (dedicated `validate:tree` CLI surface with scope/target parity to suite semantics).
+Current implementation target: **V0.1.4** (shim evidence hardening: bounded artifact surface context + intentional pass-through carveouts while preserving thin re-export shim detection).
 
 ## 1.0 Purpose
 
@@ -46,6 +46,20 @@ V0.1.x uses deterministic path-based signals only:
    - Emit info advisory for clearly unusual non-hidden top-level folders outside known repo shape.
 2. **Validator-owned-looking file outside validator tree**
    - Emit info advisory when filename/path signal strongly indicates validator ownership but file is outside `calculogic-validator/**`.
+
+3. **Shim/compat surface advisory (hardened evidence precedence, V0.1.4)**
+   - Collects deterministic shim evidence per file with bounded fields:
+     - `artifactSurface` (`quality|docs|examples|fixtures|runtimeish`)
+     - folder token signals, basename token signals
+     - `thinReexportShim`, `canonicalTargetPath`, `reexportTargetCount`
+     - `insideCompatSurface`
+     - intentional pass-through markers (`isCanonicalHostPassThrough`, `isPublicEntryPointPassThrough`)
+   - Thin re-export remains the strongest/high-confidence shim signal.
+   - Token/path-only shim signals on non-runtime surfaces (`quality/docs/examples/fixtures`) are suppressed from shim-debt findings.
+   - Intentional pass-through surfaces are excluded from shim debt:
+     - canonical `*.host.* -> sibling *.wiring.*` forwarding inside owned slices
+     - public package entrypoint barrel (`calculogic-validator/src/index.mjs`)
+   - Runtimeish token/path-only matches remain info-level observability (`TREE_SHIM_SURFACE_PRESENT`) and do not emit debt-style `TREE_SHIM_OUTSIDE_COMPAT` unless thin re-export evidence exists.
 
 
 ### 2.4 Input ownership split (V0.1.2)


### PR DESCRIPTION
### Motivation
- Reduce false positives from token/path-only shim signals (e.g. `core-compat-shims.test.mjs`) while preserving high-confidence thin re-export shim detection. 
- Make shim findings more explainable and future-proof by collecting structured evidence rather than flattening signals early. 
- Explicitly recognize intentional pass-through surfaces (canonical host→wiring and public barrels) so they are not labeled as shim debt.

### Description
- Added bounded artifact-surface inference via `inferArtifactSurface(relativePath)` with values `quality|docs|examples|fixtures|runtimeish` to distinguish non-runtime surfaces from runtimeish ones. (file: `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs`)
- Replaced the flat early `isShimLike` decision with structured evidence via `collectShimEvidence(relativePath, rawContent)` that returns `{ surface, folderSignals, nameTokenSignals, insideCompatSurface, thinReexportShim, canonicalTargetPath, reexportTargetCount, isCanonicalHostPassThrough, isPublicEntryPointPassThrough }`. (file: `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs`)
- Kept thin flat re-export detection as the highest-confidence signal via `parseThinReexportShim(rawContent)` and continued to emit `TREE_SHIM_OUTSIDE_COMPAT` only when thin re-export evidence exists and the path is outside a `compat` surface.
- Added deterministic intentional pass-through carveouts: canonical `*.host.*` forwarding to sibling `*.wiring.*` and the package/public barrel `calculogic-validator/src/index.mjs` are excluded from shim-debt findings. (file: `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs`)
- Suppressed debt-style shim findings for token/path-only signals when the inferred `artifactSurface` is one of `quality|docs|examples|fixtures`; runtimeish token-only signals remain info-level observability (`TREE_SHIM_SURFACE_PRESENT`). (file: `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs`)
- Enhanced finding `details` payload to include `artifactSurface`, `matchedShimSignals`, `insideCompatSurface`, `canonicalTargetPath`, `reexportTargetCount`, and suppression flags for explainability. (file: `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs`)
- Added focused tests covering suppression of the known false-positive (`calculogic-validator/test/core-compat-shims.test.mjs`), preservation of thin re-export detection, runtime token-only info behavior, canonical host→wiring pass-through, and public index barrel pass-through. (file: `calculogic-validator/test/tree-structure-advisor.test.mjs`)
- Updated NL config and validator spec docs to document the hardened behavior and evidence precedence (files: `doc/nl-config/cfg-treeStructureAdvisor.md`, `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`).

### Testing
- Ran the tree-advisor unit tests directly with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and all tree-advisor tests passed (covering the new suppression and pass-through cases). ✅
- Ran scoped validator audit with `npm run validate:tree -- --scope=validator` and inspected the JSON report; the known false positive (`calculogic-validator/test/core-compat-shims.test.mjs`) is no longer present while thin re-export shim counts remain detected (high-confidence shims unchanged). ✅
- Ran the full test suite `npm test`; there is an unrelated pre-existing failure in a CLI JSON-parse test caused by environment `npm` warning prefixing that test’s captured output (this failure is not caused by the tree-advisor changes). ❌
- Commit contains updated logic, tests, and docs and preserves report-only behavior and deterministic output ordering for the tree advisor findings. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac44c774e4833182af86f7a545ced4)