### PR TITLE
refactor(validator): extract suite-core CLI helpers

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -42,6 +42,8 @@ For successful validator report runs across suite CLIs (`validate:naming`, `vali
 
 This keeps report capture deterministic while preserving explicit invalid-usage and explicit-failure behavior.
 
+Implementation note: suite CLI scripts should reuse suite-core helpers in `src/core/validator-cli-output.logic.mjs` for report emission and usage/error output flow, rather than duplicating ad hoc CLI output scaffolding.
+
 ## 5) Current exit-code policy (as implemented today)
 
 Current implementation policy:

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -12,6 +12,12 @@ import {
 } from '../src/core/validator-report-meta.logic.mjs';
 import { deriveExitCodeFromRunnerReport } from '../src/core/validator-exit-code.logic.mjs';
 import { detectNpmArgForwardingFootgun } from '../src/core/npm-arg-forwarding-guard.logic.mjs';
+import {
+  writeValidatorReportToStdout,
+  setValidatorReportExitCode,
+  printValidatorUsageToStdout,
+  printValidatorUsageErrorToStderr,
+} from '../src/core/validator-cli-output.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
@@ -113,27 +119,24 @@ const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
 });
 
 if (npmArgForwardingMessage) {
-  console.error(npmArgForwardingMessage);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(npmArgForwardingMessage, usageLines);
   process.exit(1);
 }
 
 try {
   parsed = parseCliArgs(process.argv.slice(2));
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }
 
 if (parsed.helpRequested) {
-  console.log(usageLines.join('\n'));
+  printValidatorUsageToStdout(usageLines);
   process.exit(0);
 }
 
 if (parsed.selectedScope && !getValidatorScopeProfile(parsed.selectedScope)) {
-  console.error(`Invalid scope: ${parsed.selectedScope}`);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(`Invalid scope: ${parsed.selectedScope}`, usageLines);
   process.exit(1);
 }
 
@@ -153,10 +156,9 @@ try {
     ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-  process.exitCode = deriveExitCodeFromRunnerReport(report, { strict: parsed.strict });
+  writeValidatorReportToStdout(report);
+  setValidatorReportExitCode(deriveExitCodeFromRunnerReport(report, { strict: parsed.strict }));
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -13,6 +13,12 @@ import {
 import { deriveExitCodeFromFindings } from '../src/core/validator-exit-code.logic.mjs';
 import { detectNpmArgForwardingFootgun } from '../src/core/npm-arg-forwarding-guard.logic.mjs';
 import { getSourceSnapshot } from '../src/core/source-snapshot.logic.mjs';
+import {
+  writeValidatorReportToStdout,
+  setValidatorReportExitCode,
+  printValidatorUsageToStdout,
+  printValidatorUsageErrorToStderr,
+} from '../src/core/validator-cli-output.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
@@ -100,29 +106,26 @@ const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
 });
 
 if (npmArgForwardingMessage) {
-  console.error(npmArgForwardingMessage);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(npmArgForwardingMessage, usageLines);
   process.exit(1);
 }
 
 try {
   parsed = parseScopeFromCli(process.argv.slice(2));
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }
 
 const { helpRequested, selectedScope, configPath, strict, targets } = parsed;
 
 if (helpRequested) {
-  console.log(usageLines.join('\n'));
+  printValidatorUsageToStdout(usageLines);
   process.exit(0);
 }
 
 if (!getScopeProfile(selectedScope)) {
-  console.error(`Invalid scope: ${selectedScope}`);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(`Invalid scope: ${selectedScope}`, usageLines);
   process.exit(1);
 }
 
@@ -132,8 +135,7 @@ let config;
 try {
   config = configPath ? loadValidatorConfigFromFile(configPath, { cwd: process.cwd() }) : undefined;
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }
 
@@ -144,8 +146,7 @@ let validatorResult;
 try {
   validatorResult = runNamingValidator(repositoryRoot, { scope: selectedScope, config, targets });
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }
 const { findings, totalFilesScanned, scope, filters } = validatorResult;
@@ -191,5 +192,5 @@ const report = {
   findings,
 };
 
-process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-process.exitCode = deriveExitCodeFromFindings(findings, { strict });
+writeValidatorReportToStdout(report);
+setValidatorReportExitCode(deriveExitCodeFromFindings(findings, { strict }));

--- a/calculogic-validator/scripts/validate-tree.mjs
+++ b/calculogic-validator/scripts/validate-tree.mjs
@@ -11,6 +11,12 @@ import {
 import { loadValidatorConfigFromFile } from '../src/core/config/validator-config.logic.mjs';
 import { deriveExitCodeFromRunnerReport } from '../src/core/validator-exit-code.logic.mjs';
 import { detectNpmArgForwardingFootgun } from '../src/core/npm-arg-forwarding-guard.logic.mjs';
+import {
+  writeValidatorReportToStdout,
+  setValidatorReportExitCode,
+  printValidatorUsageToStdout,
+  printValidatorUsageErrorToStderr,
+} from '../src/core/validator-cli-output.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
@@ -89,8 +95,7 @@ const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
 });
 
 if (npmArgForwardingMessage) {
-  console.error(npmArgForwardingMessage);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(npmArgForwardingMessage, usageLines);
   process.exit(1);
 }
 
@@ -98,19 +103,17 @@ let parsed;
 try {
   parsed = parseCliArgs(process.argv.slice(2));
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }
 
 if (parsed.helpRequested) {
-  console.log(usageLines.join('\n'));
+  printValidatorUsageToStdout(usageLines);
   process.exit(0);
 }
 
 if (parsed.selectedScope && !getValidatorScopeProfile(parsed.selectedScope)) {
-  console.error(`Invalid scope: ${parsed.selectedScope}`);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(`Invalid scope: ${parsed.selectedScope}`, usageLines);
   process.exit(1);
 }
 
@@ -130,10 +133,9 @@ try {
     ...(config ? { configDigest: computeConfigDigest(config) } : {}),
   });
 
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-  process.exitCode = deriveExitCodeFromRunnerReport(report);
+  writeValidatorReportToStdout(report);
+  setValidatorReportExitCode(deriveExitCodeFromRunnerReport(report));
 } catch (error) {
-  console.error(error.message);
-  console.error(usageLines.join('\n'));
+  printValidatorUsageErrorToStderr(error.message, usageLines);
   process.exit(1);
 }

--- a/calculogic-validator/src/core/validator-cli-output.logic.mjs
+++ b/calculogic-validator/src/core/validator-cli-output.logic.mjs
@@ -1,0 +1,18 @@
+const formatValidatorCliUsageLines = (usageLines) => usageLines.join('\n');
+
+export const writeValidatorReportToStdout = (report) => {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+};
+
+export const setValidatorReportExitCode = (exitCode) => {
+  process.exitCode = exitCode;
+};
+
+export const printValidatorUsageToStdout = (usageLines) => {
+  console.log(formatValidatorCliUsageLines(usageLines));
+};
+
+export const printValidatorUsageErrorToStderr = (message, usageLines) => {
+  console.error(message);
+  console.error(formatValidatorCliUsageLines(usageLines));
+};


### PR DESCRIPTION
### Motivation
- Reduce duplicated CLI scaffolding across validator scripts by centralizing deterministic report emission, exit handling, and usage/error printing into a suite-owned helper layer. 
- Make it obvious and easy for future validator slices to wire consistent stdout/stderr and exit-code behavior without changing report schemas or slice-specific logic. 

### Description
- Added a suite-core helper module `calculogic-validator/src/core/validator-cli-output.logic.mjs` that exports `writeValidatorReportToStdout`, `setValidatorReportExitCode`, `printValidatorUsageToStdout`, and `printValidatorUsageErrorToStderr`. 
- Refactored the three CLI scripts `calculogic-validator/scripts/validate-naming.mjs`, `calculogic-validator/scripts/validate-tree.mjs`, and `calculogic-validator/scripts/validate-all.mjs` to use the new helpers for report emission, `process.exitCode` assignment, and consistent usage/error printing while preserving each script’s existing argument parsing and slice-specific report shaping. 
- Updated the suite contracts doc `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` with an implementation note directing future validator CLIs to reuse the new suite-core helpers. 

### Testing
- Ran the full test suite via `npm test`, which completed successfully (`188` tests passing). 
- Executed the modified CLIs: `npm run validate:naming -- --scope=validator`, `npm run validate:tree -- --scope=validator`, and `npm run validate:all -- --scope=validator`, and each run emitted valid JSON reports to stdout and returned exit codes consistent with existing policy. 
- All automated tests and the three validator script runs succeeded with no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb61c956883319ab2b84074ffeba5)