### PR TITLE
Add contract-lock tests for system-scope compatibility wildcard expansion

### DIFF
--- a/calculogic-validator/test/validator-system-scope-compatibility.contract.test.mjs
+++ b/calculogic-validator/test/validator-system-scope-compatibility.contract.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_VALIDATOR_SCOPE,
+  getValidatorScopeProfile,
+} from '../src/core/validator-scopes.runtime.mjs';
+import { ROOT_APP_FILES } from '../src/core/validator-root-files.knowledge.mjs';
+
+const SYSTEM_SCOPE = 'system';
+
+const expectedSystemScopeRootFiles = [
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'package-lock.json',
+  'package.json',
+  'tsconfig.app.json',
+  'tsconfig.json',
+  'tsconfig.node.json',
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.ts',
+];
+
+test('system scope compatibility wildcards are fully resolved and never leak literal tokens', () => {
+  const systemProfile = getValidatorScopeProfile(SYSTEM_SCOPE);
+
+  assert.ok(systemProfile);
+  assert.deepEqual(systemProfile.includeRootFiles, expectedSystemScopeRootFiles);
+  assert.equal(systemProfile.includeRootFiles.some((rootFile) => rootFile.includes('*')), false);
+});
+
+test('system scope compatibility expansion output is deterministic and sorted', () => {
+  const firstSystemScope = getValidatorScopeProfile(SYSTEM_SCOPE);
+  const secondSystemScope = getValidatorScopeProfile(SYSTEM_SCOPE);
+
+  assert.ok(firstSystemScope);
+  assert.ok(secondSystemScope);
+  assert.deepEqual(firstSystemScope.includeRootFiles, secondSystemScope.includeRootFiles);
+
+  const sortedRootFiles = [...firstSystemScope.includeRootFiles].sort((left, right) =>
+    left.localeCompare(right),
+  );
+  assert.deepEqual(firstSystemScope.includeRootFiles, sortedRootFiles);
+});
+
+test('system scope compatibility expansion remains bounded to ROOT_APP_FILES', () => {
+  const systemProfile = getValidatorScopeProfile(SYSTEM_SCOPE);
+
+  assert.ok(systemProfile);
+  assert.equal(systemProfile.includeRootFiles.every((rootFile) => ROOT_APP_FILES.has(rootFile)), true);
+});
+
+test('default scope fallback behavior remains unchanged', () => {
+  const implicitDefaultProfile = getValidatorScopeProfile(undefined);
+  const explicitDefaultProfile = getValidatorScopeProfile(DEFAULT_VALIDATOR_SCOPE);
+
+  assert.ok(implicitDefaultProfile);
+  assert.ok(explicitDefaultProfile);
+  assert.deepEqual(implicitDefaultProfile, explicitDefaultProfile);
+});


### PR DESCRIPTION
### Motivation
- Harden the hardcoded system-scope compatibility bridge so future edits cannot silently change which root files are included by wildcard-like compatibility tokens.
- Lock the runtime contract required by the post-registry reassessment: no wildcard tokens leak, expansions are deterministic/sorted, and expansions remain bounded to the intended root-file universe.

### Description
- Add `calculogic-validator/test/validator-system-scope-compatibility.contract.test.mjs` which verifies that `getValidatorScopeProfile('system')` expands compatibility patterns to explicit root-file paths and does not expose literal wildcard tokens.
- The test asserts deterministic sorted output, that all expanded entries come from `ROOT_APP_FILES`, and that `getValidatorScopeProfile(undefined)` equals `getValidatorScopeProfile(DEFAULT_VALIDATOR_SCOPE)` to lock fallback behavior.
- No runtime behavior, registry extraction, or schema changes were made; this is test-only coverage to lock the current contract.

### Testing
- Ran the new test with `node --test calculogic-validator/test/validator-system-scope-compatibility.contract.test.mjs` and all 4 assertions passed.
- The test execution completed successfully and confirms the expected contract remains intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae45b2d0e48331bf4704f8582e8f77)