### PR TITLE
docs(validator): fix NamingInterpretationHardening touchpoint rationale for runtime-input-boundary test

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingInterpretationHardening-TransitionalInventory.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingInterpretationHardening-TransitionalInventory.md
@@ -102,8 +102,8 @@ Tranche note: this is naming-first hardening, but better deterministic filename 
 - `calculogic-validator/naming/src/naming-runtime-converters.logic.mjs` — converter/runtime preparation layer that compiles registry payload shapes into executable state.
 - `calculogic-validator/naming/src/registries/_builtin/case-rules.registry.json` — current builtin case-policy payload (semantic-name case baseline).
 - `calculogic-validator/naming/src/registries/_builtin/roles.registry.json` — canonical role vocabulary payload consumed by role-slot checks.
-- `calculogic-validator/naming/test/naming-validator.test.mjs` — primary naming behavior coverage location for extending disambiguation matrix scenarios.
-- `calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` — runtime input/collection boundary tests where folder-context lane/scope distinctions can be hardened.
+- `calculogic-validator/naming/test/naming-validator.test.mjs` — primary naming behavior coverage location for expanding the disambiguation matrix, including role-like folder tokens remaining contextual vs explicit role-slot authority.
+- `calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` — prepared dependency-injection contract and runtime input-boundary enforcement surface (prepared runtimes/sets required, with path selection/walk exclusions as mechanics).
 
 ## 7) Out-of-scope guardrails for this tranche document
 


### PR DESCRIPTION
### Motivation
- Align the transitional inventory wording with the actual responsibilities of the referenced naming tests by correcting a misleading rationale that implied `naming-runtime-input-boundary.test.mjs` was for folder-token interpretation-lane hardening, and to emphasize `naming-validator.test.mjs` as the behavior-matrix home for folder-token disambiguation; required convention docs were reviewed per repo guidance.

### Description
- Updated `calculogic-validator/doc/ConventionRoutines/NamingInterpretationHardening-TransitionalInventory.md` §6 to rephrase the two touchpoints so `naming-runtime-input-boundary.test.mjs` is described as a prepared dependency-injection / runtime input-boundary enforcement surface and `naming-validator.test.mjs` is explicitly framed as the primary place to expand the disambiguation matrix (including role-like folder tokens remaining contextual vs explicit role-slot authority); this is a docs-only change.

### Testing
- Ran automated repository verification checks confirming the change is limited to the transitional inventory doc and that both referenced test files exist, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af34538c908331aa1d78193602bc9e)