### PR TITLE
tree-advisor: remove inert shim suppression detail flags

### DIFF
--- a/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/src/tree/tree-structure-advisor.logic.mjs
@@ -259,8 +259,6 @@ const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
         insideCompatSurface: evidence.insideCompatSurface,
         canonicalTargetPath: evidence.canonicalTargetPath,
         reexportTargetCount: evidence.reexportTargetCount,
-        suppressedAsIntentionalPassThrough: false,
-        suppressedBySurfaceContext: false,
       },
     });
 
@@ -282,8 +280,6 @@ const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
         insideCompatSurface: evidence.insideCompatSurface,
         canonicalTargetPath: evidence.canonicalTargetPath,
         reexportTargetCount: evidence.reexportTargetCount,
-        suppressedAsIntentionalPassThrough: false,
-        suppressedBySurfaceContext: false,
       },
     });
   }

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -113,6 +113,8 @@ test('tree-structure-advisor detects flat thin re-export shim deterministically'
       '../calculogic-validator/src/core/validator-runner.logic.mjs',
     );
     assert.equal(shimSurface.details.insideCompatSurface, false);
+    assert.equal('suppressedAsIntentionalPassThrough' in shimSurface.details, false);
+    assert.equal('suppressedBySurfaceContext' in shimSurface.details, false);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Emitted shim findings included `suppressedAsIntentionalPassThrough` and `suppressedBySurfaceContext` but those fields were always `false`, creating residual shape noise in reports.
- Tighten emitted finding payloads so they contain only meaningful detail fields and keep report output minimal and honest.
- Preserve existing shim-detection and intentional-pass-through suppression behavior while removing inert data.

### Description
- Removed the inert detail fields `suppressedAsIntentionalPassThrough` and `suppressedBySurfaceContext` from emitted shim findings in `calculogic-validator/src/tree/tree-structure-advisor.logic.mjs` for both `TREE_SHIM_SURFACE_PRESENT` and `TREE_SHIM_OUTSIDE_COMPAT`.
- Updated the shim-focused test in `calculogic-validator/test/tree-structure-advisor.test.mjs` to assert those suppression keys are not present in `details` for emitted shim findings.
- Did not repurpose the flags; they were removed because they never carried real information, and no other behavior or detection logic was changed.
- No documentation files required edits because the spec and NL doc remain aligned with the actual emitted payload shape.

### Testing
- Ran the focused test command `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and test suite completed successfully with all tests passing.
- Verified the specific shim-detection scenarios (thin re-export, inside `compat/`, runtime token-only, public entrypoint barrels, canonical host->wiring pass-through) remain unchanged and covered by the existing tests.
- Validation summary: suppression flags were removed (not repurposed) and docs did not require wording changes to match the new emitted payload shape.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac4b14675483318d20e5bb7e78632e)