### PR TITLE
docs: tighten registry contract wording and align naming examples with active roles

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
+++ b/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
@@ -131,15 +131,15 @@ Classification: Illustrative
 
 ### 9.1 Explicit role slot wins over role-like semantic token
 
-- Filename: `order.role-summary.view.tsx`
-- Interpreted canonical dominant role slot: `.view.tsx`
+- Filename: `order.role-summary.logic.mjs`
+- Interpreted canonical dominant role slot: `.logic.mjs`
 - `role-summary` in semantic name is treated as semantic reference text, not a competing canonical role.
 
 ### 9.2 Role-like folder token treated as contextual
 
-- Path: `components/view/order-details.logic.mjs`
+- Path: `components/host/order-details.logic.mjs`
 - Filename canonical dominant role slot: `.logic.mjs`
-- Folder token `view` is contextual and does not supersede filename role-slot ownership.
+- Folder token `host` is role-like context and does not supersede filename role-slot ownership.
 
 ### 9.3 Semantic name is important but subordinate to explicit canonical role
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
@@ -130,12 +130,12 @@ Classification: Illustrative
 
 ### 8.2 Role-like folder token with explicit role slot
 
-Path example: `validators/view/naming-role-index.logic.mjs`
+Path example: `validators/host/naming-role-index.logic.mjs`
 
 - Canonical role: `logic` (from explicit `.logic.mjs` slot)
 - Semantic name: `naming-role-index`
 - Optional semantic-family-style interpretation: `naming` family with `role-index` grouping (optional)
-- Folder context: `view` is role-like but contextual in this interpretation lane
+- Folder context: `host` is role-like but contextual in this interpretation lane
 - Why role-like tokens are not reclassified: explicit role slot remains authority; folder token and semantic-name token are contextual/semantic.
 
 ### 8.3 Semantic grouping with explicit role slot

--- a/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
@@ -12,7 +12,7 @@ This spec intentionally formalizes **model rules**, not runtime rewrites. Existi
 
 ## Terminology
 
-- **Canonical entities**: Core nouns that represent canonical_source policy meaning in the model.
+- **Canonical entities**: Core nouns that represent canonical policy meaning in the model.
 - **Perspective/projection registry**: A registry shape that emphasizes one view over shared canonical meaning (for example grouped policy view or allowed-surface view).
 - **Normalization/resolution layer**: Deterministic logic that compiles one or more registry inputs into runtime-ready interpretation.
 - **Slice-local registry surface**: Registry payloads owned by a single validator slice and not yet elevated to suite-shared ownership.
@@ -65,7 +65,7 @@ Contract rules:
 - Not every perspective must exist in code to be part of this model.
 - Perspective registries are contract-valid even when introduced incrementally.
 - Perspective registries must reference canonical meaning through explicit normalization/resolution rules.
-- Perspective registries must not become shadow canonical_source stores through undocumented duplication.
+- Perspective registries must not become shadow canonical stores through undocumented duplication.
 
 ## Normalization/resolution
 
@@ -140,8 +140,8 @@ Expected future interconnection patterns:
 
 Current validator artifacts map into this model as follows:
 
-- **Naming built-in categories registry** (`naming/src/registries/_builtin/categories.registry.json`): canonical entity vocabulary payload (category-focused canonical_source within naming scope).
-- **Naming built-in roles registry** (`naming/src/registries/_builtin/roles.registry.json`): canonical entity payload with role/category assignments and grouped perspectives.
+- **Naming built-in categories registry** (`naming/src/registries/_builtin/categories.registry.json`): canonical entity vocabulary payload (category-focused canonical source within naming scope).
+- **Naming built-in roles registry** (`naming/src/registries/_builtin/roles.registry.json`): grouped storage payload (`rolesByCategory`) for role/category policy entries; runtime normalization resolves this grouped storage shape into canonical flattened role entries for validator interpretation.
 - **Suite scope-profiles registry** (`src/registries/_builtin/scope-profiles.registry.json`): suite-level perspective registry for scope surface targeting used across runner/slice execution contexts.
 - **Naming registry-state normalization logic** (`naming/src/registries/registry-state.logic.mjs`): normalization/resolution contract implementation for active registry-state selection and deterministic digest/state handling.
 - **Suite validator registry composition** (`src/core/validator-registry.knowledge.mjs`): suite-level composition registry for slice runners/entrypoints.


### PR DESCRIPTION
### Motivation
- Remove accidental `canonical_source` wording artifacts that could confuse storage vs runtime meaning in the suite-level registry model. 
- Make the parent spec precisely describe the actual stored shape for the naming roles registry and the normalization step that produces runtime role entries. 
- Align illustrative examples with the current active role vocabulary so examples represent valid, non-deprecated patterns while preserving the original teaching intent.

### Description
- Reworded residual `canonical_source` phrasing to intentional scoped terms like `canonical`, `canonical source`, and `canonical stores` in `registry-model-and-slice-interaction-spec.md`. 
- Clarified the “Current validator mapping” entry for `naming/src/registries/_builtin/roles.registry.json` to state it is a grouped storage payload (`rolesByCategory`) and that runtime normalization flattens this grouped shape into canonical role entries. 
- Replaced illustrative example filenames/paths in `filename-case-and-interpretation-contract.md` and `naming-semantic-name-and-role-disambiguation-spec.md` to use active role vocabulary (for example `logic` and `host`) instead of deprecated/ambiguous tokens, keeping the semantic teaching points unchanged. 
- Files modified: `calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`, `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md`, and `calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md`.

### Testing
- Verified absence of the `canonical_source` artifact via repository text search and confirmed updated phrasing in `registry-model-and-slice-interaction-spec.md`, which succeeded. 
- Inspected `naming/src/registries/_builtin/roles.registry.json` and `naming/src/registries/registry-state.logic.mjs` to confirm the `rolesByCategory` grouped storage shape and the runtime flattening logic, which matches the revised description. 
- Reviewed diffs and the edited docs to ensure examples now use active role vocabulary and that the precedence semantics (explicit role-slot wins) remain intact, which succeeded. 
- No runtime code or registry payloads were modified and no behavioral tests were required beyond the documentary verifications above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addca0cf1883319f66a6ecb31a0f1b)