### PR TITLE
refactor(naming): route case-rules through registry-state and prepared runtime

### DIFF
--- a/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
+++ b/calculogic-validator/naming/src/naming-runtime-converters.logic.mjs
@@ -61,3 +61,29 @@ export const toFindingPolicyRuntime = (findingPolicy) =>
       },
     ]),
   );
+
+const CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const toCaseRulesRuntime = (caseRules) => {
+  if (!caseRules || typeof caseRules !== 'object' || Array.isArray(caseRules)) {
+    throw new Error('Naming runtime case rules must be an object.');
+  }
+
+  if (!caseRules.semanticName || typeof caseRules.semanticName !== 'object') {
+    throw new Error('Naming runtime case rules semanticName must be an object.');
+  }
+
+  const semanticStyle =
+    typeof caseRules.semanticName.style === 'string' ? caseRules.semanticName.style.trim() : '';
+
+  if (semanticStyle !== 'kebab-case') {
+    throw new Error(`Unsupported semantic-name style in case rules runtime: ${semanticStyle}`);
+  }
+
+  return {
+    semanticName: {
+      style: semanticStyle,
+      pattern: CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN,
+    },
+  };
+};

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -93,6 +93,21 @@ const assertPreparedFindingPolicyRuntime = (findingPolicyRuntime) => {
   );
 };
 
+const assertPreparedCaseRulesRuntime = (caseRulesRuntime) => {
+  if (
+    caseRulesRuntime &&
+    caseRulesRuntime.semanticName &&
+    typeof caseRulesRuntime.semanticName.style === 'string' &&
+    caseRulesRuntime.semanticName.pattern instanceof RegExp
+  ) {
+    return caseRulesRuntime;
+  }
+
+  throw new Error(
+    'Naming runtime requires prepared caseRulesRuntime from wiring/runtime adapter.',
+  );
+};
+
 const NAMING_DECISION_OUTCOME_IDS = Object.freeze({
   ALLOWED_SPECIAL_CASE: 'allowed-special-case',
   DEPRECATED_ROLE: 'deprecated-role',
@@ -281,10 +296,12 @@ export const classifyPath = (
   namingRolesRuntime,
   missingRolePatternsRuntime,
   findingPolicyRuntime,
+  caseRulesRuntime,
 ) => {
   const runtime = assertPreparedNamingRolesRuntime(namingRolesRuntime);
   const missingRolePatterns = assertPreparedMissingRolePatternsRuntime(missingRolePatternsRuntime);
   const findingPolicy = assertPreparedFindingPolicyRuntime(findingPolicyRuntime);
+  const caseRules = assertPreparedCaseRulesRuntime(caseRulesRuntime);
   const normalizedPath = normalizePath(relativePath);
   const basename = path.posix.basename(normalizedPath);
 
@@ -337,7 +354,7 @@ export const classifyPath = (
       });
     }
 
-    if (!isCanonicalSemanticName(parsed.semanticName)) {
+    if (!isCanonicalSemanticName(parsed.semanticName, caseRules)) {
       return createFindingFromOutcome({
         outcomeId: NAMING_DECISION_OUTCOME_IDS.BAD_SEMANTIC_CASE,
         path: normalizedPath,
@@ -407,8 +424,15 @@ export const runNamingValidator = (preparedInputs = {}) => {
   const findingPolicyRuntime = assertPreparedFindingPolicyRuntime(
     preparedInputs.findingPolicyRuntime,
   );
+  const caseRulesRuntime = assertPreparedCaseRulesRuntime(preparedInputs.caseRulesRuntime);
   const findings = selectedPaths.map((pathname) =>
-    classifyPath(pathname, namingRolesRuntime, missingRolePatternsRuntime, findingPolicyRuntime),
+    classifyPath(
+      pathname,
+      namingRolesRuntime,
+      missingRolePatternsRuntime,
+      findingPolicyRuntime,
+      caseRulesRuntime,
+    ),
   );
 
   return {

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -7,6 +7,7 @@ import {
   toSummaryBucketsRuntime,
   toMissingRolePatternsRuntime,
   toFindingPolicyRuntime,
+  toCaseRulesRuntime,
 } from './naming-runtime-converters.logic.mjs';
 import {
   parseCanonicalName,
@@ -37,6 +38,7 @@ export const prepareNamingRuntimeInputs = (config) => {
     summaryBucketsRuntime: toSummaryBucketsRuntime(registryInputs.summaryBuckets),
     missingRolePatternsRuntime: toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
     findingPolicyRuntime: toFindingPolicyRuntime(registryInputs.findingPolicy),
+    caseRulesRuntime: toCaseRulesRuntime(registryInputs.caseRules),
     registry: {
       registryState: registryInputs.registryState,
       registrySource: registryInputs.registrySource,
@@ -96,6 +98,7 @@ export const classifyPath = (relativePath, namingRolesRuntime, options = {}) => 
     namingRolesRuntime ?? runtimeInputs.namingRolesRuntime,
     runtimeInputs.missingRolePatternsRuntime,
     runtimeInputs.findingPolicyRuntime,
+    runtimeInputs.caseRulesRuntime,
   );
 };
 

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -19,6 +19,7 @@ const REQUIRED_BUILTIN_REGISTRY_FILES = [
   'missing-role-patterns.registry.json',
   'finding-policy.registry.json',
   'overlay-capabilities.registry.json',
+  'case-rules.registry.json',
 ];
 
 const ALLOWED_ROLE_STATUSES = new Set(['active', 'deprecated']);
@@ -250,6 +251,30 @@ const loadBuiltinMissingRolePatterns = ({ builtinRegistryDir }) =>
 const loadBuiltinFindingPolicy = ({ builtinRegistryDir }) =>
   loadFindingPolicyFromFile(path.join(builtinRegistryDir, 'finding-policy.registry.json'));
 
+const loadBuiltinCaseRules = ({ builtinRegistryDir }) => {
+  const parsed = loadJsonFile(path.join(builtinRegistryDir, 'case-rules.registry.json'));
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid builtin case-rules registry: expected an object.');
+  }
+
+  const semanticName = parsed.semanticName;
+  if (!semanticName || typeof semanticName !== 'object' || Array.isArray(semanticName)) {
+    throw new Error('Invalid builtin case-rules registry: expected semanticName object.');
+  }
+
+  const style = typeof semanticName.style === 'string' ? semanticName.style.trim() : '';
+  if (!style) {
+    throw new Error('Invalid builtin case-rules registry: semanticName.style must be a non-empty string.');
+  }
+
+  return {
+    semanticName: {
+      style,
+    },
+  };
+};
+
 const loadRegistryState = (registryRootDir) => {
   const statePath = path.join(registryRootDir, 'registry-state.json');
   if (!fs.existsSync(statePath)) {
@@ -302,6 +327,7 @@ const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
     summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
     missingRolePatterns: loadBuiltinMissingRolePatterns({ builtinRegistryDir }),
     findingPolicy: loadBuiltinFindingPolicy({ builtinRegistryDir }),
+    caseRules: loadBuiltinCaseRules({ builtinRegistryDir }),
   };
 };
 
@@ -312,6 +338,7 @@ const buildBuiltinPayload = ({ builtinRegistryDir }) => ({
   summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
   missingRolePatterns: loadBuiltinMissingRolePatterns({ builtinRegistryDir }),
   findingPolicy: loadBuiltinFindingPolicy({ builtinRegistryDir }),
+  caseRules: loadBuiltinCaseRules({ builtinRegistryDir }),
 });
 
 const loadBuiltinOverlayCapabilities = ({ builtinRegistryDir }) =>
@@ -378,6 +405,7 @@ const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
     summaryBuckets: builtinPayload.summaryBuckets,
     missingRolePatterns: builtinPayload.missingRolePatterns,
     findingPolicy: builtinPayload.findingPolicy,
+    caseRules: builtinPayload.caseRules,
   };
 };
 
@@ -442,5 +470,6 @@ export const resolveNamingRegistryInputs = ({ config, registryRootDir } = {}) =>
     summaryBuckets: resolvedPayload.summaryBuckets,
     missingRolePatterns: resolvedPayload.missingRolePatterns,
     findingPolicy: resolvedPayload.findingPolicy,
+    caseRules: resolvedPayload.caseRules,
   };
 };

--- a/calculogic-validator/naming/src/rules/naming-rule-check-semantic-case.logic.mjs
+++ b/calculogic-validator/naming/src/rules/naming-rule-check-semantic-case.logic.mjs
@@ -1,38 +1,4 @@
-import builtinCaseRulesRegistry from '../registries/_builtin/case-rules.registry.json' with { type: 'json' };
+export const getSemanticNameCaseRule = (caseRulesRuntime) => caseRulesRuntime.semanticName;
 
-const CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
-const assertBuiltinCaseRulesRegistry = (registry) => {
-  if (typeof registry !== 'object' || registry === null) {
-    throw new TypeError('Builtin case-rules registry must be an object.');
-  }
-
-  if (typeof registry.semanticName !== 'object' || registry.semanticName === null) {
-    throw new TypeError('Builtin case-rules registry semanticName must be an object.');
-  }
-
-  if (typeof registry.semanticName.style !== 'string') {
-    throw new TypeError('Builtin case-rules registry semanticName.style must be a string.');
-  }
-};
-
-const resolveSemanticNamePatternByStyle = (semanticNameStyle) => {
-  if (semanticNameStyle === 'kebab-case') {
-    return CANONICAL_KEBAB_CASE_SEMANTIC_PATTERN;
-  }
-
-  throw new Error(`Unsupported builtin semantic-name style: ${semanticNameStyle}`);
-};
-
-assertBuiltinCaseRulesRegistry(builtinCaseRulesRegistry);
-
-const semanticNameStyle = builtinCaseRulesRegistry.semanticName.style;
-const canonicalSemanticPattern = resolveSemanticNamePatternByStyle(semanticNameStyle);
-
-export const getSemanticNameCaseRule = () => ({
-  style: semanticNameStyle,
-  pattern: canonicalSemanticPattern,
-});
-
-export const isCanonicalSemanticName = (semanticName) =>
-  getSemanticNameCaseRule().pattern.test(semanticName);
+export const isCanonicalSemanticName = (semanticName, caseRulesRuntime) =>
+  getSemanticNameCaseRule(caseRulesRuntime).pattern.test(semanticName);

--- a/calculogic-validator/naming/test/naming-case-rules-registry.test.mjs
+++ b/calculogic-validator/naming/test/naming-case-rules-registry.test.mjs
@@ -1,11 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import caseRulesRegistry from '../src/registries/_builtin/case-rules.registry.json' with { type: 'json' };
+import { resolveNamingRegistryInputs } from '../src/registries/registry-state.logic.mjs';
+import { toCaseRulesRuntime } from '../src/naming-runtime-converters.logic.mjs';
 import { getSemanticNameCaseRule } from '../src/rules/naming-rule-check-semantic-case.logic.mjs';
 import { isCanonicalSemanticName } from '../src/rules/naming-rule-check-semantic-case.logic.mjs';
 
+const getPreparedCaseRulesRuntime = () => {
+  const registryInputs = resolveNamingRegistryInputs({ config: {} });
+  return toCaseRulesRuntime(registryInputs.caseRules);
+};
+
 test('semantic-name case rule runtime is sourced from builtin registry style', () => {
-  const semanticCaseRule = getSemanticNameCaseRule();
+  const semanticCaseRule = getSemanticNameCaseRule(getPreparedCaseRulesRuntime());
 
   assert.equal(semanticCaseRule.style, caseRulesRegistry.semanticName.style);
   assert.equal(semanticCaseRule.style, 'kebab-case');
@@ -14,16 +21,18 @@ test('semantic-name case rule runtime is sourced from builtin registry style', (
 });
 
 test('kebab-case semantic names are canonical', () => {
-  assert.equal(isCanonicalSemanticName('leftpanel'), true);
-  assert.equal(isCanonicalSemanticName('left-panel'), true);
-  assert.equal(isCanonicalSemanticName('left-panel-v2'), true);
-  assert.equal(isCanonicalSemanticName('v2-left-panel'), true);
+  const caseRulesRuntime = getPreparedCaseRulesRuntime();
+  assert.equal(isCanonicalSemanticName('leftpanel', caseRulesRuntime), true);
+  assert.equal(isCanonicalSemanticName('left-panel', caseRulesRuntime), true);
+  assert.equal(isCanonicalSemanticName('left-panel-v2', caseRulesRuntime), true);
+  assert.equal(isCanonicalSemanticName('v2-left-panel', caseRulesRuntime), true);
 });
 
 test('non-kebab semantic names are non-canonical', () => {
-  assert.equal(isCanonicalSemanticName('LeftPanel'), false);
-  assert.equal(isCanonicalSemanticName('leftPanel'), false);
-  assert.equal(isCanonicalSemanticName('left_panel'), false);
-  assert.equal(isCanonicalSemanticName('left..panel'), false);
-  assert.equal(isCanonicalSemanticName('left--panel'), false);
+  const caseRulesRuntime = getPreparedCaseRulesRuntime();
+  assert.equal(isCanonicalSemanticName('LeftPanel', caseRulesRuntime), false);
+  assert.equal(isCanonicalSemanticName('leftPanel', caseRulesRuntime), false);
+  assert.equal(isCanonicalSemanticName('left_panel', caseRulesRuntime), false);
+  assert.equal(isCanonicalSemanticName('left..panel', caseRulesRuntime), false);
+  assert.equal(isCanonicalSemanticName('left--panel', caseRulesRuntime), false);
 });

--- a/calculogic-validator/naming/test/naming-default-runtime-registry-alignment.test.mjs
+++ b/calculogic-validator/naming/test/naming-default-runtime-registry-alignment.test.mjs
@@ -30,6 +30,7 @@ test('wiring-injected classifyPath aligns with runtime when using prepared regis
     prepared.namingRolesRuntime,
     prepared.missingRolePatternsRuntime,
     prepared.findingPolicyRuntime,
+    prepared.caseRulesRuntime,
   );
   assert.deepEqual(wiringCanonical, runtimeCanonical);
 
@@ -39,6 +40,7 @@ test('wiring-injected classifyPath aligns with runtime when using prepared regis
     prepared.namingRolesRuntime,
     prepared.missingRolePatternsRuntime,
     prepared.findingPolicyRuntime,
+    prepared.caseRulesRuntime,
   );
   assert.deepEqual(wiringDeprecated, runtimeDeprecated);
 });

--- a/calculogic-validator/naming/test/naming-finding-policy-registry.test.mjs
+++ b/calculogic-validator/naming/test/naming-finding-policy-registry.test.mjs
@@ -5,7 +5,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { loadFindingPolicyFromFile } from '../src/registries/naming-finding-policy.registry.logic.mjs';
 import { resolveNamingRegistryInputs } from '../src/registries/registry-state.logic.mjs';
-import { toNamingRolesRuntime, toMissingRolePatternsRuntime } from '../src/naming-runtime-converters.logic.mjs';
+import {
+  toNamingRolesRuntime,
+  toMissingRolePatternsRuntime,
+  toCaseRulesRuntime,
+} from '../src/naming-runtime-converters.logic.mjs';
 import { classifyPath } from '../src/naming-validator.logic.mjs';
 
 const writeJson = (filePath, value) => {
@@ -47,6 +51,7 @@ test('missing outcome policy entry fails deterministically during classification
         toNamingRolesRuntime(registryInputs.roles),
         toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
         new Map(),
+        toCaseRulesRuntime(registryInputs.caseRules),
       ),
     /Missing naming finding policy for outcome "canonical"/u,
   );

--- a/calculogic-validator/naming/test/naming-runtime-converters.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-converters.test.mjs
@@ -10,6 +10,7 @@ import {
   toReportableRootFilesSet,
   toMissingRolePatternsRuntime,
   toFindingPolicyRuntime,
+  toCaseRulesRuntime,
 } from '../src/naming-runtime-converters.logic.mjs';
 import { runNamingValidator as runNamingValidatorRuntime } from '../src/naming-validator.logic.mjs';
 import { getBuiltinWalkExclusions } from '../src/registries/naming-walk-exclusions.registry.logic.mjs';
@@ -118,6 +119,7 @@ test('direct runtime and wiring derive equivalent runtime validation output from
       namingRolesRuntime: toNamingRolesRuntime(registryInputs.roles),
       missingRolePatternsRuntime: toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
       findingPolicyRuntime: toFindingPolicyRuntime(registryInputs.findingPolicy),
+      caseRulesRuntime: toCaseRulesRuntime(registryInputs.caseRules),
     });
 
     const wiringResult = runNamingValidatorWiring(tempRoot, { scope: 'repo', config: {} });

--- a/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
+++ b/calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs
@@ -16,6 +16,7 @@ import {
   toReportableRootFilesSet,
   toMissingRolePatternsRuntime,
   toFindingPolicyRuntime,
+  toCaseRulesRuntime,
 } from '../src/naming-runtime-converters.logic.mjs';
 import { getBuiltinWalkExclusions } from '../src/registries/naming-walk-exclusions.registry.logic.mjs';
 
@@ -36,6 +37,7 @@ test('runtime accepts externally prepared naming runtime dependencies', () => {
     namingRolesRuntime,
     toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
     toFindingPolicyRuntime(registryInputs.findingPolicy),
+    toCaseRulesRuntime(registryInputs.caseRules),
   );
   assert.equal(canonicalFinding.code, 'NAMING_CANONICAL');
 
@@ -56,6 +58,7 @@ test('runtime accepts externally prepared naming runtime dependencies', () => {
       namingRolesRuntime,
       missingRolePatternsRuntime: toMissingRolePatternsRuntime(registryInputs.missingRolePatterns),
       findingPolicyRuntime: toFindingPolicyRuntime(registryInputs.findingPolicy),
+      caseRulesRuntime: toCaseRulesRuntime(registryInputs.caseRules),
       targets: [],
     });
 
@@ -95,6 +98,17 @@ test('runtime enforces prepared dependency injection contract', () => {
   );
 
   assert.throws(
+    () =>
+      classifyPath(
+        'src/rightpanel.results-style.css',
+        toNamingRolesRuntime(resolveNamingRegistryInputs({ config: {} }).roles),
+        toMissingRolePatternsRuntime(resolveNamingRegistryInputs({ config: {} }).missingRolePatterns),
+        toFindingPolicyRuntime(resolveNamingRegistryInputs({ config: {} }).findingPolicy),
+      ),
+    /requires prepared caseRulesRuntime/u,
+  );
+
+  assert.throws(
     () => runNamingValidator({
       scope: 'repo',
       namingRolesRuntime: toNamingRolesRuntime(resolveNamingRegistryInputs({ config: {} }).roles),
@@ -102,6 +116,7 @@ test('runtime enforces prepared dependency injection contract', () => {
         resolveNamingRegistryInputs({ config: {} }).missingRolePatterns,
       ),
       findingPolicyRuntime: toFindingPolicyRuntime(resolveNamingRegistryInputs({ config: {} }).findingPolicy),
+      caseRulesRuntime: toCaseRulesRuntime(resolveNamingRegistryInputs({ config: {} }).caseRules),
       targets: [],
     }),
     /requires prepared selectedPaths/u,

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -73,6 +73,7 @@ test('resolver contract shape remains stable', () => {
   const result = resolveNamingRegistryInputs();
 
   assert.deepEqual(Object.keys(result).sort((a, b) => a.localeCompare(b)), [
+    'caseRules',
     'findingPolicy',
     'missingRolePatterns',
     'registryDigests',
@@ -246,6 +247,9 @@ test('registryRootDir drives builtin roles, extensions, and categories from the 
       path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'),
       DEFAULT_OVERLAY_CAPABILITIES_REGISTRY,
     );
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
+      semanticName: { style: 'kebab-case' },
+    });
 
     const builtinResult = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
     assert.deepEqual(builtinResult.roles, [
@@ -616,6 +620,10 @@ test('throws when overlay capabilities registry is malformed', () => {
           ruleRef: 'naming-spec',
         },
       },
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
+      semanticName: { style: 'kebab-case' },
     });
 
     writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {


### PR DESCRIPTION
### Motivation
- Bring the semantic-case rule under the same registry-state → prepared-runtime flow used by other naming registries so case-policy ownership is deterministic and extensible.
- Preserve existing behavior (kebab-case only) while making the case rules a prepared runtime input instead of a direct builtin import.

### Description
- Load and validate `case-rules.registry.json` in the naming registry resolver and include `caseRules` in the `resolveNamingRegistryInputs(...)` payload. (registry-state logic updated.)
- Add `toCaseRulesRuntime(...)` in `naming-runtime-converters.logic.mjs` that compiles the supported `semanticName.style` into a runtime pattern and currently accepts only `kebab-case`.
- Thread `caseRulesRuntime` through wiring and runtime entrypoints (`naming-validator.wiring.mjs`, `naming-validator.logic.mjs`) and add a prepared-runtime assertion guard for `caseRulesRuntime` in the validator logic.
- Update semantic-case helper to be a pure rule over prepared runtime input (`getSemanticNameCaseRule(caseRulesRuntime)` / `isCanonicalSemanticName(..., caseRulesRuntime)`), removing the direct builtin JSON import from the rule file.
- Update tests to require and prepare `caseRulesRuntime` where appropriate and adjust registry-state tests to include the new builtin fixture expectations.

### Testing
- Ran `node --test calculogic-validator/naming/test/naming-runtime-input-boundary.test.mjs` and it passed.
- Ran `node --test calculogic-validator/naming/test/naming-validator.test.mjs` and it passed (semantic-case behavior unchanged; existing invalid-case examples still fail the same way).
- Ran the full suite with `npm test` and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af61d40858833197e8a43589923f17)