### PR TITLE
docs(validator): codify direct-builtin vs registry-state ownership semantics

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -119,6 +119,19 @@ calculogic-validator/
 - Slice-owned shared concerns belong in semantic slice areas under `<slice>/src/<area>/`.
 - Prefer semantic owner areas over generic catch-all `shared/` folders when a clearer owner exists.
 
+#### Loader ownership boundary (registry-state vs direct builtin)
+
+- Use a **registry-state owner** when a slice must compose multiple policy payloads (for example builtin + overlay/custom), enforce deterministic precedence/canonicalization, and maintain digest/cache state as a first-class contract.
+- Use a **direct builtin loader** when policy vocabulary is intentionally local, bounded, and consumed by one slice path without needing a generic cross-slice state aggregator.
+- Keep **suite-core surfaces** as local owners when they are composition/runtime mechanics (runner orchestration, scope/runtime contracts, slice registry composition) rather than slice policy payload normalization.
+- Do not force every registry surface through one generic state layer: this creates ownership blur, over-couples independent slices, and encourages catch-all loader sprawl.
+
+Current intentional pattern:
+
+- Naming centralizes major extracted policy surfaces through `naming/src/registries/registry-state.logic.mjs`.
+- Tree signal/core-scope policy uses direct local builtin loaders under tree-owned registry logic modules.
+- Suite-core runtime composition remains locally owned under `src/core/**` instead of acting as a universal registry-state host.
+
 ## 3) Quickstart (repo root)
 
 ```bash

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md
@@ -84,6 +84,28 @@ Suite core composes slice runners and shared runtime contracts; it does not repl
   - `tree/src/tree-structure-advisor.wiring.mjs`
   - `tree/src/tree-structure-advisor.logic.mjs`
 
+
+## 6.4 Direct builtin-loader vs registry-state ownership semantics
+
+Use this decision rule to keep ownership deterministic and avoid generic loader sprawl:
+
+1. **Choose a registry-state owner** (for example `naming/src/registries/registry-state.logic.mjs`) when a slice requires:
+   - multi-source policy composition (builtin + custom/overlay),
+   - explicit precedence/merge/canonicalization contracts,
+   - digest/cache/state lifecycle as part of the slice runtime contract.
+2. **Choose a direct builtin loader** (for example tree slice local registry logic) when policy payloads are intentionally slice-local and bounded, and no cross-slice generic state host is required.
+3. **Keep suite-core surfaces locally owned** for composition/runtime mechanics (`src/core/**`) instead of promoting them into a generic registry-state aggregator.
+
+Why this is normative:
+
+- Naming centralization through a registry-state owner is intentional because naming has broader extracted policy surfaces and overlay precedence needs.
+- Tree direct builtin loading is intentional because tree policy vocabularies are bounded and locally consumed.
+- Suite-core local ownership is intentional because runner/registry/scopes modules are composition mechanics, not slice-policy canonicalization hosts.
+
+Anti-pattern to avoid:
+
+- Do **not** flatten every registry surface behind one universal state layer; that pattern obscures ownership, increases coupling, and weakens clear extraction paths.
+
 ## 7. Canonical usage rule
 
 When documenting or implementing validator slices, treat this contract as the canonical ownership reference for loader-converter-runtime boundaries.

--- a/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
@@ -87,6 +87,25 @@ Examples of allowed behavior:
 Normalization/resolution owns deterministic runtime interpretation; storage convenience shape does not.
 For canonical loader-converter-runtime ownership boundaries (including mechanics that must remain outside registries), see [`../ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md`](../ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md).
 
+
+## Registry-state vs direct builtin ownership rule
+
+This spec adopts a non-flat ownership model:
+
+- A slice should use a **registry-state owner** when policy assembly requires multi-source state composition, precedence normalization, and explicit state lifecycle contracts.
+- A slice should use **direct builtin loaders** when policy payloads are intentionally local and bounded to that slice, with deterministic local normalization only.
+- **Suite-core** should remain a local owner for suite composition/runtime mechanics and must not become a forced universal state layer for all registries.
+
+Current intentional mapping:
+
+- Naming uses a registry-state owner (`naming/src/registries/registry-state.logic.mjs`) for centralized policy-state composition.
+- Tree keeps local direct builtin loaders (`tree/src/registries/*.registry.logic.mjs`) for bounded tree-owned policy vocabularies.
+- Suite-core keeps composition ownership under `src/core/**` without flattening all registry ownership through one path.
+
+Rationale:
+
+- This preserves clear ownership boundaries and extraction paths, avoids mega-loader coupling, and keeps registry policy ownership aligned to the slice that consumes it.
+
 ## Slice-local vs suite-level ownership
 
 ### Slice-local ownership (default)


### PR DESCRIPTION
### Motivation

- Clarify ownership rules to prevent future refactors from collapsing slice-local builtin loaders into a generic shared loader and to preserve clear extraction/ownership boundaries.
- Document the intentional pattern where naming uses a registry-state owner while tree and suite-core retain local builtin/compose ownership to avoid accidental coupling.

### Description

- Added a `Loader ownership boundary (registry-state vs direct builtin)` subsection to `calculogic-validator/README.md` that describes when to choose a registry-state owner vs a direct builtin loader and notes the current naming/tree/suite-core mapping.
- Extended `doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md` with a new normative section `6.4 Direct builtin-loader vs registry-state ownership semantics` that codifies selection criteria, rationale, and anti-pattern guidance.
- Updated `doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md` to adopt the non-flat ownership rule and to explicitly align current naming/tree/suite-core usage with the rule; no runtime code or behavior was changed.
- Committed the documentation-only changes with message `docs(validator): codify direct-builtin vs registry-state ownership semantics`.

### Testing

- Ran an automated file-existence check `test -f calculogic-validator/naming/src/registries/registry-state.logic.mjs` which succeeded and returned `OK1`.
- Executed repository searches (`rg`) to verify the new wording references existing module paths and occurrences, which completed successfully.
- Performed `git diff` and committed the three modified files, confirming the patch was applied and recorded in version control.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af10836fe48331a933c38b4a11729c)