### PR TITLE
refactor(validator): extract suite-core scope-usage helpers

### DIFF
--- a/calculogic-validator/bin/calculogic-validate.mjs
+++ b/calculogic-validator/bin/calculogic-validate.mjs
@@ -21,22 +21,20 @@ import {
   printValidatorUsageToStdout,
   printValidatorUsageErrorToStderr,
 } from '../src/core/cli/validator-cli-usage.logic.mjs';
+import {
+  buildSupportedScopeToken,
+  buildValidatorScopeUsageLinesFromRuntimeProfiles,
+} from '../src/core/cli/validator-cli-scopes.logic.mjs';
 
 const supportedScopes = listValidatorScopes();
-const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
-const supportedScopesToken = preferredScopeOrder
-  .filter((scope) => supportedScopes.includes(scope))
-  .join('|');
+const supportedScopesToken = buildSupportedScopeToken(supportedScopes);
 
 const usageLines = [
   `Usage: calculogic-validate [--scope=<${supportedScopesToken}>] [--validators=<id1,id2>] [--config=<path>] [--strict]`,
   'Validators:',
   ...listRegisteredValidators().map((validatorId) => `  - ${validatorId}`),
   'Scopes:',
-  ...supportedScopes.map((scope) => {
-    const profile = getValidatorScopeProfile(scope);
-    return `  - ${scope}: ${profile?.description ?? ''}`;
-  }),
+  ...buildValidatorScopeUsageLinesFromRuntimeProfiles(supportedScopes),
   'Default scope: validator default (repo for naming)',
   'Default validators: all registered validators',
   'Examples:',

--- a/calculogic-validator/scripts/validate-all.mjs
+++ b/calculogic-validator/scripts/validate-all.mjs
@@ -21,24 +21,22 @@ import {
   printValidatorUsageErrorToStderr,
 } from '../src/core/cli/validator-cli-usage.logic.mjs';
 import { parseRepeatableTargetArgument } from '../src/core/cli/validator-cli-targets.logic.mjs';
+import {
+  buildSupportedScopeToken,
+  buildValidatorScopeUsageLinesFromRuntimeProfiles,
+} from '../src/core/cli/validator-cli-scopes.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
 const supportedScopes = listValidatorScopes();
-const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
-const supportedScopesToken = preferredScopeOrder
-  .filter((scope) => supportedScopes.includes(scope))
-  .join('|');
+const supportedScopesToken = buildSupportedScopeToken(supportedScopes);
 
 const usageLines = [
   `Usage: npm run validate:all -- [--scope=<${supportedScopesToken}>] [--validators=<id1,id2>] [--target=<path>]... [--config=<path>] [--strict]`,
   'Validators:',
   ...listRegisteredValidators().map((validatorId) => `  - ${validatorId}`),
   'Scopes:',
-  ...supportedScopes.map((scope) => {
-    const profile = getValidatorScopeProfile(scope);
-    return `  - ${scope}: ${profile?.description ?? ''}`;
-  }),
+  ...buildValidatorScopeUsageLinesFromRuntimeProfiles(supportedScopes),
   'Default scope: validator default (repo for naming)',
   'Default validators: all registered validators',
   'Examples:',

--- a/calculogic-validator/scripts/validate-tree.mjs
+++ b/calculogic-validator/scripts/validate-tree.mjs
@@ -20,22 +20,20 @@ import {
   printValidatorUsageErrorToStderr,
 } from '../src/core/cli/validator-cli-usage.logic.mjs';
 import { parseRepeatableTargetArgument } from '../src/core/cli/validator-cli-targets.logic.mjs';
+import {
+  buildSupportedScopeToken,
+  buildValidatorScopeUsageLinesFromRuntimeProfiles,
+} from '../src/core/cli/validator-cli-scopes.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
 const supportedScopes = listValidatorScopes();
-const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
-const supportedScopesToken = preferredScopeOrder
-  .filter((scope) => supportedScopes.includes(scope))
-  .join('|');
+const supportedScopesToken = buildSupportedScopeToken(supportedScopes);
 
 const usageLines = [
   `Usage: npm run validate:tree -- [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>]`,
   'Scopes:',
-  ...supportedScopes.map((scope) => {
-    const profile = getValidatorScopeProfile(scope);
-    return `  - ${scope}: ${profile?.description ?? ''}`;
-  }),
+  ...buildValidatorScopeUsageLinesFromRuntimeProfiles(supportedScopes),
   'Default scope: validator default (repo for tree-structure-advisor)',
   'Validator: tree-structure-advisor',
   'Examples:',

--- a/calculogic-validator/src/core/cli/validator-cli-scopes.logic.mjs
+++ b/calculogic-validator/src/core/cli/validator-cli-scopes.logic.mjs
@@ -1,0 +1,22 @@
+import { getValidatorScopeProfile } from '../validator-scopes.runtime.mjs';
+
+const PREFERRED_VALIDATOR_SCOPE_ORDER = ['repo', 'app', 'docs', 'validator', 'system'];
+
+export const getPreferredValidatorScopeOrder = () => [...PREFERRED_VALIDATOR_SCOPE_ORDER];
+
+export const buildSupportedScopeToken = (supportedScopes) =>
+  getPreferredValidatorScopeOrder()
+    .filter((scope) => supportedScopes.includes(scope))
+    .join('|');
+
+export const buildValidatorScopeUsageLines = ({ supportedScopes, getScopeProfile }) =>
+  supportedScopes.map((scope) => {
+    const profile = getScopeProfile(scope);
+    return `  - ${scope}: ${profile?.description ?? ''}`;
+  });
+
+export const buildValidatorScopeUsageLinesFromRuntimeProfiles = (supportedScopes) =>
+  buildValidatorScopeUsageLines({
+    supportedScopes,
+    getScopeProfile: getValidatorScopeProfile,
+  });


### PR DESCRIPTION
### Motivation
- Reduce duplicated scope-usage construction (preferred ordering, supported-scope token, scope description lines) that lived in multiple suite-owned CLI entrypoints. 
- Keep scope vocabulary and formatting owned by the validator suite core rather than duplicated in each script. 

### Description
- Added a new suite-core helper `calculogic-validator/src/core/cli/validator-cli-scopes.logic.mjs` that centralizes preferred scope order, builds the supported-scope token, and emits scope description usage lines. 
- Refactored `calculogic-validator/scripts/validate-tree.mjs` to use `buildSupportedScopeToken` and `buildValidatorScopeUsageLinesFromRuntimeProfiles` from the new helper. 
- Refactored `calculogic-validator/scripts/validate-all.mjs` to use the same new helper for scope token and scope lines. 
- Refactored `calculogic-validator/bin/calculogic-validate.mjs` to reuse the new helper for its usage output. 
- Preserved existing helper ownership by continuing to use `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, `validator-cli-targets.logic.mjs`, and `validator-scopes.runtime.mjs`, and left naming-owned usage logic unchanged. 

### Testing
- Ran `node calculogic-validator/scripts/validate-tree.mjs --help` and it printed help successfully. 
- Ran `node calculogic-validator/scripts/validate-all.mjs --help` and it printed help successfully. 
- Ran `node calculogic-validator/bin/calculogic-validate.mjs --help` and it printed help successfully. 
- Ran `node calculogic-validator/scripts/validate-all.mjs --target` and confirmed the usage error printed to stderr and exited non-zero. 
- Ran `npm run validate:tree -- --scope=validator` and the command executed successfully. 
- Ran `npm run validate:all -- --scope=validator` and the command executed (returned non-zero due to existing validator findings), confirming no behavioral changes to validation/reporting logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd10cced08331abce4096b01ace02)