### PR TITLE
test(naming): alias disambiguationRoleTokens locally for readability

### DIFF
--- a/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
@@ -139,9 +139,10 @@ test('runtime enforces prepared dependency injection contract', () => {
 test('toNamingRolesRuntime prepares disambiguation role token set for runtime consumers', () => {
   const registryInputs = resolveNamingRegistryInputs({ config: {} });
   const namingRolesRuntime = toNamingRolesRuntime(registryInputs.roles);
+  const disambiguationRoleTokens = namingRolesRuntime.disambiguationRoleTokens;
 
-  assert.ok(namingRolesRuntime.disambiguationRoleTokens instanceof Set);
-  assert.equal(namingRolesRuntime.disambiguationRoleTokens.has('host'), true);
-  assert.equal(namingRolesRuntime.disambiguationRoleTokens.has('wiring'), true);
-  assert.equal(namingRolesRuntime.disambiguationRoleTokens.has('logic'), false);
+  assert.ok(disambiguationRoleTokens instanceof Set);
+  assert.equal(disambiguationRoleTokens.has('host'), true);
+  assert.equal(disambiguationRoleTokens.has('wiring'), true);
+  assert.equal(disambiguationRoleTokens.has('logic'), false);
 });


### PR DESCRIPTION
### Motivation
- Reduce repeated `namingRolesRuntime.disambiguationRoleTokens` property access in the test so the assertion block is easier to scan without changing behavior.

### Description
- In `calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` inside the `toNamingRolesRuntime prepares disambiguation role token set for runtime consumers` test, added `const disambiguationRoleTokens = namingRolesRuntime.disambiguationRoleTokens;` and updated the four assertions to reference `disambiguationRoleTokens` instead of repeated property access; no behavioral or coverage changes.

### Testing
- Ran `node --test calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` and `npm test`, and both completed successfully with the test suite passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af5d6cd33c83318a99484811c04e17)