### PR TITLE
Preserve builtin summaryBuckets in custom registry payload

### DIFF
--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -287,6 +287,7 @@ const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
     }),
     reportableExtensions: canonicalizeExtensions(extensionsRaw),
     reportableRootFiles: loadBuiltinReportableRootFiles({ builtinRegistryDir }),
+    summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
   };
 };
 

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { resolveNamingRegistryInputs } from '../src/registries/registry-state.logic.mjs';
+import { toSummaryBucketsRuntime } from '../src/naming-runtime-converters.logic.mjs';
+import { summarizeFindings } from '../src/naming-validator.logic.mjs';
 
 const REGISTRY_MODULE_ROOT = path.resolve('calculogic-validator/naming/src/registries');
 
@@ -199,6 +201,10 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
 
     const customResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
     assert.ok(customResult.roles.some((entry) => entry.role === 'temp-custom-role'));
+    assert.deepEqual(customResult.summaryBuckets, {
+      classificationBuckets: ['bucket-a', 'bucket-b'],
+      secondaryBucketFamilies: ['codeCounts'],
+    });
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -273,6 +279,39 @@ test('custom state selects custom and digests diverge from builtin when payload 
     assert.equal(result.registryDigests.resolved, result.registryDigests.custom);
     assert.ok(result.roles.some((entry) => entry.role === 'custom-role'));
     assert.ok(result.reportableExtensions.includes('.abc'));
+    assert.ok(Array.isArray(result.summaryBuckets.classificationBuckets));
+    assert.ok(Array.isArray(result.summaryBuckets.secondaryBucketFamilies));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+
+test('custom state preserves builtin summary buckets for summary runtime preparation', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'host', category: 'architecture-support', status: 'active' },
+      { role: 'custom-role', category: 'architecture-support', status: 'active' },
+    ]);
+
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), [
+      '.ts',
+      '.abc',
+    ]);
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    const summaryBucketsRuntime = toSummaryBucketsRuntime(result.summaryBuckets);
+    const summary = summarizeFindings([], summaryBucketsRuntime);
+
+    assert.ok(Object.hasOwn(summary, 'counts'));
+    assert.ok(Object.hasOwn(summary, 'codeCounts'));
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -145,8 +145,10 @@ Runtime behavior in this slice resolves naming registries via registry-state log
 - resolver computes one effective built-in registry root per call (defaulting to `calculogic-validator/naming/src/registries/_builtin`)
 - built-in roles are loaded from that effective root `roles.registry.json` (`rolesByCategory` flattened into `{ role, category, status, notes? }`)
 - built-in reportable extensions are loaded from that effective root `reportable-extensions.registry.json` (`reportableExtensions`)
+- built-in summary buckets are loaded from that effective root `summary-buckets.registry.json` (`summaryBuckets`)
 - built-in allowed categories for role validation are loaded from that same effective root `categories.registry.json`
-- resolver returns normalized arrays for `reportableExtensions` and `roles`
+- when `activeRegistry` is `custom`, custom payload uses `_custom` roles/extensions plus builtin-backed `reportableRootFiles` and `summaryBuckets`
+- resolver returns normalized arrays for `reportableExtensions` and `roles`, plus `reportableRootFiles` and `summaryBuckets`
 - wiring converts arrays into runtime structures expected by naming runtime:
   - `reportableExtensions` → `Set`
   - `roles` → `{ roleMetadata: Map, activeRoles: Set, roleSuffixes: string[] }` where role suffixes are length-desc sorted


### PR DESCRIPTION
### Motivation
- The custom registry path omitted `summaryBuckets` from the resolved payload, which left `resolvedPayload.summaryBuckets` missing when `activeRegistry === 'custom'` and caused runtime summary preparation to risk a missing-field failure.
- The intent is to keep the resolved payload shape identical to builtin/config-overlay paths by carrying builtin-backed `summaryBuckets` through the custom path (no new custom override support). 

### Description
- Added `summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir })` to the `loadCustomPayload(...)` return value in `calculogic-validator/naming/src/registries/registry-state.logic.mjs` so custom-mode payloads include builtin `summaryBuckets`.
- Updated `calculogic-validator/naming/test/registry-state.logic.test.mjs` to assert `summaryBuckets` presence in custom mode and to exercise summary runtime preparation via `toSummaryBucketsRuntime(...)` and `summarizeFindings(...)` to prevent a missing-runtime failure.
- Updated `doc/nl-config/cfg-namingValidator.md` to document that resolver preserves builtin-backed `reportableRootFiles` and `summaryBuckets` in custom mode; kept behavior and contracts unchanged otherwise.
- Digest computation unchanged because `customPayload` is still digested after construction, so `registryDigests.custom` now reflects the payload including `summaryBuckets`.

### Testing
- Ran the naming test subset: `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs`, and all tests passed (17 tests, 0 failures). 
- The updated tests exercise: custom-mode resolution success, presence of `summaryBuckets` in resolved inputs, and that summary generation works in custom mode using the prepared runtime buckets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adfcaf08f88331b249b0d4e7f02686)