### PR TITLE
docs(validator): include scope helper in CLI implementation note

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -42,7 +42,7 @@ For successful validator report runs across suite CLIs (`validate:naming`, `vali
 
 This keeps report capture deterministic while preserving explicit invalid-usage and explicit-failure behavior.
 
-Implementation note: suite CLI scripts should reuse suite-core helpers in `calculogic-validator/src/core/cli/` (for example `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, and `validator-cli-targets.logic.mjs`) for report emission, usage/error output flow, and repeatable `--target` parsing rather than duplicating ad hoc CLI scaffolding. This suite-core CLI helper area is intentionally discoverable for current and future validator slices.
+Implementation note: suite CLI scripts should reuse suite-core helpers in `calculogic-validator/src/core/cli/` (for example `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, `validator-cli-targets.logic.mjs`, and `validator-cli-scopes.logic.mjs`) for report emission, usage/error output flow, and repeatable `--target` parsing rather than duplicating ad hoc CLI scaffolding. This suite-core CLI helper area is intentionally discoverable for current and future validator slices.
 
 For helper-area ownership and reuse routing across suite-core and slice-owned semantic areas, see [`ValidatorHelperAreas-And-Reuse-Conventions.md`](./ValidatorHelperAreas-And-Reuse-Conventions.md).
 


### PR DESCRIPTION
### Motivation
- The suite-core CLI helper area in `calculogic-validator/src/core/cli/` now includes a scope helper and the inline implementation note in the suite contracts doc should reflect that for completeness and discoverability.

### Description
- Added `validator-cli-scopes.logic.mjs` to the inline example helper list in the "Shared CLI report emission contract" implementation note in `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` and kept the change narrowly scoped to that single line.

### Testing
- Verified the updated file contents by reading `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` with `sed -n '1,260p'` and `sed -n '34,80p'`, confirming the helper list contains `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, `validator-cli-targets.logic.mjs`, and `validator-cli-scopes.logic.mjs`.
- Ran `nl -ba calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md | sed -n '40,65p'` and `git status --short` to validate the change was applied and staged as a single documentation modification, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acda27644883318d84091476ff4e01)