### PR TITLE
Extract naming summary bucket policy into registry-backed surface

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -33,7 +33,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 | Default scope fallback (runtime) | `naming/src/naming-validator.logic.mjs` and `naming/src/naming-validator.wiring.mjs` | Fallback now reads suite-owned `DEFAULT_VALIDATOR_SCOPE` (no local `'repo'` hardcoding). | Default scope selection is policy; now centralized to suite runtime owner. | `DEFAULT_VALIDATOR_SCOPE` in suite runtime. | `completed` | Keep centralized owner and guard with drift tests. | Consolidation completed in scope-default unification slice. |
 | Default scope fallback (CLI) | `naming/src/cli/naming-cli-args.logic.mjs` and `src/core/validator-scopes.runtime.mjs` | CLI parser now initializes from suite-owned `DEFAULT_VALIDATOR_SCOPE`; runtime normalizes from same owner. | Canonical owner removes CLI/runtime drift risk. | `DEFAULT_VALIDATOR_SCOPE` in suite runtime. | `completed` | Preserve behavior (`repo`) while keeping one owner. | Parser behavior unchanged; ownership consolidated. |
 | Finding severity/classification/message family mapping | `naming/src/naming-validator.logic.mjs` | `classifyPath(...)` hardcodes `severity`, `classification`, `code`, and message templates per branch. | Branch-to-finding mapping is policy vocabulary and enforcement semantics, not parsing mechanics. | `finding-policy.registry.json` keyed by decision outcome IDs. | `registry-ready-after-normalization` | First normalize decision outcome IDs; then map outcomes → finding metadata via registry. | Explicit hotspot requested. |
-| Summary bucket structure | `naming/src/naming-validator.logic.mjs` | `summarizeFindings(...)` seeds fixed counts for four classifications and fixed secondary bucket families. | Report vocabulary and summary grouping are policy surface decisions. | `summary-buckets.registry.json` (classification buckets + optional facets). | `registry-ready-now` | Extract bucket schema while preserving sort/count behavior. | Explicit hotspot requested. |
+| Summary bucket structure | `naming/src/registries/_builtin/summary-buckets.registry.json` + `naming/src/naming-validator.logic.mjs` | `summarizeFindings(...)` now consumes wiring-prepared summary bucket policy sourced from builtin registry. | Report vocabulary and summary grouping are policy surface decisions and now have a deterministic owner. | `summary-buckets.registry.json` (classification buckets + optional facets). | `completed` | Keep schema bounded and preserve deterministic sort/count behavior. | Extracted in V0.1.24 without output-shape changes. |
 | Config overlay limits | `naming/src/registries/registry-state.logic.mjs` | `applyConfigOverlay(...)` only supports `naming.reportableExtensions.add` and `naming.roles.add`. | Overlay capability is narrow policy contract, currently not extensible to other policy surfaces. | `overlay-capabilities.registry.json` (declared add-only fields and merge mode). | `registry-ready-after-normalization` | Define bounded overlay capability map before adding new policy registries. | Explicit hotspot requested. |
 | Exit behavior mapping | `src/core/validator-exit-code.logic.mjs` | Exit code derivation is hardcoded (`warn => 2`, strict+legacy exception => 1). | Severity/classification → exit code is policy contract. | `exit-policy.registry.json` (ordered predicates). | `registry-ready-after-normalization` | Extract only after naming finding policy is normalized to stable outcome semantics. | Cross-validator relevance; keep deterministic ordering. |
 | Tree top-level shape vocabulary | `tree/src/tree-structure-advisor.logic.mjs` | `KNOWN_TOP_LEVEL_DIRECTORIES` hardcoded set. | Allowed root directories are repository policy, not algorithmic necessity. | `tree-known-roots.registry.json`. | `registry-ready-now` | Extract if tree advisor is expected to evolve per-repo without code edits. | Good ROI if tree advisor is actively used. |
@@ -45,7 +45,6 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 ### registry-ready-now
 
-- Summary bucket schema extraction.
 - Tree known-root vocabulary (if tree policy churn is expected).
 
 ### registry-ready-after-normalization
@@ -65,19 +64,17 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 Prioritized by structural ROI (clean policy ownership boundaries first):
 
-1. **Report summary bucket policy**
-   - Registry-drive summary count buckets and optional facet counters.
-2. **Placement / adjacency policy (tree known roots)**
+1. **Placement / adjacency policy (tree known roots)**
    - Externalize known top-level root vocabulary where tree advisor policy churn is expected.
-3. **Missing-role / extension-pattern policy**
+2. **Missing-role / extension-pattern policy**
    - Normalize and extract `detectMissingRoleCandidate(...)` patterns.
-4. **Severity/classification defaults**
+3. **Severity/classification defaults**
    - Introduce stable decision outcomes and externalize finding metadata mapping.
-5. **Overlay capability contract expansion**
+4. **Overlay capability contract expansion**
    - Add explicit capability declarations for newly extracted registry surfaces.
-6. **Exit policy mapping**
+5. **Exit policy mapping**
    - Externalize severity/classification-to-exit predicates after finding outcomes stabilize.
-7. **Deeper semantic relationship metadata (tree signals)**
+6. **Deeper semantic relationship metadata (tree signals)**
    - Add bounded registries for shim signal semantics and cross-surface suppression behavior.
 
 ## Keep-hardcoded-for-now
@@ -98,32 +95,28 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 
 ## Next-step implementation slices
 
-1. **Slice A — Summary bucket registry**
-   - Externalize default classification buckets + optional facet families.
-   - Preserve counter sorting and unknown-classification handling behavior.
-
-2. **Slice B — Tree known-root vocabulary extraction**
+1. **Slice A — Tree known-root vocabulary extraction**
    - Extract `KNOWN_TOP_LEVEL_DIRECTORIES` into a bounded registry payload.
    - Keep advisor decision flow and deterministic ordering behavior unchanged.
 
-3. **Slice C — Missing-role pattern registry introduction**
+2. **Slice B — Missing-role pattern registry introduction**
    - Define normalized pattern schema (`dotSegments`, `compoundExtension`, optional constraints).
    - Replace direct hardcoded branches with runtime-compiled pattern checks.
    - Verify current `module.css` semantics remain exact.
 
-4. **Slice D — Finding policy map**
+3. **Slice C — Finding policy map**
    - Introduce stable internal decision outcome IDs.
    - Move outcome→`{code,severity,classification,message,ruleRef,suggestedFix}` mapping to registry.
    - Keep rule evaluation flow unchanged.
 
-5. **Slice E — Overlay capability expansion contract**
+4. **Slice D — Overlay capability expansion contract**
    - Add deterministic overlay capability declarations for newly extracted registries.
    - Keep add-only semantics where required and explicit.
 
-6. **Slice F — Exit policy mapping extraction**
+5. **Slice E — Exit policy mapping extraction**
    - Externalize ordered exit predicates after finding policy outcomes are stable.
    - Preserve strict/legacy exception behavior semantics.
 
-7. **Slice G — Tree signal policy extraction**
+6. **Slice F — Tree signal policy extraction**
    - Extract known roots first (small bounded vocabulary).
    - Then extract validator-owned basename/shim signals after schema normalization (or skip known-root step if Slice B already landed).

--- a/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
+++ b/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
@@ -28,3 +28,9 @@ export const toNamingRolesRuntime = (rolesArray) => {
 
 
 export const toReportableRootFilesSet = (rootFilesArray) => new Set(rootFilesArray);
+
+
+export const toSummaryBucketsRuntime = (summaryBuckets) => ({
+  classificationBuckets: [...summaryBuckets.classificationBuckets],
+  secondaryBucketFamilies: [...summaryBuckets.secondaryBucketFamilies],
+});

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -70,6 +70,22 @@ const assertPreparedNamingRolesRuntime = (namingRolesRuntime) => {
 };
 
 
+
+
+const assertPreparedSummaryBucketsRuntime = (summaryBucketsRuntime) => {
+  if (
+    summaryBucketsRuntime &&
+    Array.isArray(summaryBucketsRuntime.classificationBuckets) &&
+    Array.isArray(summaryBucketsRuntime.secondaryBucketFamilies)
+  ) {
+    return summaryBucketsRuntime;
+  }
+
+  throw new Error(
+    'Naming summary requires prepared summaryBucketsRuntime from wiring/runtime adapter.',
+  );
+};
+
 const assertPreparedWalkExclusions = (walkExclusions) => {
   if (
     walkExclusions &&
@@ -364,40 +380,46 @@ const incrementCounter = (counts, key) => {
 const sortCountObject = (counts) =>
   Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
 
-export const summarizeFindings = (findings) => {
-  const counts = {
-    canonical: 0,
-    'allowed-special-case': 0,
-    'legacy-exception': 0,
-    'invalid-ambiguous': 0,
+export const summarizeFindings = (findings, summaryBucketsRuntime) => {
+  const summaryBuckets = assertPreparedSummaryBucketsRuntime(summaryBucketsRuntime);
+  const counts = Object.fromEntries(
+    summaryBuckets.classificationBuckets.map((classification) => [classification, 0]),
+  );
+
+  const secondaryCountsByFamily = Object.fromEntries(
+    summaryBuckets.secondaryBucketFamilies.map((bucketFamily) => [bucketFamily, {}]),
+  );
+
+  const incrementSecondaryFamilyCounter = (bucketFamily, counterKey) => {
+    if (!secondaryCountsByFamily[bucketFamily]) {
+      return;
+    }
+
+    incrementCounter(secondaryCountsByFamily[bucketFamily], counterKey);
   };
-  const codeCounts = {};
-  const specialCaseTypeCounts = {};
-  const warningRoleStatusCounts = {};
-  const warningRoleCategoryCounts = {};
 
   for (const finding of findings) {
     incrementCounter(counts, finding.classification);
-    incrementCounter(codeCounts, finding.code);
+    incrementSecondaryFamilyCounter('codeCounts', finding.code);
 
     if (finding.details?.specialCaseType) {
-      incrementCounter(specialCaseTypeCounts, finding.details.specialCaseType);
+      incrementSecondaryFamilyCounter('specialCaseTypeCounts', finding.details.specialCaseType);
     }
 
     if (finding.severity === 'warn' && finding.details?.roleStatus) {
-      incrementCounter(warningRoleStatusCounts, finding.details.roleStatus);
+      incrementSecondaryFamilyCounter('warningRoleStatusCounts', finding.details.roleStatus);
     }
 
     if (finding.severity === 'warn' && finding.details?.roleCategory) {
-      incrementCounter(warningRoleCategoryCounts, finding.details.roleCategory);
+      incrementSecondaryFamilyCounter('warningRoleCategoryCounts', finding.details.roleCategory);
     }
   }
 
   return {
     counts,
-    codeCounts: sortCountObject(codeCounts),
-    specialCaseTypeCounts: sortCountObject(specialCaseTypeCounts),
-    warningRoleStatusCounts: sortCountObject(warningRoleStatusCounts),
-    warningRoleCategoryCounts: sortCountObject(warningRoleCategoryCounts),
+    codeCounts: sortCountObject(secondaryCountsByFamily.codeCounts ?? {}),
+    specialCaseTypeCounts: sortCountObject(secondaryCountsByFamily.specialCaseTypeCounts ?? {}),
+    warningRoleStatusCounts: sortCountObject(secondaryCountsByFamily.warningRoleStatusCounts ?? {}),
+    warningRoleCategoryCounts: sortCountObject(secondaryCountsByFamily.warningRoleCategoryCounts ?? {}),
   };
 };

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -4,6 +4,7 @@ import {
   toNamingRolesRuntime,
   toReportableExtensionsSet,
   toReportableRootFilesSet,
+  toSummaryBucketsRuntime,
 } from './naming-runtime-converters.logic.mjs';
 import {
   parseCanonicalName,
@@ -14,7 +15,7 @@ import {
   runNamingValidator as runNamingValidatorRuntime,
   listNamingValidatorScopes,
   getScopeProfile,
-  summarizeFindings,
+  summarizeFindings as summarizeFindingsRuntime,
 } from './naming-validator.logic.mjs';
 import {
   normalizePath,
@@ -31,6 +32,7 @@ export const prepareNamingRuntimeInputs = (config) => {
     reportableRootFiles: toReportableRootFilesSet(registryInputs.reportableRootFiles),
     namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
     walkExclusions: getBuiltinWalkExclusions(),
+    summaryBucketsRuntime: toSummaryBucketsRuntime(registryInputs.summaryBuckets),
     registry: {
       registryState: registryInputs.registryState,
       registrySource: registryInputs.registrySource,
@@ -88,6 +90,12 @@ export const classifyPath = (relativePath, namingRolesRuntime, options = {}) => 
   return classifyPathRuntime(relativePath, namingRolesRuntime ?? runtimeInputs.namingRolesRuntime);
 };
 
+export const summarizeFindings = (findings, options = {}) => {
+  const runtimeInputs = prepareNamingRuntimeInputs(options.config);
+  const summaryBucketsRuntime = options.summaryBucketsRuntime ?? runtimeInputs.summaryBucketsRuntime;
+  return summarizeFindingsRuntime(findings, summaryBucketsRuntime);
+};
+
 export {
   parseCanonicalName,
   getSpecialCaseType,
@@ -95,5 +103,4 @@ export {
   normalizePath,
   listNamingValidatorScopes,
   getScopeProfile,
-  summarizeFindings,
 };

--- a/calculogic-validator/naming/src/registries/_builtin/summary-buckets.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/summary-buckets.registry.json
@@ -1,0 +1,14 @@
+{
+  "classificationBuckets": [
+    "canonical",
+    "allowed-special-case",
+    "legacy-exception",
+    "invalid-ambiguous"
+  ],
+  "secondaryBucketFamilies": [
+    "codeCounts",
+    "specialCaseTypeCounts",
+    "warningRoleStatusCounts",
+    "warningRoleCategoryCounts"
+  ]
+}

--- a/calculogic-validator/naming/src/registries/naming-summary-buckets.registry.logic.mjs
+++ b/calculogic-validator/naming/src/registries/naming-summary-buckets.registry.logic.mjs
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
+
+export const BUILTIN_SUMMARY_BUCKETS_REGISTRY_PATH = fileURLToPath(
+  new URL('summary-buckets.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+let cachedBuiltinSummaryBuckets = null;
+
+const ensureStringArray = (value, fieldName) => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid builtin summary-buckets registry: missing ${fieldName} array.`);
+  }
+
+  const seen = new Set();
+  const normalized = [];
+
+  value.forEach((entry, index) => {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      throw new Error(
+        `Invalid builtin summary-buckets registry: ${fieldName}[${index}] must be a non-empty string.`,
+      );
+    }
+
+    if (!seen.has(entry)) {
+      seen.add(entry);
+      normalized.push(entry);
+    }
+  });
+
+  return normalized;
+};
+
+export const loadSummaryBucketsFromFile = (registryPath) => {
+  const payload = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid builtin summary-buckets registry: expected object payload.');
+  }
+
+  return {
+    classificationBuckets: ensureStringArray(payload.classificationBuckets, 'classificationBuckets'),
+    secondaryBucketFamilies: ensureStringArray(
+      payload.secondaryBucketFamilies,
+      'secondaryBucketFamilies',
+    ),
+  };
+};
+
+export const getBuiltinSummaryBuckets = () => {
+  if (cachedBuiltinSummaryBuckets === null) {
+    cachedBuiltinSummaryBuckets = loadSummaryBucketsFromFile(BUILTIN_SUMMARY_BUCKETS_REGISTRY_PATH);
+  }
+
+  return cachedBuiltinSummaryBuckets;
+};

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stableStringify, sha256Hex } from '../../../src/core/validator-report-meta.logic.mjs';
+import { loadSummaryBucketsFromFile } from './naming-summary-buckets.registry.logic.mjs';
 
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -11,6 +12,7 @@ const REQUIRED_BUILTIN_REGISTRY_FILES = [
   'roles.registry.json',
   'reportable-extensions.registry.json',
   'reportable-root-files.registry.json',
+  'summary-buckets.registry.json',
 ];
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
@@ -233,6 +235,9 @@ const loadBuiltinReportableRootFiles = ({ builtinRegistryDir }) => {
   return canonicalizeRootFilenames(parsed.reportableRootFiles);
 };
 
+const loadBuiltinSummaryBuckets = ({ builtinRegistryDir }) =>
+  loadSummaryBucketsFromFile(path.join(builtinRegistryDir, 'summary-buckets.registry.json'));
+
 const loadRegistryState = (registryRootDir) => {
   const statePath = path.join(registryRootDir, 'registry-state.json');
   if (!fs.existsSync(statePath)) {
@@ -289,6 +294,7 @@ const buildBuiltinPayload = ({ builtinRegistryDir }) => ({
   roles: loadBuiltinRolesPayload({ builtinRegistryDir }),
   reportableExtensions: loadBuiltinReportableExtensions({ builtinRegistryDir }),
   reportableRootFiles: loadBuiltinReportableRootFiles({ builtinRegistryDir }),
+  summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
 });
 
 const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
@@ -316,6 +322,7 @@ const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
     roles: canonicalizeRoles([...builtinPayload.roles, ...rolesToAppend], { allowedCategories }),
     reportableExtensions: mergedExtensions,
     reportableRootFiles: builtinPayload.reportableRootFiles,
+    summaryBuckets: builtinPayload.summaryBuckets,
   };
 };
 
@@ -377,5 +384,6 @@ export const resolveNamingRegistryInputs = ({ config, registryRootDir } = {}) =>
     roles: resolvedPayload.roles,
     reportableExtensions: resolvedPayload.reportableExtensions,
     reportableRootFiles: resolvedPayload.reportableRootFiles,
+    summaryBuckets: resolvedPayload.summaryBuckets,
   };
 };

--- a/calculogic-validator/naming/test/naming-registry-metadata.test.mjs
+++ b/calculogic-validator/naming/test/naming-registry-metadata.test.mjs
@@ -31,6 +31,8 @@ test('prepareNamingRuntimeInputs exposes prepared dependencies and stable regist
   assert.ok(prepared.walkExclusions.excludedDirectories instanceof Set);
   assert.equal(typeof prepared.walkExclusions.skipDotDirectories, 'boolean');
   assert.ok(prepared.walkExclusions.allowDotFiles instanceof Set);
+  assert.ok(Array.isArray(prepared.summaryBucketsRuntime.classificationBuckets));
+  assert.ok(Array.isArray(prepared.summaryBucketsRuntime.secondaryBucketFamilies));
   assert.ok(prepared.registry);
 
   const result = runNamingValidator(process.cwd(), { scope: 'system', config: {} });

--- a/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
@@ -7,6 +7,7 @@ import {
   classifyPath,
   collectRepositoryPaths,
   runNamingValidator,
+  summarizeFindings,
 } from '../src/naming-validator.logic.mjs';
 import { resolveNamingRegistryInputs } from '../src/registries/registry-state.logic.mjs';
 import {
@@ -94,5 +95,11 @@ test('runtime enforces prepared dependency injection contract', () => {
       reportableRootFiles: new Set(['package.json']),
     }),
     /requires prepared walkExclusions/u,
+  );
+
+
+  assert.throws(
+    () => summarizeFindings([]),
+    /requires prepared summaryBucketsRuntime/u,
   );
 });

--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -8,6 +8,7 @@ import {
   classifyPath,
   parseCanonicalName,
   collectRepositoryPaths,
+  summarizeFindings,
 } from '../src/naming-validator.host.mjs';
 
 test('parse canonical filename with simple extension', () => {
@@ -208,4 +209,65 @@ test('invalid CLI scope returns deterministic usage error and non-zero exit', ()
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Invalid scope: invalid-scope/u);
   assert.match(result.stderr, /Usage: npm run validate:naming/u);
+});
+
+
+test('summary keeps default classification buckets and empty secondary families for empty findings', () => {
+  const summary = summarizeFindings([]);
+
+  assert.deepEqual(summary.counts, {
+    canonical: 0,
+    'allowed-special-case': 0,
+    'legacy-exception': 0,
+    'invalid-ambiguous': 0,
+  });
+  assert.deepEqual(summary.codeCounts, {});
+  assert.deepEqual(summary.specialCaseTypeCounts, {});
+  assert.deepEqual(summary.warningRoleStatusCounts, {});
+  assert.deepEqual(summary.warningRoleCategoryCounts, {});
+});
+
+test('summary preserves deterministic ordering and warning facet behavior', () => {
+  const summary = summarizeFindings([
+    {
+      classification: 'invalid-ambiguous',
+      code: 'Z_CODE',
+      severity: 'warn',
+      details: { roleStatus: 'deprecated', roleCategory: 'documentation' },
+    },
+    {
+      classification: 'allowed-special-case',
+      code: 'A_CODE',
+      severity: 'info',
+      details: { specialCaseType: 'ecosystem-required' },
+    },
+    {
+      classification: 'invalid-ambiguous',
+      code: 'A_CODE',
+      severity: 'warn',
+      details: { roleStatus: 'active', roleCategory: 'architecture-support' },
+    },
+  ]);
+
+  assert.deepEqual(summary.counts, {
+    canonical: 0,
+    'allowed-special-case': 1,
+    'legacy-exception': 0,
+    'invalid-ambiguous': 2,
+  });
+  assert.deepEqual(summary.codeCounts, {
+    A_CODE: 2,
+    Z_CODE: 1,
+  });
+  assert.deepEqual(summary.specialCaseTypeCounts, {
+    'ecosystem-required': 1,
+  });
+  assert.deepEqual(summary.warningRoleStatusCounts, {
+    active: 1,
+    deprecated: 1,
+  });
+  assert.deepEqual(summary.warningRoleCategoryCounts, {
+    'architecture-support': 1,
+    documentation: 1,
+  });
 });

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -58,6 +58,7 @@ test('resolver contract shape remains stable', () => {
     'reportableExtensions',
     'reportableRootFiles',
     'roles',
+    'summaryBuckets',
   ]);
   assert.deepEqual(Object.keys(result.registryDigests).sort((a, b) => a.localeCompare(b)), [
     'builtin',
@@ -135,6 +136,18 @@ test('builtin resolution loads roles and reportable extensions from _builtin JSO
   assert.deepEqual(result.roles, expectedRoles);
   assert.deepEqual(result.reportableExtensions, expectedExtensions);
   assert.deepEqual(result.reportableRootFiles, expectedRootFiles);
+
+  const builtinSummaryBucketsRegistry = JSON.parse(
+    fs.readFileSync(
+      path.join(REGISTRY_MODULE_ROOT, '_builtin', 'summary-buckets.registry.json'),
+      'utf8',
+    ),
+  );
+
+  assert.deepEqual(result.summaryBuckets, {
+    classificationBuckets: builtinSummaryBucketsRegistry.classificationBuckets,
+    secondaryBucketFamilies: builtinSummaryBucketsRegistry.secondaryBucketFamilies,
+  });
 });
 
 test('registryRootDir drives builtin roles, extensions, and categories from the same _builtin root', () => {
@@ -159,12 +172,21 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
       reportableRootFiles: ['root-b.json', 'root-a.json', 'root-b.json'],
     });
 
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
+      classificationBuckets: ['bucket-a', 'bucket-b'],
+      secondaryBucketFamilies: ['codeCounts'],
+    });
+
     const builtinResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
     assert.deepEqual(builtinResult.roles, [
       { role: 'temp-builtin-role', category: 'from-temp-root', status: 'active' },
     ]);
     assert.deepEqual(builtinResult.reportableExtensions, ['.alt', '.tmp']);
     assert.deepEqual(builtinResult.reportableRootFiles, ['root-a.json', 'root-b.json']);
+    assert.deepEqual(builtinResult.summaryBuckets, {
+      classificationBuckets: ['bucket-a', 'bucket-b'],
+      secondaryBucketFamilies: ['codeCounts'],
+    });
 
     writeJson(path.join(tempRoot, 'registry-state.json'), {
       schemaVersion: '1',

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -10,7 +10,7 @@
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.23** (naming runtime dependencies are wiring-provided; runtime no longer composes builtin registry defaults internally).
+Current implementation target: **V0.1.24** (summary bucket policy is registry-backed and wiring-provided; runtime no longer hardcodes summary bucket vocabulary).
 
 ## 1.0 Purpose
 
@@ -233,6 +233,24 @@ Future alignment note:
 - `walkExclusions` are currently prepared in wiring from the builtin walk-exclusions loader path.
 - future customization may align `walkExclusions` with the same registry-state/config-driven composition path used for roles and reportable extensions.
 - this is an architecture alignment note only, not a current contract violation.
+
+
+### 2.11 Summary bucket policy runtime source (V0.1.24)
+
+Naming summary bucket vocabulary is sourced from builtin registry JSON at:
+
+- `calculogic-validator/naming/src/registries/_builtin/summary-buckets.registry.json`
+
+Runtime summary policy fields:
+
+- `classificationBuckets`: default classification bucket keys seeded in summary `counts`.
+- `secondaryBucketFamilies`: enabled secondary summary families (`codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`).
+
+Ownership boundary:
+
+- registry resolver loads summary-bucket policy as part of naming registry inputs.
+- wiring prepares and injects summary-bucket runtime dependencies into summary generation.
+- runtime summary logic consumes prepared summary policy and preserves deterministic ordering/count semantics.
 
 ## 3.0 Classification Contract
 


### PR DESCRIPTION
### Motivation
- Remove hardcoded summary-bucket vocabulary from `summarizeFindings(...)` and give it a deterministic registry owner so summary/report vocabulary is policy-owned, not embedded in runtime logic.
- Keep existing summary output shape, counts, and deterministic ordering exactly as before while moving the schema to a bounded builtin payload.
- Make future registry-driven evolution of summary facets straightforward and testable without changing classification logic.

### Description
- Add a builtin summary-buckets registry at `calculogic-validator/naming/src/registries/_builtin/summary-buckets.registry.json` defining `classificationBuckets` and `secondaryBucketFamilies`.
- Add a loader/validator `calculogic-validator/naming/src/registries/naming-summary-buckets.registry.logic.mjs` and wire registry resolution to include `summaryBuckets` in `resolveNamingRegistryInputs(...)`.
- Add converter `toSummaryBucketsRuntime` and thread `summaryBucketsRuntime` through wiring (`naming-validator.wiring.mjs`) so prepared runtime inputs include the summary schema.
- Replace hardcoded seeding in `summarizeFindings(...)` (in `naming-validator.logic.mjs`) with a registry-backed implementation that seeds `counts` and secondary families from the prepared `summaryBucketsRuntime` while preserving counter logic and deterministic sorting.
- Update host/wiring export so callers can invoke `summarizeFindings(findings[, options])` with an optional `summaryBucketsRuntime` override, preserving previous behavior by default.
- Update tests and NL/audit docs to reflect the new registry-backed ownership and to lock the resolver contract and summary behavior.

### Testing
- Ran naming unit tests: `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-validator.test.mjs calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs calculogic-validator/naming/test/naming-registry-metadata.test.mjs calculogic-validator/naming/test/naming-default-runtime-registry-alignment.test.mjs`, all passed.
- Ran validator runner tests: `node --test calculogic-validator/test/validator-runner.test.mjs calculogic-validator/test/validate-runner-registry-meta.test.mjs`, both suites passed.
- Summary-specific assertions were added to naming tests to verify empty/default buckets, secondary-family behavior, deterministic ordering, and resolver shape, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf151cb948331a8c9198f4882e5e9)