### PR TITLE
chore(validator): normalize CLI report emission contract

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -32,7 +32,17 @@ Normative rule:
 
 Report-first means findings are emitted deterministically before enforcement/fixes. It does **not** require a success exit code. Exit behavior may still be policy-driven (for example, to keep CI visibility) without changing detection or report ordering.
 
-## 4) Current exit-code policy (as implemented today)
+## 4) Shared CLI report emission contract (Canonical)
+
+For successful validator report runs across suite CLIs (`validate:naming`, `validate:tree`, `validate:all`):
+
+- Emit structured report JSON to `stdout`.
+- Set report-derived exit status via `process.exitCode` after report emission.
+- Reserve `stderr` for usage and runtime/config errors.
+
+This keeps report capture deterministic while preserving explicit invalid-usage and explicit-failure behavior.
+
+## 5) Current exit-code policy (as implemented today)
 
 Current implementation policy:
 
@@ -43,7 +53,7 @@ Current implementation policy:
 
 This is the current implementation policy and may later be generalized under suite modes (`soft-fail` / `hard-fail` / `correct` / `replace`), while detection remains unchanged.
 
-## 5) Shared scope vocabulary (Canonical)
+## 6) Shared scope vocabulary (Canonical)
 
 Current supported scope names are:
 
@@ -55,7 +65,7 @@ Current supported scope names are:
 
 Slices may implement scope-specific include/exclude details, but the scope vocabulary should remain consistent across suite docs and slice specs.
 
-## 6) Shared Report Envelope (Canonical)
+## 7) Shared Report Envelope (Canonical)
 
 This document defines the suite-level shape contract. For the canonical full schema reference (including slice report vs runner report envelopes, finding baseline shape, and deterministic ordering rules), see [`ValidatorReportSchema-V0_1.md`](./ValidatorReportSchema-V0_1.md).
 
@@ -88,7 +98,7 @@ Canonical envelope is the stable suite contract; some slices currently emit equi
 - `findings[]` → `findings[]`
 - `sourceSnapshot` → `sourceSnapshot`
 
-## 7) Shared Determinism Rules (Canonical)
+## 8) Shared Determinism Rules (Canonical)
 
 All slices should follow these deterministic rules:
 

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -153,8 +153,8 @@ try {
     ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 
-  console.log(JSON.stringify(report, null, 2));
-  process.exit(deriveExitCodeFromRunnerReport(report, { strict: parsed.strict }));
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = deriveExitCodeFromRunnerReport(report, { strict: parsed.strict });
 } catch (error) {
   console.error(error.message);
   console.error(usageLines.join('\n'));

--- a/calculogic-validator/scripts/validate-tree.mjs
+++ b/calculogic-validator/scripts/validate-tree.mjs
@@ -130,8 +130,8 @@ try {
     ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 
-  console.log(JSON.stringify(report, null, 2));
-  process.exit(deriveExitCodeFromRunnerReport(report));
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = deriveExitCodeFromRunnerReport(report);
 } catch (error) {
   console.error(error.message);
   console.error(usageLines.join('\n'));


### PR DESCRIPTION
### Motivation
- The validator CLIs had inconsistent emission behavior: `validate-naming` already wrote structured JSON to `stdout` and set `process.exitCode`, while `validate:tree` and `validate:all` used `console.log(...)` plus immediate `process.exit(...)`, creating an unstable capture contract for consumers.
- The suite is converging on shared core behavior and needs an explicit, documented CLI emission convention to keep future validators consistent.

### Description
- Updated `calculogic-validator/scripts/validate-tree.mjs` to emit the report via `process.stdout.write(JSON.stringify(report, null, 2) + "\n")` and set the report-derived status via `process.exitCode` instead of calling `process.exit(...)` on success.
- Updated `calculogic-validator/scripts/validate-all.mjs` to use the same `stdout` + `process.exitCode` pattern for successful report emission.
- Added a canonical CLI emission contract section to `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` documenting that structured report JSON goes to `stdout`, exit status is set via `process.exitCode` after emission, and `stderr` is reserved for usage/runtime errors.
- Preserved explicit invalid-usage, help, and error-path behavior (those still write to `stderr` and use deterministic non-zero exits where appropriate), and made no changes to finding logic or report schema shapes.

### Testing
- Ran `npm test` and the full test suite completed successfully (`188` tests, all passing).
- Ran `npm run validate:naming -- --scope=validator` and verified the emitted output is parseable JSON and that the run returned the expected policy-driven non-zero exit code for warning-bearing runs (`EXIT:2`).
- Ran `npm run validate:tree -- --scope=validator` and verified the emitted output is parseable JSON and the exit code matched expectations (`EXIT:0`).
- Ran `npm run validate:all -- --scope=validator` and verified the emitted output is parseable JSON and the exit code matched expectations (`EXIT:2`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb1255b448331b057e411573bc368)