### PR TITLE
perf(naming): precompute disambiguation role token set in runtime

### DIFF
--- a/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
+++ b/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
@@ -1,3 +1,5 @@
+import { prepareDisambiguationRoleTokens } from './rules/naming-rule-derive-disambiguation-hints.logic.mjs';
+
 export const toReportableExtensionsSet = (extensionArray) => new Set(extensionArray);
 
 export const toNamingRolesRuntime = (rolesArray) => {
@@ -19,10 +21,17 @@ export const toNamingRolesRuntime = (rolesArray) => {
     (left, right) => right.length - left.length,
   );
 
+  const disambiguationRoleTokens = prepareDisambiguationRoleTokens({
+    roleMetadata,
+    activeRoles,
+    roleSuffixes,
+  });
+
   return {
     roleMetadata,
     activeRoles,
     roleSuffixes,
+    disambiguationRoleTokens,
   };
 };
 

--- a/calculogic-validator/naming/src/rules/naming-rule-derive-disambiguation-hints.logic.mjs
+++ b/calculogic-validator/naming/src/rules/naming-rule-derive-disambiguation-hints.logic.mjs
@@ -4,7 +4,7 @@ const CONFUSABLE_ROLE_CATEGORIES = new Set(['surface-system', 'architecture-supp
 
 const toSortedUnique = (tokens) => Array.from(new Set(tokens)).sort((left, right) => left.localeCompare(right));
 
-const collectConfusableActiveRoles = (namingRolesRuntime) =>
+export const prepareDisambiguationRoleTokens = (namingRolesRuntime) =>
   Array.from(namingRolesRuntime.roleMetadata.entries()).reduce((roleSet, [role, metadata]) => {
     if (
       metadata?.status === 'active' &&
@@ -18,7 +18,10 @@ const collectConfusableActiveRoles = (namingRolesRuntime) =>
   }, new Set());
 
 export const deriveDisambiguationHints = ({ normalizedPath, parsed, namingRolesRuntime }) => {
-  const confusableRoles = collectConfusableActiveRoles(namingRolesRuntime);
+  const confusableRoles =
+    namingRolesRuntime.disambiguationRoleTokens instanceof Set
+      ? namingRolesRuntime.disambiguationRoleTokens
+      : prepareDisambiguationRoleTokens(namingRolesRuntime);
 
   const dirname = path.posix.dirname(normalizedPath);
   const directorySegments = dirname === '.' ? [] : dirname.split('/').filter(Boolean);


### PR DESCRIPTION
### Motivation
- `deriveDisambiguationHints` rebuilt the confusable/active role set on every call, which is expensive when `classifyPath` invokes it per-file.
- The goal is to preserve existing hint semantics while avoiding repeated collection work by computing the token set once when preparing the naming runtime.

### Description
- Exported `prepareDisambiguationRoleTokens(namingRolesRuntime)` from the disambiguation rule module to encapsulate the existing confusable-active role collection logic.
- Updated `deriveDisambiguationHints` to prefer `namingRolesRuntime.disambiguationRoleTokens` when it is a `Set`, and to fall back to `prepareDisambiguationRoleTokens(...)` for compatibility.
- Updated `toNamingRolesRuntime` to call `prepareDisambiguationRoleTokens(...)` after `roleMetadata`, `activeRoles`, and `roleSuffixes` are built and attach `disambiguationRoleTokens` to the returned runtime object.

### Testing
- Ran `node --test calculogic-validator/naming/test/naming-validator.test.mjs` and the naming tests passed (27/27).
- Ran `npm test` for the full test suite and all tests passed (231/231 in this run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af53b36f0c833190a5b060c4aa6910)