### PR TITLE
Add cross-slice deterministic invariant tests and refresh post-registry audit ordering

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/Post-Registry-Reassessment.audit.md
+++ b/calculogic-validator/doc/ConventionRoutines/Post-Registry-Reassessment.audit.md
@@ -42,14 +42,14 @@ The prior audit’s extraction queue is effectively complete for this scope (no 
 
 ### 1) High-ROI next tasks
 
-1. **Add focused “contract-lock” tests for system-scope compatibility expansion boundaries.**
+1. **Add cross-slice invariant tests for deterministic ordering/fallback behavior.**
    - Why ROI is high:
-     - This is the main remaining policy-shaped hardcoded seam.
-     - Drift here can silently change system-scope inclusion.
+     - Determinism is implemented in many local helpers (`localeCompare` sorts, first-match exit policy, canonical key sorts).
+     - Registry operationalization increases need for stable, test-locked ordering contracts.
    - Focus:
-     - ensure wildcard tokens never leak as literals into runtime scope profiles,
-     - ensure expansion remains deterministic and sorted,
-     - ensure expansions only map to allowed root-file universe.
+     - policy first-match semantics (exit policy),
+     - sorted outputs for summary/code buckets and path sets,
+     - stable fallback behavior (`DEFAULT_VALIDATOR_SCOPE`, unknown-scope null handling).
 
 2. **Document explicit ownership contract for “loader vs converter vs runtime” in one validator-facing convention note.**
    - Why ROI is high:
@@ -60,14 +60,11 @@ The prior audit’s extraction queue is effectively complete for this scope (no 
      - formalize where canonicalization/conversion lives,
      - formalize runtime-only invariants (immutable clones, deterministic ordering, fallback semantics).
 
-3. **Add cross-slice invariant tests for deterministic ordering/fallback behavior.**
-   - Why ROI is high:
-     - Determinism is implemented in many local helpers (`localeCompare` sorts, first-match exit policy, canonical key sorts).
-     - Registry operationalization increases need for stable, test-locked ordering contracts.
-   - Focus:
-     - policy first-match semantics (exit policy),
-     - sorted outputs for summary/code buckets and path sets,
-     - stable fallback behavior (`DEFAULT_VALIDATOR_SCOPE`, unknown-scope null handling).
+3. **System-scope compatibility expansion contract-lock tests are complete in practice; preserve as maintained baseline coverage.**
+   - Completion note:
+     - wildcard tokens are contract-locked as non-leaking literals,
+     - expansion remains deterministic/sorted and bounded to root-file compatibility universe,
+     - current test coverage and passing suite already enforce this behavior.
 
 ### 2) Worthwhile but later
 
@@ -120,9 +117,9 @@ Assessment: strong baseline; best next ROI is **cross-slice invariant test reinf
 
 ## high-ROI next task
 
-1. System-scope compatibility expansion contract-lock tests (core + naming scope contract coverage).
-2. Cross-slice deterministic ordering/fallback invariant tests.
-3. Single authoritative doc note for registry ownership layering (loader/converter/runtime logic).
+1. Cross-slice deterministic ordering/fallback invariant tests.
+2. Single authoritative doc note for registry ownership layering (loader/converter/runtime logic).
+3. Maintain completed system-scope compatibility expansion contract-lock coverage as regression baseline.
 
 ## worthwhile but later
 
@@ -140,9 +137,9 @@ Assessment: strong baseline; best next ROI is **cross-slice invariant test reinf
 
 ## Recommended next task order (ranked)
 
-1. **Contract-lock tests for system-scope wildcard expansion behavior** (highest immediate drift-prevention ROI).
-2. **Cross-slice deterministic invariants test pass** (ordering, first-match, fallback semantics).
-3. **Ownership contract note for loader/converter/runtime boundaries** (prevents future coupling regressions).
+1. **Cross-slice deterministic invariants test pass** (ordering, first-match, fallback semantics).
+2. **Ownership contract note for loader/converter/runtime boundaries** (prevents future coupling regressions).
+3. **Maintain system-scope wildcard-expansion contract-lock coverage as completed baseline** (already done in practice; keep green).
 4. **Targeted documentation cleanup for direct-builtin vs registry-state ownership semantics**.
 5. **Optional low-risk utility normalization pass** for duplicated loader helpers (only if still justified after tasks 1–4).
 

--- a/calculogic-validator/test/cross-slice-deterministic-invariants.test.mjs
+++ b/calculogic-validator/test/cross-slice-deterministic-invariants.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_VALIDATOR_SCOPE,
+  getValidatorScopeProfile,
+  listValidatorScopes,
+} from '../src/core/validator-scopes.runtime.mjs';
+import { deriveExitCodeFromFindings } from '../src/core/validator-exit-code.logic.mjs';
+import { getBuiltinExitPolicies } from '../src/registries/validator-exit-policy.registry.runtime.mjs';
+import {
+  collectRepositoryPaths,
+  summarizeFindings as summarizeNamingFindings,
+} from '../naming/src/naming-validator.host.mjs';
+import {
+  prepareTreeStructureAdvisorInputs,
+  summarizeFindings as summarizeTreeFindings,
+} from '../tree/src/tree-structure-advisor.host.mjs';
+
+test('cross-slice invariant: exit policy evaluation remains deterministic first-match', () => {
+  assert.deepEqual(
+    getBuiltinExitPolicies().map((policy) => policy.id),
+    ['warn-findings', 'strict-legacy-exception', 'default-success'],
+  );
+
+  assert.equal(
+    deriveExitCodeFromFindings([{ severity: 'warn', classification: 'legacy-exception' }], {
+      strict: true,
+    }),
+    2,
+  );
+});
+
+test('cross-slice invariant: naming and tree summary buckets remain deterministically ordered', () => {
+  const namingSummary = summarizeNamingFindings([
+    {
+      classification: 'invalid-ambiguous',
+      code: 'Z_CODE',
+      severity: 'warn',
+      details: { roleStatus: 'deprecated', roleCategory: 'documentation' },
+    },
+    {
+      classification: 'allowed-special-case',
+      code: 'A_CODE',
+      severity: 'info',
+      details: { specialCaseType: 'ecosystem-required' },
+    },
+    {
+      classification: 'invalid-ambiguous',
+      code: 'A_CODE',
+      severity: 'warn',
+      details: { roleStatus: 'active', roleCategory: 'architecture-support' },
+    },
+  ]);
+
+  assert.deepEqual(Object.keys(namingSummary.counts), [
+    'canonical',
+    'allowed-special-case',
+    'legacy-exception',
+    'invalid-ambiguous',
+  ]);
+  assert.deepEqual(Object.keys(namingSummary.codeCounts), ['A_CODE', 'Z_CODE']);
+  assert.deepEqual(Object.keys(namingSummary.specialCaseTypeCounts), ['ecosystem-required']);
+  assert.deepEqual(Object.keys(namingSummary.warningRoleStatusCounts), ['active', 'deprecated']);
+  assert.deepEqual(Object.keys(namingSummary.warningRoleCategoryCounts), [
+    'architecture-support',
+    'documentation',
+  ]);
+
+  const treeSummary = summarizeTreeFindings([
+    { classification: 'advisory-structure', code: 'TREE_Z_LAST' },
+    { classification: 'advisory-structure', code: 'TREE_A_FIRST' },
+  ]);
+
+  assert.deepEqual(Object.keys(treeSummary.codeCounts), ['TREE_A_FIRST', 'TREE_Z_LAST']);
+});
+
+test('cross-slice invariant: scoped path sets stay sorted and stable across naming/tree surfaces', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cross-slice-path-order-'));
+
+  try {
+    fs.mkdirSync(path.join(tempRoot, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(tempRoot, 'test'), { recursive: true });
+
+    fs.writeFileSync(path.join(tempRoot, 'src', 'z-last.logic.ts'), '');
+    fs.writeFileSync(path.join(tempRoot, 'src', 'a-first.logic.ts'), '');
+    fs.writeFileSync(path.join(tempRoot, 'test', 'm-middle.test.mjs'), '');
+
+    const namingPaths = collectRepositoryPaths(tempRoot, { scope: 'app' });
+    const treePrepared = prepareTreeStructureAdvisorInputs(tempRoot, { scope: 'app' });
+
+    assert.deepEqual(namingPaths, [...namingPaths].sort((left, right) => left.localeCompare(right)));
+    assert.deepEqual(treePrepared.selectedPaths, [
+      ...treePrepared.selectedPaths,
+    ].sort((left, right) => left.localeCompare(right)));
+    assert.deepEqual(treePrepared.selectedPaths, namingPaths);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('cross-slice invariant: scope fallback/default/unknown behavior remains stable', () => {
+  const implicitDefaultProfile = getValidatorScopeProfile(undefined);
+  const explicitDefaultProfile = getValidatorScopeProfile(DEFAULT_VALIDATOR_SCOPE);
+
+  assert.equal(DEFAULT_VALIDATOR_SCOPE, 'repo');
+  assert.ok(implicitDefaultProfile);
+  assert.deepEqual(implicitDefaultProfile, explicitDefaultProfile);
+  assert.equal(getValidatorScopeProfile('definitely-not-a-real-scope'), null);
+
+  const sortedScopeIds = [...listValidatorScopes()].sort((left, right) => left.localeCompare(right));
+  assert.deepEqual(listValidatorScopes(), sortedScopeIds);
+});


### PR DESCRIPTION
### Motivation

- Lock deterministic contracts that span core, naming, and tree surfaces (first-match exit policy, sorted summaries/path sets, and scope fallback) so future registry/loader changes are detected early.  
- The post-registry reassessment audit ranked system wildcard-expansion tests first, but that work is already covered by the current suite; the ranked order needed updating to reflect ROI.  
- Keep this as a hardening slice only: preserve runtime behavior and avoid additional registry extraction or architecture rewrites.

### Description

- Added a focused cross-slice invariant test file `calculogic-validator/test/cross-slice-deterministic-invariants.test.mjs` that asserts deterministic `exit` policy first-match semantics, deterministic ordering for naming/tree summary buckets and scoped path-sets, and stable scope fallback/unknown-scope behavior.  
- The new tests exercise shared runtime helpers used by core (`deriveExitCodeFromFindings`, builtin exit policies), naming (`summarizeFindings`, `collectRepositoryPaths`) and tree (`prepareTreeStructureAdvisorInputs`, `summarizeFindings`) surfaces to ensure invariants are enforced across slices.  
- Updated `calculogic-validator/doc/ConventionRoutines/Post-Registry-Reassessment.audit.md` to make the cross-slice deterministic invariants test pass the top-ranked next task and to mark the system-scope wildcard-expansion contract-lock work as completed-in-practice and retained as baseline coverage.  
- No runtime behavior changes were made; this is a test + doc hardening pass only.

### Testing

- Ran the validation subset with: `node --test calculogic-validator/test/cross-slice-deterministic-invariants.test.mjs calculogic-validator/test/validator-system-scope-compatibility.contract.test.mjs calculogic-validator/test/validator-exit-policy.registry.test.mjs calculogic-validator/naming/test/naming-validator.test.mjs calculogic-validator/test/tree-structure-advisor.test.mjs`.  
- Result: the executed tests passed (suite run reported all tests passing).  
- No behavioral regressions observed; the added tests assert and preserve existing deterministic behavior across slices.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4e880d74833186d154ca7a411eb7)