### PR TITLE
test(naming): lock prepared disambiguationRoleTokens on naming runtime

### DIFF
--- a/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
@@ -135,3 +135,13 @@ test('runtime enforces prepared dependency injection contract', () => {
     /requires prepared summaryBucketsRuntime/u,
   );
 });
+
+test('toNamingRolesRuntime prepares disambiguation role token set for runtime consumers', () => {
+  const registryInputs = resolveNamingRegistryInputs({ config: {} });
+  const namingRolesRuntime = toNamingRolesRuntime(registryInputs.roles);
+
+  assert.ok(namingRolesRuntime.disambiguationRoleTokens instanceof Set);
+  assert.equal(namingRolesRuntime.disambiguationRoleTokens.has('host'), true);
+  assert.equal(namingRolesRuntime.disambiguationRoleTokens.has('wiring'), true);
+  assert.equal(namingRolesRuntime.disambiguationRoleTokens.has('logic'), false);
+});


### PR DESCRIPTION
### Motivation
- Ensure the new prepared runtime surface `disambiguationRoleTokens` returned by `toNamingRolesRuntime(...)` is part of the public runtime contract so future refactors cannot remove/rename/broaden it silently.

### Description
- Added a focused test in `calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` that constructs `registryInputs` via `resolveNamingRegistryInputs({ config: {} })` and `namingRolesRuntime` via `toNamingRolesRuntime(registryInputs.roles)` and asserts `disambiguationRoleTokens` is a `Set`.
- The test asserts the set includes representative confusable tokens `host` and `wiring` and excludes a non-confusable token `logic`, keeping assertions contract-oriented rather than reimplementing derivation logic.

### Testing
- Ran `node --test calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` and the new test passed.
- Ran full suite with `npm test` and all tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af594e2a5c8331916f1c2dcc83c623)