### PR TITLE
Extract tree signal policy into bounded registries

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md
@@ -26,6 +26,8 @@ These areas are already registry-backed and should not be redundantly re-extract
 - Default validator scope policy via `DEFAULT_VALIDATOR_SCOPE` in `validator-scopes.runtime.mjs` (canonical suite-owned default consumed by runtime + naming CLI/wiring).
 - Special cases registry (`special-cases.registry.json`) via `naming-special-case-rules.registry.logic.mjs`.
 - Tree known-roots registry (`tree-known-roots.registry.json`) via `tree-known-roots.registry.logic.mjs`.
+- Tree validator-owned signal registry (`validator-owned-signals.registry.json`) via `tree-signal-policy.registry.logic.mjs` + `tree-structure-advisor.logic.mjs`.
+- Tree shim detection vocabularies registry (`shim-detection-signals.registry.json`) via `tree-signal-policy.registry.logic.mjs` + `tree-shim-detection.logic.mjs`.
 - Walk exclusions registry (`walk-exclusions.registry.json`) via `naming-walk-exclusions.registry.logic.mjs`.
 
 ## Hardcoded-policy inventory
@@ -41,8 +43,8 @@ These areas are already registry-backed and should not be redundantly re-extract
 | Config overlay limits | `naming/src/registries/registry-state.logic.mjs` + `naming/src/registries/_builtin/overlay-capabilities.registry.json` | Runtime now resolves bounded overlay support from registry-declared capabilities and preserves add-only handling for `naming.reportableExtensions.add` and `naming.roles.add`. | Overlay capability is a policy contract surface; contract declaration is now registry-owned while merge mechanics remain engine-owned. | `overlay-capabilities.registry.json` (declared add-only fields and merge mode). | `completed` | Keep overlay schema bounded to current naming surfaces and preserve unsupported-path behavior. | Extraction completed as bounded contract-first slice without broadening overlay semantics. |
 | Exit behavior mapping | `src/registries/_builtin/exit-policy.registry.json` + `src/registries/validator-exit-policy.registry.runtime.mjs` + `src/core/validator-exit-code.logic.mjs` | Runtime now resolves ordered exit-policy predicates from bounded builtin registry and evaluates those predicates deterministically in code. | Severity/classification + strict-mode to exit-code mapping is policy contract, while semantic evaluation remains engine-owned. | `exit-policy.registry.json` (ordered predicates). | `completed` | Keep schema bounded to current semantics and preserve deterministic first-match ordering. | Extraction completed in Slice A without exit-semantic changes. |
 | Tree top-level shape vocabulary | `tree/src/registries/_builtin/tree-known-roots.registry.json` + `tree/src/tree-structure-advisor.logic.mjs` | Runtime now consumes `knownTopLevelDirectories` from bounded tree registry payload. | Allowed root directories are repository policy, not algorithmic necessity. | `tree-known-roots.registry.json`. | `completed` | Keep payload bounded to current top-level vocabulary and preserve deterministic ordering in findings details. | Extraction completed without decision-flow changes. |
-| Tree validator-owned basename signals | `tree/src/tree-structure-advisor.logic.mjs` | `VALIDATOR_OWNED_BASENAME_PATTERNS` regex list hardcoded. | File ownership signal vocabulary is policy-shaped and expected to drift over time. | `validator-owned-signals.registry.json`. | `registry-ready-after-normalization` | Normalize signal taxonomy (entrypoint/test/module classes) before extraction. | Avoid turning regex into unmanaged catch-all lists. |
-| Shim detection token vocabularies | `tree/src/tree-shim-detection.logic.mjs` | Multiple token/surface sets: folder signals, name tokens, suppressed surfaces, extension allowlist. | These are heuristic policy knobs for advisory behavior. | `shim-detection-signals.registry.json`. | `registry-ready-after-normalization` | Split into bounded vocab sections (signals, suppressions, extensions) before extraction. | Ensure deterministic precedence remains code-owned. |
+| Tree validator-owned basename signals | `tree/src/registries/_builtin/validator-owned-signals.registry.json` + `tree/src/registries/tree-signal-policy.registry.logic.mjs` + `tree/src/tree-structure-advisor.logic.mjs` | Runtime now consumes normalized validator-owned basename signal entries from bounded builtin registry payload and compiles deterministic matcher order in loader. | File ownership signal vocabulary is policy-shaped and now registry-owned with code-owned evaluation mechanics. | `validator-owned-signals.registry.json`. | `completed` | Keep bounded taxonomy (`validator-module-surface`, `validator-cli-entrypoint`, `validator-quality-surface`) and preserve deterministic matcher precedence. | Extraction completed without changing advisor finding semantics. |
+| Shim detection token vocabularies | `tree/src/registries/_builtin/shim-detection-signals.registry.json` + `tree/src/registries/tree-signal-policy.registry.logic.mjs` + `tree/src/tree-shim-detection.logic.mjs` | Runtime now consumes normalized shim taxonomy sections (signals, suppressions, extension allowlist) from bounded registry payload. | Heuristic vocabulary is registry-owned while shim evidence parsing/suppression precedence remains code-owned. | `shim-detection-signals.registry.json`. | `completed` | Keep schema bounded and preserve deterministic matching/suppression behavior. | Extraction completed with no behavior drift in tree shim findings. |
 | System-scope compatibility expansions | `src/core/validator-scopes.runtime.mjs` | Hardcoded expansion for `eslint.config.*`, `vite.config.*`, `tsconfig*.json`. | Pattern expansion vocabulary is scope policy adjunct. | Scope-profile adjunct registry for compatibility pattern expansions. | `keep-hardcoded-for-now` | Keep local until root-file discovery contracts stabilize. | Tight coupling with `ROOT_APP_FILES` may not justify extraction yet. |
 
 ## Candidate classification
@@ -53,8 +55,7 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 ### registry-ready-after-normalization
 
-- Tree basename ownership signal taxonomy.
-- Shim detection signal/suppression vocabulary.
+- No pending items in this class for the current audit scope.
 
 ### keep-hardcoded-for-now
 
@@ -64,8 +65,8 @@ These areas are already registry-backed and should not be redundantly re-extract
 
 Prioritized by structural ROI (clean policy ownership boundaries first):
 
-1. **Deeper semantic relationship metadata (tree signals)**
-   - Add bounded registries for shim signal semantics and cross-surface suppression behavior.
+1. **Tree signal policy extraction (completed in current-state baseline)**
+   - Bounded registries now own validator-owned basename signals and shim detection vocabularies while evaluation flow remains code-owned.
 
 ## Keep-hardcoded-for-now
 
@@ -85,6 +86,6 @@ Retain hardcoded implementation behavior for now where code is primarily **engin
 
 ## Next-step implementation slices
 
-1. **Slice A — Tree signal policy extraction**
-   - Extract validator-owned basename/shim signals after schema normalization.
-   - Keep tree known-roots extraction completed and isolated from broader signal policy work.
+1. **Slice A — Tree signal policy extraction (completed)**
+   - Validator-owned basename and shim-detection vocabularies are now registry-backed with deterministic loader validation.
+   - Keep extraction bounded and avoid broadening into wildcard/system-scope expansion work.

--- a/calculogic-validator/test/tree-signal-policy.registry.test.mjs
+++ b/calculogic-validator/test/tree-signal-policy.registry.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import {
+  BUILTIN_SHIM_DETECTION_SIGNALS_REGISTRY_PATH,
+  BUILTIN_VALIDATOR_OWNED_SIGNALS_REGISTRY_PATH,
+  loadBuiltinTreeSignalPolicy,
+} from '../tree/src/registries/tree-signal-policy.registry.logic.mjs';
+
+test('tree signal policy loader compiles validator-owned basename matchers deterministically', () => {
+  const policy = loadBuiltinTreeSignalPolicy();
+
+  assert.equal(Array.isArray(policy.validatorOwnedBasenameSignalMatchers), true);
+  assert.equal(policy.validatorOwnedBasenameSignalMatchers.length, 7);
+  assert.equal(policy.validatorOwnedBasenameSignalMatchers[0].matcher.test('naming-validator.logic.mjs'), true);
+  assert.equal(policy.validatorOwnedBasenameSignalMatchers[0].matcher.test('unknown.logic.mjs'), false);
+});
+
+test('tree signal policy loader normalizes shim vocabularies into lowercased allowlists', () => {
+  const policy = loadBuiltinTreeSignalPolicy();
+
+  assert.equal(policy.shimFolderSignals.has('compat'), true);
+  assert.equal(policy.shimRelevantFileExtensions.has('.mjs'), true);
+  assert.equal(policy.nonRuntimeWeakSignalSuppressedSurfaces.has('quality'), true);
+});
+
+test('tree signal policy loader fails deterministically on malformed validator-owned registry payloads', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-signal-validator-owned-invalid-'));
+
+  try {
+    const invalidPath = path.join(fixtureDir, 'validator-owned-signals.registry.json');
+    await fs.writeFile(
+      invalidPath,
+      JSON.stringify(
+        {
+          validatorOwnedBasenameSignals: [{ signalClass: 'validator-module-surface', matchType: 'regex' }],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    assert.throws(
+      () =>
+        loadBuiltinTreeSignalPolicy({
+          validatorOwnedSignalsRegistryPath: invalidPath,
+          shimDetectionSignalsRegistryPath: BUILTIN_SHIM_DETECTION_SIGNALS_REGISTRY_PATH,
+        }),
+      /validatorOwnedBasenameSignals\[0\]\.pattern must be a non-empty string/u,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree signal policy loader fails deterministically on malformed shim-detection registry payloads', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-signal-shim-invalid-'));
+
+  try {
+    const invalidPath = path.join(fixtureDir, 'shim-detection-signals.registry.json');
+    await fs.writeFile(
+      invalidPath,
+      JSON.stringify(
+        {
+          shimDetectionSignals: {
+            folderSignals: ['compat'],
+            nameTokenSignals: ['shim'],
+            surfaceSegmentSignals: ['shims'],
+          },
+          shimSuppressionVocabularies: {
+            nonRuntimeWeakSignalSurfaces: ['quality'],
+            detectorImplementationTokens: ['detector'],
+          },
+          shimExtensionAllowlist: {
+            relevantFileExtensions: '.mjs',
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    assert.throws(
+      () =>
+        loadBuiltinTreeSignalPolicy({
+          validatorOwnedSignalsRegistryPath: BUILTIN_VALIDATOR_OWNED_SIGNALS_REGISTRY_PATH,
+          shimDetectionSignalsRegistryPath: invalidPath,
+        }),
+      /shimExtensionAllowlist\.relevantFileExtensions must be an array/u,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/tree/src/registries/_builtin/shim-detection-signals.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/shim-detection-signals.registry.json
@@ -1,0 +1,14 @@
+{
+  "shimDetectionSignals": {
+    "folderSignals": ["compat", "shims", "adapters", "bridges"],
+    "nameTokenSignals": ["shim", "compat", "adapter", "bridge", "migration"],
+    "surfaceSegmentSignals": ["compat", "shims"]
+  },
+  "shimSuppressionVocabularies": {
+    "nonRuntimeWeakSignalSurfaces": ["quality", "docs", "examples", "fixtures"],
+    "detectorImplementationTokens": ["detection", "detector"]
+  },
+  "shimExtensionAllowlist": {
+    "relevantFileExtensions": [".mjs", ".js", ".cjs", ".ts", ".tsx", ".jsx"]
+  }
+}

--- a/calculogic-validator/tree/src/registries/_builtin/validator-owned-signals.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/validator-owned-signals.registry.json
@@ -1,0 +1,39 @@
+{
+  "validatorOwnedBasenameSignals": [
+    {
+      "signalClass": "validator-module-surface",
+      "matchType": "regex",
+      "pattern": "^naming-validator\\.(logic|host|wiring|contracts)\\.mjs$"
+    },
+    {
+      "signalClass": "validator-module-surface",
+      "matchType": "regex",
+      "pattern": "^tree-structure-advisor\\.(logic|host|wiring|contracts)\\.mjs$"
+    },
+    {
+      "signalClass": "validator-module-surface",
+      "matchType": "regex",
+      "pattern": "^validator-(?:runner|registry|config|exit-code|report|scopes|health-check).+\\.mjs$"
+    },
+    {
+      "signalClass": "validator-cli-entrypoint",
+      "matchType": "regex",
+      "pattern": "^validate-(?:all|naming)\\.mjs$"
+    },
+    {
+      "signalClass": "validator-cli-entrypoint",
+      "matchType": "regex",
+      "pattern": "^calculogic-validate(?:-naming|-validator-health)?\\.mjs$"
+    },
+    {
+      "signalClass": "validator-quality-surface",
+      "matchType": "regex",
+      "pattern": "^validator-.+\\.test\\.mjs$"
+    },
+    {
+      "signalClass": "validator-quality-surface",
+      "matchType": "regex",
+      "pattern": "^naming-.+\\.test\\.mjs$"
+    }
+  ]
+}

--- a/calculogic-validator/tree/src/registries/tree-signal-policy.registry.logic.mjs
+++ b/calculogic-validator/tree/src/registries/tree-signal-policy.registry.logic.mjs
@@ -1,0 +1,184 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
+
+export const BUILTIN_VALIDATOR_OWNED_SIGNALS_REGISTRY_PATH = fileURLToPath(
+  new URL('validator-owned-signals.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+export const BUILTIN_SHIM_DETECTION_SIGNALS_REGISTRY_PATH = fileURLToPath(
+  new URL('shim-detection-signals.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+const VALIDATOR_OWNED_SIGNAL_CLASSES = new Set([
+  'validator-module-surface',
+  'validator-cli-entrypoint',
+  'validator-quality-surface',
+]);
+
+const assertStringList = ({ payload, keyPath }) => {
+  if (!Array.isArray(payload)) {
+    throw new Error(`Invalid builtin tree-signal registry: ${keyPath} must be an array.`);
+  }
+
+  payload.forEach((value, index) => {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(
+        `Invalid builtin tree-signal registry: ${keyPath}[${index}] must be a non-empty string.`,
+      );
+    }
+  });
+
+  return payload.map((value) => value.toLowerCase());
+};
+
+const loadValidatorOwnedSignalsRegistryPayload = (registryPath) => {
+  const payload = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid builtin tree-signal registry: validator-owned payload must be an object.');
+  }
+
+  if (!Array.isArray(payload.validatorOwnedBasenameSignals)) {
+    throw new Error(
+      'Invalid builtin tree-signal registry: validatorOwnedBasenameSignals must be an array.',
+    );
+  }
+
+  const validatorOwnedBasenameSignalMatchers = payload.validatorOwnedBasenameSignals.map(
+    (signal, index) => {
+      if (!signal || typeof signal !== 'object') {
+        throw new Error(
+          `Invalid builtin tree-signal registry: validatorOwnedBasenameSignals[${index}] must be an object.`,
+        );
+      }
+
+      if (!VALIDATOR_OWNED_SIGNAL_CLASSES.has(signal.signalClass)) {
+        throw new Error(
+          `Invalid builtin tree-signal registry: validatorOwnedBasenameSignals[${index}].signalClass must be one of validator-module-surface, validator-cli-entrypoint, validator-quality-surface.`,
+        );
+      }
+
+      if (signal.matchType !== 'regex') {
+        throw new Error(
+          `Invalid builtin tree-signal registry: validatorOwnedBasenameSignals[${index}].matchType must be "regex".`,
+        );
+      }
+
+      if (typeof signal.pattern !== 'string' || signal.pattern.length === 0) {
+        throw new Error(
+          `Invalid builtin tree-signal registry: validatorOwnedBasenameSignals[${index}].pattern must be a non-empty string.`,
+        );
+      }
+
+      let pattern;
+      try {
+        pattern = new RegExp(signal.pattern, 'u');
+      } catch (error) {
+        throw new Error(
+          `Invalid builtin tree-signal registry: validatorOwnedBasenameSignals[${index}].pattern must compile as a regex: ${error.message}`,
+        );
+      }
+
+      return {
+        signalClass: signal.signalClass,
+        matcher: pattern,
+      };
+    },
+  );
+
+  return {
+    validatorOwnedBasenameSignalMatchers,
+  };
+};
+
+const loadShimDetectionSignalsRegistryPayload = (registryPath) => {
+  const payload = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid builtin tree-signal registry: shim-detection payload must be an object.');
+  }
+
+  const shimDetectionSignals = payload.shimDetectionSignals;
+  const shimSuppressionVocabularies = payload.shimSuppressionVocabularies;
+  const shimExtensionAllowlist = payload.shimExtensionAllowlist;
+
+  if (!shimDetectionSignals || typeof shimDetectionSignals !== 'object') {
+    throw new Error('Invalid builtin tree-signal registry: shimDetectionSignals must be an object.');
+  }
+
+  if (!shimSuppressionVocabularies || typeof shimSuppressionVocabularies !== 'object') {
+    throw new Error(
+      'Invalid builtin tree-signal registry: shimSuppressionVocabularies must be an object.',
+    );
+  }
+
+  if (!shimExtensionAllowlist || typeof shimExtensionAllowlist !== 'object') {
+    throw new Error('Invalid builtin tree-signal registry: shimExtensionAllowlist must be an object.');
+  }
+
+  return {
+    shimFolderSignals: new Set(
+      assertStringList({
+        payload: shimDetectionSignals.folderSignals,
+        keyPath: 'shimDetectionSignals.folderSignals',
+      }),
+    ),
+    shimNameTokenSignals: new Set(
+      assertStringList({
+        payload: shimDetectionSignals.nameTokenSignals,
+        keyPath: 'shimDetectionSignals.nameTokenSignals',
+      }),
+    ),
+    shimSurfaceSegmentSignals: new Set(
+      assertStringList({
+        payload: shimDetectionSignals.surfaceSegmentSignals,
+        keyPath: 'shimDetectionSignals.surfaceSegmentSignals',
+      }),
+    ),
+    nonRuntimeWeakSignalSuppressedSurfaces: new Set(
+      assertStringList({
+        payload: shimSuppressionVocabularies.nonRuntimeWeakSignalSurfaces,
+        keyPath: 'shimSuppressionVocabularies.nonRuntimeWeakSignalSurfaces',
+      }),
+    ),
+    shimDetectorImplementationTokens: new Set(
+      assertStringList({
+        payload: shimSuppressionVocabularies.detectorImplementationTokens,
+        keyPath: 'shimSuppressionVocabularies.detectorImplementationTokens',
+      }),
+    ),
+    shimRelevantFileExtensions: new Set(
+      assertStringList({
+        payload: shimExtensionAllowlist.relevantFileExtensions,
+        keyPath: 'shimExtensionAllowlist.relevantFileExtensions',
+      }),
+    ),
+  };
+};
+
+let cachedBuiltinTreeSignalPolicy = null;
+
+export const loadBuiltinTreeSignalPolicy = ({
+  validatorOwnedSignalsRegistryPath = BUILTIN_VALIDATOR_OWNED_SIGNALS_REGISTRY_PATH,
+  shimDetectionSignalsRegistryPath = BUILTIN_SHIM_DETECTION_SIGNALS_REGISTRY_PATH,
+} = {}) => {
+  const validatorOwnedSignals = loadValidatorOwnedSignalsRegistryPayload(
+    validatorOwnedSignalsRegistryPath,
+  );
+  const shimDetectionSignals = loadShimDetectionSignalsRegistryPayload(shimDetectionSignalsRegistryPath);
+
+  return {
+    ...validatorOwnedSignals,
+    ...shimDetectionSignals,
+  };
+};
+
+export const getBuiltinTreeSignalPolicy = () => {
+  if (cachedBuiltinTreeSignalPolicy === null) {
+    cachedBuiltinTreeSignalPolicy = loadBuiltinTreeSignalPolicy();
+  }
+
+  return cachedBuiltinTreeSignalPolicy;
+};

--- a/calculogic-validator/tree/src/tree-shim-detection.logic.mjs
+++ b/calculogic-validator/tree/src/tree-shim-detection.logic.mjs
@@ -1,11 +1,7 @@
 import path from 'node:path';
+import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy.registry.logic.mjs';
 
-const SHIM_FOLDER_SIGNALS = new Set(['compat', 'shims', 'adapters', 'bridges']);
-const SHIM_NAME_TOKEN_SIGNALS = new Set(['shim', 'compat', 'adapter', 'bridge', 'migration']);
-const SHIM_SURFACE_SEGMENT_SIGNALS = new Set(['compat', 'shims']);
-const SHIM_RELEVANT_FILE_EXTENSIONS = new Set(['.mjs', '.js', '.cjs', '.ts', '.tsx', '.jsx']);
-const NON_RUNTIME_SHIM_SUPPRESSED_SURFACES = new Set(['quality', 'docs', 'examples', 'fixtures']);
-const SHIM_DETECTOR_IMPLEMENTATION_TOKENS = new Set(['detection', 'detector']);
+const TREE_SIGNAL_POLICY = getBuiltinTreeSignalPolicy();
 
 const tokenizeBasename = (basename) =>
   basename
@@ -53,13 +49,13 @@ export const collectPathShimSignals = (relativePath) => {
   const basename = segments.at(-1) ?? '';
   const normalizedDirectories = directorySegments.map((segment) => segment.toLowerCase());
 
-  const folderSignals = normalizedDirectories.filter((segment) => SHIM_FOLDER_SIGNALS.has(segment));
-  const basenameTokens = tokenizeBasename(basename).filter((token) => SHIM_NAME_TOKEN_SIGNALS.has(token));
+  const folderSignals = normalizedDirectories.filter((segment) => TREE_SIGNAL_POLICY.shimFolderSignals.has(segment));
+  const basenameTokens = tokenizeBasename(basename).filter((token) => TREE_SIGNAL_POLICY.shimNameTokenSignals.has(token));
 
   return {
     folderSignals,
     basenameTokens,
-    insideCompatSurface: normalizedDirectories.some((segment) => SHIM_SURFACE_SEGMENT_SIGNALS.has(segment)),
+    insideCompatSurface: normalizedDirectories.some((segment) => TREE_SIGNAL_POLICY.shimSurfaceSegmentSignals.has(segment)),
   };
 };
 
@@ -166,7 +162,7 @@ export const collectShimEvidence = (relativePath, rawContent) => {
   const isShimDetectorImplementationModule =
     relativePath.startsWith('calculogic-validator/tree/src/') &&
     basenameTokens.includes('shim') &&
-    basenameTokens.some((token) => SHIM_DETECTOR_IMPLEMENTATION_TOKENS.has(token));
+    basenameTokens.some((token) => TREE_SIGNAL_POLICY.shimDetectorImplementationTokens.has(token));
 
   return {
     surface,
@@ -187,7 +183,7 @@ export const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
 
   for (const relativePath of paths) {
     const extension = path.posix.extname(relativePath).toLowerCase();
-    if (!SHIM_RELEVANT_FILE_EXTENSIONS.has(extension)) {
+    if (!TREE_SIGNAL_POLICY.shimRelevantFileExtensions.has(extension)) {
       continue;
     }
 
@@ -207,7 +203,7 @@ export const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
       continue;
     }
 
-    if (hasWeakSignalOnly && NON_RUNTIME_SHIM_SUPPRESSED_SURFACES.has(evidence.surface)) {
+    if (hasWeakSignalOnly && TREE_SIGNAL_POLICY.nonRuntimeWeakSignalSuppressedSurfaces.has(evidence.surface)) {
       continue;
     }
 

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -1,18 +1,10 @@
 import path from 'node:path';
 import { collectShimCompatFindings } from './tree-shim-detection.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots.registry.logic.mjs';
+import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy.registry.logic.mjs';
 
 const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
-
-const VALIDATOR_OWNED_BASENAME_PATTERNS = [
-  /^naming-validator\.(logic|host|wiring|contracts)\.mjs$/u,
-  /^tree-structure-advisor\.(logic|host|wiring|contracts)\.mjs$/u,
-  /^validator-(?:runner|registry|config|exit-code|report|scopes|health-check).+\.mjs$/u,
-  /^validate-(?:all|naming)\.mjs$/u,
-  /^calculogic-validate(?:-naming|-validator-health)?\.mjs$/u,
-  /^validator-.+\.test\.mjs$/u,
-  /^naming-.+\.test\.mjs$/u,
-];
+const TREE_SIGNAL_POLICY = getBuiltinTreeSignalPolicy();
 
 const sortByPathThenCode = (left, right) => {
   const byPath = left.path.localeCompare(right.path);
@@ -24,7 +16,7 @@ const sortByPathThenCode = (left, right) => {
 };
 
 const isValidatorOwnedBasenameSignal = (basename) =>
-  VALIDATOR_OWNED_BASENAME_PATTERNS.some((pattern) => pattern.test(basename));
+  TREE_SIGNAL_POLICY.validatorOwnedBasenameSignalMatchers.some(({ matcher }) => matcher.test(basename));
 
 const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope) => {
   if ((scope ?? 'repo') !== 'repo') {


### PR DESCRIPTION
### Motivation
- Normalize the tree signal taxonomy (validator-owned basename signals and shim-detection vocabularies) before extracting policy so runtime behavior remains code-owned and deterministic.
- Move heuristic vocabularies out of hardcoded lists into bounded, validated registry payloads to reduce drift and make future customization explicit.
- Update the audit to reflect the newly-created registry-backed surfaces and close the recurring audit freshness gap for recently completed registry surfaces.

### Description
- Added two builtin registry payloads: `tree/src/registries/_builtin/validator-owned-signals.registry.json` and `tree/src/registries/_builtin/shim-detection-signals.registry.json` that hold normalized signal taxonomy, suppression vocabularies, and extension allowlists.
- Introduced `tree/src/registries/tree-signal-policy.registry.logic.mjs`, a loader that validates registry shape, canonicalizes string lists, compiles deterministic regex matchers, and exposes runtime-ready sets/matchers with caching.
- Updated `tree/src/tree-structure-advisor.logic.mjs` and `tree/src/tree-shim-detection.logic.mjs` to consume the registry-backed vocabularies while preserving existing evaluation and precedence logic.
- Added focused tests in `calculogic-validator/test/tree-signal-policy.registry.test.mjs` and kept existing `tree-structure-advisor` tests intact, and refreshed `Registry-Expansion-Candidates.audit.md` to include the new registry-backed tree signal surfaces.

### Testing
- Ran the unit/integration test set with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs calculogic-validator/test/tree-signal-policy.registry.test.mjs` and all tests passed (22 tests total including the new registry-loader tests).
- The new registry-loader tests exercise successful normalization/compilation and deterministic failure modes for malformed payloads and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae36309bc083319ec5503471ab4d70)