### PR TITLE
feat(validator-config): allow config-driven strict exit behavior for naming CLI

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -254,7 +254,7 @@ Validator config schema:
 
 Runtime behavior is strict and rejects unknown keys where the schema disallows them. Root-level `$schema` is allowed as an editor hint.
 
-**Report-only note (current CLI behavior):** Config currently affects report classification/metadata only. Enforcement/fix modes are not implemented in naming CLI behavior yet.
+**Report-first note (current CLI behavior):** Config affects report classification/metadata and can opt into existing strict exit semantics via `strictExit: true`. Detection behavior is unchanged and broader enforcement/fix modes are not implemented yet.
 
 Use `--config=<path>` to pass a config file explicitly:
 

--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -186,7 +186,7 @@ Invalid scope behavior:
 
 Config reference: [`validator-config-spec.md`](../ValidatorSpecs/validator-config-spec.md).
 
-Current naming behavior remains report-only in implementation. Passing `--config=<path>` does **not** enable enforcement or fix execution in the naming slice.
+Current naming behavior remains report-first in implementation. Passing `--config=<path>` does **not** enable fix execution or broader enforcement modes, but config may enable strict-exit semantics via `strictExit`.
 
 When provided, config only affects naming report inputs for:
 
@@ -342,6 +342,7 @@ Naming V0.1.7 currently implements:
   - invalid CLI usage (e.g., unknown `--scope`) exits `1`
 
 `--strict` in this naming slice is an exit-policy modifier, not a separate detection mode. See [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md) for canonical policy framing.
+When both CLI and config are present, CLI `--strict` has precedence for strict-exit resolution.
 
 Suite policy options are shared contracts but deferred for naming implementation:
 

--- a/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
@@ -4,7 +4,7 @@ Status: **Canonical**
 
 ## Report-only note (current behavior)
 
-The naming validator currently operates in **report-only** mode. Supplying validator config changes report inputs and report metadata only (classification registries and optional `configDigest` in report output). It does **not** enable enforcement mode or fix execution.
+The naming validator remains **report-first** for detection and findings emission. Supplying validator config changes report inputs/metadata and may additionally enable strict exit semantics via `strictExit`. It does **not** enable fix execution or broader mode selection.
 
 ## 1) Purpose
 
@@ -37,6 +37,7 @@ Allowed root keys:
 
 - `version` (required, const `"0.1"`)
 - `$schema` (optional string hint)
+- `strictExit` (optional boolean; enables strict exit semantics for naming CLI)
 - `naming` (optional object)
 
 ### 4.2 `naming`
@@ -99,6 +100,7 @@ Special case:
 Runtime loading returns normalized config with deterministic shaping:
 
 - Output always sets `version: "0.1"`.
+- `strictExit` is retained only when provided.
 - `role` strings are trimmed.
 - extension strings are trimmed.
 - extension additions are de-duplicated after trim (`Set` semantics).
@@ -129,6 +131,13 @@ Current failure modes when config is supplied:
 When a valid config is supplied, naming reports may include:
 
 - `configDigest`
+
+Strict-exit resolution for naming CLI uses existing exit-policy semantics:
+
+- CLI `--strict` enables strict exit behavior.
+- Config `strictExit: true` enables strict exit behavior even without CLI `--strict`.
+- CLI precedence is deterministic: `--strict` wins over config when both are present.
+- Report JSON is emitted before exit code is derived/applied.
 
 This behavior applies to:
 
@@ -200,5 +209,14 @@ This behavior applies to:
       ]
     }
   }
+}
+```
+
+### 9.5 Strict exit via config
+
+```json
+{
+  "version": "0.1",
+  "strictExit": true
 }
 ```

--- a/calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs
@@ -77,8 +77,12 @@ export const runNamingCli = ({ argv, usageLines, repositoryRoot, npmArgForwardin
     endedAtDate,
   });
 
+  const effectiveStrictExit = parsed.strict ? true : config?.strictExit === true;
+
   writeValidatorReportToStdout(report);
-  setValidatorReportExitCode(deriveExitCodeFromFindings(validatorResult.findings, { strict: parsed.strict }));
+  setValidatorReportExitCode(
+    deriveExitCodeFromFindings(validatorResult.findings, { strict: effectiveStrictExit }),
+  );
 
   return { shouldExit: false };
 };

--- a/calculogic-validator/src/core/config/validator-config.logic.mjs
+++ b/calculogic-validator/src/core/config/validator-config.logic.mjs
@@ -51,6 +51,7 @@ const normalizeRoleAdditions = (additions) => {
 const normalizeConfig = (config) => {
   const normalized = {
     version: VALIDATOR_CONFIG_VERSION,
+    ...(config?.strictExit === undefined ? {} : { strictExit: config.strictExit }),
   };
 
   const extensionAdditions = config?.naming?.reportableExtensions?.add;
@@ -163,10 +164,14 @@ const validateConfig = (config) => {
     fail('root must be an object.');
   }
 
-  assertOnlyKeys(config, ['version', 'naming', '$schema'], 'root');
+  assertOnlyKeys(config, ['version', 'strictExit', 'naming', '$schema'], 'root');
 
   if (config.version !== VALIDATOR_CONFIG_VERSION) {
     fail(`version must be "${VALIDATOR_CONFIG_VERSION}".`);
+  }
+
+  if (config.strictExit !== undefined && typeof config.strictExit !== 'boolean') {
+    fail('strictExit must be a boolean when provided.');
   }
 
   const naming = config.naming;

--- a/calculogic-validator/src/core/config/validator-config.schema.json
+++ b/calculogic-validator/src/core/config/validator-config.schema.json
@@ -4,13 +4,18 @@
   "title": "Calculogic Validator Config",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version"],
+  "required": [
+    "version"
+  ],
   "properties": {
     "$schema": {
       "type": "string"
     },
     "version": {
       "const": "0.1"
+    },
+    "strictExit": {
+      "type": "boolean"
     },
     "naming": {
       "type": "object",
@@ -38,17 +43,29 @@
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["role", "category", "status"],
+                "required": [
+                  "role",
+                  "category",
+                  "status"
+                ],
                 "properties": {
                   "role": {
                     "type": "string",
                     "minLength": 1
                   },
                   "category": {
-                    "enum": ["concern-core", "architecture-support", "documentation", "deprecated"]
+                    "enum": [
+                      "concern-core",
+                      "architecture-support",
+                      "documentation",
+                      "deprecated"
+                    ]
                   },
                   "status": {
-                    "enum": ["active", "deprecated"]
+                    "enum": [
+                      "active",
+                      "deprecated"
+                    ]
                   },
                   "notes": {
                     "type": "string"

--- a/calculogic-validator/src/validator-config.schema.json
+++ b/calculogic-validator/src/validator-config.schema.json
@@ -4,13 +4,18 @@
   "title": "Calculogic Validator Config",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version"],
+  "required": [
+    "version"
+  ],
   "properties": {
     "$schema": {
       "type": "string"
     },
     "version": {
       "const": "0.1"
+    },
+    "strictExit": {
+      "type": "boolean"
     },
     "naming": {
       "type": "object",
@@ -38,17 +43,29 @@
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["role", "category", "status"],
+                "required": [
+                  "role",
+                  "category",
+                  "status"
+                ],
                 "properties": {
                   "role": {
                     "type": "string",
                     "minLength": 1
                   },
                   "category": {
-                    "enum": ["concern-core", "architecture-support", "documentation", "deprecated"]
+                    "enum": [
+                      "concern-core",
+                      "architecture-support",
+                      "documentation",
+                      "deprecated"
+                    ]
                   },
                   "status": {
-                    "enum": ["active", "deprecated"]
+                    "enum": [
+                      "active",
+                      "deprecated"
+                    ]
                   },
                   "notes": {
                     "type": "string"

--- a/calculogic-validator/test/validator-config-strictness.test.mjs
+++ b/calculogic-validator/test/validator-config-strictness.test.mjs
@@ -88,3 +88,34 @@ test('still loads existing roles fixture under strict validation', () => {
   assert.equal(config.version, '0.1');
   assert.equal(config.naming?.roles?.add?.[0]?.role, 'provider');
 });
+
+
+test('accepts strictExit at root and preserves normalized value', () => {
+  const tempPath = writeTempConfig('tmp-config-strict-exit-true.json', {
+    version: '0.1',
+    strictExit: true,
+  });
+
+  try {
+    const config = loadValidatorConfigFromFile(tempPath, { cwd: '/' });
+    assert.equal(config.strictExit, true);
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
+test('fails when strictExit is not a boolean', () => {
+  const tempPath = writeTempConfig('tmp-config-strict-exit-invalid.json', {
+    version: '0.1',
+    strictExit: 'yes',
+  });
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(tempPath, { cwd: '/' }),
+      /Invalid validator config: strictExit must be a boolean when provided\./u,
+    );
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});

--- a/calculogic-validator/test/validator-exit-codes.test.mjs
+++ b/calculogic-validator/test/validator-exit-codes.test.mjs
@@ -43,6 +43,7 @@ const parseJsonStdout = (result) => {
 
 test('validate-naming exits 2 by default when warnings are present', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+  let configDir;
 
   try {
     await writeFixtureRepo(fixtureDir);
@@ -65,6 +66,7 @@ test('validate-naming exits 2 by default when warnings are present', async () =>
 
 test('validate-naming exits 0 by default and 1 in strict mode for legacy-exception-only findings', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+  let configDir;
 
   try {
     await writeFixtureRepo(fixtureDir);
@@ -91,6 +93,109 @@ test('validate-naming exits 0 by default and 1 in strict mode for legacy-excepti
   }
 });
 
+
+
+test('validate-naming stays default-success for legacy-exception-only findings when config strictExit is absent or false', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+  let configDir;
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-config-'));
+    const absentConfigPath = path.join(configDir, 'validator-config.absent-strict.json');
+    await fs.writeFile(
+      absentConfigPath,
+      JSON.stringify({ version: '0.1' }, null, 2),
+      'utf8',
+    );
+
+    const absentStrictResult = runNodeScript(
+      namingScriptPath,
+      [`--config=${absentConfigPath}`],
+      fixtureDir,
+    );
+    assert.equal(absentStrictResult.status, 0);
+
+    const falseConfigPath = path.join(configDir, 'validator-config.strict-false.json');
+    await fs.writeFile(
+      falseConfigPath,
+      JSON.stringify({ version: '0.1', strictExit: false }, null, 2),
+      'utf8',
+    );
+
+    const falseStrictResult = runNodeScript(
+      namingScriptPath,
+      [`--config=${falseConfigPath}`],
+      fixtureDir,
+    );
+    assert.equal(falseStrictResult.status, 0);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    if (typeof configDir === 'string') {
+      await fs.rm(configDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('validate-naming exits 1 for legacy-exception-only findings when config strictExit is true', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+  let configDir;
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-config-'));
+    const configPath = path.join(configDir, 'validator-config.strict-true.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ version: '0.1', strictExit: true }, null, 2),
+      'utf8',
+    );
+
+    const result = runNodeScript(namingScriptPath, [`--config=${configPath}`], fixtureDir);
+    assert.equal(result.status, 1);
+
+    const report = parseJsonStdout(result);
+    assert.ok(
+      report.findings.some((finding) => finding?.classification === 'legacy-exception'),
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    if (typeof configDir === 'string') {
+      await fs.rm(configDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('validate-naming CLI --strict takes precedence over config strictExit false', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+  let configDir;
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-config-'));
+    const configPath = path.join(configDir, 'validator-config.strict-false.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ version: '0.1', strictExit: false }, null, 2),
+      'utf8',
+    );
+
+    const result = runNodeScript(
+      namingScriptPath,
+      ['--strict', `--config=${configPath}`],
+      fixtureDir,
+    );
+    assert.equal(result.status, 1);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    if (typeof configDir === 'string') {
+      await fs.rm(configDir, { recursive: true, force: true });
+    }
+  }
+});
 test('validate-all mirrors exit policy from aggregated findings', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
 


### PR DESCRIPTION
### Motivation

- Bridge validator config into the already-implemented strict exit semantics so configs can deterministically opt the naming CLI into enforcement-adjacent exit behavior without changing detection or findings emission. 
- Keep the change narrow and deterministic: do not add new modes or autofix, and preserve existing CLI precedence semantics.

### Description

- Add an optional root-level `strictExit` boolean to the config JSON schema (`src/validator-config.schema.json` and `src/core/config/validator-config.schema.json`) and retain it in normalized runtime output. 
- Validate and normalize `strictExit` in runtime loader (`src/core/config/validator-config.logic.mjs`) including strict-type checks and deterministic inclusion when provided. 
- Compute `effectiveStrictExit` in the naming CLI runner (`naming/src/cli/naming-cli-runner.logic.mjs`) as `CLI --strict` OR `config.strictExit === true`, with CLI flag taking precedence, and pass that boolean into the existing `deriveExitCodeFromFindings` path so existing exit-policy semantics are reused. 
- Preserve behavior that the JSON report is written before exit-code derivation is applied, and update docs/spec README wording to reflect precise "report-first" plus optional strict-exit bridge. 
- Add tests to cover config strict absent/false, config strict true, CLI `--strict` behavior, and CLI/config precedence and strictness validation (`calculogic-validator/test/validator-config-strictness.test.mjs` and `calculogic-validator/test/validator-exit-codes.test.mjs`).

### Testing

- Ran the validator config and naming exit tests with: `node --test calculogic-validator/test/validator-config-strictness.test.mjs calculogic-validator/test/validator-config.extensions.test.mjs calculogic-validator/test/validator-config-schema-sync.test.mjs calculogic-validator/test/validator-exit-codes.test.mjs`. 
- All executed tests passed (21/21 subtests passed) and the new strictness behaviors validated as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af069f67208331967bf1033871bbc9)