### PR TITLE
feat(validator/naming): expand health-check to validator and system scopes

### DIFF
--- a/calculogic-validator/naming/src/health/naming-health-check.logic.mjs
+++ b/calculogic-validator/naming/src/health/naming-health-check.logic.mjs
@@ -7,7 +7,7 @@ import {
 } from '../naming-validator.host.mjs';
 import { resolveRepositoryRoot } from '../../../src/core/repository-root.logic.mjs';
 
-export const NAMING_HEALTH_SCOPES = ['repo', 'app', 'docs'];
+export const NAMING_HEALTH_SCOPES = ['repo', 'app', 'docs', 'validator', 'system'];
 
 const COMPARABLE_SUMMARY_KEYS = [
   'counts',
@@ -96,7 +96,7 @@ export const runNamingHealthCheckEntrypoint = () => {
     const repositoryRoot = resolveRepositoryRoot();
     runNamingHealthCheck(repositoryRoot);
 
-    console.log('OK: naming validator deterministic for repo|app|docs');
+    console.log('OK: naming validator deterministic for repo|app|docs|validator|system');
     console.log('OK: docs match app scope roots');
     process.exit(0);
   } catch (error) {

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -116,7 +116,7 @@ The health-check performs deterministic, CI-friendly assertions for scope profil
 
 - required scope profiles must resolve via host API
 - repeated in-process runs per scope must keep stable summary-level outputs (`totalFilesScanned`, `counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`)
-- docs contract checks ensure scope documentation continues to state app/docs/validator/system split behavior
+- docs contract checks ensure scope documentation continues to state repo/app/docs/validator/system split behavior
 
 Health-check behavior is fail-fast semantics: any contract violation returns non-zero exit status.
 


### PR DESCRIPTION
### Motivation
- The naming health-check previously asserted determinism only for `repo`, `app`, and `docs` even though the naming validator supports `validator` and `system` scope profiles, leaving a coverage gap.
- Expanding the health-check to include `validator` and `system` hardens the naming slice by validating its full supported scope surface.

### Description
- Updated the canonical health scope list `NAMING_HEALTH_SCOPES` in `calculogic-validator/naming/src/health/naming-health-check.logic.mjs` to include `validator` and `system` while preserving the existing deterministic two-run comparison model. 
- Adjusted the health-check success output message to report `repo|app|docs|validator|system` in the same file. 
- Aligned the NL-config doc `doc/nl-config/cfg-namingValidator.md` wording to reflect the expanded scope coverage. 

### Testing
- Ran `node calculogic-validator/scripts/validator-health-check.host.mjs` and it completed successfully reporting the updated scopes. 
- Ran `node calculogic-validator/bin/calculogic-validator-health.mjs` and it completed successfully reporting the updated scopes. 
- Ran `npm run validate:naming -- --scope=validator` which produced a non-zero exit due to existing naming findings in the validator scope (pre-existing; behavior unchanged). 
- Ran `npm run validate:naming -- --scope=system` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accbceb07c8331864c579a6ed5f721)