### PR TITLE
Externalize validator exit-code mapping to builtin exit-policy registry

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -39,7 +39,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 | Finding severity/classification/message family mapping | `naming/src/naming-validator.logic.mjs` + `naming/src/registries/_builtin/finding-policy.registry.json` | Runtime now resolves finding metadata (`severity`, `classification`, `code`, message templates, rule refs, optional suggested fix) from registry entries keyed by stable outcome IDs. | Branch-to-finding mapping is policy vocabulary and enforcement semantics, with algorithmic decision flow staying code-owned. | `finding-policy.registry.json` keyed by decision outcome IDs. | `completed` | Keep outcome IDs stable and preserve deterministic metadata lookup semantics. | Extraction completed via registry loader/state wiring with runtime lookup ownership in naming validator logic. |
 | Summary bucket structure | `naming/src/registries/_builtin/summary-buckets.registry.json` + `naming/src/naming-validator.logic.mjs` | `summarizeFindings(...)` now consumes wiring-prepared summary bucket policy sourced from builtin registry. | Report vocabulary and summary grouping are policy surface decisions and now have a deterministic owner. | `summary-buckets.registry.json` (classification buckets + optional facets). | `completed` | Keep schema bounded and preserve deterministic sort/count behavior. | Extracted in V0.1.24 without output-shape changes. |
 | Config overlay limits | `naming/src/registries/registry-state.logic.mjs` + `naming/src/registries/_builtin/overlay-capabilities.registry.json` | Runtime now resolves bounded overlay support from registry-declared capabilities and preserves add-only handling for `naming.reportableExtensions.add` and `naming.roles.add`. | Overlay capability is a policy contract surface; contract declaration is now registry-owned while merge mechanics remain engine-owned. | `overlay-capabilities.registry.json` (declared add-only fields and merge mode). | `completed` | Keep overlay schema bounded to current naming surfaces and preserve unsupported-path behavior. | Extraction completed as bounded contract-first slice without broadening overlay semantics. |
-| Exit behavior mapping | `src/core/validator-exit-code.logic.mjs` | Exit code derivation is hardcoded (`warn => 2`, strict+legacy exception => 1). | Severity/classification → exit code is policy contract. | `exit-policy.registry.json` (ordered predicates). | `registry-ready-after-normalization` | Extract only after naming finding policy is normalized to stable outcome semantics. | Cross-validator relevance; keep deterministic ordering. |
+| Exit behavior mapping | `src/registries/_builtin/exit-policy.registry.json` + `src/registries/validator-exit-policy.registry.runtime.mjs` + `src/core/validator-exit-code.logic.mjs` | Runtime now resolves ordered exit-policy predicates from bounded builtin registry and evaluates those predicates deterministically in code. | Severity/classification + strict-mode to exit-code mapping is policy contract, while semantic evaluation remains engine-owned. | `exit-policy.registry.json` (ordered predicates). | `completed` | Keep schema bounded to current semantics and preserve deterministic first-match ordering. | Extraction completed in Slice A without exit-semantic changes. |
 | Tree top-level shape vocabulary | `tree/src/registries/_builtin/tree-known-roots.registry.json` + `tree/src/tree-structure-advisor.logic.mjs` | Runtime now consumes `knownTopLevelDirectories` from bounded tree registry payload. | Allowed root directories are repository policy, not algorithmic necessity. | `tree-known-roots.registry.json`. | `completed` | Keep payload bounded to current top-level vocabulary and preserve deterministic ordering in findings details. | Extraction completed without decision-flow changes. |
 | Tree validator-owned basename signals | `tree/src/tree-structure-advisor.logic.mjs` | `VALIDATOR_OWNED_BASENAME_PATTERNS` regex list hardcoded. | File ownership signal vocabulary is policy-shaped and expected to drift over time. | `validator-owned-signals.registry.json`. | `registry-ready-after-normalization` | Normalize signal taxonomy (entrypoint/test/module classes) before extraction. | Avoid turning regex into unmanaged catch-all lists. |
 | Shim detection token vocabularies | `tree/src/tree-shim-detection.logic.mjs` | Multiple token/surface sets: folder signals, name tokens, suppressed surfaces, extension allowlist. | These are heuristic policy knobs for advisory behavior. | `shim-detection-signals.registry.json`. | `registry-ready-after-normalization` | Split into bounded vocab sections (signals, suppressions, extensions) before extraction. | Ensure deterministic precedence remains code-owned. |
@@ -53,7 +53,6 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 ### registry-ready-after-normalization
 
-- Exit policy mapping.
 - Tree basename ownership signal taxonomy.
 - Shim detection signal/suppression vocabulary.
 
@@ -65,9 +64,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 Prioritized by structural ROI (clean policy ownership boundaries first):
 
-1. **Exit policy mapping**
-   - Externalize severity/classification-to-exit predicates after finding outcomes stabilize.
-2. **Deeper semantic relationship metadata (tree signals)**
+1. **Deeper semantic relationship metadata (tree signals)**
    - Add bounded registries for shim signal semantics and cross-surface suppression behavior.
 
 ## Keep-hardcoded-for-now
@@ -88,10 +85,6 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 
 ## Next-step implementation slices
 
-1. **Slice A — Exit policy mapping extraction**
-   - Externalize ordered exit predicates after finding policy outcomes are stable.
-   - Preserve strict/legacy exception behavior semantics.
-
-2. **Slice B — Tree signal policy extraction**
+1. **Slice A — Tree signal policy extraction**
    - Extract validator-owned basename/shim signals after schema normalization.
    - Keep tree known-roots extraction completed and isolated from broader signal policy work.

--- a/calculogic-validator/src/core/validator-exit-code.logic.mjs
+++ b/calculogic-validator/src/core/validator-exit-code.logic.mjs
@@ -1,20 +1,48 @@
+import { getBuiltinExitPolicies } from '../registries/validator-exit-policy.registry.runtime.mjs';
+
 const toBooleanStrictOption = (options) => Boolean(options?.strict);
 
-export const deriveExitCodeFromFindings = (findings = [], options = {}) => {
-  const hasWarn = findings.some((finding) => finding?.severity === 'warn');
-  const hasLegacyException = findings.some(
+const getExitSemantics = (findings, options) => ({
+  strictMode: toBooleanStrictOption(options),
+  anyWarnFindings: findings.some((finding) => finding?.severity === 'warn'),
+  anyLegacyExceptionFindings: findings.some(
     (finding) => finding?.classification === 'legacy-exception',
+  ),
+});
+
+const doesPolicyMatchSemantics = (policy, semantics) => {
+  const { predicate } = policy;
+
+  if (predicate.always) {
+    return true;
+  }
+
+  if (predicate.strictMode && !semantics.strictMode) {
+    return false;
+  }
+
+  if (predicate.anyWarnFindings && !semantics.anyWarnFindings) {
+    return false;
+  }
+
+  if (predicate.noWarnFindings && semantics.anyWarnFindings) {
+    return false;
+  }
+
+  if (predicate.anyLegacyExceptionFindings && !semantics.anyLegacyExceptionFindings) {
+    return false;
+  }
+
+  return true;
+};
+
+export const deriveExitCodeFromFindings = (findings = [], options = {}) => {
+  const semantics = getExitSemantics(findings, options);
+  const matchingPolicy = getBuiltinExitPolicies().find((policy) =>
+    doesPolicyMatchSemantics(policy, semantics),
   );
 
-  if (hasWarn) {
-    return 2;
-  }
-
-  if (toBooleanStrictOption(options) && hasLegacyException) {
-    return 1;
-  }
-
-  return 0;
+  return matchingPolicy?.exitCode ?? 0;
 };
 
 export const deriveExitCodeFromRunnerReport = (report, options = {}) => {

--- a/calculogic-validator/src/registries/_builtin/exit-policy.registry.json
+++ b/calculogic-validator/src/registries/_builtin/exit-policy.registry.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "policies": [
+    {
+      "id": "warn-findings",
+      "exitCode": 2,
+      "predicate": {
+        "anyWarnFindings": true
+      }
+    },
+    {
+      "id": "strict-legacy-exception",
+      "exitCode": 1,
+      "predicate": {
+        "strictMode": true,
+        "anyLegacyExceptionFindings": true,
+        "noWarnFindings": true
+      }
+    },
+    {
+      "id": "default-success",
+      "exitCode": 0,
+      "predicate": {
+        "always": true
+      }
+    }
+  ]
+}

--- a/calculogic-validator/src/registries/validator-exit-policy.registry.runtime.mjs
+++ b/calculogic-validator/src/registries/validator-exit-policy.registry.runtime.mjs
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const BUILTIN_EXIT_POLICY_REGISTRY_PATH = path.join(
+  MODULE_DIR,
+  '_builtin',
+  'exit-policy.registry.json',
+);
+
+const ALLOWED_PREDICATE_KEYS = new Set([
+  'always',
+  'strictMode',
+  'anyWarnFindings',
+  'noWarnFindings',
+  'anyLegacyExceptionFindings',
+]);
+
+const isPlainObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const loadJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+const validatePredicateShape = (predicate, { policyId }) => {
+  if (!isPlainObject(predicate)) {
+    throw new Error(
+      `Invalid builtin exit policy registry: predicate for policy "${policyId}" must be an object.`,
+    );
+  }
+
+  const predicateKeys = Object.keys(predicate);
+  if (predicateKeys.length === 0) {
+    throw new Error(
+      `Invalid builtin exit policy registry: predicate for policy "${policyId}" must declare at least one condition.`,
+    );
+  }
+
+  for (const key of predicateKeys) {
+    if (!ALLOWED_PREDICATE_KEYS.has(key)) {
+      throw new Error(
+        `Invalid builtin exit policy registry: unsupported predicate key "${key}" in policy "${policyId}".`,
+      );
+    }
+
+    if (typeof predicate[key] !== 'boolean') {
+      throw new Error(
+        `Invalid builtin exit policy registry: predicate key "${key}" in policy "${policyId}" must be boolean.`,
+      );
+    }
+  }
+};
+
+const canonicalizeExitPolicyEntry = (policyEntry) => {
+  if (!isPlainObject(policyEntry)) {
+    throw new Error('Invalid builtin exit policy registry: each policy entry must be an object.');
+  }
+
+  const id = typeof policyEntry.id === 'string' ? policyEntry.id.trim() : '';
+  if (!id) {
+    throw new Error('Invalid builtin exit policy registry: each policy entry requires a non-empty id.');
+  }
+
+  if (!Number.isInteger(policyEntry.exitCode) || policyEntry.exitCode < 0) {
+    throw new Error(
+      `Invalid builtin exit policy registry: exitCode for policy "${id}" must be a non-negative integer.`,
+    );
+  }
+
+  validatePredicateShape(policyEntry.predicate, { policyId: id });
+
+  return {
+    id,
+    exitCode: policyEntry.exitCode,
+    predicate: {
+      always: policyEntry.predicate.always === true,
+      strictMode: policyEntry.predicate.strictMode === true,
+      anyWarnFindings: policyEntry.predicate.anyWarnFindings === true,
+      noWarnFindings: policyEntry.predicate.noWarnFindings === true,
+      anyLegacyExceptionFindings: policyEntry.predicate.anyLegacyExceptionFindings === true,
+    },
+  };
+};
+
+export const loadExitPolicyRegistryFromPayload = (payload) => {
+  if (!isPlainObject(payload)) {
+    throw new Error('Invalid builtin exit policy registry: expected root object payload.');
+  }
+
+  if (!Array.isArray(payload.policies)) {
+    throw new Error('Invalid builtin exit policy registry: expected policies array.');
+  }
+
+  const canonicalPolicies = payload.policies.map((policyEntry) =>
+    canonicalizeExitPolicyEntry(policyEntry),
+  );
+
+  if (canonicalPolicies.length === 0) {
+    throw new Error('Invalid builtin exit policy registry: policies array must not be empty.');
+  }
+
+  const dedupedPolicyIds = new Set();
+  for (const policy of canonicalPolicies) {
+    if (dedupedPolicyIds.has(policy.id)) {
+      throw new Error(
+        `Invalid builtin exit policy registry: duplicate policy id "${policy.id}" is not allowed.`,
+      );
+    }
+
+    dedupedPolicyIds.add(policy.id);
+  }
+
+  if (!canonicalPolicies.some((policy) => policy.predicate.always)) {
+    throw new Error(
+      'Invalid builtin exit policy registry: policies must include a deterministic fallback predicate with always=true.',
+    );
+  }
+
+  return canonicalPolicies;
+};
+
+let cachedBuiltinExitPolicies = null;
+
+export const getBuiltinExitPolicies = () => {
+  if (!cachedBuiltinExitPolicies) {
+    cachedBuiltinExitPolicies = loadExitPolicyRegistryFromPayload(
+      loadJsonFile(BUILTIN_EXIT_POLICY_REGISTRY_PATH),
+    );
+  }
+
+  return cachedBuiltinExitPolicies.map((policy) => ({
+    id: policy.id,
+    exitCode: policy.exitCode,
+    predicate: { ...policy.predicate },
+  }));
+};

--- a/calculogic-validator/test/validator-exit-policy.registry.test.mjs
+++ b/calculogic-validator/test/validator-exit-policy.registry.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  getBuiltinExitPolicies,
+  loadExitPolicyRegistryFromPayload,
+} from '../src/registries/validator-exit-policy.registry.runtime.mjs';
+import { deriveExitCodeFromFindings } from '../src/core/validator-exit-code.logic.mjs';
+
+test('builtin exit policy registry preserves deterministic policy order', () => {
+  const policies = getBuiltinExitPolicies();
+  assert.deepEqual(
+    policies.map((policy) => policy.id),
+    ['warn-findings', 'strict-legacy-exception', 'default-success'],
+  );
+});
+
+test('deriveExitCodeFromFindings preserves existing warn and strict legacy semantics', () => {
+  assert.equal(
+    deriveExitCodeFromFindings([{ severity: 'warn', classification: 'legacy-exception' }], {
+      strict: false,
+    }),
+    2,
+  );
+
+  assert.equal(
+    deriveExitCodeFromFindings([{ classification: 'legacy-exception' }], { strict: false }),
+    0,
+  );
+
+  assert.equal(
+    deriveExitCodeFromFindings([{ classification: 'legacy-exception' }], { strict: true }),
+    1,
+  );
+
+  assert.equal(deriveExitCodeFromFindings([], { strict: true }), 0);
+});
+
+test('exit policy loader fails deterministically for malformed payloads', () => {
+  assert.throws(
+    () => loadExitPolicyRegistryFromPayload({ policies: [{ id: 'warn-findings', exitCode: 2 }] }),
+    /predicate for policy "warn-findings" must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      loadExitPolicyRegistryFromPayload({
+        policies: [
+          {
+            id: 'warn-findings',
+            exitCode: 2,
+            predicate: { unsupported: true },
+          },
+        ],
+      }),
+    /unsupported predicate key "unsupported"/,
+  );
+
+  assert.throws(
+    () => loadExitPolicyRegistryFromPayload({ policies: [] }),
+    /policies array must not be empty/,
+  );
+});

--- a/doc/nl-config/cfg-validatorRunner.md
+++ b/doc/nl-config/cfg-validatorRunner.md
@@ -97,6 +97,7 @@ Each validator entry includes:
   - Fallback suspicious env detection uses stable ordering and low-false-positive rules: known scopes (`repo|app|docs|validator|system`), non-empty target/config, truthy strict (`true|1|yes`), and validator list indicators (`naming` or comma-list).
 - Executes runner with selected options.
 - Writes JSON report to stdout.
+- Resolves ordered exit-policy mappings from builtin validator registry payload (`src/registries/_builtin/exit-policy.registry.json`) via runtime loader while keeping predicate evaluation deterministic in code.
 - Exits `2` when any aggregated finding has `severity="warn"`.
 - Exits `1` only in strict mode when no warnings exist and any aggregated finding has `classification="legacy-exception"`.
 - Exits `0` when neither condition applies.


### PR DESCRIPTION
### Motivation

- Move the hardcoded severity/classification → exit-code mapping into a bounded, builtin registry so policy vocabulary is owned by a registry payload while evaluation semantics remain engine-owned. 
- Preserve existing semantics for warn and strict legacy-exception handling while enabling deterministic, ordered predicates to be declared in data. 

### Description

- Added a builtin registry payload at `src/registries/_builtin/exit-policy.registry.json` that declares ordered exit predicates and their `exitCode` values. 
- Implemented a runtime loader/validator at `src/registries/validator-exit-policy.registry.runtime.mjs` that canonicalizes and validates the registry payload and exposes `getBuiltinExitPolicies()`. 
- Updated `src/core/validator-exit-code.logic.mjs` to load builtin policies and derive exit codes by matching predicates (`deriveExitCodeFromFindings`). 
- Added unit tests in `test/validator-exit-policy.registry.test.mjs` and updated CLI contract docs in `doc/nl-config/cfg-validatorRunner.md` to reflect the registry-driven exit-policy behavior. 

### Testing

- Ran the new unit tests in `test/validator-exit-policy.registry.test.mjs` which assert policy ordering, preserved warn/strict semantics via `deriveExitCodeFromFindings`, and loader validation error cases, and they passed. 
- The exit-policy loader validation asserts malformed payloads fail deterministically and those assertions succeeded in tests. 
- No other behavioral changes to existing exit semantics were observed by the unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae3266d4a88331bd288f620aaec161)