### PR TITLE
test(naming): split disambiguation precedence matrix into per-case tests

### DIFF
--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -53,81 +53,81 @@ test('classifies unknown role as invalid-ambiguous', () => {
   assert.equal(finding.suggestedFix, 'Use a role from the active role registry.');
 });
 
-test('disambiguation precedence matrix preserves explicit role slot authority', () => {
-  const cases = [
-    {
-      name: 'role-like folder token remains contextual when explicit role slot exists',
-      inputPath: 'src/host/rightpanel.logic.ts',
-      expected: {
-        classification: 'canonical',
-        code: 'NAMING_CANONICAL',
-        details: {
-          semanticName: 'rightpanel',
-          role: 'logic',
-          roleCategory: 'concern-core',
-          roleStatus: 'active',
-        },
+const disambiguationPrecedenceCases = [
+  {
+    name: 'role-like folder token remains contextual when explicit role slot exists',
+    inputPath: 'src/host/rightpanel.logic.ts',
+    expected: {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      details: {
+        semanticName: 'rightpanel',
+        role: 'logic',
+        roleCategory: 'concern-core',
+        roleStatus: 'active',
       },
     },
-    {
-      name: 'role-like semantic token remains semantic when explicit role slot exists',
-      inputPath: 'src/rightpanel-host.logic.ts',
-      expected: {
-        classification: 'canonical',
-        code: 'NAMING_CANONICAL',
-        details: {
-          semanticName: 'rightpanel-host',
-          role: 'logic',
-          roleCategory: 'concern-core',
-          roleStatus: 'active',
-        },
+  },
+  {
+    name: 'role-like semantic token remains semantic when explicit role slot exists',
+    inputPath: 'src/rightpanel-host.logic.ts',
+    expected: {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      details: {
+        semanticName: 'rightpanel-host',
+        role: 'logic',
+        roleCategory: 'concern-core',
+        roleStatus: 'active',
       },
     },
-    {
-      name: 'hyphen-appended role ambiguity does not trigger when explicit role slot exists',
-      inputPath: 'src/leftpanel-wiring.logic.ts',
-      expected: {
-        classification: 'canonical',
-        code: 'NAMING_CANONICAL',
-        details: {
-          semanticName: 'leftpanel-wiring',
-          role: 'logic',
-          roleCategory: 'concern-core',
-          roleStatus: 'active',
-        },
+  },
+  {
+    name: 'hyphen-appended role ambiguity does not trigger when explicit role slot exists',
+    inputPath: 'src/leftpanel-wiring.logic.ts',
+    expected: {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      details: {
+        semanticName: 'leftpanel-wiring',
+        role: 'logic',
+        roleCategory: 'concern-core',
+        roleStatus: 'active',
       },
     },
-    {
-      name: 'role-like folder token does not rescue unknown filename role',
-      inputPath: 'src/host/rightpanel.widget.ts',
-      expected: {
-        classification: 'invalid-ambiguous',
-        code: 'NAMING_UNKNOWN_ROLE',
-        message: 'Unknown role segment "widget" in canonical position.',
-        suggestedFix: 'Use a role from the active role registry.',
-      },
+  },
+  {
+    name: 'role-like folder token does not rescue unknown filename role',
+    inputPath: 'src/host/rightpanel.widget.ts',
+    expected: {
+      classification: 'invalid-ambiguous',
+      code: 'NAMING_UNKNOWN_ROLE',
+      message: 'Unknown role segment "widget" in canonical position.',
+      suggestedFix: 'Use a role from the active role registry.',
     },
-  ];
+  },
+];
 
-  cases.forEach(({ name, inputPath, expected }) => {
+disambiguationPrecedenceCases.forEach(({ name, inputPath, expected }) => {
+  test(name, () => {
     const finding = classifyPath(inputPath);
 
-    assert.equal(finding.classification, expected.classification, `${name}: classification`);
-    assert.equal(finding.code, expected.code, `${name}: code`);
+    assert.equal(finding.classification, expected.classification);
+    assert.equal(finding.code, expected.code);
 
     if (expected.details) {
-      assert.equal(finding.details?.semanticName, expected.details.semanticName, `${name}: semanticName`);
-      assert.equal(finding.details?.role, expected.details.role, `${name}: role`);
-      assert.equal(finding.details?.roleCategory, expected.details.roleCategory, `${name}: roleCategory`);
-      assert.equal(finding.details?.roleStatus, expected.details.roleStatus, `${name}: roleStatus`);
+      assert.equal(finding.details?.semanticName, expected.details.semanticName);
+      assert.equal(finding.details?.role, expected.details.role);
+      assert.equal(finding.details?.roleCategory, expected.details.roleCategory);
+      assert.equal(finding.details?.roleStatus, expected.details.roleStatus);
     }
 
     if (expected.message) {
-      assert.equal(finding.message, expected.message, `${name}: message`);
+      assert.equal(finding.message, expected.message);
     }
 
     if (expected.suggestedFix) {
-      assert.equal(finding.suggestedFix, expected.suggestedFix, `${name}: suggestedFix`);
+      assert.equal(finding.suggestedFix, expected.suggestedFix);
     }
   });
 });


### PR DESCRIPTION
### Motivation
- The disambiguation precedence coverage was implemented as one aggregated `test()` that iterated cases, which made single-case failures noisier to interpret; splitting into per-case `test()` entries makes node:test output and regressions easier to localize.

### Description
- Extracted the four scenarios into `disambiguationPrecedenceCases` and register each as its own `test(name, ...)` instead of a single `test()` loop.
- Preserved the same four scenario inputs and exact expectations (`classification`, `code`, and `details` / `message` / `suggestedFix` where applicable) with no runtime or registry changes.
- Removed the per-assert `${name}: ...` suffixes now that each scenario has its own `test()` name; this is a tests-only refactor in `calculogic-validator/naming/test/naming-validator.test.mjs`.

### Testing
- Ran `node --test calculogic-validator/naming/test/naming-validator.test.mjs` and the file-level tests passed. 
- Ran the full suite with `npm test -- --runInBand` and all validator tests passed (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af429510188331ac9c3f8292eec748)