### PR TITLE
test(naming): add disambiguation precedence matrix for role-like semantic + folder tokens

### DIFF
--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -53,6 +53,85 @@ test('classifies unknown role as invalid-ambiguous', () => {
   assert.equal(finding.suggestedFix, 'Use a role from the active role registry.');
 });
 
+test('disambiguation precedence matrix preserves explicit role slot authority', () => {
+  const cases = [
+    {
+      name: 'role-like folder token remains contextual when explicit role slot exists',
+      inputPath: 'src/host/rightpanel.logic.ts',
+      expected: {
+        classification: 'canonical',
+        code: 'NAMING_CANONICAL',
+        details: {
+          semanticName: 'rightpanel',
+          role: 'logic',
+          roleCategory: 'concern-core',
+          roleStatus: 'active',
+        },
+      },
+    },
+    {
+      name: 'role-like semantic token remains semantic when explicit role slot exists',
+      inputPath: 'src/rightpanel-host.logic.ts',
+      expected: {
+        classification: 'canonical',
+        code: 'NAMING_CANONICAL',
+        details: {
+          semanticName: 'rightpanel-host',
+          role: 'logic',
+          roleCategory: 'concern-core',
+          roleStatus: 'active',
+        },
+      },
+    },
+    {
+      name: 'hyphen-appended role ambiguity does not trigger when explicit role slot exists',
+      inputPath: 'src/leftpanel-wiring.logic.ts',
+      expected: {
+        classification: 'canonical',
+        code: 'NAMING_CANONICAL',
+        details: {
+          semanticName: 'leftpanel-wiring',
+          role: 'logic',
+          roleCategory: 'concern-core',
+          roleStatus: 'active',
+        },
+      },
+    },
+    {
+      name: 'role-like folder token does not rescue unknown filename role',
+      inputPath: 'src/host/rightpanel.widget.ts',
+      expected: {
+        classification: 'invalid-ambiguous',
+        code: 'NAMING_UNKNOWN_ROLE',
+        message: 'Unknown role segment "widget" in canonical position.',
+        suggestedFix: 'Use a role from the active role registry.',
+      },
+    },
+  ];
+
+  cases.forEach(({ name, inputPath, expected }) => {
+    const finding = classifyPath(inputPath);
+
+    assert.equal(finding.classification, expected.classification, `${name}: classification`);
+    assert.equal(finding.code, expected.code, `${name}: code`);
+
+    if (expected.details) {
+      assert.equal(finding.details?.semanticName, expected.details.semanticName, `${name}: semanticName`);
+      assert.equal(finding.details?.role, expected.details.role, `${name}: role`);
+      assert.equal(finding.details?.roleCategory, expected.details.roleCategory, `${name}: roleCategory`);
+      assert.equal(finding.details?.roleStatus, expected.details.roleStatus, `${name}: roleStatus`);
+    }
+
+    if (expected.message) {
+      assert.equal(finding.message, expected.message, `${name}: message`);
+    }
+
+    if (expected.suggestedFix) {
+      assert.equal(finding.suggestedFix, expected.suggestedFix, `${name}: suggestedFix`);
+    }
+  });
+});
+
 test('classifies semantic-name casing violation as invalid-ambiguous', () => {
   const finding = classifyPath('src/RightPanel.logic.ts');
   assert.equal(finding.classification, 'invalid-ambiguous');


### PR DESCRIPTION
### Motivation
- Prevent accidental refactors that would let role-like folder names or role-like semantic tokens compete with an explicit filename role slot. 
- Make the contract explicit that hyphen-appended role ambiguity is only considered after canonical parsing fails. 
- Lock the intended precedence rules in `classifyPath()` with deterministic tests so future changes cannot regress this behavior.

### Description
- Added a table-driven “disambiguation precedence” test block to `calculogic-validator/naming/test/naming-validator.test.mjs` that exercises the real runtime via `classifyPath()`.
- The matrix covers four cases: `src/host/rightpanel.logic.ts` (folder token contextual), `src/rightpanel-host.logic.ts` (semantic token remains semantic), `src/leftpanel-wiring.logic.ts` (hyphen-appended ambiguity does not trigger when explicit role exists), and `src/host/rightpanel.widget.ts` (folder token does not rescue unknown filename role).
- Assertions verify `classification`, `code`, and canonical `details` (`semanticName`, `role`, `roleCategory`, `roleStatus`) for canonical cases and preserve the existing unknown-role message/suggestedFix expectations for the erroneous case, with no registry or runtime surface additions.

### Testing
- Ran the focused test: `node --test calculogic-validator/naming/test/naming-validator.test.mjs` and it passed. 
- Ran the full suite subset: `npm test -- --runInBand` and the test suite completed successfully with all tests passing. 
- No runtime changes were required; tests validate current behavior and guard the expected precedence semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af3b7521fc8331a66471aa79f42716)