### PR TITLE
docs(validator): tighten ownership and strict-exit wording nits

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -128,9 +128,9 @@ calculogic-validator/
 
 Current intentional pattern:
 
-- Naming centralizes major extracted policy surfaces through `naming/src/registries/registry-state.logic.mjs`.
-- Tree signal/core-scope policy uses direct local builtin loaders under tree-owned registry logic modules.
-- Suite-core runtime composition remains locally owned under `src/core/**` instead of acting as a universal registry-state host.
+- Naming centralizes extracted registry-state ownership through `naming/src/registries/registry-state.logic.mjs`.
+- Tree slice policy payloads remain under direct local builtin-loader ownership in tree-owned registry logic modules.
+- Suite-core scope/runtime composition ownership remains local under `src/core/**` instead of acting as a universal registry-state host.
 
 ## 3) Quickstart (repo root)
 

--- a/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
@@ -134,9 +134,9 @@ When a valid config is supplied, naming reports may include:
 
 Strict-exit resolution for naming CLI uses existing exit-policy semantics:
 
-- CLI `--strict` enables strict exit behavior.
-- Config `strictExit: true` enables strict exit behavior even without CLI `--strict`.
-- CLI precedence is deterministic: `--strict` wins over config when both are present.
+- Effective strictness is `true` when CLI `--strict` is present.
+- Otherwise, effective strictness is `true` when `config.strictExit === true`.
+- Otherwise, effective strictness is `false`.
 - Report JSON is emitted before exit code is derived/applied.
 
 This behavior applies to:


### PR DESCRIPTION
### Motivation
- Fix two small documentation wording nits so published validator docs exactly reflect the canonical ownership contract and the implemented CLI strict-exit resolution: the README blended tree-owned loader wording with suite-core scope policy, and the config spec implied a two-way CLI precedence model that the runtime does not implement. 

### Description
- Clarify ownership wording in `calculogic-validator/README.md` to separately state naming registry-state ownership, tree slice direct builtin-loader ownership, and suite-core scope/runtime ownership, and update `calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md` to describe effective strictness as: CLI `--strict` ⇒ true, else `config.strictExit === true` ⇒ true, else false; retain the explicit note that report JSON is emitted before exit-code derivation; this is a docs-only change with no runtime, schema, or test logic modifications. 

### Testing
- Verified the file diffs contain only documentation edits; cross-checked updated wording against `calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md`, `calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`, and the CLI implementation at `calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs`, and ran repository search checks to confirm the new phrases appear consistently; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af13de927083318e8198ad3a38c669)