### PR TITLE
refactor(validator/naming): split health host wrapper from pure health logic

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -86,7 +86,8 @@ calculogic-validator/
 │  │  │  ├─ naming-cli-usage.logic.mjs
 │  │  │  └─ naming-report-builder.logic.mjs
 │  │  ├─ health/
-│  │  │  └─ naming-health-check.logic.mjs
+│  │  │  ├─ naming-health-check.logic.mjs
+│  │  │  └─ naming-health-check.host.mjs
 │  │  ├─ registries/                  # *.knowledge.*
 │  │  │  └─ _builtin/
 │  │  │     ├─ roles.registry.json

--- a/calculogic-validator/bin/calculogic-validator-health.mjs
+++ b/calculogic-validator/bin/calculogic-validator-health.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-import { runNamingHealthCheckEntrypoint } from '../naming/src/health/naming-health-check.logic.mjs';
+import { runNamingHealthCheckEntrypoint } from '../naming/src/health/naming-health-check.host.mjs';
 
 runNamingHealthCheckEntrypoint();

--- a/calculogic-validator/naming/src/health/naming-health-check.host.mjs
+++ b/calculogic-validator/naming/src/health/naming-health-check.host.mjs
@@ -1,0 +1,17 @@
+import { runNamingHealthCheck } from './naming-health-check.logic.mjs';
+import { resolveRepositoryRoot } from '../../../src/core/repository-root.logic.mjs';
+
+export const runNamingHealthCheckEntrypoint = () => {
+  try {
+    const repositoryRoot = resolveRepositoryRoot();
+    runNamingHealthCheck(repositoryRoot);
+
+    console.log('OK: naming validator deterministic for repo|app|docs|validator|system');
+    console.log('OK: docs match app scope roots');
+    process.exit(0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Validator health check failed: ${message}`);
+    process.exit(1);
+  }
+};

--- a/calculogic-validator/naming/src/health/naming-health-check.logic.mjs
+++ b/calculogic-validator/naming/src/health/naming-health-check.logic.mjs
@@ -5,7 +5,6 @@ import {
   runNamingValidator,
   summarizeFindings,
 } from '../naming-validator.host.mjs';
-import { resolveRepositoryRoot } from '../../../src/core/repository-root.logic.mjs';
 
 export const NAMING_HEALTH_SCOPES = ['repo', 'app', 'docs', 'validator', 'system'];
 
@@ -89,19 +88,4 @@ export const runNamingHealthCheck = (repositoryRoot) => {
   }
 
   assertNamingHealthDocs(repositoryRoot);
-};
-
-export const runNamingHealthCheckEntrypoint = () => {
-  try {
-    const repositoryRoot = resolveRepositoryRoot();
-    runNamingHealthCheck(repositoryRoot);
-
-    console.log('OK: naming validator deterministic for repo|app|docs|validator|system');
-    console.log('OK: docs match app scope roots');
-    process.exit(0);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`Validator health check failed: ${message}`);
-    process.exit(1);
-  }
 };

--- a/calculogic-validator/scripts/validator-health-check.host.mjs
+++ b/calculogic-validator/scripts/validator-health-check.host.mjs
@@ -1,3 +1,3 @@
-import { runNamingHealthCheckEntrypoint } from '../naming/src/health/naming-health-check.logic.mjs';
+import { runNamingHealthCheckEntrypoint } from '../naming/src/health/naming-health-check.host.mjs';
 
 runNamingHealthCheckEntrypoint();

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -91,7 +91,7 @@ Validator implementation assets live under top-level `calculogic-validator/`:
 
 - canonical module layout: `calculogic-validator/naming/src/{naming-validator.host.mjs,naming-validator.wiring.mjs,naming-validator.logic.mjs,naming-validator.contracts.mjs}`
 - naming-owned CLI semantic area: `calculogic-validator/naming/src/cli/` (`naming-cli-args.logic.mjs`, `naming-cli-usage.logic.mjs`, `naming-report-builder.logic.mjs`, `naming-cli-runner.logic.mjs`)
-- naming-owned health semantic area: `calculogic-validator/naming/src/health/` (`naming-health-check.logic.mjs`)
+- naming-owned health semantic area: `calculogic-validator/naming/src/health/` (`naming-health-check.logic.mjs`, `naming-health-check.host.mjs`)
 - extension-point folders: `calculogic-validator/naming/src/registries/` and `calculogic-validator/naming/src/rules/`
 - suite-core CLI semantic area: `calculogic-validator/src/core/cli/` (`validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, `validator-cli-targets.logic.mjs`)
 - package export barrel: `calculogic-validator/src/index.mjs`
@@ -110,7 +110,7 @@ Thin-wrapper contract for naming entrypoints: repo-local scripts and installable
 
 Health-check entrypoint lives at `calculogic-validator/scripts/validator-health-check.host.mjs` and is exposed via root script `npm run health:validator`.
 Stable installable health bin entrypoint lives at `calculogic-validator/bin/calculogic-validator-health.mjs`.
-Canonical naming-owned health implementation lives at `calculogic-validator/naming/src/health/naming-health-check.logic.mjs`; both entrypoints are thin wrappers that delegate to naming-owned semantic-area logic.
+Canonical naming-owned health implementation is split by concern: pure assertions live at `calculogic-validator/naming/src/health/naming-health-check.logic.mjs`, while process entrypoint behavior lives at `calculogic-validator/naming/src/health/naming-health-check.host.mjs`; repo-local script/bin entrypoints remain thin wrappers that delegate to the naming-owned host wrapper.
 
 The health-check performs deterministic, CI-friendly assertions for scope profiles `repo`, `app`, `docs`, `validator`, and `system`:
 


### PR DESCRIPTION
### Motivation

- Extract process-level entrypoint responsibilities out of the naming health logic so the logic file contains only pure, deterministic health assertions and docs checks.
- Align the naming health area with the existing host-over-logic structural pattern used elsewhere in the validator suite for clearer ownership and easier reuse.

### Description

- Removed process I/O and `process.exit` behavior from `calculogic-validator/naming/src/health/naming-health-check.logic.mjs` so it now exports only pure assertions (e.g. `NAMING_HEALTH_SCOPES`, `assertDeterministicNamingScope`, `assertNamingHealthDocs`, and `runNamingHealthCheck(repositoryRoot)`).
- Added `calculogic-validator/naming/src/health/naming-health-check.host.mjs` which resolves the repository root, invokes `runNamingHealthCheck(repositoryRoot)`, prints success/failure messages, and exits with the appropriate status.
- Updated the thin wrappers `calculogic-validator/scripts/validator-health-check.host.mjs` and `calculogic-validator/bin/calculogic-validator-health.mjs` to delegate to the new naming-owned host wrapper instead of importing process behavior from the logic file.
- Updated docs to reflect the split: `doc/nl-config/cfg-namingValidator.md` and `calculogic-validator/README.md` now mention both `naming-health-check.logic.mjs` and `naming-health-check.host.mjs` and describe the new boundary.

### Testing

- Ran `node calculogic-validator/scripts/validator-health-check.host.mjs` which printed success messages and exited with status 0 (succeeded).
- Ran `node calculogic-validator/bin/calculogic-validator-health.mjs` which printed success messages and exited with status 0 (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd42844448331a023528655a71427)