### PR TITLE
docs(audit): add tree known-roots to current registry-backed areas

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -22,6 +22,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 - Scope profiles registry (`scope-profiles.registry.json`) via `validator-scopes.runtime.mjs`.
 - Default validator scope policy via `DEFAULT_VALIDATOR_SCOPE` in `validator-scopes.runtime.mjs` (canonical suite-owned default consumed by runtime + naming CLI/wiring).
 - Special cases registry (`special-cases.registry.json`) via `naming-special-case-rules.registry.logic.mjs`.
+- Tree known-roots registry (`tree-known-roots.registry.json`) via `tree-known-roots.registry.logic.mjs`.
 - Walk exclusions registry (`walk-exclusions.registry.json`) via `naming-walk-exclusions.registry.logic.mjs`.
 
 ## Hardcoded-policy inventory
@@ -114,4 +115,3 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 5. **Slice E — Tree signal policy extraction**
    - Extract validator-owned basename/shim signals after schema normalization.
    - Keep tree known-roots extraction completed and isolated from broader signal policy work.
-


### PR DESCRIPTION
### Motivation
- Fix a documentation freshness inconsistency by recording the completed tree known-roots registry-backed surface in the audit’s “Current registry-backed areas” summary so the audit is internally complete and consistent.

### Description
- Updated `calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md` to add a bullet for the tree known-roots registry referencing `tree-known-roots.registry.json` and its loader `tree-known-roots.registry.logic.mjs` in the same style as the adjacent entries; this is a documentation-only change and makes no runtime or payload modifications.

### Testing
- Inspected the loader and payload with `sed` to confirm ownership (`tree-known-roots.registry.logic.mjs` and `_builtin/tree-known-roots.registry.json`) and then ran `git status --short`, `git diff -- <file>`, and `git commit -m "docs(audit): list tree known-roots in current registry-backed areas"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae05d6a72c8331b874dbe86ed9bde6)