### PR TITLE
Extract tree known-root vocabulary into builtin registry

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -36,7 +36,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 | Summary bucket structure | `naming/src/registries/_builtin/summary-buckets.registry.json` + `naming/src/naming-validator.logic.mjs` | `summarizeFindings(...)` now consumes wiring-prepared summary bucket policy sourced from builtin registry. | Report vocabulary and summary grouping are policy surface decisions and now have a deterministic owner. | `summary-buckets.registry.json` (classification buckets + optional facets). | `completed` | Keep schema bounded and preserve deterministic sort/count behavior. | Extracted in V0.1.24 without output-shape changes. |
 | Config overlay limits | `naming/src/registries/registry-state.logic.mjs` | `applyConfigOverlay(...)` only supports `naming.reportableExtensions.add` and `naming.roles.add`. | Overlay capability is narrow policy contract, currently not extensible to other policy surfaces. | `overlay-capabilities.registry.json` (declared add-only fields and merge mode). | `registry-ready-after-normalization` | Define bounded overlay capability map before adding new policy registries. | Explicit hotspot requested. |
 | Exit behavior mapping | `src/core/validator-exit-code.logic.mjs` | Exit code derivation is hardcoded (`warn => 2`, strict+legacy exception => 1). | Severity/classification → exit code is policy contract. | `exit-policy.registry.json` (ordered predicates). | `registry-ready-after-normalization` | Extract only after naming finding policy is normalized to stable outcome semantics. | Cross-validator relevance; keep deterministic ordering. |
-| Tree top-level shape vocabulary | `tree/src/tree-structure-advisor.logic.mjs` | `KNOWN_TOP_LEVEL_DIRECTORIES` hardcoded set. | Allowed root directories are repository policy, not algorithmic necessity. | `tree-known-roots.registry.json`. | `registry-ready-now` | Extract if tree advisor is expected to evolve per-repo without code edits. | Good ROI if tree advisor is actively used. |
+| Tree top-level shape vocabulary | `tree/src/registries/_builtin/tree-known-roots.registry.json` + `tree/src/tree-structure-advisor.logic.mjs` | Runtime now consumes `knownTopLevelDirectories` from bounded tree registry payload. | Allowed root directories are repository policy, not algorithmic necessity. | `tree-known-roots.registry.json`. | `completed` | Keep payload bounded to current top-level vocabulary and preserve deterministic ordering in findings details. | Extraction completed without decision-flow changes. |
 | Tree validator-owned basename signals | `tree/src/tree-structure-advisor.logic.mjs` | `VALIDATOR_OWNED_BASENAME_PATTERNS` regex list hardcoded. | File ownership signal vocabulary is policy-shaped and expected to drift over time. | `validator-owned-signals.registry.json`. | `registry-ready-after-normalization` | Normalize signal taxonomy (entrypoint/test/module classes) before extraction. | Avoid turning regex into unmanaged catch-all lists. |
 | Shim detection token vocabularies | `tree/src/tree-shim-detection.logic.mjs` | Multiple token/surface sets: folder signals, name tokens, suppressed surfaces, extension allowlist. | These are heuristic policy knobs for advisory behavior. | `shim-detection-signals.registry.json`. | `registry-ready-after-normalization` | Split into bounded vocab sections (signals, suppressions, extensions) before extraction. | Ensure deterministic precedence remains code-owned. |
 | System-scope compatibility expansions | `src/core/validator-scopes.runtime.mjs` | Hardcoded expansion for `eslint.config.*`, `vite.config.*`, `tsconfig*.json`. | Pattern expansion vocabulary is scope policy adjunct. | Scope-profile adjunct registry for compatibility pattern expansions. | `keep-hardcoded-for-now` | Keep local until root-file discovery contracts stabilize. | Tight coupling with `ROOT_APP_FILES` may not justify extraction yet. |
@@ -45,7 +45,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 ### registry-ready-now
 
-- Tree known-root vocabulary (if tree policy churn is expected).
+- None currently.
 
 ### registry-ready-after-normalization
 
@@ -64,17 +64,15 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 Prioritized by structural ROI (clean policy ownership boundaries first):
 
-1. **Placement / adjacency policy (tree known roots)**
-   - Externalize known top-level root vocabulary where tree advisor policy churn is expected.
-2. **Missing-role / extension-pattern policy**
+1. **Missing-role / extension-pattern policy**
    - Normalize and extract `detectMissingRoleCandidate(...)` patterns.
-3. **Severity/classification defaults**
+2. **Severity/classification defaults**
    - Introduce stable decision outcomes and externalize finding metadata mapping.
-4. **Overlay capability contract expansion**
+3. **Overlay capability contract expansion**
    - Add explicit capability declarations for newly extracted registry surfaces.
-5. **Exit policy mapping**
+4. **Exit policy mapping**
    - Externalize severity/classification-to-exit predicates after finding outcomes stabilize.
-6. **Deeper semantic relationship metadata (tree signals)**
+5. **Deeper semantic relationship metadata (tree signals)**
    - Add bounded registries for shim signal semantics and cross-surface suppression behavior.
 
 ## Keep-hardcoded-for-now
@@ -95,28 +93,25 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 
 ## Next-step implementation slices
 
-1. **Slice A — Tree known-root vocabulary extraction**
-   - Extract `KNOWN_TOP_LEVEL_DIRECTORIES` into a bounded registry payload.
-   - Keep advisor decision flow and deterministic ordering behavior unchanged.
-
-2. **Slice B — Missing-role pattern registry introduction**
+1. **Slice A — Missing-role pattern registry introduction**
    - Define normalized pattern schema (`dotSegments`, `compoundExtension`, optional constraints).
    - Replace direct hardcoded branches with runtime-compiled pattern checks.
    - Verify current `module.css` semantics remain exact.
 
-3. **Slice C — Finding policy map**
+2. **Slice B — Finding policy map**
    - Introduce stable internal decision outcome IDs.
    - Move outcome→`{code,severity,classification,message,ruleRef,suggestedFix}` mapping to registry.
    - Keep rule evaluation flow unchanged.
 
-4. **Slice D — Overlay capability expansion contract**
+3. **Slice C — Overlay capability expansion contract**
    - Add deterministic overlay capability declarations for newly extracted registries.
    - Keep add-only semantics where required and explicit.
 
-5. **Slice E — Exit policy mapping extraction**
+4. **Slice D — Exit policy mapping extraction**
    - Externalize ordered exit predicates after finding policy outcomes are stable.
    - Preserve strict/legacy exception behavior semantics.
 
-6. **Slice F — Tree signal policy extraction**
-   - Extract known roots first (small bounded vocabulary).
-   - Then extract validator-owned basename/shim signals after schema normalization (or skip known-root step if Slice B already landed).
+5. **Slice E — Tree signal policy extraction**
+   - Extract validator-owned basename/shim signals after schema normalization.
+   - Keep tree known-roots extraction completed and isolated from broader signal policy work.
+

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -52,6 +52,36 @@ test('tree-structure-advisor is conservative for normal known repository shape',
   }
 });
 
+
+test('tree-structure-advisor known roots come from bounded registry policy without behavior drift', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-known-roots-registry-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'experiments'), { recursive: true });
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const advisory = result.findings.find(
+      (finding) => finding.code === 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER' && finding.path === 'experiments',
+    );
+
+    assert.ok(advisory);
+    assert.deepEqual(advisory.details.knownRoots, [
+      'bin',
+      'calculogic-validator',
+      'doc',
+      'docs',
+      'public',
+      'scripts',
+      'src',
+      'test',
+      'tools',
+    ]);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor findings are deterministic and summary-stable', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-deterministic-'));
 

--- a/calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json
@@ -1,0 +1,13 @@
+{
+  "knownTopLevelDirectories": [
+    "bin",
+    "calculogic-validator",
+    "doc",
+    "docs",
+    "public",
+    "scripts",
+    "src",
+    "test",
+    "tools"
+  ]
+}

--- a/calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs
+++ b/calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
+
+export const BUILTIN_TREE_KNOWN_ROOTS_REGISTRY_PATH = fileURLToPath(
+  new URL('tree-known-roots.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+let cachedBuiltinTreeKnownRoots = null;
+
+const loadBuiltinTreeKnownRoots = () => {
+  const payload = JSON.parse(fs.readFileSync(BUILTIN_TREE_KNOWN_ROOTS_REGISTRY_PATH, 'utf8'));
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid builtin tree-known-roots registry: expected object payload.');
+  }
+
+  if (!Array.isArray(payload.knownTopLevelDirectories)) {
+    throw new Error(
+      'Invalid builtin tree-known-roots registry: missing knownTopLevelDirectories array.',
+    );
+  }
+
+  payload.knownTopLevelDirectories.forEach((directoryName, index) => {
+    if (typeof directoryName !== 'string' || directoryName.length === 0) {
+      throw new Error(
+        `Invalid builtin tree-known-roots registry: knownTopLevelDirectories[${index}] must be a non-empty string.`,
+      );
+    }
+  });
+
+  return {
+    knownTopLevelDirectories: new Set(payload.knownTopLevelDirectories),
+  };
+};
+
+export const getBuiltinTreeKnownRoots = () => {
+  if (cachedBuiltinTreeKnownRoots === null) {
+    cachedBuiltinTreeKnownRoots = loadBuiltinTreeKnownRoots();
+  }
+
+  return cachedBuiltinTreeKnownRoots;
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -1,17 +1,8 @@
 import path from 'node:path';
 import { collectShimCompatFindings } from './tree-shim-detection.logic.mjs';
+import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots.registry.logic.mjs';
 
-const KNOWN_TOP_LEVEL_DIRECTORIES = new Set([
-  'bin',
-  'calculogic-validator',
-  'doc',
-  'docs',
-  'public',
-  'scripts',
-  'src',
-  'test',
-  'tools',
-]);
+const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
 
 const VALIDATOR_OWNED_BASENAME_PATTERNS = [
   /^naming-validator\.(logic|host|wiring|contracts)\.mjs$/u,
@@ -41,7 +32,7 @@ const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope) 
   }
 
   return topLevelDirectoryNames
-    .filter((directoryName) => !KNOWN_TOP_LEVEL_DIRECTORIES.has(directoryName))
+    .filter((directoryName) => !TREE_KNOWN_ROOTS.knownTopLevelDirectories.has(directoryName))
     .sort((left, right) => left.localeCompare(right))
     .map((directoryName) => ({
       code: 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER',
@@ -52,7 +43,9 @@ const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope) 
         'Top-level folder is outside the known project shape for this repository and may indicate structural drift.',
       ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
       details: {
-        knownRoots: Array.from(KNOWN_TOP_LEVEL_DIRECTORIES).sort((a, b) => a.localeCompare(b)),
+        knownRoots: Array.from(TREE_KNOWN_ROOTS.knownTopLevelDirectories).sort((a, b) =>
+          a.localeCompare(b),
+        ),
       },
     }));
 };


### PR DESCRIPTION
### Motivation

- The tree advisor still owned a hardcoded `KNOWN_TOP_LEVEL_DIRECTORIES` set which is repository policy rather than algorithmic logic and was flagged as the highest-value extraction in the registry expansion audit. 
- Move the bounded known-root vocabulary into a deterministic builtin registry so policy can be owned/configured without changing advisor flow. 
- Preserve current advisor behavior exactly while making the policy surface explicit and testable.

### Description

- Added a bounded builtin payload `calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json` that lists `knownTopLevelDirectories` and kept the payload intentionally small and explicit. 
- Implemented a loader/helper `calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs` that reads, validates, caches, and normalizes the payload into a deterministic `Set` for runtime consumption. 
- Updated `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs` to consume the registry via `getBuiltinTreeKnownRoots()` and removed the hardcoded `KNOWN_TOP_LEVEL_DIRECTORIES` usage while preserving all decision flow and output shapes. 
- Added a focused regression test in `calculogic-validator/test/tree-structure-advisor.test.mjs` that asserts the advisor still treats the same top-level folders as known and reports identical `knownRoots` details for unexpected folders. 
- Updated the registry expansion audit `calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md` to mark this extraction as completed and to adjust the remaining extraction sequencing accordingly.

### Testing

- Ran the tree unit tests with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and the suite reported all tests passing. 
- Ran the validate-tree integration tests with `node --test calculogic-validator/test/validate-tree.script.integration.test.mjs` and they passed. 
- The new test confirms no behavioral drift: the advisor still reports the same `knownRoots` ordering and advisory outputs for current fixtures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae01c57b788331abdd0dc1a643e83a)