### PR TITLE
docs(validator): sync projected README tree with current CLI helpers

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -38,6 +38,7 @@ calculogic-validator/
 │  │  ├─ validator-exit-code.logic.mjs
 │  │  ├─ cli/
 │  │  │  ├─ validator-cli-output.logic.mjs
+│  │  │  ├─ validator-cli-scopes.logic.mjs
 │  │  │  ├─ validator-cli-targets.logic.mjs
 │  │  │  └─ validator-cli-usage.logic.mjs
 │  │  ├─ validator-report.contracts.mjs


### PR DESCRIPTION
### Motivation
- The `Projected package layout (target)` tree in `calculogic-validator/README.md` omitted `validator-cli-scopes.logic.mjs` under `src/core/cli/`, leaving the documented CLI helper area slightly out of date.

### Description
- Add `validator-cli-scopes.logic.mjs` to the `src/core/cli/` subtree in the `Projected package layout (target)` section of `calculogic-validator/README.md` without changing surrounding framing.

### Testing
- Ran `ls calculogic-validator/src/core/cli` to confirm the helper file exists and inspected `calculogic-validator/README.md` to verify the `validator-cli-scopes.logic.mjs` entry is present; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acdc5bf9dc83318096475d882f11b2)