### PR TITLE
Harden public-entrypoint barrel detection; align tree spec wording

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -1,4 +1,4 @@
-# Tree Structure Advisor Validator Spec (Draft V0.0.1)
+# Tree Structure Advisor Validator Spec (Report-Only Advisory, V0.1.5)
 
 ## Purpose and Scope
 
@@ -13,9 +13,9 @@ This slice exists to reduce “tree drift” as additional validators beyond nam
 
 ## Suite Contract Alignment
 
-This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor Draft V0.0.1 remains report-only even though additional policy modes exist suite-wide.
+This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor V0.1.5 remains report-only even though additional policy modes exist suite-wide.
 
-### In scope (V0.0.1)
+### In scope (V0.1.5 hardened subset)
 
 - Parse `<semantic-name>.<role>.<ext>` metadata when applicable
 - Use role registry metadata (role category/status) as structured signal
@@ -25,8 +25,9 @@ This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-M
   - consolidation of scattered semantic families
   - separation of mixed lanes where mixing predicts growth pain
   - normalization of repeated validator-subtree scaffolds (for future validators)
+- Shim/compat advisory hardening with bounded evidence precedence and intentional pass-through carveouts, including package/public barrel pass-through (`calculogic-validator/src/index.mjs`) with `export * from`, `export * as <name> from`, and optional `export { ... } from` forms
 
-### Out of scope (V0.0.1)
+### Out of scope (V0.1.5)
 
 - Applying any filesystem changes (no auto-move, no auto-fix)
 - Enforcing a single “correct tree” (recommendations are heuristic + explainable)

--- a/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
@@ -133,6 +133,45 @@ const parseThinReexportShim = (rawContent) => {
   };
 };
 
+const parsePublicEntrypointBarrelPassThrough = (relativePath, rawContent) => {
+  if (relativePath !== 'calculogic-validator/src/index.mjs' || typeof rawContent !== 'string') {
+    return null;
+  }
+
+  const lines = rawContent
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('//'));
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const barrelTargets = [];
+  for (const line of lines) {
+    const match = line.match(
+      /^export\s+(?:\*|\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s+['"]([^'"]+)['"];?$/u,
+    );
+    if (!match) {
+      return null;
+    }
+
+    barrelTargets.push(match[1]);
+  }
+
+  const hasCanonicalTargetOnly = barrelTargets.every((targetPath) =>
+    /^(?:\.\/)?(?:core|naming|tree)\//u.test(targetPath),
+  );
+  if (!hasCanonicalTargetOnly) {
+    return null;
+  }
+
+  return {
+    isPublicEntrypointBarrelPassThrough: true,
+    barrelTargetCount: barrelTargets.length,
+  };
+};
+
 const detectCanonicalHostPassThrough = (relativePath, thinReexportSignal) => {
   if (!thinReexportSignal || thinReexportSignal.reexportTargetCount !== 1) {
     return false;
@@ -147,15 +186,15 @@ const detectCanonicalHostPassThrough = (relativePath, thinReexportSignal) => {
   return thinReexportSignal.canonicalTargetPath === expectedSiblingWiringTarget;
 };
 
-const detectPublicEntrypointPassThrough = (relativePath, thinReexportSignal) =>
-  relativePath === 'calculogic-validator/src/index.mjs' && thinReexportSignal !== null;
+const detectPublicEntrypointPassThrough = (relativePath, rawContent) =>
+  parsePublicEntrypointBarrelPassThrough(relativePath, rawContent) !== null;
 
 const collectShimEvidence = (relativePath, rawContent) => {
   const shimSignals = collectPathShimSignals(relativePath);
   const thinReexportSignal = parseThinReexportShim(rawContent);
   const surface = inferArtifactSurface(relativePath);
   const isCanonicalHostPassThrough = detectCanonicalHostPassThrough(relativePath, thinReexportSignal);
-  const isPublicEntryPointPassThrough = detectPublicEntrypointPassThrough(relativePath, thinReexportSignal);
+  const isPublicEntryPointPassThrough = detectPublicEntrypointPassThrough(relativePath, rawContent);
 
   return {
     surface,

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -239,13 +239,29 @@ test('tree-structure-advisor does not treat public index entrypoint barrel as sh
     await writeBaseFixtureRepo(fixtureDir);
     await fs.writeFile(
       path.join(fixtureDir, 'calculogic-validator', 'src', 'index.mjs'),
-      "export * from './core/validator-runner.logic.mjs';\n",
+      [
+        "export * from './core/validator-runner.logic.mjs';",
+        "export * as naming from './naming/naming-validator.host.mjs';",
+        "export * as treeStructureAdvisor from './tree/tree-structure-advisor.host.mjs';",
+      ].join('\n'),
       'utf8',
     );
     await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'core'), { recursive: true });
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'naming'), { recursive: true });
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'tree'), { recursive: true });
     await fs.writeFile(
       path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'validator-runner.logic.mjs'),
       'export const validatorRunner = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'naming', 'naming-validator.host.mjs'),
+      'export const namingHost = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'tree', 'tree-structure-advisor.host.mjs'),
+      'export const treeHost = true\n',
       'utf8',
     );
 

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -2,7 +2,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.4** (shim evidence hardening: bounded artifact surface context + intentional pass-through carveouts while preserving thin re-export shim detection).
+Current implementation target: **V0.1.5** (shim evidence hardening with robust public-entrypoint barrel carveout coverage for `export *`, `export * as <name>`, and optional `export { ... } from` pass-through forms while preserving thin re-export shim detection).
 
 ## 1.0 Purpose
 
@@ -47,7 +47,7 @@ V0.1.x uses deterministic path-based signals only:
 2. **Validator-owned-looking file outside validator tree**
    - Emit info advisory when filename/path signal strongly indicates validator ownership but file is outside `calculogic-validator/**`.
 
-3. **Shim/compat surface advisory (hardened evidence precedence, V0.1.4)**
+3. **Shim/compat surface advisory (hardened evidence precedence, V0.1.5)**
    - Collects deterministic shim evidence per file with bounded fields:
      - `artifactSurface` (`quality|docs|examples|fixtures|runtimeish`)
      - folder token signals, basename token signals
@@ -58,7 +58,7 @@ V0.1.x uses deterministic path-based signals only:
    - Token/path-only shim signals on non-runtime surfaces (`quality/docs/examples/fixtures`) are suppressed from shim-debt findings.
    - Intentional pass-through surfaces are excluded from shim debt:
      - canonical `*.host.* -> sibling *.wiring.*` forwarding inside owned slices
-     - public package entrypoint barrel (`calculogic-validator/src/index.mjs`)
+     - public package entrypoint barrel (`calculogic-validator/src/index.mjs`) including `export * from`, namespace re-export (`export * as <name> from`), and optional `export { ... } from` forms
    - Runtimeish token/path-only matches remain info-level observability (`TREE_SHIM_SURFACE_PRESENT`) and do not emit debt-style `TREE_SHIM_OUTSIDE_COMPAT` unless thin re-export evidence exists.
 
 


### PR DESCRIPTION
### Motivation
- Close a shim-hardening residue where public-entrypoint detection relied on `parseThinReexportShim(...)` and missed namespace re-exports in the real `calculogic-validator/src/index.mjs` barrel shape. 
- Preserve strong thin re-export shim detection while allowing a bounded, deterministic carveout for intentional package/public barrels. 
- Make spec/NL wording consistent with the implemented hardened subset and explicitly document the barrel carveout forms.

### Description
- Added a dedicated helper `parsePublicEntrypointBarrelPassThrough(relativePath, rawContent)` in `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs` to recognize `calculogic-validator/src/index.mjs` barrels that use `export * from`, `export * as <name> from`, and `export { ... } from` forms, and wired `detectPublicEntrypointPassThrough` to call it. 
- Kept `parseThinReexportShim(...)` unchanged so thin re-export shim detection remains a separate, high-confidence signal. 
- Updated `calculogic-validator/test/tree-structure-advisor.test.mjs` to use a more realistic `index.mjs` fixture that includes both `export * from` and namespace re-exports and added the minimal target files (`core`, `naming`, `tree`) so the test asserts the barrel is not treated as shim debt. 
- Cleaned up docs: updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` and `doc/nl-config/cfg-treeStructureAdvisor.md` to a consistent `V0.1.5` wording that documents the hardened, report-only subset and the public-entrypoint barrel carveout.

### Testing
- Ran `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and all tests passed (16 tests, 0 failures). 
- Ran `npm run validate:tree -- --scope=validator`; the validator executed and produced advisory/warn findings for the repository (returned non-zero exit due to expected advisory/warn findings), confirming the tree advisor still emits its report-only warnings while excluding the intentional public barrel entrypoint from shim-debt findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac48c436e08331994495d69da9102d)