### PR TITLE
docs: replace non-active report role examples in naming specs

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
+++ b/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
@@ -143,9 +143,9 @@ Classification: Illustrative
 
 ### 9.3 Semantic name is important but subordinate to explicit canonical role
 
-- Filename: `validator-core-normalization.report.mjs`
+- Filename: `validator-core-normalization.logic.mjs`
 - Semantic name lane: `validator-core-normalization` (high importance)
-- Canonical dominant role slot: `.report.mjs` (authoritative ownership lane)
+- Canonical dominant role slot: `.logic.mjs` (authoritative ownership lane)
 
 ### 9.4 Case-policy lanes separated from role ownership
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
@@ -140,12 +140,12 @@ Path example: `validators/host/naming-role-index.logic.mjs`
 
 ### 8.3 Semantic grouping with explicit role slot
 
-Filename example: `role-catalog-family-map.report.mjs`
+Filename example: `role-catalog-family-map.contracts.mjs`
 
-- Canonical role: `report`
+- Canonical role: `contracts`
 - Semantic name: `role-catalog-family-map`
 - Optional semantic-family-style interpretation: `catalog` or `family-map` grouping (optional and policy-dependent)
-- Why role-like tokens are not reclassified: `role` token is semantic reference content; explicit `.report.mjs` slot remains canonical ownership declaration.
+- Why role-like tokens are not reclassified: `role` token is semantic reference content; explicit `.contracts.mjs` slot remains canonical ownership declaration.
 
 ## 9) Ambiguity Handling
 


### PR DESCRIPTION
### Motivation

- Remove residual illustrative examples that used the non-active `report` role slot and align examples with the active builtin naming roles registry while preserving the original teaching points.

### Description

- Replaced `validator-core-normalization.report.mjs` with `validator-core-normalization.logic.mjs` and updated the canonical role note to `.logic.mjs` in `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md` to keep the semantic-name-vs-role-slot lesson intact. 
- Replaced `role-catalog-family-map.report.mjs` with `role-catalog-family-map.contracts.mjs` and updated the canonical role wording to `contracts` / `.contracts.mjs` in `calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md` while preserving the same disambiguation explanation. 
- Docs-only change: no runtime behavior, registry payload, file renames, or code edits were made; examples were chosen from active roles (`logic`, `contracts`) for natural reading and cross-doc consistency. 
- Skill used: none (straightforward documentation alignment pass).

### Testing

- Searched the two target spec documents for remaining illustrative `.report.*` filename-slot examples using `rg` and confirmed none remain. 
- Reviewed the produced diffs to ensure only the intended example lines and their explanatory text were changed and that role-slot precedence and teaching intent remain unchanged. 
- Verified repository status shows the two documentation files modified and no other files were affected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade06fd230833185e85fcaec9ed43b)