### PR TITLE
refactor(validator/naming): extract naming CLI helpers into naming/src/cli

### DIFF
--- a/calculogic-validator/bin/calculogic-validate-naming.mjs
+++ b/calculogic-validator/bin/calculogic-validate-naming.mjs
@@ -1,185 +1,21 @@
 #!/usr/bin/env node
 
-import {
-  runNamingValidator,
-  summarizeFindings,
-  listNamingValidatorScopes,
-  getScopeProfile,
-} from '../naming/src/naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../src/core/repository-root.logic.mjs';
-import { loadValidatorConfigFromFile } from '../src/core/config/validator-config.logic.mjs';
-import {
-  computeConfigDigest,
-  getValidatorToolVersion,
-} from '../src/core/validator-report-meta.logic.mjs';
-import { deriveExitCodeFromFindings } from '../src/core/validator-exit-code.logic.mjs';
-import { getSourceSnapshot } from '../src/core/source-snapshot.logic.mjs';
-import {
-  writeValidatorReportToStdout,
-  setValidatorReportExitCode,
-} from '../src/core/cli/validator-cli-output.logic.mjs';
-import {
-  printValidatorUsageToStdout,
-  printValidatorUsageErrorToStderr,
-} from '../src/core/cli/validator-cli-usage.logic.mjs';
-import { parseRepeatableTargetArgument } from '../src/core/cli/validator-cli-targets.logic.mjs';
+import { buildNamingCliUsageLines } from '../naming/src/cli/naming-cli-usage.logic.mjs';
+import { runNamingCli } from '../naming/src/cli/naming-cli-runner.logic.mjs';
 
-const parseScopeFromCli = (argv) => {
-  let selectedScope = 'repo';
-  let configPath;
-  let strict = false;
-  const targets = [];
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index];
-
-    if (argument.startsWith('--scope=')) {
-      selectedScope = argument.slice('--scope='.length);
-      continue;
-    }
-
-    const targetArgumentResult = parseRepeatableTargetArgument({
-      argv,
-      index,
-      argument,
-      targets,
-    });
-    if (targetArgumentResult.handled) {
-      index = targetArgumentResult.nextIndex;
-      continue;
-    }
-
-    if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath, strict, targets };
-    }
-
-    if (argument.startsWith('--config=')) {
-      configPath = argument.slice('--config='.length);
-      continue;
-    }
-
-    if (argument === '--strict') {
-      strict = true;
-      continue;
-    }
-
-    throw new Error(`Invalid argument: ${argument}`);
-  }
-
-  return { helpRequested: false, selectedScope, configPath, strict, targets };
-};
-
-const supportedScopes = listNamingValidatorScopes();
-const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
-const supportedScopesToken = preferredScopeOrder
-  .filter((scope) => supportedScopes.includes(scope))
-  .join('|');
-
-const usageLines = [
-  `Usage: calculogic-validate-naming [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
-  'Scopes:',
-  ...supportedScopes.map((scope) => {
-    const profile = getScopeProfile(scope);
-    return `  - ${scope}: ${profile?.description ?? ''}`;
-  }),
-  'Default scope: repo',
-  'Examples:',
-  '  ✅ npm run validate:naming -- --scope=app',
-  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
-  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
-  '  ✅ npm run validate:all -- --validators=naming --scope=docs',
-  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
-  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
-  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=repo --strict',
-];
-
-let parsed;
-try {
-  parsed = parseScopeFromCli(process.argv.slice(2));
-} catch (error) {
-  printValidatorUsageErrorToStderr(error.message, usageLines);
-  process.exit(1);
-}
-
-if (parsed.helpRequested) {
-  printValidatorUsageToStdout(usageLines);
-  process.exit(0);
-}
-
-if (!getScopeProfile(parsed.selectedScope)) {
-  printValidatorUsageErrorToStderr(`Invalid scope: ${parsed.selectedScope}`, usageLines);
-  process.exit(1);
-}
-
-const selectedScopeProfile = getScopeProfile(parsed.selectedScope);
 const repositoryRoot = resolveRepositoryRoot();
+const usageLines = buildNamingCliUsageLines({
+  commandPrefix: 'calculogic-validate-naming',
+  strictExampleCommand: 'node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=repo --strict',
+});
 
-let config;
-try {
-  config = parsed.configPath
-    ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
-    : undefined;
-} catch (error) {
-  printValidatorUsageErrorToStderr(error.message, usageLines);
-  process.exit(1);
+const result = runNamingCli({
+  argv: process.argv.slice(2),
+  usageLines,
+  repositoryRoot,
+});
+
+if (result.shouldExit) {
+  process.exit(result.exitCode);
 }
-
-const toolVersion = getValidatorToolVersion();
-const configDigest = config ? computeConfigDigest(config) : undefined;
-const startedAtDate = new Date();
-let validatorResult;
-try {
-  validatorResult = runNamingValidator(repositoryRoot, {
-    scope: parsed.selectedScope,
-    config,
-    targets: parsed.targets,
-  });
-} catch (error) {
-  printValidatorUsageErrorToStderr(error.message, usageLines);
-  process.exit(1);
-}
-const { findings, totalFilesScanned, scope, filters } = validatorResult;
-const registry = validatorResult.registry;
-const endedAtDate = new Date();
-const summary = summarizeFindings(findings);
-
-const report = {
-  mode: 'report',
-  validatorId: 'naming',
-  toolVersion,
-  ...(toolVersion ? { validatorVersion: toolVersion } : {}),
-  ...(configDigest ? { configDigest } : {}),
-  sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot }),
-  ...(registry
-    ? {
-        registryState: registry.registryState,
-        registrySource: registry.registrySource,
-        registryDigests: registry.registryDigests,
-      }
-    : {}),
-  startedAt: startedAtDate.toISOString(),
-  endedAt: endedAtDate.toISOString(),
-  durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
-  scope,
-  totalFilesScanned,
-  filters,
-  scopeSummary: {
-    scope,
-    reportableFilesInScope: totalFilesScanned,
-    findingsGenerated: findings.length,
-  },
-  scopeContract: {
-    description: selectedScopeProfile?.description ?? '',
-    includeRoots: selectedScopeProfile?.includeRoots ?? [],
-    includeRootFiles: selectedScopeProfile?.includeRootFiles ?? [],
-  },
-  counts: summary.counts,
-  codeCounts: summary.codeCounts,
-  specialCaseTypeCounts: summary.specialCaseTypeCounts,
-  warningRoleStatusCounts: summary.warningRoleStatusCounts,
-  warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
-  findings,
-};
-
-writeValidatorReportToStdout(report);
-setValidatorReportExitCode(deriveExitCodeFromFindings(findings, { strict: parsed.strict }));

--- a/calculogic-validator/naming/src/cli/naming-cli-args.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-cli-args.logic.mjs
@@ -1,0 +1,47 @@
+import { parseRepeatableTargetArgument } from '../../../src/core/cli/validator-cli-targets.logic.mjs';
+
+export const parseNamingCliArguments = (argv) => {
+  let selectedScope = 'repo';
+  let configPath;
+  let strict = false;
+  const targets = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument.startsWith('--scope=')) {
+      selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    const targetArgumentResult = parseRepeatableTargetArgument({
+      argv,
+      index,
+      argument,
+      targets,
+    });
+
+    if (targetArgumentResult.handled) {
+      index = targetArgumentResult.nextIndex;
+      continue;
+    }
+
+    if (argument === '--help' || argument === '-h') {
+      return { helpRequested: true, selectedScope, configPath, strict, targets };
+    }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
+      continue;
+    }
+
+    if (argument === '--strict') {
+      strict = true;
+      continue;
+    }
+
+    throw new Error(`Invalid argument: ${argument}`);
+  }
+
+  return { helpRequested: false, selectedScope, configPath, strict, targets };
+};

--- a/calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs
@@ -1,0 +1,84 @@
+import { runNamingValidator, getScopeProfile } from '../naming-validator.host.mjs';
+import { loadValidatorConfigFromFile } from '../../../src/core/config/validator-config.logic.mjs';
+import {
+  computeConfigDigest,
+  getValidatorToolVersion,
+} from '../../../src/core/validator-report-meta.logic.mjs';
+import { deriveExitCodeFromFindings } from '../../../src/core/validator-exit-code.logic.mjs';
+import { getSourceSnapshot } from '../../../src/core/source-snapshot.logic.mjs';
+import {
+  writeValidatorReportToStdout,
+  setValidatorReportExitCode,
+} from '../../../src/core/cli/validator-cli-output.logic.mjs';
+import {
+  printValidatorUsageToStdout,
+  printValidatorUsageErrorToStderr,
+} from '../../../src/core/cli/validator-cli-usage.logic.mjs';
+import { parseNamingCliArguments } from './naming-cli-args.logic.mjs';
+import { buildNamingValidatorReport } from './naming-report-builder.logic.mjs';
+
+export const runNamingCli = ({ argv, usageLines, repositoryRoot, npmArgForwardingMessage }) => {
+  if (npmArgForwardingMessage) {
+    printValidatorUsageErrorToStderr(npmArgForwardingMessage, usageLines);
+    return { shouldExit: true, exitCode: 1 };
+  }
+
+  let parsed;
+  try {
+    parsed = parseNamingCliArguments(argv);
+  } catch (error) {
+    printValidatorUsageErrorToStderr(error.message, usageLines);
+    return { shouldExit: true, exitCode: 1 };
+  }
+
+  if (parsed.helpRequested) {
+    printValidatorUsageToStdout(usageLines);
+    return { shouldExit: true, exitCode: 0 };
+  }
+
+  const selectedScopeProfile = getScopeProfile(parsed.selectedScope);
+  if (!selectedScopeProfile) {
+    printValidatorUsageErrorToStderr(`Invalid scope: ${parsed.selectedScope}`, usageLines);
+    return { shouldExit: true, exitCode: 1 };
+  }
+
+  let config;
+  try {
+    config = parsed.configPath
+      ? loadValidatorConfigFromFile(parsed.configPath, { cwd: process.cwd() })
+      : undefined;
+  } catch (error) {
+    printValidatorUsageErrorToStderr(error.message, usageLines);
+    return { shouldExit: true, exitCode: 1 };
+  }
+
+  const startedAtDate = new Date();
+  let validatorResult;
+  try {
+    validatorResult = runNamingValidator(repositoryRoot, {
+      scope: parsed.selectedScope,
+      config,
+      targets: parsed.targets,
+    });
+  } catch (error) {
+    printValidatorUsageErrorToStderr(error.message, usageLines);
+    return { shouldExit: true, exitCode: 1 };
+  }
+
+  const endedAtDate = new Date();
+  const report = buildNamingValidatorReport({
+    ...validatorResult,
+    registry: validatorResult.registry,
+    toolVersion: getValidatorToolVersion(),
+    configDigest: config ? computeConfigDigest(config) : undefined,
+    sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot }),
+    selectedScopeProfile,
+    startedAtDate,
+    endedAtDate,
+  });
+
+  writeValidatorReportToStdout(report);
+  setValidatorReportExitCode(deriveExitCodeFromFindings(validatorResult.findings, { strict: parsed.strict }));
+
+  return { shouldExit: false };
+};

--- a/calculogic-validator/naming/src/cli/naming-cli-usage.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-cli-usage.logic.mjs
@@ -1,0 +1,29 @@
+import { listNamingValidatorScopes, getScopeProfile } from '../naming-validator.host.mjs';
+
+const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
+
+const buildScopeToken = (supportedScopes) =>
+  preferredScopeOrder.filter((scope) => supportedScopes.includes(scope)).join('|');
+
+export const buildNamingCliUsageLines = ({ commandPrefix, strictExampleCommand }) => {
+  const supportedScopes = listNamingValidatorScopes();
+  const supportedScopesToken = buildScopeToken(supportedScopes);
+
+  return [
+    `Usage: ${commandPrefix} [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
+    'Scopes:',
+    ...supportedScopes.map((scope) => {
+      const profile = getScopeProfile(scope);
+      return `  - ${scope}: ${profile?.description ?? ''}`;
+    }),
+    'Default scope: repo',
+    'Examples:',
+    '  ✅ npm run validate:naming -- --scope=app',
+    '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
+    '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
+    '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+    '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
+    '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
+    `  ✅ ${strictExampleCommand}`,
+  ];
+};

--- a/calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs
@@ -1,0 +1,55 @@
+import { summarizeFindings } from '../naming-validator.host.mjs';
+
+export const buildNamingValidatorReport = ({
+  findings,
+  totalFilesScanned,
+  scope,
+  filters,
+  registry,
+  toolVersion,
+  configDigest,
+  sourceSnapshot,
+  selectedScopeProfile,
+  startedAtDate,
+  endedAtDate,
+}) => {
+  const summary = summarizeFindings(findings);
+
+  return {
+    mode: 'report',
+    validatorId: 'naming',
+    toolVersion,
+    ...(toolVersion ? { validatorVersion: toolVersion } : {}),
+    ...(configDigest ? { configDigest } : {}),
+    sourceSnapshot,
+    ...(registry
+      ? {
+          registryState: registry.registryState,
+          registrySource: registry.registrySource,
+          registryDigests: registry.registryDigests,
+        }
+      : {}),
+    startedAt: startedAtDate.toISOString(),
+    endedAt: endedAtDate.toISOString(),
+    durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
+    scope,
+    totalFilesScanned,
+    filters,
+    scopeSummary: {
+      scope,
+      reportableFilesInScope: totalFilesScanned,
+      findingsGenerated: findings.length,
+    },
+    scopeContract: {
+      description: selectedScopeProfile?.description ?? '',
+      includeRoots: selectedScopeProfile?.includeRoots ?? [],
+      includeRootFiles: selectedScopeProfile?.includeRootFiles ?? [],
+    },
+    counts: summary.counts,
+    codeCounts: summary.codeCounts,
+    specialCaseTypeCounts: summary.specialCaseTypeCounts,
+    warningRoleStatusCounts: summary.warningRoleStatusCounts,
+    warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
+    findings,
+  };
+};

--- a/calculogic-validator/scripts/validate-naming.mjs
+++ b/calculogic-validator/scripts/validate-naming.mjs
@@ -1,100 +1,14 @@
-import {
-  runNamingValidator,
-  summarizeFindings,
-  listNamingValidatorScopes,
-  getScopeProfile,
-} from '../naming/src/naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../src/core/repository-root.logic.mjs';
-import { loadValidatorConfigFromFile } from '../src/core/config/validator-config.logic.mjs';
-import {
-  computeConfigDigest,
-  getValidatorToolVersion,
-} from '../src/core/validator-report-meta.logic.mjs';
-import { deriveExitCodeFromFindings } from '../src/core/validator-exit-code.logic.mjs';
 import { detectNpmArgForwardingFootgun } from '../src/core/npm-arg-forwarding-guard.logic.mjs';
-import { getSourceSnapshot } from '../src/core/source-snapshot.logic.mjs';
-import {
-  writeValidatorReportToStdout,
-  setValidatorReportExitCode,
-} from '../src/core/cli/validator-cli-output.logic.mjs';
-import {
-  printValidatorUsageToStdout,
-  printValidatorUsageErrorToStderr,
-} from '../src/core/cli/validator-cli-usage.logic.mjs';
-import { parseRepeatableTargetArgument } from '../src/core/cli/validator-cli-targets.logic.mjs';
+import { buildNamingCliUsageLines } from '../naming/src/cli/naming-cli-usage.logic.mjs';
+import { runNamingCli } from '../naming/src/cli/naming-cli-runner.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
+const usageLines = buildNamingCliUsageLines({
+  commandPrefix: 'npm run validate:naming --',
+  strictExampleCommand: 'npm run validate:naming -- --scope=repo --strict',
+});
 
-const parseScopeFromCli = (argv) => {
-  let selectedScope = 'repo';
-  let configPath;
-  let strict = false;
-  const targets = [];
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index];
-
-    if (argument.startsWith('--scope=')) {
-      selectedScope = argument.slice('--scope='.length);
-      continue;
-    }
-
-    const targetArgumentResult = parseRepeatableTargetArgument({
-      argv,
-      index,
-      argument,
-      targets,
-    });
-    if (targetArgumentResult.handled) {
-      index = targetArgumentResult.nextIndex;
-      continue;
-    }
-
-    if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath, strict, targets };
-    }
-
-    if (argument.startsWith('--config=')) {
-      configPath = argument.slice('--config='.length);
-      continue;
-    }
-
-    if (argument === '--strict') {
-      strict = true;
-      continue;
-    }
-
-    throw new Error(`Invalid argument: ${argument}`);
-  }
-
-  return { helpRequested: false, selectedScope, configPath, strict, targets };
-};
-
-const supportedScopes = listNamingValidatorScopes();
-const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
-const supportedScopesToken = preferredScopeOrder
-  .filter((scope) => supportedScopes.includes(scope))
-  .join('|');
-
-const usageLines = [
-  `Usage: npm run validate:naming -- [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
-  'Scopes:',
-  ...supportedScopes.map((scope) => {
-    const profile = getScopeProfile(scope);
-    return `  - ${scope}: ${profile?.description ?? ''}`;
-  }),
-  'Default scope: repo',
-  'Examples:',
-  '  ✅ npm run validate:naming -- --scope=app',
-  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
-  '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
-  '  ✅ npm run validate:all -- --validators=naming --scope=docs',
-  '  ✅ node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=app',
-  '  ✅ node calculogic-validator/bin/calculogic-validate.mjs --scope=docs',
-  '  ✅ npm run validate:naming -- --scope=repo --strict',
-];
-
-let parsed;
 const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
   argv: process.argv.slice(2),
   npmConfigArgvJson: process.env.npm_config_argv,
@@ -103,92 +17,13 @@ const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
   supportedFlagNames: ['scope', 'target', 'config', 'strict'],
 });
 
-if (npmArgForwardingMessage) {
-  printValidatorUsageErrorToStderr(npmArgForwardingMessage, usageLines);
-  process.exit(1);
+const result = runNamingCli({
+  argv: process.argv.slice(2),
+  usageLines,
+  repositoryRoot,
+  npmArgForwardingMessage,
+});
+
+if (result.shouldExit) {
+  process.exit(result.exitCode);
 }
-
-try {
-  parsed = parseScopeFromCli(process.argv.slice(2));
-} catch (error) {
-  printValidatorUsageErrorToStderr(error.message, usageLines);
-  process.exit(1);
-}
-
-const { helpRequested, selectedScope, configPath, strict, targets } = parsed;
-
-if (helpRequested) {
-  printValidatorUsageToStdout(usageLines);
-  process.exit(0);
-}
-
-if (!getScopeProfile(selectedScope)) {
-  printValidatorUsageErrorToStderr(`Invalid scope: ${selectedScope}`, usageLines);
-  process.exit(1);
-}
-
-const selectedScopeProfile = getScopeProfile(selectedScope);
-
-let config;
-try {
-  config = configPath ? loadValidatorConfigFromFile(configPath, { cwd: process.cwd() }) : undefined;
-} catch (error) {
-  printValidatorUsageErrorToStderr(error.message, usageLines);
-  process.exit(1);
-}
-
-const toolVersion = getValidatorToolVersion();
-const configDigest = config ? computeConfigDigest(config) : undefined;
-const startedAtDate = new Date();
-let validatorResult;
-try {
-  validatorResult = runNamingValidator(repositoryRoot, { scope: selectedScope, config, targets });
-} catch (error) {
-  printValidatorUsageErrorToStderr(error.message, usageLines);
-  process.exit(1);
-}
-const { findings, totalFilesScanned, scope, filters } = validatorResult;
-const registry = validatorResult.registry;
-const endedAtDate = new Date();
-const summary = summarizeFindings(findings);
-
-const report = {
-  mode: 'report',
-  validatorId: 'naming',
-  toolVersion,
-  ...(toolVersion ? { validatorVersion: toolVersion } : {}),
-  ...(configDigest ? { configDigest } : {}),
-  sourceSnapshot: getSourceSnapshot({ cwd: repositoryRoot }),
-  ...(registry
-    ? {
-        registryState: registry.registryState,
-        registrySource: registry.registrySource,
-        registryDigests: registry.registryDigests,
-      }
-    : {}),
-  startedAt: startedAtDate.toISOString(),
-  endedAt: endedAtDate.toISOString(),
-  durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
-  scope,
-  totalFilesScanned,
-  filters,
-  scopeSummary: {
-    scope,
-    reportableFilesInScope: totalFilesScanned,
-    findingsGenerated: findings.length,
-  },
-  scopeContract: {
-    description: selectedScopeProfile?.description ?? '',
-    includeRoots: selectedScopeProfile?.includeRoots ?? [],
-    includeRootFiles: selectedScopeProfile?.includeRootFiles ?? [],
-  },
-  counts: summary.counts,
-  codeCounts: summary.codeCounts,
-  specialCaseTypeCounts: summary.specialCaseTypeCounts,
-  warningRoleStatusCounts: summary.warningRoleStatusCounts,
-  warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
-  findings,
-};
-
-writeValidatorReportToStdout(report);
-setValidatorReportExitCode(deriveExitCodeFromFindings(findings, { strict }));


### PR DESCRIPTION
### Motivation
- Reduce duplication between `scripts/validate-naming.mjs` and `bin/calculogic-validate-naming.mjs` by moving naming-owned CLI logic out of suite-core entrypoints. 
- Keep suite-wide CLI concerns in `src/core/cli/` while placing naming-specific parsing, usage text, and report shaping in a dedicated naming area.
- Make entrypoints thinner and clearer so naming report assembly and usage behavior are owned by the naming slice.

### Description
- Added a new naming CLI area at `calculogic-validator/naming/src/cli/` containing: `naming-cli-args.logic.mjs`, `naming-cli-usage.logic.mjs`, `naming-report-builder.logic.mjs`, and `naming-cli-runner.logic.mjs` to centralize naming-specific CLI helpers and report assembly. 
- Updated `calculogic-validator/scripts/validate-naming.mjs` and `calculogic-validator/bin/calculogic-validate-naming.mjs` to delegate to the new `runNamingCli(...)` runner and `buildNamingCliUsageLines(...)`, making both entrypoints thinner and focused on runtime wiring. 
- Kept all suite-wide utilities (config loading, report output helpers, npm-arg-forwarding guard, target parsing) in `src/core/` and used them from the new naming helpers as needed. 
- No change in CLI semantics or report shape; this is a structural extraction that centralizes naming-owned CLI/report behavior.

### Testing
- Ran `node calculogic-validator/scripts/validate-naming.mjs --help` and `node calculogic-validator/bin/calculogic-validate-naming.mjs --help` to verify usage text prints; both succeeded. 
- Ran `node calculogic-validator/bin/calculogic-validate-naming.mjs --scope=system > /tmp/naming_system_report.json` and validated the produced JSON with a Node one-liner, confirming a valid naming report (printed `naming system 7 true`); execution succeeded. 
- No automated unit tests were added or modified; manual CLI smoke tests above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc13bfba08331b5678dd250ec24d3)