### PR TITLE
docs: refresh registry expansion audit registry-backed surfaces

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -19,6 +19,8 @@ These areas are already registry-backed and should not be redundantly re-extract
 - Builtin roles registry (`roles.registry.json`) via `registry-state.logic.mjs`.
 - Reportable extensions registry (`reportable-extensions.registry.json`) via `registry-state.logic.mjs`.
 - Reportable root-file adjunct registry (`reportable-root-files.registry.json`) via `registry-state.logic.mjs`.
+- Missing-role patterns registry (`missing-role-patterns.registry.json`) via `registry-state.logic.mjs` + `naming-missing-role-patterns.registry.logic.mjs`.
+- Summary buckets registry (`summary-buckets.registry.json`) via `registry-state.logic.mjs` + `naming-summary-buckets.registry.logic.mjs` + `naming-validator.logic.mjs`.
 - Scope profiles registry (`scope-profiles.registry.json`) via `validator-scopes.runtime.mjs`.
 - Default validator scope policy via `DEFAULT_VALIDATOR_SCOPE` in `validator-scopes.runtime.mjs` (canonical suite-owned default consumed by runtime + naming CLI/wiring).
 - Special cases registry (`special-cases.registry.json`) via `naming-special-case-rules.registry.logic.mjs`.


### PR DESCRIPTION
### Motivation
- The audit previously documented that missing-role pattern extraction and summary-buckets extraction were completed in the hardcoded-policy inventory but the “Current registry-backed areas” list did not include those two registry-backed surfaces, leaving the audit internally inconsistent.

### Description
- Updated `calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md` to add two bullets to the “Current registry-backed areas” list: `Missing-role patterns registry (missing-role-patterns.registry.json) via registry-state.logic.mjs + naming-missing-role-patterns.registry.logic.mjs` and `Summary buckets registry (summary-buckets.registry.json) via registry-state.logic.mjs + naming-summary-buckets.registry.logic.mjs + naming-validator.logic.mjs`, keeping the existing short-name + filename + ownership-path phrasing and making no runtime or payload changes.

### Testing
- Verified the updated audit file with `sed -n '1,70p' calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md` and inspected the added lines with `nl -ba calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md | sed -n '14,32p'`, both confirming the new bullets were present and formatted consistently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae2242e500833183ec3c2c8b10d7fc)