### PR TITLE
docs(validator): add canonical loader-converter-runtime ownership contract

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -6,6 +6,8 @@
 
 Registry expansion roadmap note: see [`doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md`](./doc/ConventionRoutines/Registry-Expansion-Candidates.audit.md) for the current hardcoded-policy audit and prioritized extraction plan.
 
+Canonical ownership boundary note: for loader → converter → runtime ownership and policy-data vs engine-mechanics separation, see [`doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md`](./doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md).
+
 ## 2) Projected package layout (target)
 
 This is the intended target structure for the validator suite as refactors continue.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md
@@ -1,0 +1,94 @@
+# Validator Loader → Converter → Runtime Ownership Contract (V1)
+
+Classification: Normative
+
+## 1. Purpose
+
+This convention defines the canonical ownership split for validator slice assembly:
+
+1. **Loader** (registry-state loading and policy-data canonicalization)
+2. **Converter** (validated payload → runtime-ready structures)
+3. **Runtime / wiring / logic** (execution mechanics and findings/report derivation)
+
+The goal is deterministic boundaries between **policy data** and **engine mechanics** so slice internals stay modular and extraction-friendly.
+
+## 2. Loader ownership (policy-data boundary)
+
+A loader owns:
+
+- Schema/shape checks and deterministic validation of registry payloads.
+- Payload loading from builtin/custom registry sources.
+- Canonicalization of payload entries (trim/normalize/dedupe/sort where policy data requires canonical forms).
+- Builtin/custom source resolution and precedence handling.
+- Bounded cache/state lifecycle for loaded registry-state snapshots.
+
+A loader must not own runtime traversal, report derivation, finding mechanics, or validator decision flow.
+
+## 3. Converter ownership (runtime-shape preparation)
+
+A converter owns deterministic transformation from validated payloads into runtime-ready structures, for example:
+
+- `Set`/`Map` representations.
+- Matcher arrays/compiled matcher state.
+- Runtime object clones that preserve immutability expectations at runtime call sites.
+
+Converters do not make final validator findings and do not execute repository traversal or algorithmic runtime decisions.
+
+## 4. Runtime / wiring / logic ownership (engine mechanics)
+
+Runtime/wiring/logic own execution semantics, including:
+
+- Scope fallback/defaulting and scoped target filtering.
+- Deterministic ordering of paths/findings/output projections.
+- Immutable clone usage and prepared-input assertions.
+- Execution mechanics (walk/traversal, rule flow, decision application).
+- Report derivation/summarization and findings emission.
+
+Runtime/wiring consume prepared runtime inputs from loader+converter layers rather than re-owning registry canonicalization rules.
+
+## 5. What must not be pushed into registries
+
+Registries are policy data, not engines. Do **not** push these into registries:
+
+- Parser grammar or parser control flow.
+- Traversal mechanics.
+- Sorting mechanics that belong to deterministic runtime pipelines.
+- Algorithmic decision flow and execution branching.
+
+Registries may describe bounded policy vocabulary and lookup content, but mechanics stay in runtime logic modules.
+
+## 6. Where this appears today
+
+### 6.1 Naming slice
+
+- Loader ownership appears in `naming/src/registries/registry-state.logic.mjs` via builtin/custom registry resolution, payload checks, canonicalization, and registry digest/state handling.
+- Converter ownership appears in `naming/src/naming-runtime-converters.logic.mjs` via runtime set/map/runtime-shape conversion helpers.
+- Runtime/wiring/logic ownership appears in:
+  - `naming/src/naming-validator.wiring.mjs` for prepared runtime input assembly and scope-target runtime preparation.
+  - `naming/src/naming-validator.logic.mjs` for traversal/classification/decision flow/findings/summaries.
+
+### 6.2 Suite core
+
+- Runtime/wiring/logic ownership appears in suite-core runner and composition modules such as:
+  - `src/core/validator-runner.logic.mjs`
+  - `src/core/validator-registry.knowledge.mjs`
+
+Suite core composes slice runners and shared runtime contracts; it does not replace slice-local loader/converter responsibilities.
+
+### 6.3 Tree slice
+
+- Loader-style policy loading appears in tree registry logic modules:
+  - `tree/src/registries/tree-known-roots.registry.logic.mjs`
+  - `tree/src/registries/tree-signal-policy.registry.logic.mjs`
+- Runtime/wiring/logic ownership appears in:
+  - `tree/src/tree-structure-advisor.wiring.mjs`
+  - `tree/src/tree-structure-advisor.logic.mjs`
+
+## 7. Canonical usage rule
+
+When documenting or implementing validator slices, treat this contract as the canonical ownership reference for loader-converter-runtime boundaries.
+
+Related references:
+
+- `doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`
+- `doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -45,6 +45,7 @@ This keeps report capture deterministic while preserving explicit invalid-usage 
 Implementation note: suite CLI scripts should reuse suite-core helpers in `calculogic-validator/src/core/cli/` (for example `validator-cli-output.logic.mjs`, `validator-cli-usage.logic.mjs`, `validator-cli-targets.logic.mjs`, and `validator-cli-scopes.logic.mjs`) for report emission, usage/error output flow, and repeatable `--target` parsing rather than duplicating ad hoc CLI scaffolding. This suite-core CLI helper area is intentionally discoverable for current and future validator slices.
 
 For helper-area ownership and reuse routing across suite-core and slice-owned semantic areas, see [`ValidatorHelperAreas-And-Reuse-Conventions.md`](./ValidatorHelperAreas-And-Reuse-Conventions.md).
+For canonical loader → converter → runtime ownership boundaries (including what belongs to policy-data loaders/converters vs engine runtime mechanics), see [`ValidatorLoaderConverterRuntimeOwnership-Contract.md`](./ValidatorLoaderConverterRuntimeOwnership-Contract.md).
 
 ## 5) Current exit-code policy (as implemented today)
 

--- a/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
@@ -85,6 +85,7 @@ Examples of allowed behavior:
 - Merge built-in + overlay/custom inputs when contract rules define this.
 
 Normalization/resolution owns deterministic runtime interpretation; storage convenience shape does not.
+For canonical loader-converter-runtime ownership boundaries (including mechanics that must remain outside registries), see [`../ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md`](../ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md).
 
 ## Slice-local vs suite-level ownership
 


### PR DESCRIPTION
### Motivation

- Reduce scattered implicit ownership by creating a single canonical note that clarifies loader → converter → runtime responsibilities for validator slices. 
- Make the validator-owned convention the authoritative pointer for distinguishing policy data (registries) from engine mechanics (runtime logic). 

### Description

- Add a new canonical convention note at `calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md` that defines loader, converter, and runtime/wiring/logic ownership and enumerates what must not be pushed into registries. 
- Wire discoverable pointers to the new note from `calculogic-validator/README.md`, `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`, and `calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`. 
- The new note includes concrete “where this appears today” mappings with examples from the naming slice, suite-core, and tree slice, and is explicitly marked `Classification: Normative` as the canonical ownership reference. 
- This change is documentation-only and contains no runtime or algorithmic behavior changes. 

### Testing

- Ran targeted unit/regression checks via `node --test calculogic-validator/test/cross-slice-deterministic-invariants.test.mjs calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-runtime-converters.test.mjs calculogic-validator/test/tree-signal-policy.registry.test.mjs` and all tests passed. 
- Verified pointer/link presence via grep (`rg`) across the updated docs and the new file and confirmed the new references are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af0447d8188331a21f425441700167)