### PR TITLE
Extract missing-role naming patterns into bounded registry policy

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -192,6 +192,7 @@ When provided, config only affects naming report inputs for:
 
 - reportable extension set (defaults ∪ additions)
 - naming role registry runtime (defaults + add-only role additions)
+- missing-role pattern policy runtime (builtin normalized schema for legacy exception detection)
 
 In current behavior, these config effects are limited to classification/runtime registries only for report generation.
 
@@ -362,6 +363,9 @@ For incremental adoption, V0.1.2 classifies non-canonical in-scope files as `leg
 
 A file is `invalid-ambiguous` instead of `legacy-exception` when it presents canonical intent but violates contract deterministically, including:
 
+- missing-role candidate detection is bounded by normalized registry-backed patterns:
+  - two-dot-segment form: `<semantic>.<ext>`
+  - compound extension form: `<semantic>.module.css` (reported extension remains `module.css`)
 - unknown role segment in canonical position
 - deprecated role segment in canonical position
 - semantic-name casing violation in canonical position

--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -30,7 +30,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 | Area | File | Current hardcoded thing | Why it is policy-like | Candidate registry type | Extraction readiness | Recommended action | Notes |
 |---|---|---|---|---|---|---|---|
 | Naming reportability adjunct policy | `naming/src/naming-validator.logic.mjs` | Runtime now consumes `reportableRootFiles` from registry inputs as additive reportability adjunct policy. | This is repo policy vocabulary for reportability, not traversal mechanics. | `reportable-root-files.registry.json` | `completed` | Keep defaults bounded (`package.json`, `package-lock.json`) and maintain deterministic additive behavior with extension reportability. | Extraction completed without changing report semantics. |
-| Missing-role heuristic | `naming/src/naming-validator.logic.mjs` | `detectMissingRoleCandidate(...)` hardcodes only 2-segment and `module.css` forms. | Heuristic encodes extension-pattern policy and legacy exception semantics. | `missing-role-patterns.registry.json` with deterministic pattern forms. | `registry-ready-after-normalization` | Normalize to explicit pattern descriptors before extraction to avoid regex sprawl. | Explicit hotspot requested, includes module.css branch. |
+| Missing-role heuristic | `naming/src/naming-validator.logic.mjs` + `naming/src/registries/_builtin/missing-role-patterns.registry.json` | Runtime now consumes normalized missing-role pattern descriptors (2-segment and `module.css`) from builtin registry payload. | Heuristic remains engine-owned while extension-pattern policy vocabulary is registry-owned. | `missing-role-patterns.registry.json` with deterministic pattern forms. | `completed` | Keep schema bounded (`dotSegments`, segment indexes, literal constraints, optional compound extension) and preserve exact legacy exception semantics. | Extraction completed after normalization-first pass; parser/tokenization remains code-owned. |
 | Default scope fallback (runtime) | `naming/src/naming-validator.logic.mjs` and `naming/src/naming-validator.wiring.mjs` | Fallback now reads suite-owned `DEFAULT_VALIDATOR_SCOPE` (no local `'repo'` hardcoding). | Default scope selection is policy; now centralized to suite runtime owner. | `DEFAULT_VALIDATOR_SCOPE` in suite runtime. | `completed` | Keep centralized owner and guard with drift tests. | Consolidation completed in scope-default unification slice. |
 | Default scope fallback (CLI) | `naming/src/cli/naming-cli-args.logic.mjs` and `src/core/validator-scopes.runtime.mjs` | CLI parser now initializes from suite-owned `DEFAULT_VALIDATOR_SCOPE`; runtime normalizes from same owner. | Canonical owner removes CLI/runtime drift risk. | `DEFAULT_VALIDATOR_SCOPE` in suite runtime. | `completed` | Preserve behavior (`repo`) while keeping one owner. | Parser behavior unchanged; ownership consolidated. |
 | Finding severity/classification/message family mapping | `naming/src/naming-validator.logic.mjs` | `classifyPath(...)` hardcodes `severity`, `classification`, `code`, and message templates per branch. | Branch-to-finding mapping is policy vocabulary and enforcement semantics, not parsing mechanics. | `finding-policy.registry.json` keyed by decision outcome IDs. | `registry-ready-after-normalization` | First normalize decision outcome IDs; then map outcomes → finding metadata via registry. | Explicit hotspot requested. |
@@ -50,7 +50,6 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 ### registry-ready-after-normalization
 
-- Missing-role and extension-pattern heuristics.
 - Finding outcome-to-metadata mapping (severity/classification/message families).
 - Config overlay capability matrix.
 - Exit policy mapping.
@@ -65,15 +64,13 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 Prioritized by structural ROI (clean policy ownership boundaries first):
 
-1. **Missing-role / extension-pattern policy**
-   - Normalize and extract `detectMissingRoleCandidate(...)` patterns.
-2. **Severity/classification defaults**
+1. **Severity/classification defaults**
    - Introduce stable decision outcomes and externalize finding metadata mapping.
-3. **Overlay capability contract expansion**
+2. **Overlay capability contract expansion**
    - Add explicit capability declarations for newly extracted registry surfaces.
-4. **Exit policy mapping**
+3. **Exit policy mapping**
    - Externalize severity/classification-to-exit predicates after finding outcomes stabilize.
-5. **Deeper semantic relationship metadata (tree signals)**
+4. **Deeper semantic relationship metadata (tree signals)**
    - Add bounded registries for shim signal semantics and cross-surface suppression behavior.
 
 ## Keep-hardcoded-for-now
@@ -94,24 +91,19 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 
 ## Next-step implementation slices
 
-1. **Slice A — Missing-role pattern registry introduction**
-   - Define normalized pattern schema (`dotSegments`, `compoundExtension`, optional constraints).
-   - Replace direct hardcoded branches with runtime-compiled pattern checks.
-   - Verify current `module.css` semantics remain exact.
-
-2. **Slice B — Finding policy map**
+1. **Slice A — Finding policy map**
    - Introduce stable internal decision outcome IDs.
    - Move outcome→`{code,severity,classification,message,ruleRef,suggestedFix}` mapping to registry.
    - Keep rule evaluation flow unchanged.
 
-3. **Slice C — Overlay capability expansion contract**
+2. **Slice B — Overlay capability expansion contract**
    - Add deterministic overlay capability declarations for newly extracted registries.
    - Keep add-only semantics where required and explicit.
 
-4. **Slice D — Exit policy mapping extraction**
+3. **Slice C — Exit policy mapping extraction**
    - Externalize ordered exit predicates after finding policy outcomes are stable.
    - Preserve strict/legacy exception behavior semantics.
 
-5. **Slice E — Tree signal policy extraction**
+4. **Slice D — Tree signal policy extraction**
    - Extract validator-owned basename/shim signals after schema normalization.
    - Keep tree known-roots extraction completed and isolated from broader signal policy work.

--- a/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
+++ b/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
@@ -34,3 +34,11 @@ export const toSummaryBucketsRuntime = (summaryBuckets) => ({
   classificationBuckets: [...summaryBuckets.classificationBuckets],
   secondaryBucketFamilies: [...summaryBuckets.secondaryBucketFamilies],
 });
+
+
+export const toMissingRolePatternsRuntime = (missingRolePatterns) =>
+  missingRolePatterns.map((pattern) => ({
+    ...pattern,
+    extensionSegmentIndexes: [...pattern.extensionSegmentIndexes],
+    literalSegmentConstraints: { ...pattern.literalSegmentConstraints },
+  }));

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -72,6 +72,16 @@ const assertPreparedNamingRolesRuntime = (namingRolesRuntime) => {
 
 
 
+const assertPreparedMissingRolePatternsRuntime = (missingRolePatternsRuntime) => {
+  if (Array.isArray(missingRolePatternsRuntime)) {
+    return missingRolePatternsRuntime;
+  }
+
+  throw new Error(
+    'Naming runtime requires prepared missingRolePatternsRuntime from wiring/runtime adapter.',
+  );
+};
+
 const assertPreparedSummaryBucketsRuntime = (summaryBucketsRuntime) => {
   if (
     summaryBucketsRuntime &&
@@ -156,20 +166,29 @@ export const listNamingValidatorScopes = () => listValidatorScopes();
 
 export const getScopeProfile = (scope) => getValidatorScopeProfile(scope);
 
-const detectMissingRoleCandidate = (basename) => {
+const detectMissingRoleCandidate = (basename, missingRolePatternsRuntime) => {
   const segments = basename.split('.');
 
-  if (segments.length === 2) {
-    return {
-      semanticNameCandidate: segments[0],
-      extension: segments[1],
-    };
-  }
+  for (const pattern of missingRolePatternsRuntime) {
+    if (segments.length !== pattern.dotSegments) {
+      continue;
+    }
 
-  if (segments.length === 3 && segments[1] === 'module' && segments[2] === 'css') {
+    const doesMatchLiteralConstraints = Object.entries(pattern.literalSegmentConstraints).every(
+      ([segmentIndexRaw, segmentValue]) => segments[Number(segmentIndexRaw)] === segmentValue,
+    );
+
+    if (!doesMatchLiteralConstraints) {
+      continue;
+    }
+
+    const extension =
+      pattern.compoundExtension ||
+      pattern.extensionSegmentIndexes.map((segmentIndex) => segments[segmentIndex]).join('.');
+
     return {
-      semanticNameCandidate: segments[0],
-      extension: 'module.css',
+      semanticNameCandidate: segments[pattern.semanticSegmentIndex],
+      extension,
     };
   }
 
@@ -196,8 +215,9 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   return filterScopedPathsByProfile(allReportablePaths, profile);
 };
 
-export const classifyPath = (relativePath, namingRolesRuntime) => {
+export const classifyPath = (relativePath, namingRolesRuntime, missingRolePatternsRuntime) => {
   const runtime = assertPreparedNamingRolesRuntime(namingRolesRuntime);
+  const missingRolePatterns = assertPreparedMissingRolePatternsRuntime(missingRolePatternsRuntime);
   const normalizedPath = normalizePath(relativePath);
   const basename = path.posix.basename(normalizedPath);
 
@@ -217,7 +237,7 @@ export const classifyPath = (relativePath, namingRolesRuntime) => {
 
   const parsed = parseCanonicalName(basename);
   if (parsed) {
-    const missingRoleCandidate = detectMissingRoleCandidate(basename);
+    const missingRoleCandidate = detectMissingRoleCandidate(basename, missingRolePatterns);
     if (missingRoleCandidate && parsed.role === 'module' && parsed.extension === 'css') {
       return {
         code: 'NAMING_MISSING_ROLE',
@@ -316,7 +336,7 @@ export const classifyPath = (relativePath, namingRolesRuntime) => {
     };
   }
 
-  const missingRoleCandidate = detectMissingRoleCandidate(basename);
+  const missingRoleCandidate = detectMissingRoleCandidate(basename, missingRolePatterns);
   if (missingRoleCandidate) {
     return {
       code: 'NAMING_MISSING_ROLE',
@@ -348,7 +368,12 @@ export const runNamingValidator = (preparedInputs = {}) => {
   const selectedPaths = assertPreparedSelectedPaths(preparedInputs.selectedPaths);
   const namingRolesRuntime = assertPreparedNamingRolesRuntime(preparedInputs.namingRolesRuntime);
   const resolvedTargets = Array.isArray(preparedInputs.targets) ? preparedInputs.targets : [];
-  const findings = selectedPaths.map((pathname) => classifyPath(pathname, namingRolesRuntime));
+  const missingRolePatternsRuntime = assertPreparedMissingRolePatternsRuntime(
+    preparedInputs.missingRolePatternsRuntime,
+  );
+  const findings = selectedPaths.map((pathname) =>
+    classifyPath(pathname, namingRolesRuntime, missingRolePatternsRuntime),
+  );
 
   return {
     findings,

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -5,6 +5,7 @@ import {
   toReportableExtensionsSet,
   toReportableRootFilesSet,
   toSummaryBucketsRuntime,
+  toMissingRolePatternsRuntime,
 } from './naming-runtime-converters.logic.mjs';
 import {
   parseCanonicalName,
@@ -33,6 +34,7 @@ export const prepareNamingRuntimeInputs = (config) => {
     namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
     walkExclusions: getBuiltinWalkExclusions(),
     summaryBucketsRuntime: toSummaryBucketsRuntime(registryInputs.summaryBuckets),
+    missingRolePatternsRuntime: toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
     registry: {
       registryState: registryInputs.registryState,
       registrySource: registryInputs.registrySource,
@@ -87,7 +89,11 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
 
 export const classifyPath = (relativePath, namingRolesRuntime, options = {}) => {
   const runtimeInputs = prepareNamingRuntimeInputs(options.config);
-  return classifyPathRuntime(relativePath, namingRolesRuntime ?? runtimeInputs.namingRolesRuntime);
+  return classifyPathRuntime(
+    relativePath,
+    namingRolesRuntime ?? runtimeInputs.namingRolesRuntime,
+    runtimeInputs.missingRolePatternsRuntime,
+  );
 };
 
 export const summarizeFindings = (findings, options = {}) => {

--- a/calculogic-validator/naming/src/registries/_builtin/missing-role-patterns.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/missing-role-patterns.registry.json
@@ -1,0 +1,21 @@
+{
+  "missingRolePatterns": [
+    {
+      "patternId": "single-extension",
+      "dotSegments": 2,
+      "semanticSegmentIndex": 0,
+      "extensionSegmentIndexes": [1]
+    },
+    {
+      "patternId": "module-css-compound-extension",
+      "dotSegments": 3,
+      "semanticSegmentIndex": 0,
+      "extensionSegmentIndexes": [1, 2],
+      "compoundExtension": "module.css",
+      "literalSegmentConstraints": {
+        "1": "module",
+        "2": "css"
+      }
+    }
+  ]
+}

--- a/calculogic-validator/naming/src/registries/naming-missing-role-patterns.registry.logic.mjs
+++ b/calculogic-validator/naming/src/registries/naming-missing-role-patterns.registry.logic.mjs
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+
+const toPositiveInteger = (value, label) => {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid missing-role patterns registry: ${label} must be a non-negative integer.`);
+  }
+
+  return value;
+};
+
+const canonicalizeExtensionSegmentIndexes = (indexes) => {
+  if (!Array.isArray(indexes) || indexes.length === 0) {
+    throw new Error(
+      'Invalid missing-role patterns registry: extensionSegmentIndexes must be a non-empty array.',
+    );
+  }
+
+  const deduped = new Set(indexes.map((index) => toPositiveInteger(index, 'extension segment index')));
+
+  return [...deduped].sort((left, right) => left - right);
+};
+
+const canonicalizeLiteralSegmentConstraints = (literalSegmentConstraints = {}) => {
+  if (
+    !literalSegmentConstraints ||
+    typeof literalSegmentConstraints !== 'object' ||
+    Array.isArray(literalSegmentConstraints)
+  ) {
+    throw new Error(
+      'Invalid missing-role patterns registry: literalSegmentConstraints must be an object when provided.',
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(literalSegmentConstraints)
+      .map(([segmentIndexRaw, literalValue]) => {
+        const segmentIndex = toPositiveInteger(Number(segmentIndexRaw), 'literal segment index');
+
+        if (typeof literalValue !== 'string' || !literalValue.trim()) {
+          throw new Error(
+            'Invalid missing-role patterns registry: constrained literal values must be non-empty strings.',
+          );
+        }
+
+        return [segmentIndex, literalValue.trim()];
+      })
+      .sort(([left], [right]) => left - right),
+  );
+};
+
+const canonicalizeMissingRolePattern = (patternEntry) => {
+  if (!patternEntry || typeof patternEntry !== 'object' || Array.isArray(patternEntry)) {
+    throw new Error('Invalid missing-role patterns registry: each pattern must be an object.');
+  }
+
+  const patternId = typeof patternEntry.patternId === 'string' ? patternEntry.patternId.trim() : '';
+  const dotSegments = toPositiveInteger(patternEntry.dotSegments, 'dotSegments');
+  const semanticSegmentIndex = toPositiveInteger(
+    patternEntry.semanticSegmentIndex,
+    'semanticSegmentIndex',
+  );
+  const extensionSegmentIndexes = canonicalizeExtensionSegmentIndexes(
+    patternEntry.extensionSegmentIndexes,
+  );
+  const literalSegmentConstraints = canonicalizeLiteralSegmentConstraints(
+    patternEntry.literalSegmentConstraints,
+  );
+
+  if (!patternId) {
+    throw new Error('Invalid missing-role patterns registry: patternId must be a non-empty string.');
+  }
+
+  if (semanticSegmentIndex >= dotSegments) {
+    throw new Error(
+      'Invalid missing-role patterns registry: semanticSegmentIndex must be inside dot segment bounds.',
+    );
+  }
+
+  if (extensionSegmentIndexes.some((index) => index >= dotSegments)) {
+    throw new Error(
+      'Invalid missing-role patterns registry: extensionSegmentIndexes must be inside dot segment bounds.',
+    );
+  }
+
+  const literalConstraintIndexes = Object.keys(literalSegmentConstraints).map(Number);
+  if (literalConstraintIndexes.some((index) => index >= dotSegments)) {
+    throw new Error(
+      'Invalid missing-role patterns registry: literalSegmentConstraints must be inside dot segment bounds.',
+    );
+  }
+
+  if (typeof patternEntry.compoundExtension === 'string' && !patternEntry.compoundExtension.trim()) {
+    throw new Error(
+      'Invalid missing-role patterns registry: compoundExtension must be non-empty when provided.',
+    );
+  }
+
+  const compoundExtension =
+    typeof patternEntry.compoundExtension === 'string'
+      ? patternEntry.compoundExtension.trim()
+      : extensionSegmentIndexes.map((index) => literalSegmentConstraints[index]).filter(Boolean).join('.');
+
+  return {
+    patternId,
+    dotSegments,
+    semanticSegmentIndex,
+    extensionSegmentIndexes,
+    literalSegmentConstraints,
+    compoundExtension,
+  };
+};
+
+export const loadMissingRolePatternsFromFile = (registryFilePath) => {
+  const parsed = JSON.parse(fs.readFileSync(registryFilePath, 'utf8'));
+
+  if (!Array.isArray(parsed?.missingRolePatterns)) {
+    throw new Error(
+      'Invalid missing-role patterns registry: expected missingRolePatterns array.',
+    );
+  }
+
+  const dedupedPatterns = new Map();
+
+  for (const patternEntry of parsed.missingRolePatterns) {
+    const pattern = canonicalizeMissingRolePattern(patternEntry);
+    if (!dedupedPatterns.has(pattern.patternId)) {
+      dedupedPatterns.set(pattern.patternId, pattern);
+    }
+  }
+
+  return [...dedupedPatterns.values()];
+};

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stableStringify, sha256Hex } from '../../../src/core/validator-report-meta.logic.mjs';
 import { loadSummaryBucketsFromFile } from './naming-summary-buckets.registry.logic.mjs';
+import { loadMissingRolePatternsFromFile } from './naming-missing-role-patterns.registry.logic.mjs';
 
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -13,6 +14,7 @@ const REQUIRED_BUILTIN_REGISTRY_FILES = [
   'reportable-extensions.registry.json',
   'reportable-root-files.registry.json',
   'summary-buckets.registry.json',
+  'missing-role-patterns.registry.json',
 ];
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
@@ -238,6 +240,9 @@ const loadBuiltinReportableRootFiles = ({ builtinRegistryDir }) => {
 const loadBuiltinSummaryBuckets = ({ builtinRegistryDir }) =>
   loadSummaryBucketsFromFile(path.join(builtinRegistryDir, 'summary-buckets.registry.json'));
 
+const loadBuiltinMissingRolePatterns = ({ builtinRegistryDir }) =>
+  loadMissingRolePatternsFromFile(path.join(builtinRegistryDir, 'missing-role-patterns.registry.json'));
+
 const loadRegistryState = (registryRootDir) => {
   const statePath = path.join(registryRootDir, 'registry-state.json');
   if (!fs.existsSync(statePath)) {
@@ -288,6 +293,7 @@ const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
     reportableExtensions: canonicalizeExtensions(extensionsRaw),
     reportableRootFiles: loadBuiltinReportableRootFiles({ builtinRegistryDir }),
     summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
+    missingRolePatterns: loadBuiltinMissingRolePatterns({ builtinRegistryDir }),
   };
 };
 
@@ -296,6 +302,7 @@ const buildBuiltinPayload = ({ builtinRegistryDir }) => ({
   reportableExtensions: loadBuiltinReportableExtensions({ builtinRegistryDir }),
   reportableRootFiles: loadBuiltinReportableRootFiles({ builtinRegistryDir }),
   summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
+  missingRolePatterns: loadBuiltinMissingRolePatterns({ builtinRegistryDir }),
 });
 
 const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
@@ -324,6 +331,7 @@ const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
     reportableExtensions: mergedExtensions,
     reportableRootFiles: builtinPayload.reportableRootFiles,
     summaryBuckets: builtinPayload.summaryBuckets,
+    missingRolePatterns: builtinPayload.missingRolePatterns,
   };
 };
 
@@ -386,5 +394,6 @@ export const resolveNamingRegistryInputs = ({ config, registryRootDir } = {}) =>
     reportableExtensions: resolvedPayload.reportableExtensions,
     reportableRootFiles: resolvedPayload.reportableRootFiles,
     summaryBuckets: resolvedPayload.summaryBuckets,
+    missingRolePatterns: resolvedPayload.missingRolePatterns,
   };
 };

--- a/calculogic-validator/naming/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/naming/test/naming-default-runtime-registry-alignment.test.mjs
@@ -28,6 +28,7 @@ test('wiring-injected classifyPath aligns with runtime when using prepared regis
   const runtimeCanonical = classifyPathRuntime(
     'src/rightpanel.results-style.css',
     prepared.namingRolesRuntime,
+    prepared.missingRolePatternsRuntime,
   );
   assert.deepEqual(wiringCanonical, runtimeCanonical);
 
@@ -35,6 +36,7 @@ test('wiring-injected classifyPath aligns with runtime when using prepared regis
   const runtimeDeprecated = classifyPathRuntime(
     'src/tabs/build/BuildSurface.view.css',
     prepared.namingRolesRuntime,
+    prepared.missingRolePatternsRuntime,
   );
   assert.deepEqual(wiringDeprecated, runtimeDeprecated);
 });

--- a/calculogic-validator/naming/test/naming-registry-metadata.test.mjs
+++ b/calculogic-validator/naming/test/naming-registry-metadata.test.mjs
@@ -33,6 +33,7 @@ test('prepareNamingRuntimeInputs exposes prepared dependencies and stable regist
   assert.ok(prepared.walkExclusions.allowDotFiles instanceof Set);
   assert.ok(Array.isArray(prepared.summaryBucketsRuntime.classificationBuckets));
   assert.ok(Array.isArray(prepared.summaryBucketsRuntime.secondaryBucketFamilies));
+  assert.ok(Array.isArray(prepared.missingRolePatternsRuntime));
   assert.ok(prepared.registry);
 
   const result = runNamingValidator(process.cwd(), { scope: 'system', config: {} });

--- a/calculogic-validator/naming/test/naming-runtime-converters.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-converters.test.mjs
@@ -8,6 +8,7 @@ import {
   toNamingRolesRuntime,
   toReportableExtensionsSet,
   toReportableRootFilesSet,
+  toMissingRolePatternsRuntime,
 } from '../src/naming-runtime-converters.logic.mjs';
 import { runNamingValidator as runNamingValidatorRuntime } from '../src/naming-validator.logic.mjs';
 import { getBuiltinWalkExclusions } from '../src/registries/naming-walk-exclusions.registry.logic.mjs';
@@ -55,6 +56,25 @@ test('shared reportable root files converter returns a Set preserving filename m
   assert.equal(reportableRootFiles.size, 2);
 });
 
+
+test('missing-role pattern runtime converter preserves deterministic pattern entries', () => {
+  const runtimePatterns = toMissingRolePatternsRuntime([
+    {
+      patternId: 'single-extension',
+      dotSegments: 2,
+      semanticSegmentIndex: 0,
+      extensionSegmentIndexes: [1],
+      literalSegmentConstraints: {},
+      compoundExtension: '',
+    },
+  ]);
+
+  assert.equal(Array.isArray(runtimePatterns), true);
+  assert.equal(runtimePatterns[0].patternId, 'single-extension');
+  assert.deepEqual(runtimePatterns[0].extensionSegmentIndexes, [1]);
+  assert.deepEqual(runtimePatterns[0].literalSegmentConstraints, {});
+});
+
 test('direct runtime and wiring derive equivalent runtime validation output from the same resolver payload', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-runtime-converter-parity-'));
 
@@ -74,6 +94,7 @@ test('direct runtime and wiring derive equivalent runtime validation output from
       }),
       targets: [],
       namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
+      missingRolePatternsRuntime: toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
     });
 
     const wiringResult = runNamingValidatorWiring(tempRoot, { scope: 'repo', config: {} });

--- a/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
@@ -14,6 +14,7 @@ import {
   toNamingRolesRuntime,
   toReportableExtensionsSet,
   toReportableRootFilesSet,
+  toMissingRolePatternsRuntime,
 } from '../src/naming-runtime-converters.logic.mjs';
 import { getBuiltinWalkExclusions } from '../src/registries/naming-walk-exclusions.registry.logic.mjs';
 
@@ -29,7 +30,11 @@ test('runtime accepts externally prepared naming runtime dependencies', () => {
   const reportableExtensions = toReportableExtensionsSet(registryInputs.reportableExtensions);
   const reportableRootFiles = toReportableRootFilesSet(registryInputs.reportableRootFiles);
 
-  const canonicalFinding = classifyPath('src/rightpanel.results-style.css', namingRolesRuntime);
+  const canonicalFinding = classifyPath(
+    'src/rightpanel.results-style.css',
+    namingRolesRuntime,
+    toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
+  );
   assert.equal(canonicalFinding.code, 'NAMING_CANONICAL');
 
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-runtime-inputs-'));
@@ -47,6 +52,7 @@ test('runtime accepts externally prepared naming runtime dependencies', () => {
         walkExclusions: getBuiltinWalkExclusions(),
       }),
       namingRolesRuntime,
+      missingRolePatternsRuntime: toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
       targets: [],
     });
 
@@ -67,9 +73,21 @@ test('runtime enforces prepared dependency injection contract', () => {
   );
 
   assert.throws(
+    () =>
+      classifyPath(
+        'src/rightpanel.results-style.css',
+        toNamingRolesRuntime(resolveNamingRegistryInputs({ config: {} }).roles),
+      ),
+    /requires prepared missingRolePatternsRuntime/u,
+  );
+
+  assert.throws(
     () => runNamingValidator({
       scope: 'repo',
       namingRolesRuntime: toNamingRolesRuntime(resolveNamingRegistryInputs({ config: {} }).roles),
+      missingRolePatternsRuntime: toMissingRolePatternsRuntime(
+        resolveNamingRegistryInputs({ config: {} }).missingRolePatterns,
+      ),
       targets: [],
     }),
     /requires prepared selectedPaths/u,

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -54,6 +54,7 @@ test('resolver contract shape remains stable', () => {
   const result = resolveNamingRegistryInputs();
 
   assert.deepEqual(Object.keys(result).sort((a, b) => a.localeCompare(b)), [
+    'missingRolePatterns',
     'registryDigests',
     'registrySource',
     'registryState',
@@ -150,6 +151,15 @@ test('builtin resolution loads roles and reportable extensions from _builtin JSO
     classificationBuckets: builtinSummaryBucketsRegistry.classificationBuckets,
     secondaryBucketFamilies: builtinSummaryBucketsRegistry.secondaryBucketFamilies,
   });
+
+  const builtinMissingRolePatternsRegistry = JSON.parse(
+    fs.readFileSync(
+      path.join(REGISTRY_MODULE_ROOT, '_builtin', 'missing-role-patterns.registry.json'),
+      'utf8',
+    ),
+  );
+
+  assert.deepEqual(result.missingRolePatterns.length, builtinMissingRolePatternsRegistry.missingRolePatterns.length);
 });
 
 test('registryRootDir drives builtin roles, extensions, and categories from the same _builtin root', () => {
@@ -179,6 +189,17 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
       secondaryBucketFamilies: ['codeCounts'],
     });
 
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
+      missingRolePatterns: [
+        {
+          patternId: 'single-extension',
+          dotSegments: 2,
+          semanticSegmentIndex: 0,
+          extensionSegmentIndexes: [1],
+        },
+      ],
+    });
+
     const builtinResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
     assert.deepEqual(builtinResult.roles, [
       { role: 'temp-builtin-role', category: 'from-temp-root', status: 'active' },
@@ -189,6 +210,7 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
       classificationBuckets: ['bucket-a', 'bucket-b'],
       secondaryBucketFamilies: ['codeCounts'],
     });
+    assert.equal(builtinResult.missingRolePatterns.length, 1);
 
     writeJson(path.join(tempRoot, 'registry-state.json'), {
       schemaVersion: '1',
@@ -205,6 +227,7 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
       classificationBuckets: ['bucket-a', 'bucket-b'],
       secondaryBucketFamilies: ['codeCounts'],
     });
+    assert.equal(customResult.missingRolePatterns.length, 1);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation

- Normalize the current hardcoded missing-role heuristic into a small deterministic schema so it can be owned by a registry rather than embedded logic while preserving exact runtime semantics. 
- Make the missing-role pattern surface registry-backed and deterministic to prevent future regex-dump extraction and to enable controlled config overlays later. 

### Description

- Add a builtin registry payload `calculogic-validator/naming/src/registries/_builtin/missing-role-patterns.registry.json` that encodes normalized pattern descriptors (`dotSegments`, `semanticSegmentIndex`, `extensionSegmentIndexes`, optional `compoundExtension`, and `literalSegmentConstraints`).
- Implement `naming-missing-role-patterns.registry.logic.mjs` to validate/canonicalize registry entries and expose a loader `loadMissingRolePatternsFromFile`.
- Thread the resolved patterns through the registry resolver and wiring: `resolveNamingRegistryInputs` now returns `missingRolePatterns`, converters include `toMissingRolePatternsRuntime`, and `prepareNamingRuntimeInputs` exposes `missingRolePatternsRuntime`.
- Replace the previous hardcoded `detectMissingRoleCandidate(...)` branches in `naming/src/naming-validator.logic.mjs` with a registry-driven matcher that preserves the original outputs (two-segment `<semantic>.<ext>` and the `module.css` compound-extension behavior) and add `assertPreparedMissingRolePatternsRuntime` runtime checks.
- Update wiring and host helpers (`naming-validator.wiring.mjs`, converters, and runtime adapters) and adjust tests and minimal docs to reflect the new registry-backed surface while keeping parser/tokenization and finding semantics unchanged.

### Testing

- Ran the naming test suite with `node --test --experimental-strip-types calculogic-validator/naming/test/**/*.test.mjs` and all tests passed (full suite completed successfully).
- Existing missing-role behavior is asserted by `naming-missing-role.test.mjs` and remains unchanged (two-segment detection and `module.css` compound-extension reported as `extension: 'module.css'`).
- Added unit tests for the runtime converter `toMissingRolePatternsRuntime`, registry resolver inclusion, and runtime dependency boundary checks (all tests succeeded).
- Verified wiring/runtime parity by comparing `classifyPath` outputs from wiring helpers and direct runtime calls using prepared registry payloads (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae1e733560833192602827e080d22b)