### PR TITLE
Add bounded overlay capability registry for naming config overlays

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -194,6 +194,7 @@ When provided, config only affects naming report inputs for:
 - naming role registry runtime (defaults + add-only role additions)
 - missing-role pattern policy runtime (builtin normalized schema for legacy exception detection)
 - finding-policy runtime (builtin outcome→finding metadata mapping for stable decision outcomes)
+- overlay capability contract runtime (`overlay-capabilities.registry.json`) that bounds supported config overlay surfaces to add-only `naming.reportableExtensions.add` and `naming.roles.add`
 
 In current behavior, these config effects are limited to classification/runtime registries only for report generation.
 

--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -38,7 +38,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 | Default scope fallback (CLI) | `naming/src/cli/naming-cli-args.logic.mjs` and `src/core/validator-scopes.runtime.mjs` | CLI parser now initializes from suite-owned `DEFAULT_VALIDATOR_SCOPE`; runtime normalizes from same owner. | Canonical owner removes CLI/runtime drift risk. | `DEFAULT_VALIDATOR_SCOPE` in suite runtime. | `completed` | Preserve behavior (`repo`) while keeping one owner. | Parser behavior unchanged; ownership consolidated. |
 | Finding severity/classification/message family mapping | `naming/src/naming-validator.logic.mjs` + `naming/src/registries/_builtin/finding-policy.registry.json` | Runtime now resolves finding metadata (`severity`, `classification`, `code`, message templates, rule refs, optional suggested fix) from registry entries keyed by stable outcome IDs. | Branch-to-finding mapping is policy vocabulary and enforcement semantics, with algorithmic decision flow staying code-owned. | `finding-policy.registry.json` keyed by decision outcome IDs. | `completed` | Keep outcome IDs stable and preserve deterministic metadata lookup semantics. | Extraction completed via registry loader/state wiring with runtime lookup ownership in naming validator logic. |
 | Summary bucket structure | `naming/src/registries/_builtin/summary-buckets.registry.json` + `naming/src/naming-validator.logic.mjs` | `summarizeFindings(...)` now consumes wiring-prepared summary bucket policy sourced from builtin registry. | Report vocabulary and summary grouping are policy surface decisions and now have a deterministic owner. | `summary-buckets.registry.json` (classification buckets + optional facets). | `completed` | Keep schema bounded and preserve deterministic sort/count behavior. | Extracted in V0.1.24 without output-shape changes. |
-| Config overlay limits | `naming/src/registries/registry-state.logic.mjs` | `applyConfigOverlay(...)` only supports `naming.reportableExtensions.add` and `naming.roles.add`. | Overlay capability is narrow policy contract, currently not extensible to other policy surfaces. | `overlay-capabilities.registry.json` (declared add-only fields and merge mode). | `registry-ready-after-normalization` | Define bounded overlay capability map before adding new policy registries. | Explicit hotspot requested. |
+| Config overlay limits | `naming/src/registries/registry-state.logic.mjs` + `naming/src/registries/_builtin/overlay-capabilities.registry.json` | Runtime now resolves bounded overlay support from registry-declared capabilities and preserves add-only handling for `naming.reportableExtensions.add` and `naming.roles.add`. | Overlay capability is a policy contract surface; contract declaration is now registry-owned while merge mechanics remain engine-owned. | `overlay-capabilities.registry.json` (declared add-only fields and merge mode). | `completed` | Keep overlay schema bounded to current naming surfaces and preserve unsupported-path behavior. | Extraction completed as bounded contract-first slice without broadening overlay semantics. |
 | Exit behavior mapping | `src/core/validator-exit-code.logic.mjs` | Exit code derivation is hardcoded (`warn => 2`, strict+legacy exception => 1). | Severity/classification → exit code is policy contract. | `exit-policy.registry.json` (ordered predicates). | `registry-ready-after-normalization` | Extract only after naming finding policy is normalized to stable outcome semantics. | Cross-validator relevance; keep deterministic ordering. |
 | Tree top-level shape vocabulary | `tree/src/registries/_builtin/tree-known-roots.registry.json` + `tree/src/tree-structure-advisor.logic.mjs` | Runtime now consumes `knownTopLevelDirectories` from bounded tree registry payload. | Allowed root directories are repository policy, not algorithmic necessity. | `tree-known-roots.registry.json`. | `completed` | Keep payload bounded to current top-level vocabulary and preserve deterministic ordering in findings details. | Extraction completed without decision-flow changes. |
 | Tree validator-owned basename signals | `tree/src/tree-structure-advisor.logic.mjs` | `VALIDATOR_OWNED_BASENAME_PATTERNS` regex list hardcoded. | File ownership signal vocabulary is policy-shaped and expected to drift over time. | `validator-owned-signals.registry.json`. | `registry-ready-after-normalization` | Normalize signal taxonomy (entrypoint/test/module classes) before extraction. | Avoid turning regex into unmanaged catch-all lists. |
@@ -53,7 +53,6 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 ### registry-ready-after-normalization
 
-- Config overlay capability matrix.
 - Exit policy mapping.
 - Tree basename ownership signal taxonomy.
 - Shim detection signal/suppression vocabulary.
@@ -66,11 +65,9 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 Prioritized by structural ROI (clean policy ownership boundaries first):
 
-1. **Overlay capability contract expansion**
-   - Add explicit capability declarations for newly extracted registry surfaces.
-2. **Exit policy mapping**
+1. **Exit policy mapping**
    - Externalize severity/classification-to-exit predicates after finding outcomes stabilize.
-3. **Deeper semantic relationship metadata (tree signals)**
+2. **Deeper semantic relationship metadata (tree signals)**
    - Add bounded registries for shim signal semantics and cross-surface suppression behavior.
 
 ## Keep-hardcoded-for-now
@@ -91,14 +88,10 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 
 ## Next-step implementation slices
 
-1. **Slice B — Overlay capability expansion contract**
-   - Add deterministic overlay capability declarations for newly extracted registries.
-   - Keep add-only semantics where required and explicit.
-
-2. **Slice C — Exit policy mapping extraction**
+1. **Slice A — Exit policy mapping extraction**
    - Externalize ordered exit predicates after finding policy outcomes are stable.
    - Preserve strict/legacy exception behavior semantics.
 
-3. **Slice D — Tree signal policy extraction**
+2. **Slice B — Tree signal policy extraction**
    - Extract validator-owned basename/shim signals after schema normalization.
    - Keep tree known-roots extraction completed and isolated from broader signal policy work.

--- a/calculogic-validator/naming/src/registries/_builtin/overlay-capabilities.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/overlay-capabilities.registry.json
@@ -1,0 +1,17 @@
+{
+  "version": "1",
+  "capabilities": [
+    {
+      "configPath": "naming.reportableExtensions",
+      "operation": "add",
+      "payloadType": "string-array",
+      "target": "reportableExtensions"
+    },
+    {
+      "configPath": "naming.roles",
+      "operation": "add",
+      "payloadType": "role-array",
+      "target": "roles"
+    }
+  ]
+}

--- a/calculogic-validator/naming/src/registries/naming-overlay-capabilities.registry.logic.mjs
+++ b/calculogic-validator/naming/src/registries/naming-overlay-capabilities.registry.logic.mjs
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+
+const ALLOWED_TARGETS = new Set(['reportableExtensions', 'roles']);
+const ALLOWED_PAYLOAD_TYPES = new Set(['string-array', 'role-array']);
+const ALLOWED_OPERATION = 'add';
+
+const assertNonEmptyString = (value, fieldName) => {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Invalid overlay-capabilities registry: ${fieldName} must be a non-empty string.`);
+  }
+
+  return value.trim();
+};
+
+const canonicalizeCapabilityEntry = (entry, index) => {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(
+      `Invalid overlay-capabilities registry: capabilities[${index}] must be an object.`,
+    );
+  }
+
+  const configPath = assertNonEmptyString(entry.configPath, `capabilities[${index}].configPath`);
+  const operation = assertNonEmptyString(entry.operation, `capabilities[${index}].operation`);
+  const payloadType = assertNonEmptyString(entry.payloadType, `capabilities[${index}].payloadType`);
+  const target = assertNonEmptyString(entry.target, `capabilities[${index}].target`);
+
+  if (operation !== ALLOWED_OPERATION) {
+    throw new Error(
+      `Invalid overlay-capabilities registry: capabilities[${index}].operation must be "${ALLOWED_OPERATION}".`,
+    );
+  }
+
+  if (!ALLOWED_PAYLOAD_TYPES.has(payloadType)) {
+    throw new Error(
+      `Invalid overlay-capabilities registry: capabilities[${index}].payloadType must be one of ${[...ALLOWED_PAYLOAD_TYPES].join(', ')}.`,
+    );
+  }
+
+  if (!ALLOWED_TARGETS.has(target)) {
+    throw new Error(
+      `Invalid overlay-capabilities registry: capabilities[${index}].target must be one of ${[...ALLOWED_TARGETS].join(', ')}.`,
+    );
+  }
+
+  return {
+    configPath,
+    operation,
+    payloadType,
+    target,
+  };
+};
+
+export const loadOverlayCapabilitiesFromFile = (registryPath) => {
+  const parsed = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid overlay-capabilities registry: expected object payload.');
+  }
+
+  if (!Array.isArray(parsed.capabilities)) {
+    throw new Error('Invalid overlay-capabilities registry: expected capabilities array.');
+  }
+
+  const dedupedByKey = new Map();
+
+  parsed.capabilities.forEach((entry, index) => {
+    const canonical = canonicalizeCapabilityEntry(entry, index);
+    dedupedByKey.set(`${canonical.configPath}:${canonical.operation}`, canonical);
+  });
+
+  const canonicalCapabilities = [...dedupedByKey.values()].sort((left, right) => {
+    const byPath = left.configPath.localeCompare(right.configPath);
+    return byPath !== 0 ? byPath : left.operation.localeCompare(right.operation);
+  });
+
+  if (canonicalCapabilities.length === 0) {
+    throw new Error('Invalid overlay-capabilities registry: capabilities must not be empty.');
+  }
+
+  return {
+    entries: canonicalCapabilities,
+    byPathOperation: Object.fromEntries(
+      canonicalCapabilities.map((entry) => [
+        `${entry.configPath}:${entry.operation}`,
+        {
+          configPath: entry.configPath,
+          payloadType: entry.payloadType,
+          target: entry.target,
+        },
+      ]),
+    ),
+  };
+};

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -5,6 +5,7 @@ import { stableStringify, sha256Hex } from '../../../src/core/validator-report-m
 import { loadSummaryBucketsFromFile } from './naming-summary-buckets.registry.logic.mjs';
 import { loadMissingRolePatternsFromFile } from './naming-missing-role-patterns.registry.logic.mjs';
 import { loadFindingPolicyFromFile } from './naming-finding-policy.registry.logic.mjs';
+import { loadOverlayCapabilitiesFromFile } from './naming-overlay-capabilities.registry.logic.mjs';
 
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -17,6 +18,7 @@ const REQUIRED_BUILTIN_REGISTRY_FILES = [
   'summary-buckets.registry.json',
   'missing-role-patterns.registry.json',
   'finding-policy.registry.json',
+  'overlay-capabilities.registry.json',
 ];
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
@@ -312,9 +314,45 @@ const buildBuiltinPayload = ({ builtinRegistryDir }) => ({
   findingPolicy: loadBuiltinFindingPolicy({ builtinRegistryDir }),
 });
 
+const loadBuiltinOverlayCapabilities = ({ builtinRegistryDir }) =>
+  loadOverlayCapabilitiesFromFile(path.join(builtinRegistryDir, 'overlay-capabilities.registry.json'));
+
+const readOverlayAddPayload = ({ config, configPath, payloadType }) => {
+  const [rootKey, registryKey] = configPath.split('.');
+  const addPayload = config?.[rootKey]?.[registryKey]?.add;
+  if (addPayload === undefined) {
+    return [];
+  }
+
+  if (payloadType === 'string-array' || payloadType === 'role-array') {
+    return addPayload;
+  }
+
+  return [];
+};
+
 const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
-  const extensionAdds = config?.naming?.reportableExtensions?.add ?? [];
-  const roleAdds = config?.naming?.roles?.add ?? [];
+  const overlayCapabilities = loadBuiltinOverlayCapabilities({ builtinRegistryDir });
+  const reportableExtensionsCapability =
+    overlayCapabilities.byPathOperation['naming.reportableExtensions:add'];
+  const rolesCapability = overlayCapabilities.byPathOperation['naming.roles:add'];
+
+  if (!reportableExtensionsCapability || !rolesCapability) {
+    throw new Error(
+      'Invalid overlay-capabilities registry: required naming.reportableExtensions:add and naming.roles:add capabilities are missing.',
+    );
+  }
+
+  const extensionAdds = readOverlayAddPayload({
+    config,
+    configPath: reportableExtensionsCapability.configPath,
+    payloadType: reportableExtensionsCapability.payloadType,
+  });
+  const roleAdds = readOverlayAddPayload({
+    config,
+    configPath: rolesCapability.configPath,
+    payloadType: rolesCapability.payloadType,
+  });
   const allowedCategories = loadBuiltinCategorySet({ builtinRegistryDir });
 
   const mergedExtensions = canonicalizeExtensions([

--- a/calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs
+++ b/calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadOverlayCapabilitiesFromFile } from '../src/registries/naming-overlay-capabilities.registry.logic.mjs';
+
+const writeJson = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+};
+
+test('overlay capabilities loader canonicalizes bounded entries', () => {
+  const registryPath = path.join(
+    'calculogic-validator',
+    'naming',
+    'src',
+    'registries',
+    '_builtin',
+    'overlay-capabilities.registry.json',
+  );
+
+  const loaded = loadOverlayCapabilitiesFromFile(registryPath);
+
+  assert.ok(Array.isArray(loaded.entries));
+  assert.deepEqual(Object.keys(loaded.byPathOperation).sort((a, b) => a.localeCompare(b)), [
+    'naming.reportableExtensions:add',
+    'naming.roles:add',
+  ]);
+});
+
+test('overlay capabilities loader rejects malformed payload deterministically', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-cap-registry-'));
+
+  try {
+    const malformedPath = path.join(tempRoot, 'overlay-capabilities.registry.json');
+    writeJson(malformedPath, {
+      version: '1',
+      capabilities: [
+        {
+          configPath: 'naming.roles',
+          operation: 'replace',
+          payloadType: 'role-array',
+          target: 'roles',
+        },
+      ],
+    });
+
+    assert.throws(
+      () => loadOverlayCapabilitiesFromFile(malformedPath),
+      /operation must be "add"/u,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -9,6 +9,25 @@ import { summarizeFindings } from '../src/naming-validator.logic.mjs';
 
 const REGISTRY_MODULE_ROOT = path.resolve('calculogic-validator/naming/src/registries');
 
+const DEFAULT_OVERLAY_CAPABILITIES_REGISTRY = {
+  version: '1',
+  capabilities: [
+    {
+      configPath: 'naming.reportableExtensions',
+      operation: 'add',
+      payloadType: 'string-array',
+      target: 'reportableExtensions',
+    },
+    {
+      configPath: 'naming.roles',
+      operation: 'add',
+      payloadType: 'role-array',
+      target: 'roles',
+    },
+  ],
+};
+
+
 const INTENDED_BUILTIN_REPORTABLE_EXTENSIONS = [
   '.cjs',
   '.css',
@@ -222,6 +241,11 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
         },
       },
     });
+
+    writeJson(
+      path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'),
+      DEFAULT_OVERLAY_CAPABILITIES_REGISTRY,
+    );
 
     const builtinResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
     assert.deepEqual(builtinResult.roles, [
@@ -499,6 +523,116 @@ test('throws when custom reportable extension omits leading dot', () => {
     assert.throws(
       () => resolveNamingRegistryInputs({ registryRootDir: tempRoot }),
       /must start with "\."|must start with "."/u,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+
+test('config overlay preserves supported add-only semantics for roles and reportable extensions', () => {
+  const result = resolveNamingRegistryInputs({
+    config: {
+      naming: {
+        reportableExtensions: { add: ['.xyz', '.ts'] },
+        roles: {
+          add: [
+            { role: 'overlay-role', category: 'architecture-support', status: 'active' },
+            { role: 'host', category: 'architecture-support', status: 'active' },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.equal(result.registrySource, 'config');
+  assert.ok(result.reportableExtensions.includes('.xyz'));
+  assert.ok(result.reportableExtensions.includes('.ts'));
+  assert.ok(result.roles.some((entry) => entry.role === 'overlay-role'));
+  assert.equal(result.roles.filter((entry) => entry.role === 'host').length, 1);
+});
+
+test('unsupported config overlay paths remain ignored', () => {
+  const builtin = resolveNamingRegistryInputs();
+  const withUnsupportedOverlay = resolveNamingRegistryInputs({
+    config: {
+      naming: {
+        summaryBuckets: { add: ['not-supported'] },
+      },
+    },
+  });
+
+  assert.equal(withUnsupportedOverlay.registrySource, 'config');
+  assert.deepEqual(withUnsupportedOverlay.roles, builtin.roles);
+  assert.deepEqual(withUnsupportedOverlay.reportableExtensions, builtin.reportableExtensions);
+  assert.deepEqual(withUnsupportedOverlay.summaryBuckets, builtin.summaryBuckets);
+});
+
+test('throws when overlay capabilities registry is malformed', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      rolesByCategory: {
+        'architecture-support': [{ role: 'host', status: 'active' }],
+      },
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
+      reportableExtensions: ['.ts'],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), {
+      reportableRootFiles: ['package.json'],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
+      classificationBuckets: ['canonical'],
+      secondaryBucketFamilies: ['codeCounts'],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
+      missingRolePatterns: [
+        {
+          patternId: 'single-extension',
+          dotSegments: 2,
+          semanticSegmentIndex: 0,
+          extensionSegmentIndexes: [1],
+        },
+      ],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), {
+      outcomes: {
+        canonical: {
+          code: 'NAMING_CANONICAL',
+          severity: 'info',
+          classification: 'canonical',
+          message: 'ok',
+          ruleRef: 'naming-spec',
+        },
+      },
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {
+      version: '1',
+      capabilities: [
+        {
+          configPath: 'naming.roles',
+          operation: 'replace',
+          payloadType: 'role-array',
+          target: 'roles',
+        },
+      ],
+    });
+
+    assert.throws(
+      () => resolveNamingRegistryInputs({ registryRootDir: tempRoot, config: {} }),
+      /overlay-capabilities registry/u,
     );
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
### Motivation
- Remove hardcoded knowledge of supported config overlay paths in `applyConfigOverlay(...)` by introducing a small, deterministic capability declaration for naming registries. 
- Keep existing runtime merge mechanics and preserve current add-only semantics for `naming.reportableExtensions.add` and `naming.roles.add` without expanding overlay behavior. 

### Description
- Added a builtin overlay capability registry at `calculogic-validator/naming/src/registries/_builtin/overlay-capabilities.registry.json` that declares only the supported config overlay surfaces and their add-only operation. 
- Implemented a loader/validator helper `calculogic-validator/naming/src/registries/naming-overlay-capabilities.registry.logic.mjs` that validates, canonicalizes, and exposes runtime lookup data (`byPathOperation`). 
- Refactored `applyConfigOverlay(...)` in `calculogic-validator/naming/src/registries/registry-state.logic.mjs` to consult the declared capability contract (via the loader) and to read overlay payloads deterministically; merge mechanics remain in code and preserve prior add-only behavior for roles and extensions. 
- Added tests: `calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs` (loader success + malformed payload rejection) and extended `calculogic-validator/naming/test/registry-state.logic.test.mjs` to cover config-overlay parity, unsupported-path stability, and malformed-capability failure. 
- Updated documentation/audit: `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` now documents the overlay capability contract runtime note, and `calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md` was refreshed to mark this slice completed and to adjust slice numbering/order. 

### Testing
- Ran the overlay-loader unit tests and naming registry resolution/integration tests via: `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs calculogic-validator/naming/test/validator-config.roles.integration.test.mjs calculogic-validator/naming/test/validator-config.extensions.integration.test.mjs` and all tests passed. 
- Test summary: 22 tests executed across the added loader test, updated registry-state tests, and existing integration tests, with 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae300f82d4833197b74f022198cd53)