### PR TITLE
Shim cleanup pass 2: remove 10 compat-only validator shim files

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -303,6 +303,4 @@ Tiny `sourceSnapshot` example shape:
 
 ## 10) Compatibility note
 
-Legacy imports from `src/validators/naming-validator.logic.mjs` remain supported via a thin re-export shim to the canonical naming validator host entrypoint.
-
 Legacy imports from `src/tree-structure-advisor.host.mjs` and `src/tree-structure-advisor.logic.mjs` remain supported as thin compatibility shims to the canonical `src/tree/` slice boundary.

--- a/calculogic-validator/doc/Audits/validator-shim-cleanup-pass-2.md
+++ b/calculogic-validator/doc/Audits/validator-shim-cleanup-pass-2.md
@@ -1,0 +1,56 @@
+# Validator shim cleanup — pass 2 (compat-only shim file removals)
+
+## Scope
+
+This pass removes only validator shim-debt files that had no remaining internal in-repo usage at current main state verification time.
+
+- Date: 2026-03-07
+- Basis: `final-state-validator-shim-verification-audit.md` and `validator-shim-cleanup-pass-1.md`
+- Safety rule: preserve intentional canonical/public boundaries and preserve still-test-referenced shim-debt files for later passes
+
+## Verification before deletion
+
+Each target shim path was re-checked in current main state for internal repo usage.
+
+- Result: no remaining internal runtime import usage was found for the 10 targeted shim files.
+- Residual references were documentation/audit mentions only, plus one NL config note and one README compatibility note that were updated in this pass.
+
+## Removed compat-only shim files (10)
+
+1. `calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs`
+2. `calculogic-validator/src/repository-root.logic.mjs`
+3. `calculogic-validator/src/source-snapshot.logic.mjs`
+4. `calculogic-validator/src/validator-config.contracts.mjs`
+5. `calculogic-validator/src/validator-config.logic.mjs`
+6. `calculogic-validator/src/validator-exit-code.logic.mjs`
+7. `calculogic-validator/src/validator-report-meta.logic.mjs`
+8. `calculogic-validator/src/validator-report.contracts.mjs`
+9. `calculogic-validator/src/validator-root-files.knowledge.mjs`
+10. `calculogic-validator/src/validators/naming-validator.logic.mjs`
+
+## Direct residue cleanup performed
+
+Only direct residue from the removals was updated:
+
+- Removed obsolete naming-validator shim compatibility note from `calculogic-validator/README.md`.
+- Removed obsolete temporary naming-validator shim path bullet from `doc/nl-config/cfg-namingValidator.md` repository layout contract.
+
+No broader refactor or compat-surface redesign was performed.
+
+## Preserved boundaries and deferred shim-debt files
+
+### Intentional non-debt boundaries preserved (unchanged)
+
+1. `calculogic-validator/src/index.mjs`
+2. `calculogic-validator/src/naming/naming-validator.host.mjs`
+3. `calculogic-validator/src/tree/tree-structure-advisor.host.mjs`
+
+### Still-test-referenced shim-debt files left for later passes (unchanged)
+
+1. `calculogic-validator/src/validator-runner.logic.mjs`
+2. `calculogic-validator/src/validator-registry.knowledge.mjs`
+3. `calculogic-validator/src/validator-scopes.runtime.mjs`
+4. `calculogic-validator/src/tree-structure-advisor.host.mjs`
+5. `calculogic-validator/src/tree-structure-advisor.logic.mjs`
+
+Reason: these remain intentionally referenced by `calculogic-validator/test/core-compat-shims.test.mjs` for shim parity verification in this stage.

--- a/calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs
+++ b/calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs
@@ -1,1 +1,0 @@
-export * from './core/npm-arg-forwarding-guard.logic.mjs';

--- a/calculogic-validator/src/repository-root.logic.mjs
+++ b/calculogic-validator/src/repository-root.logic.mjs
@@ -1,1 +1,0 @@
-export * from './core/repository-root.logic.mjs';

--- a/calculogic-validator/src/source-snapshot.logic.mjs
+++ b/calculogic-validator/src/source-snapshot.logic.mjs
@@ -1,1 +1,0 @@
-export * from './core/source-snapshot.logic.mjs';

--- a/calculogic-validator/src/validator-config.contracts.mjs
+++ b/calculogic-validator/src/validator-config.contracts.mjs
@@ -1,1 +1,0 @@
-export * from './core/config/validator-config.contracts.mjs';

--- a/calculogic-validator/src/validator-config.logic.mjs
+++ b/calculogic-validator/src/validator-config.logic.mjs
@@ -1,1 +1,0 @@
-export * from './core/config/validator-config.logic.mjs';

--- a/calculogic-validator/src/validator-exit-code.logic.mjs
+++ b/calculogic-validator/src/validator-exit-code.logic.mjs
@@ -1,1 +1,0 @@
-export * from './core/validator-exit-code.logic.mjs';

--- a/calculogic-validator/src/validator-report-meta.logic.mjs
+++ b/calculogic-validator/src/validator-report-meta.logic.mjs
@@ -1,1 +1,0 @@
-export * from './core/validator-report-meta.logic.mjs';

--- a/calculogic-validator/src/validator-report.contracts.mjs
+++ b/calculogic-validator/src/validator-report.contracts.mjs
@@ -1,1 +1,0 @@
-export * from './core/validator-report.contracts.mjs';

--- a/calculogic-validator/src/validator-root-files.knowledge.mjs
+++ b/calculogic-validator/src/validator-root-files.knowledge.mjs
@@ -1,1 +1,0 @@
-export * from './core/validator-root-files.knowledge.mjs';

--- a/calculogic-validator/src/validators/naming-validator.logic.mjs
+++ b/calculogic-validator/src/validators/naming-validator.logic.mjs
@@ -1,1 +1,0 @@
-export * from '../naming/naming-validator.host.mjs';

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -93,7 +93,6 @@ Validator implementation assets live under top-level `calculogic-validator/`:
 - extension-point folders: `calculogic-validator/src/naming/registries/` and `calculogic-validator/src/naming/rules/`
 - package export barrel: `calculogic-validator/src/index.mjs`
 - stable repository-root resolver shared by CLIs: `calculogic-validator/src/core/repository-root.logic.mjs`
-- temporary compatibility shim (legacy imports): `calculogic-validator/src/validators/naming-validator.logic.mjs`
 - repo-local script entrypoints remain supported: `calculogic-validator/scripts/{validate-naming.mjs,validate-tree.mjs,validate-all.mjs,validator-health-check.host.mjs}`
 - stable installable bin entrypoints: `calculogic-validator/bin/{calculogic-validate.mjs,calculogic-validate-naming.mjs,calculogic-validator-health.mjs}`
 - validator tests: `calculogic-validator/test/*.test.mjs`


### PR DESCRIPTION
### Motivation
- Remove low-risk, compat-only validator shim files that no longer have internal in-repo imports to reduce shim debt while preserving intentional public/canonical boundaries. 
- Keep this pass narrowly scoped to files with zero internal usage and avoid touching shim-debt files still referenced by parity tests. 

### Description
- Deleted the 10 compat-only shim files: `calculogic-validator/src/npm-arg-forwarding-guard.logic.mjs`, `calculogic-validator/src/repository-root.logic.mjs`, `calculogic-validator/src/source-snapshot.logic.mjs`, `calculogic-validator/src/validator-config.contracts.mjs`, `calculogic-validator/src/validator-config.logic.mjs`, `calculogic-validator/src/validator-exit-code.logic.mjs`, `calculogic-validator/src/validator-report-meta.logic.mjs`, `calculogic-validator/src/validator-report.contracts.mjs`, `calculogic-validator/src/validator-root-files.knowledge.mjs`, and `calculogic-validator/src/validators/naming-validator.logic.mjs`. 
- Added the pass-2 audit note at `calculogic-validator/doc/Audits/validator-shim-cleanup-pass-2.md` documenting verification, removals, preserved boundaries, and deferred shim-debt files. 
- Cleaned direct residue from the removals by removing the obsolete naming-validator shim note in `calculogic-validator/README.md` and the temporary shim bullet in `doc/nl-config/cfg-namingValidator.md`, while leaving other canonical entrypoints and deferred shim files unchanged. 
- Preserved intentional public/canonical boundaries: `calculogic-validator/src/index.mjs`, `calculogic-validator/src/naming/naming-validator.host.mjs`, and `calculogic-validator/src/tree/tree-structure-advisor.host.mjs`; and left the still-test-referenced shim-debt files for later passes: `calculogic-validator/src/validator-runner.logic.mjs`, `calculogic-validator/src/validator-registry.knowledge.mjs`, `calculogic-validator/src/validator-scopes.runtime.mjs`, `calculogic-validator/src/tree-structure-advisor.host.mjs`, and `calculogic-validator/src/tree-structure-advisor.logic.mjs`. 

### Testing
- Ran `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and it passed without failures. 
- Ran `npm test` and the full test suite passed (no new failures introduced by these deletions). 
- Ran `npm run validate:tree -- --scope=validator`, which executed and produced advisory shim findings (non-zero exit) for the intentionally-preserved/deferred shim files; this is the expected current baseline and not a regression from this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7e1e6b6c8331a91776780e11fcc7)