### PR TITLE
docs: add final-state validator shim verification audit after detector-noise cleanup

### DIFF
--- a/calculogic-validator/doc/Audits/final-state-validator-shim-verification-audit.md
+++ b/calculogic-validator/doc/Audits/final-state-validator-shim-verification-audit.md
@@ -1,0 +1,133 @@
+# Final-State Validator Shim Verification Audit
+
+## 1. Purpose
+
+This is a **new final-state verification audit** created after detector-noise cleanup work in the tree shim detector path. It verifies current repository reality without rewriting historical snapshots.
+
+Historical audit snapshots intentionally left in place:
+
+- `calculogic-validator/doc/Audits/current-validator-shim-audit.md`
+- `calculogic-validator/doc/Audits/post-hardening-validator-shim-audit.md`
+
+Scope of this audit:
+
+- verify the detector no longer self-flags detector implementation noise
+- verify the 15 real thin re-export compatibility shim debt files are still detected
+- verify canonical/public carveouts remain intact and unflagged
+- verify no new false positives or missed high-confidence shim debt cases appeared
+
+## 2. Command used
+
+```bash
+npm run validate:tree -- --scope=validator
+```
+
+## 3. Summary
+
+Current verifier state (manual inventory + command output comparison):
+
+- Total current shim-like files manually confirmed: **18**
+  - Confirmed compatibility shim debt: **15**
+  - Intentional canonical/public pass-through entrypoints (non-debt): **3**
+- Total files scanned by tree validator: **133**
+- Total findings reported: **30**
+  - `TREE_SHIM_OUTSIDE_COMPAT`: **15**
+  - `TREE_SHIM_SURFACE_PRESENT`: **15**
+- Confirmed matches with real shim debt cases: **15 / 15**
+- Likely false positives: **0**
+- Ambiguous cases: **0**
+- Likely missed high-confidence real shim debt cases: **0**
+
+Key final-state conclusion: detector output now aligns cleanly with the manually confirmed real shim-debt inventory, and prior detector self-flag noise is no longer present.
+
+## 4. Current confirmed shim inventory
+
+### 4.1 Confirmed thin re-export compatibility shim debt (15)
+
+1. `calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs`
+2. `calculogic-validator/src/repository-root.logic.mjs`
+3. `calculogic-validator/src/source-snapshot.logic.mjs`
+4. `calculogic-validator/src/tree-structure-advisor.host.mjs`
+5. `calculogic-validator/src/tree-structure-advisor.logic.mjs`
+6. `calculogic-validator/src/validator-config.contracts.mjs`
+7. `calculogic-validator/src/validator-config.logic.mjs`
+8. `calculogic-validator/src/validator-exit-code.logic.mjs`
+9. `calculogic-validator/src/validator-registry.knowledge.mjs`
+10. `calculogic-validator/src/validator-report-meta.logic.mjs`
+11. `calculogic-validator/src/validator-report.contracts.mjs`
+12. `calculogic-validator/src/validator-root-files.knowledge.mjs`
+13. `calculogic-validator/src/validator-runner.logic.mjs`
+14. `calculogic-validator/src/validator-scopes.runtime.mjs`
+15. `calculogic-validator/src/validators/naming-validator.logic.mjs`
+
+### 4.2 Intentional canonical/public pass-through entrypoints (non-debt, 3)
+
+1. `calculogic-validator/src/index.mjs` (public barrel entrypoint)
+2. `calculogic-validator/src/naming/naming-validator.host.mjs` (canonical host→wiring boundary)
+3. `calculogic-validator/src/tree/tree-structure-advisor.host.mjs` (canonical host→wiring boundary)
+
+## 5. Current tree validator comparison
+
+### 5.1 Correct and expected-debt findings
+
+- All 15 confirmed compatibility shim debt files are reported.
+- Each reported file carries thin re-export evidence (`thinReexportShim: true`) with a canonical target path.
+- `TREE_SHIM_SURFACE_PRESENT` + `TREE_SHIM_OUTSIDE_COMPAT` pairing is expected for this current debt shape.
+
+### 5.2 Intentional pass-through carveouts correctly unflagged
+
+- `calculogic-validator/src/index.mjs` remains unflagged (public barrel carveout preserved).
+- `calculogic-validator/src/naming/naming-validator.host.mjs` remains unflagged (canonical host boundary carveout preserved).
+- `calculogic-validator/src/tree/tree-structure-advisor.host.mjs` remains unflagged (canonical host boundary carveout preserved).
+
+### 5.3 False positive / ambiguous / missed classification
+
+- False positives: **none found**.
+- Ambiguous findings: **none found**.
+- Missed real shim debt: **none found**.
+
+## 6. Final verification of cleaned detector state
+
+### 6.1 Detector self-flag removal verified
+
+Verified: `calculogic-validator/src/tree/tree-shim-detection.logic.mjs` no longer appears in current shim-like findings.
+
+### 6.2 Thin re-export detection preserved
+
+Verified: all 15 real thin re-export compatibility shim debt files are still detected.
+
+### 6.3 Canonical/public carveouts preserved
+
+Verified:
+
+- canonical host→wiring pass-through boundaries remain unflagged
+- public `src/index.mjs` barrel remains unflagged
+
+### 6.4 Regression check
+
+No new false positives, ambiguous weak-signal cases, or missed high-confidence shim debt cases were identified in this verification run.
+
+## 7. Remaining hardening or cleanup opportunities
+
+Based on current verification evidence, shim-detector hardening for this validator slice appears **effectively complete enough** for current inventory-tracking needs:
+
+- thin re-export debt detection remains stable and specific
+- previously known detector self-flag noise is resolved
+- canonical/public carveouts are preserved
+
+No additional detector-noise hardening issue is currently evidenced by this run.
+
+## 8. Recommended next steps
+
+Given this final-state verification, likely next work should now shift from shim-detector hardening to **shim cleanup/migration planning** for the 15 confirmed compatibility shim debt files, while preserving intentional canonical/public pass-through boundaries.
+
+---
+
+Audit artifact path:
+
+- `calculogic-validator/doc/Audits/final-state-validator-shim-verification-audit.md`
+
+Historical snapshot docs left unchanged:
+
+- `calculogic-validator/doc/Audits/current-validator-shim-audit.md`
+- `calculogic-validator/doc/Audits/post-hardening-validator-shim-audit.md`

--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -53,3 +53,6 @@ Purpose: quick routing map for validator documentation so readers can distinguis
 
 - `doc/Audits/post-hardening-validator-shim-audit.md`
   Current post-hardening re-audit comparing manually confirmed shim/shim-like inventory vs `validate:tree -- --scope=validator`, including hardened carveout validation and remaining follow-up opportunities.
+
+- `doc/Audits/final-state-validator-shim-verification-audit.md`
+  Final-state verification audit after detector-noise cleanup, confirming self-flag removal, preserved thin re-export debt detection (15), preserved canonical/public carveouts, and no new false positives or missed high-confidence shim debt.


### PR DESCRIPTION
### Motivation
- Provide a new final-state verification audit that confirms the cleaner shim-detector state after detector hardening and weak-signal noise cleanup. 
- Preserve earlier audit snapshots as historical records by not editing `current-validator-shim-audit.md` or `post-hardening-validator-shim-audit.md`. 
- Produce an authoritative verification that the validator output is stable enough to shift effort from detector hardening to shim cleanup/migration planning.

### Description
- Add a new audit document at `calculogic-validator/doc/Audits/final-state-validator-shim-verification-audit.md` that records command used, counts, inventory, comparison, and conclusions. 
- Update `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to include the new audit while preserving earlier audit entries. 
- The audit explicitly verifies that `calculogic-validator/src/tree/tree-shim-detection.logic.mjs` is no longer reported, that the 15 confirmed thin re-export compatibility shim debt files remain detected, and that canonical host→wiring carveouts and the public barrel `calculogic-validator/src/index.mjs` remain unflagged. 
- No code or runtime behavior was changed as part of this PR; this is documentation-only verification.

### Testing
- Ran `npm run validate:tree -- --scope=validator` and inspected the report-mode JSON output, which completed successfully and reported `totalFilesScanned: 133`, `findings: 30`, and `codeCounts: {"TREE_SHIM_OUTSIDE_COMPAT": 15, "TREE_SHIM_SURFACE_PRESENT": 15}`. 
- Verified via the command output that `calculogic-validator/src/tree/tree-shim-detection.logic.mjs` is not present in the findings and that all 15 confirmed thin re-export shim files are reported while `calculogic-validator/src/index.mjs` and canonical host pass-through files remain unflagged. 
- No false positives, ambiguous cases, or missed high-confidence shim-debt cases were observed in this verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5ed0342c8331b7cb65604bc0c4e8)