### PR TITLE
docs(validator): sync semantic helper-area docs with current structure

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -8,8 +8,8 @@
 
 This is the intended target structure for the validator suite as refactors continue.
 Some folders and files shown below may not exist yet in the current state.
-Suite-core canonical modules are owned under `src/core/`; `src/` is reserved for shared infra boundaries (for example `src/index.mjs`) rather than root-level shim forwarders.
-The naming reflects modular suite-core boundaries, owned validator slice roots (`naming/` and `tree/`), configurable policy surfaces, and shared tools ownership.
+Suite-core canonical modules are owned under `src/core/`; `src/` is reserved for suite-level infrastructure boundaries (for example `src/index.mjs`) rather than root-level shim forwarders.
+The naming reflects modular suite-core boundaries, owned validator slice roots (`naming/` and `tree/`), and configurable policy surfaces.
 
 ```text
 calculogic-validator/
@@ -30,12 +30,16 @@ calculogic-validator/
 │  ├─ validator-health-check.host.mjs
 │  ├─ report-capture-verify.mjs
 │  └─ report-capture-summarize.mjs
-├─ src/                               # suite-core only (shared infra + compat boundary)
+├─ src/                               # suite-core only (suite-level infra + compat boundary)
 │  ├─ index.mjs
 │  ├─ core/
 │  │  ├─ repository-root.logic.mjs
 │  │  ├─ npm-arg-forwarding-guard.logic.mjs
 │  │  ├─ validator-exit-code.logic.mjs
+│  │  ├─ cli/
+│  │  │  ├─ validator-cli-output.logic.mjs
+│  │  │  ├─ validator-cli-targets.logic.mjs
+│  │  │  └─ validator-cli-usage.logic.mjs
 │  │  ├─ validator-report.contracts.mjs
 │  │  ├─ validator-report-meta.logic.mjs
 │  │  ├─ validator-runner.logic.mjs
@@ -76,6 +80,13 @@ calculogic-validator/
 │  │  ├─ naming-validator.wiring.mjs
 │  │  ├─ naming-validator.logic.mjs
 │  │  ├─ naming-validator.contracts.mjs
+│  │  ├─ cli/
+│  │  │  ├─ naming-cli-args.logic.mjs
+│  │  │  ├─ naming-cli-runner.logic.mjs
+│  │  │  ├─ naming-cli-usage.logic.mjs
+│  │  │  └─ naming-report-builder.logic.mjs
+│  │  ├─ health/
+│  │  │  └─ naming-health-check.logic.mjs
 │  │  ├─ registries/                  # *.knowledge.*
 │  │  │  └─ _builtin/
 │  │  │     ├─ roles.registry.json
@@ -95,6 +106,12 @@ calculogic-validator/
          ├─ report-capture.contracts.mjs
          └─ report-capture.knowledge.mjs
 ```
+
+### Ownership boundaries (semantic areas)
+
+- Suite-wide shared concerns belong in semantic suite-core areas under `src/core/<area>/`.
+- Slice-owned shared concerns belong in semantic slice areas under `<slice>/src/<area>/`.
+- Prefer semantic owner areas over generic catch-all `shared/` folders when a clearer owner exists.
 
 ## 3) Quickstart (repo root)
 

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -42,7 +42,7 @@ For successful validator report runs across suite CLIs (`validate:naming`, `vali
 
 This keeps report capture deterministic while preserving explicit invalid-usage and explicit-failure behavior.
 
-Implementation note: suite CLI scripts should reuse suite-core helpers in `src/core/cli/` (for example `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, and `validator-cli-targets.logic.mjs`) for report emission, usage/error output flow, and repeatable `--target` parsing rather than duplicating ad hoc CLI scaffolding.
+Implementation note: suite CLI scripts should reuse suite-core helpers in `calculogic-validator/src/core/cli/` (for example `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, and `validator-cli-targets.logic.mjs`) for report emission, usage/error output flow, and repeatable `--target` parsing rather than duplicating ad hoc CLI scaffolding. This suite-core CLI helper area is intentionally discoverable for current and future validator slices.
 
 ## 5) Current exit-code policy (as implemented today)
 

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -90,8 +90,10 @@ Deprecated historical roles:
 Validator implementation assets live under top-level `calculogic-validator/`:
 
 - canonical module layout: `calculogic-validator/naming/src/{naming-validator.host.mjs,naming-validator.wiring.mjs,naming-validator.logic.mjs,naming-validator.contracts.mjs}`
+- naming-owned CLI semantic area: `calculogic-validator/naming/src/cli/` (`naming-cli-args.logic.mjs`, `naming-cli-usage.logic.mjs`, `naming-report-builder.logic.mjs`, `naming-cli-runner.logic.mjs`)
+- naming-owned health semantic area: `calculogic-validator/naming/src/health/` (`naming-health-check.logic.mjs`)
 - extension-point folders: `calculogic-validator/naming/src/registries/` and `calculogic-validator/naming/src/rules/`
-- naming-owned health area: `calculogic-validator/naming/src/health/` (canonical health-check logic + runner)
+- suite-core CLI semantic area: `calculogic-validator/src/core/cli/` (`validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, `validator-cli-targets.logic.mjs`)
 - package export barrel: `calculogic-validator/src/index.mjs`
 - stable repository-root resolver shared by CLIs: `calculogic-validator/src/core/repository-root.logic.mjs`
 - repo-local script entrypoints remain supported: `calculogic-validator/scripts/{validate-naming.mjs,validate-tree.mjs,validate-all.mjs,validator-health-check.host.mjs}`
@@ -100,11 +102,15 @@ Validator implementation assets live under top-level `calculogic-validator/`:
 
 Root `package.json` scripts remain the canonical invocation interface (`npm run validate:naming`, `npm run validate:all`, `npm run health:validator`, `npm test`) while local package bins are testable via `npm exec` through the file dependency `@calculogic/validator`.
 
+Ownership boundary rule: suite-wide cross-slice concerns belong in semantic suite-core areas under `calculogic-validator/src/core/<area>/`; naming-owned shared concerns belong in semantic naming areas under `calculogic-validator/naming/src/<area>/`. Prefer these semantic owner areas over generic catch-all helper folders when ownership is clear.
+
 ### 2.5 Health-check contract (V0.1.11)
+
+Thin-wrapper contract for naming entrypoints: repo-local scripts and installable bins are orchestration shells only; they parse/forward CLI inputs and delegate behavior to naming-owned semantic areas (`calculogic-validator/naming/src/cli/` and `calculogic-validator/naming/src/health/`) plus suite-core CLI helpers where applicable.
 
 Health-check entrypoint lives at `calculogic-validator/scripts/validator-health-check.host.mjs` and is exposed via root script `npm run health:validator`.
 Stable installable health bin entrypoint lives at `calculogic-validator/bin/calculogic-validator-health.mjs`.
-Canonical naming-owned health implementation lives at `calculogic-validator/naming/src/health/naming-health-check.logic.mjs`; both entrypoints are thin wrappers.
+Canonical naming-owned health implementation lives at `calculogic-validator/naming/src/health/naming-health-check.logic.mjs`; both entrypoints are thin wrappers that delegate to naming-owned semantic-area logic.
 
 The health-check performs deterministic, CI-friendly assertions for scope profiles `repo`, `app`, `docs`, `validator`, and `system`:
 


### PR DESCRIPTION
### Motivation

- The validator codebase was refactored to expose clearer semantic ownership areas (suite-core vs slice-owned) and the docs needed to reflect the actual folder layout and ownership rules. 
- Existing documentation still referenced flatter or generic locations for CLI/health helpers which is confusing for future contributors and automation. 
- The intent is to keep docs aligned with implementation and to reinforce the rule that shared logic belongs in semantic owner areas rather than generic `shared/` folders.

### Description

- Updated the projected package layout in `calculogic-validator/README.md` to include the suite-core CLI helper area `calculogic-validator/src/core/cli/`, the naming-owned CLI area `calculogic-validator/naming/src/cli/` (and the concrete helper filenames), and the naming-owned health area `calculogic-validator/naming/src/health/` (and the concrete helper filename). 
- Added a short ownership/boundary note in `calculogic-validator/README.md` that prescribes `src/core/<area>/` for suite-wide concerns and `<slice>/src/<area>/` for slice-owned shared concerns and discourages generic `shared/` folders when a clearer owner exists. 
- Updated `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` to point suite CLIs toward the discoverable suite-core CLI helper area at `calculogic-validator/src/core/cli/` and to call out the concrete helper modules. 
- Revised `doc/nl-config/cfg-namingValidator.md` to explicitly document the naming-owned CLI and health semantic areas, declare the thin-wrapper contract for script/bin naming entrypoints, and replace generic “shared helper” wording with semantic-area ownership language.

### Testing

- Confirmed the helper-area files exist using `find calculogic-validator/src/core/cli calculogic-validator/naming/src/cli calculogic-validator/naming/src/health -maxdepth 1 -type f`, which returned the expected helper modules. 
- Performed a consistency search using `rg -n "src/core/cli|naming/src/cli|naming/src/health|shared/"` across the touched docs to verify updated references and removal of stale flatter-location wording, and the checks succeeded. 
- Reviewed the updated docs side-by-side with the repository tree to ensure all referenced paths and ownership notes accurately reflect the current code layout and found no contradictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc71225f48331a95dae2ace8337b1)