### PR TITLE
feat(naming): emit canonical disambiguation hints for role-like tokens

### DIFF
--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -16,6 +16,7 @@ import {
 } from './rules/naming-rule-classify-special-case.logic.mjs';
 import { hasHyphenAppendedRoleAmbiguity } from './rules/naming-rule-check-hyphen-role-ambiguity.logic.mjs';
 import { isCanonicalSemanticName } from './rules/naming-rule-check-semantic-case.logic.mjs';
+import { deriveDisambiguationHints } from './rules/naming-rule-derive-disambiguation-hints.logic.mjs';
 import {
   getRoleMetadata,
   isDeprecatedRole,
@@ -350,6 +351,12 @@ export const classifyPath = (
       });
     }
 
+    const disambiguationHints = deriveDisambiguationHints({
+      normalizedPath,
+      parsed,
+      namingRolesRuntime: runtime,
+    });
+
     return createFindingFromOutcome({
       outcomeId: NAMING_DECISION_OUTCOME_IDS.CANONICAL,
       path: normalizedPath,
@@ -358,6 +365,7 @@ export const classifyPath = (
         ...parsed,
         roleStatus: roleMetadata.status,
         roleCategory: roleMetadata.category,
+        ...(disambiguationHints ? { disambiguation: disambiguationHints } : {}),
       },
     });
   }

--- a/calculogic-validator/naming/src/rules/naming-rule-derive-disambiguation-hints.logic.mjs
+++ b/calculogic-validator/naming/src/rules/naming-rule-derive-disambiguation-hints.logic.mjs
@@ -1,0 +1,42 @@
+import path from 'node:path';
+
+const CONFUSABLE_ROLE_CATEGORIES = new Set(['surface-system', 'architecture-support']);
+
+const toSortedUnique = (tokens) => Array.from(new Set(tokens)).sort((left, right) => left.localeCompare(right));
+
+const collectConfusableActiveRoles = (namingRolesRuntime) =>
+  Array.from(namingRolesRuntime.roleMetadata.entries()).reduce((roleSet, [role, metadata]) => {
+    if (
+      metadata?.status === 'active' &&
+      CONFUSABLE_ROLE_CATEGORIES.has(metadata?.category) &&
+      namingRolesRuntime.activeRoles.has(role)
+    ) {
+      roleSet.add(role);
+    }
+
+    return roleSet;
+  }, new Set());
+
+export const deriveDisambiguationHints = ({ normalizedPath, parsed, namingRolesRuntime }) => {
+  const confusableRoles = collectConfusableActiveRoles(namingRolesRuntime);
+
+  const dirname = path.posix.dirname(normalizedPath);
+  const directorySegments = dirname === '.' ? [] : dirname.split('/').filter(Boolean);
+  const roleLikeFolderTokens = toSortedUnique(
+    directorySegments.filter((token) => token !== parsed.role && confusableRoles.has(token)),
+  );
+
+  const semanticTokens = parsed.semanticName.split(/[-.]/u).filter(Boolean);
+  const roleLikeSemanticTokens = toSortedUnique(
+    semanticTokens.filter((token) => token !== parsed.role && confusableRoles.has(token)),
+  );
+
+  if (roleLikeFolderTokens.length === 0 && roleLikeSemanticTokens.length === 0) {
+    return null;
+  }
+
+  return {
+    roleLikeSemanticTokens,
+    roleLikeFolderTokens,
+  };
+};

--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -65,6 +65,10 @@ const disambiguationPrecedenceCases = [
         role: 'logic',
         roleCategory: 'concern-core',
         roleStatus: 'active',
+        disambiguation: {
+          roleLikeFolderTokens: ['host'],
+          roleLikeSemanticTokens: [],
+        },
       },
     },
   },
@@ -79,6 +83,10 @@ const disambiguationPrecedenceCases = [
         role: 'logic',
         roleCategory: 'concern-core',
         roleStatus: 'active',
+        disambiguation: {
+          roleLikeFolderTokens: [],
+          roleLikeSemanticTokens: ['host'],
+        },
       },
     },
   },
@@ -93,6 +101,10 @@ const disambiguationPrecedenceCases = [
         role: 'logic',
         roleCategory: 'concern-core',
         roleStatus: 'active',
+        disambiguation: {
+          roleLikeFolderTokens: [],
+          roleLikeSemanticTokens: ['wiring'],
+        },
       },
     },
   },
@@ -120,6 +132,16 @@ disambiguationPrecedenceCases.forEach(({ name, inputPath, expected }) => {
       assert.equal(finding.details?.role, expected.details.role);
       assert.equal(finding.details?.roleCategory, expected.details.roleCategory);
       assert.equal(finding.details?.roleStatus, expected.details.roleStatus);
+      if (expected.details.disambiguation) {
+        assert.deepEqual(
+          finding.details?.disambiguation?.roleLikeFolderTokens,
+          expected.details.disambiguation.roleLikeFolderTokens,
+        );
+        assert.deepEqual(
+          finding.details?.disambiguation?.roleLikeSemanticTokens,
+          expected.details.disambiguation.roleLikeSemanticTokens,
+        );
+      }
     }
 
     if (expected.message) {


### PR DESCRIPTION
### Motivation
- Make the validator surface deterministic, machine-friendly hints when a canonical filename contains tokens that could be confused with role names so UI/tree tooling can display disambiguation guidance without changing existing outcomes.
- Keep all decision outcomes and selection logic unchanged while only enriching the `canonical` finding `details` payload.
- Be conservative about what counts as "confusable": only use active roles in `surface-system` and `architecture-support` categories.

### Description
- Added new rule module `deriveDisambiguationHints` which exports `deriveDisambiguationHints({ normalizedPath, parsed, namingRolesRuntime })` and returns either `null` or `{ roleLikeSemanticTokens: string[], roleLikeFolderTokens: string[] }`.
- Hint derivation rules: only consider active roles whose `category` is `surface-system` or `architecture-support`; extract `roleLikeFolderTokens` from directory segments (everything before basename) and `roleLikeSemanticTokens` by splitting `parsed.semanticName` on `-` and `.`; exclude tokens equal to `parsed.role`; dedupe and sort with `localeCompare`; return `null` if none found.
- Wired hint derivation into the canonical branch of `classifyPath` so `details` for `CANONICAL` findings get an optional `disambiguation` key when applicable, leaving all outcome selection, severity, and message logic untouched.
- Updated disambiguation precedence tests to assert the new `details.disambiguation` surface for the three canonical cases while leaving the unknown-role case unchanged.

### Testing
- Ran `node --test calculogic-validator/naming/test/naming-validator.test.mjs`, which passed (all tests in that file succeeded).
- Ran full test suite with `npm test`, which passed (all validator and repo tests executed successfully).
- Ran `npm run validate:naming`, which completed and produced a naming report showing unchanged outcome/code counts while canonical findings now include deterministic `details.disambiguation`; the script exited non-zero due to existing repo findings policy (expected behavior for repository-wide scans with warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4eda7d588331a574194f6ce18c16)