### PR TITLE
Suppress weak token-only shim noise for tree shim detector module

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -26,6 +26,7 @@ This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-M
   - separation of mixed lanes where mixing predicts growth pain
   - normalization of repeated validator-subtree scaffolds (for future validators)
 - Shim/compat advisory hardening with bounded evidence precedence and intentional pass-through carveouts, including package/public barrel pass-through (`calculogic-validator/src/index.mjs`) with `export * from`, `export * as <name> from`, and optional `export { ... } from` forms
+- Weak token/path-only shim observability may suppress detector-implementation modules inside `calculogic-validator/src/tree/` when `shim` appears only as part of the detector semantic name (for example `*shim-detection*`) and no thin re-export evidence exists
 
 ### Out of scope (V0.1.5)
 

--- a/calculogic-validator/src/tree/tree-shim-detection.logic.mjs
+++ b/calculogic-validator/src/tree/tree-shim-detection.logic.mjs
@@ -5,6 +5,7 @@ const SHIM_NAME_TOKEN_SIGNALS = new Set(['shim', 'compat', 'adapter', 'bridge', 
 const SHIM_SURFACE_SEGMENT_SIGNALS = new Set(['compat', 'shims']);
 const SHIM_RELEVANT_FILE_EXTENSIONS = new Set(['.mjs', '.js', '.cjs', '.ts', '.tsx', '.jsx']);
 const NON_RUNTIME_SHIM_SUPPRESSED_SURFACES = new Set(['quality', 'docs', 'examples', 'fixtures']);
+const SHIM_DETECTOR_IMPLEMENTATION_TOKENS = new Set(['detection', 'detector']);
 
 const tokenizeBasename = (basename) =>
   basename
@@ -159,8 +160,13 @@ export const collectShimEvidence = (relativePath, rawContent) => {
   const shimSignals = collectPathShimSignals(relativePath);
   const thinReexportSignal = parseThinReexportShim(rawContent);
   const surface = inferArtifactSurface(relativePath);
+  const basenameTokens = tokenizeBasename(path.posix.basename(relativePath));
   const isCanonicalHostPassThrough = detectCanonicalHostPassThrough(relativePath, thinReexportSignal);
   const isPublicEntryPointPassThrough = detectPublicEntrypointPassThrough(relativePath, rawContent);
+  const isShimDetectorImplementationModule =
+    relativePath.startsWith('calculogic-validator/src/tree/') &&
+    basenameTokens.includes('shim') &&
+    basenameTokens.some((token) => SHIM_DETECTOR_IMPLEMENTATION_TOKENS.has(token));
 
   return {
     surface,
@@ -172,6 +178,7 @@ export const collectShimEvidence = (relativePath, rawContent) => {
     reexportTargetCount: thinReexportSignal?.reexportTargetCount ?? 0,
     isCanonicalHostPassThrough,
     isPublicEntryPointPassThrough,
+    isShimDetectorImplementationModule,
   };
 };
 
@@ -201,6 +208,10 @@ export const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
     }
 
     if (hasWeakSignalOnly && NON_RUNTIME_SHIM_SUPPRESSED_SURFACES.has(evidence.surface)) {
+      continue;
+    }
+
+    if (hasWeakSignalOnly && evidence.isShimDetectorImplementationModule) {
       continue;
     }
 

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -204,6 +204,32 @@ test('tree-structure-advisor keeps runtime token-only shim path as informational
   }
 });
 
+
+test('tree-structure-advisor suppresses weak token-only shim signal for tree shim detector implementation file', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-detector-impl-suppressed-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'tree'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'tree', 'tree-shim-detection.logic.mjs'),
+      'export const collectShimEvidence = () => null\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some(
+        (finding) => finding.path === 'calculogic-validator/src/tree/tree-shim-detection.logic.mjs',
+      ),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor does not treat canonical host-to-wiring pass-through as shim debt', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-shim-host-wiring-pass-through-'));
 


### PR DESCRIPTION
### Motivation
- The tree shim detector implementation (`calculogic-validator/src/tree/tree-shim-detection.logic.mjs`) was being reported by the weak token-only shim heuristic solely because its semantic name contains `shim`, creating one low-confidence/ambiguous finding in the post-hardening audit. This change hardens the detector to avoid that self-flagging while preserving real shim detection.

### Description
- Added a bounded detector-module suppression heuristic to `calculogic-validator/src/tree/tree-shim-detection.logic.mjs` that marks files under `calculogic-validator/src/tree/` as detector-implementation modules when their basename tokens include `shim` plus a detector-oriented token (`detection` or `detector`), and exposes `isShimDetectorImplementationModule` in the evidence object.  
- Updated `collectShimCompatFindings` to skip weak token-only shim findings when `isShimDetectorImplementationModule` is true, leaving thin re-export detection and intentional pass-through carveouts unchanged.  
- Added a focused test in `calculogic-validator/test/tree-structure-advisor.test.mjs` asserting `calculogic-validator/src/tree/tree-shim-detection.logic.mjs` is not reported under runtime token-only logic.  
- Added a short spec note to `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` documenting the bounded suppression behavior.

### Testing
- Ran unit tests with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs`; all tests passed (17/17).  
- Ran the tree validator via `npm run validate:tree -- --scope=validator` and validated the report JSON; the detector file is no longer present as `TREE_SHIM_SURFACE_PRESENT`, and the documented thin re-export counts remain unchanged (`TREE_SHIM_SURFACE_PRESENT: 15`, `TREE_SHIM_OUTSIDE_COMPAT: 15`).  
- The refinement that removed the detector-module weak-signal report is the bounded suppression rule: skip weak token-only shim findings for files under `calculogic-validator/src/tree/` when basename tokens include `shim` and a detector token (`detection`/`detector`), while preserving thin re-export and intentional pass-through semantics; no doc rewrites beyond a minimal spec bullet were needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5ab2e8908331805c418bd733a59a)