### PR TITLE
feat(naming): add bounded case-rules custom + config integration

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -194,7 +194,7 @@ When provided, config only affects naming report inputs for:
 - naming role registry runtime (defaults + add-only role additions)
 - missing-role pattern policy runtime (builtin normalized schema for legacy exception detection)
 - finding-policy runtime (builtin outcome→finding metadata mapping for stable decision outcomes)
-- overlay capability contract runtime (`overlay-capabilities.registry.json`) that bounds supported config overlay surfaces to add-only `naming.reportableExtensions.add` and `naming.roles.add`
+- overlay capability contract runtime (`overlay-capabilities.registry.json`) that bounds supported config overlay surfaces to `naming.reportableExtensions.add`, `naming.roles.add`, and bounded whole-surface `naming.caseRules` set/replace semantics
 
 In current behavior, these config effects are limited to classification/runtime registries only for report generation.
 

--- a/calculogic-validator/naming/src/registries/_builtin/overlay-capabilities.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/overlay-capabilities.registry.json
@@ -12,6 +12,12 @@
       "operation": "add",
       "payloadType": "role-array",
       "target": "roles"
+    },
+    {
+      "configPath": "naming.caseRules",
+      "operation": "set",
+      "payloadType": "case-rules-object",
+      "target": "caseRules"
     }
   ]
 }

--- a/calculogic-validator/naming/src/registries/naming-overlay-capabilities.registry.logic.mjs
+++ b/calculogic-validator/naming/src/registries/naming-overlay-capabilities.registry.logic.mjs
@@ -1,8 +1,14 @@
 import fs from 'node:fs';
 
-const ALLOWED_TARGETS = new Set(['reportableExtensions', 'roles']);
-const ALLOWED_PAYLOAD_TYPES = new Set(['string-array', 'role-array']);
-const ALLOWED_OPERATION = 'add';
+const ALLOWED_TARGETS = new Set(['reportableExtensions', 'roles', 'caseRules']);
+const ALLOWED_PAYLOAD_TYPES = new Set(['string-array', 'role-array', 'case-rules-object']);
+const ALLOWED_OPERATIONS = new Set(['add', 'set']);
+
+const CAPABILITY_CONTRACT_BY_TARGET = {
+  reportableExtensions: { operation: 'add', payloadType: 'string-array' },
+  roles: { operation: 'add', payloadType: 'role-array' },
+  caseRules: { operation: 'set', payloadType: 'case-rules-object' },
+};
 
 const assertNonEmptyString = (value, fieldName) => {
   if (typeof value !== 'string' || !value.trim()) {
@@ -24,9 +30,9 @@ const canonicalizeCapabilityEntry = (entry, index) => {
   const payloadType = assertNonEmptyString(entry.payloadType, `capabilities[${index}].payloadType`);
   const target = assertNonEmptyString(entry.target, `capabilities[${index}].target`);
 
-  if (operation !== ALLOWED_OPERATION) {
+  if (!ALLOWED_OPERATIONS.has(operation)) {
     throw new Error(
-      `Invalid overlay-capabilities registry: capabilities[${index}].operation must be "${ALLOWED_OPERATION}".`,
+      `Invalid overlay-capabilities registry: capabilities[${index}].operation must be one of ${[...ALLOWED_OPERATIONS].join(', ')}.`,
     );
   }
 
@@ -39,6 +45,19 @@ const canonicalizeCapabilityEntry = (entry, index) => {
   if (!ALLOWED_TARGETS.has(target)) {
     throw new Error(
       `Invalid overlay-capabilities registry: capabilities[${index}].target must be one of ${[...ALLOWED_TARGETS].join(', ')}.`,
+    );
+  }
+
+  const targetContract = CAPABILITY_CONTRACT_BY_TARGET[target];
+  if (targetContract.operation !== operation) {
+    throw new Error(
+      `Invalid overlay-capabilities registry: capabilities[${index}] target "${target}" must use operation "${targetContract.operation}".`,
+    );
+  }
+
+  if (targetContract.payloadType !== payloadType) {
+    throw new Error(
+      `Invalid overlay-capabilities registry: capabilities[${index}] target "${target}" must use payloadType "${targetContract.payloadType}".`,
     );
   }
 

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -155,6 +155,30 @@ const canonicalizeExtensions = (extensions) => {
   return [...deduped].sort((a, b) => a.localeCompare(b));
 };
 
+const canonicalizeCaseRules = (caseRulesValue, { sourceLabel }) => {
+  if (!caseRulesValue || typeof caseRulesValue !== 'object' || Array.isArray(caseRulesValue)) {
+    throw new Error(`Invalid ${sourceLabel} case-rules registry: expected an object.`);
+  }
+
+  const semanticName = caseRulesValue.semanticName;
+  if (!semanticName || typeof semanticName !== 'object' || Array.isArray(semanticName)) {
+    throw new Error(`Invalid ${sourceLabel} case-rules registry: expected semanticName object.`);
+  }
+
+  const style = typeof semanticName.style === 'string' ? semanticName.style.trim() : '';
+  if (!style) {
+    throw new Error(
+      `Invalid ${sourceLabel} case-rules registry: semanticName.style must be a non-empty string.`,
+    );
+  }
+
+  return {
+    semanticName: {
+      style,
+    },
+  };
+};
+
 const digestPayload = (payload) => sha256Hex(stableStringify(payload));
 
 function loadJsonFile(filePath) {
@@ -254,25 +278,7 @@ const loadBuiltinFindingPolicy = ({ builtinRegistryDir }) =>
 const loadBuiltinCaseRules = ({ builtinRegistryDir }) => {
   const parsed = loadJsonFile(path.join(builtinRegistryDir, 'case-rules.registry.json'));
 
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('Invalid builtin case-rules registry: expected an object.');
-  }
-
-  const semanticName = parsed.semanticName;
-  if (!semanticName || typeof semanticName !== 'object' || Array.isArray(semanticName)) {
-    throw new Error('Invalid builtin case-rules registry: expected semanticName object.');
-  }
-
-  const style = typeof semanticName.style === 'string' ? semanticName.style.trim() : '';
-  if (!style) {
-    throw new Error('Invalid builtin case-rules registry: semanticName.style must be a non-empty string.');
-  }
-
-  return {
-    semanticName: {
-      style,
-    },
-  };
+  return canonicalizeCaseRules(parsed, { sourceLabel: 'builtin' });
 };
 
 const loadRegistryState = (registryRootDir) => {
@@ -300,6 +306,11 @@ const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
     '_custom',
     'reportable-extensions.registry.custom.json',
   );
+  const customCaseRulesPath = path.join(
+    registryRootDir,
+    '_custom',
+    'case-rules.registry.custom.json',
+  );
 
   if (!fs.existsSync(customRolesPath)) {
     throw new Error('Custom registry file missing: _custom/roles.registry.custom.json.');
@@ -317,6 +328,10 @@ const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
   }
 
   const extensionsRaw = loadJsonFile(customExtensionsPath);
+  const builtinCaseRules = loadBuiltinCaseRules({ builtinRegistryDir });
+  const caseRules = fs.existsSync(customCaseRulesPath)
+    ? canonicalizeCaseRules(loadJsonFile(customCaseRulesPath), { sourceLabel: 'custom' })
+    : builtinCaseRules;
 
   return {
     roles: canonicalizeRoles(rolesRaw, {
@@ -327,7 +342,7 @@ const loadCustomPayload = ({ registryRootDir, builtinRegistryDir }) => {
     summaryBuckets: loadBuiltinSummaryBuckets({ builtinRegistryDir }),
     missingRolePatterns: loadBuiltinMissingRolePatterns({ builtinRegistryDir }),
     findingPolicy: loadBuiltinFindingPolicy({ builtinRegistryDir }),
-    caseRules: loadBuiltinCaseRules({ builtinRegistryDir }),
+    caseRules,
   };
 };
 
@@ -344,18 +359,31 @@ const buildBuiltinPayload = ({ builtinRegistryDir }) => ({
 const loadBuiltinOverlayCapabilities = ({ builtinRegistryDir }) =>
   loadOverlayCapabilitiesFromFile(path.join(builtinRegistryDir, 'overlay-capabilities.registry.json'));
 
-const readOverlayAddPayload = ({ config, configPath, payloadType }) => {
+const readOverlayPayload = ({ config, configPath, payloadType, operation }) => {
   const [rootKey, registryKey] = configPath.split('.');
-  const addPayload = config?.[rootKey]?.[registryKey]?.add;
-  if (addPayload === undefined) {
+
+  if (operation === 'add') {
+    const addPayload = config?.[rootKey]?.[registryKey]?.add;
+    if (addPayload === undefined) {
+      return [];
+    }
+
+    if (payloadType === 'string-array' || payloadType === 'role-array') {
+      return addPayload;
+    }
+
     return [];
   }
 
-  if (payloadType === 'string-array' || payloadType === 'role-array') {
-    return addPayload;
+  if (operation === 'set') {
+    if (payloadType === 'case-rules-object') {
+      return config?.[rootKey]?.[registryKey];
+    }
+
+    return undefined;
   }
 
-  return [];
+  return undefined;
 };
 
 const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
@@ -363,22 +391,31 @@ const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
   const reportableExtensionsCapability =
     overlayCapabilities.byPathOperation['naming.reportableExtensions:add'];
   const rolesCapability = overlayCapabilities.byPathOperation['naming.roles:add'];
+  const caseRulesCapability = overlayCapabilities.byPathOperation['naming.caseRules:set'];
 
-  if (!reportableExtensionsCapability || !rolesCapability) {
+  if (!reportableExtensionsCapability || !rolesCapability || !caseRulesCapability) {
     throw new Error(
-      'Invalid overlay-capabilities registry: required naming.reportableExtensions:add and naming.roles:add capabilities are missing.',
+      'Invalid overlay-capabilities registry: required naming.reportableExtensions:add, naming.roles:add, and naming.caseRules:set capabilities are missing.',
     );
   }
 
-  const extensionAdds = readOverlayAddPayload({
+  const extensionAdds = readOverlayPayload({
     config,
     configPath: reportableExtensionsCapability.configPath,
     payloadType: reportableExtensionsCapability.payloadType,
+    operation: 'add',
   });
-  const roleAdds = readOverlayAddPayload({
+  const roleAdds = readOverlayPayload({
     config,
     configPath: rolesCapability.configPath,
     payloadType: rolesCapability.payloadType,
+    operation: 'add',
+  });
+  const caseRulesSet = readOverlayPayload({
+    config,
+    configPath: caseRulesCapability.configPath,
+    payloadType: caseRulesCapability.payloadType,
+    operation: 'set',
   });
   const allowedCategories = loadBuiltinCategorySet({ builtinRegistryDir });
 
@@ -405,7 +442,10 @@ const applyConfigOverlay = ({ builtinPayload, config, builtinRegistryDir }) => {
     summaryBuckets: builtinPayload.summaryBuckets,
     missingRolePatterns: builtinPayload.missingRolePatterns,
     findingPolicy: builtinPayload.findingPolicy,
-    caseRules: builtinPayload.caseRules,
+    caseRules:
+      caseRulesSet === undefined
+        ? builtinPayload.caseRules
+        : canonicalizeCaseRules(caseRulesSet, { sourceLabel: 'config overlay' }),
   };
 };
 

--- a/calculogic-validator/naming/test/naming-case-rules-registry.test.mjs
+++ b/calculogic-validator/naming/test/naming-case-rules-registry.test.mjs
@@ -1,5 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import caseRulesRegistry from '../src/registries/_builtin/case-rules.registry.json' with { type: 'json' };
 import { resolveNamingRegistryInputs } from '../src/registries/registry-state.logic.mjs';
 import { toCaseRulesRuntime } from '../src/naming-runtime-converters.logic.mjs';
@@ -35,4 +38,207 @@ test('non-kebab semantic names are non-canonical', () => {
   assert.equal(isCanonicalSemanticName('left_panel', caseRulesRuntime), false);
   assert.equal(isCanonicalSemanticName('left..panel', caseRulesRuntime), false);
   assert.equal(isCanonicalSemanticName('left--panel', caseRulesRuntime), false);
+});
+
+
+const makeTempRegistryRoot = () => fs.mkdtempSync(path.join(os.tmpdir(), 'case-rules-registry-'));
+
+const writeJson = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+};
+
+test('custom case-rules file overrides builtin when present', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      rolesByCategory: {
+        'architecture-support': [{ role: 'host', status: 'active' }],
+      },
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
+      reportableExtensions: ['.ts'],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), {
+      reportableRootFiles: ['package.json'],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
+      classificationBuckets: ['canonical'],
+      secondaryBucketFamilies: ['codeCounts'],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
+      missingRolePatterns: [
+        {
+          patternId: 'single-extension',
+          dotSegments: 2,
+          semanticSegmentIndex: 0,
+          extensionSegmentIndexes: [1],
+        },
+      ],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), {
+      outcomes: {
+        canonical: {
+          code: 'NAMING_CANONICAL',
+          severity: 'info',
+          classification: 'canonical',
+          message: 'ok',
+          ruleRef: 'naming-spec',
+        },
+      },
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {
+      version: '1',
+      capabilities: [
+        {
+          configPath: 'naming.reportableExtensions',
+          operation: 'add',
+          payloadType: 'string-array',
+          target: 'reportableExtensions',
+        },
+        {
+          configPath: 'naming.roles',
+          operation: 'add',
+          payloadType: 'role-array',
+          target: 'roles',
+        },
+        {
+          configPath: 'naming.caseRules',
+          operation: 'set',
+          payloadType: 'case-rules-object',
+          target: 'caseRules',
+        },
+      ],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
+      semanticName: { style: 'kebab-case' },
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'host', category: 'architecture-support', status: 'active' },
+    ]);
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
+    writeJson(path.join(tempRoot, '_custom', 'case-rules.registry.custom.json'), {
+      semanticName: { style: 'kebab-case' },
+    });
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.deepEqual(result.caseRules, { semanticName: { style: 'kebab-case' } });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('custom registry falls back to builtin case-rules when custom case-rules file is absent', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, 'registry-state.json'), {
+      schemaVersion: '1',
+      activeRegistry: 'custom',
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      rolesByCategory: {
+        'architecture-support': [{ role: 'host', status: 'active' }],
+      },
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
+      reportableExtensions: ['.ts'],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), {
+      reportableRootFiles: ['package.json'],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
+      classificationBuckets: ['canonical'],
+      secondaryBucketFamilies: ['codeCounts'],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
+      missingRolePatterns: [
+        {
+          patternId: 'single-extension',
+          dotSegments: 2,
+          semanticSegmentIndex: 0,
+          extensionSegmentIndexes: [1],
+        },
+      ],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), {
+      outcomes: {
+        canonical: {
+          code: 'NAMING_CANONICAL',
+          severity: 'info',
+          classification: 'canonical',
+          message: 'ok',
+          ruleRef: 'naming-spec',
+        },
+      },
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {
+      version: '1',
+      capabilities: [
+        {
+          configPath: 'naming.reportableExtensions',
+          operation: 'add',
+          payloadType: 'string-array',
+          target: 'reportableExtensions',
+        },
+        {
+          configPath: 'naming.roles',
+          operation: 'add',
+          payloadType: 'role-array',
+          target: 'roles',
+        },
+        {
+          configPath: 'naming.caseRules',
+          operation: 'set',
+          payloadType: 'case-rules-object',
+          target: 'caseRules',
+        },
+      ],
+    });
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
+      semanticName: { style: 'kebab-case' },
+    });
+
+    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+      { role: 'host', category: 'architecture-support', status: 'active' },
+    ]);
+    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.deepEqual(result.caseRules, { semanticName: { style: 'kebab-case' } });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+
+test('unsupported case-rules style still throws deterministically at runtime preparation', () => {
+  const registryInputs = resolveNamingRegistryInputs({
+    config: {
+      naming: {
+        caseRules: {
+          semanticName: { style: 'snake_case' },
+        },
+      },
+    },
+  });
+
+  assert.throws(
+    () => toCaseRulesRuntime(registryInputs.caseRules),
+    /Unsupported semantic-name style in case rules runtime: snake_case/u,
+  );
 });

--- a/calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs
+++ b/calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs
@@ -24,6 +24,7 @@ test('overlay capabilities loader canonicalizes bounded entries', () => {
 
   assert.ok(Array.isArray(loaded.entries));
   assert.deepEqual(Object.keys(loaded.byPathOperation).sort((a, b) => a.localeCompare(b)), [
+    'naming.caseRules:set',
     'naming.reportableExtensions:add',
     'naming.roles:add',
   ]);
@@ -48,7 +49,33 @@ test('overlay capabilities loader rejects malformed payload deterministically', 
 
     assert.throws(
       () => loadOverlayCapabilitiesFromFile(malformedPath),
-      /operation must be "add"/u,
+      /operation must be one of add, set/u,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('overlay capabilities loader rejects invalid case-rules capability contract deterministically', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-cap-registry-'));
+
+  try {
+    const malformedPath = path.join(tempRoot, 'overlay-capabilities.registry.json');
+    writeJson(malformedPath, {
+      version: '1',
+      capabilities: [
+        {
+          configPath: 'naming.caseRules',
+          operation: 'add',
+          payloadType: 'case-rules-object',
+          target: 'caseRules',
+        },
+      ],
+    });
+
+    assert.throws(
+      () => loadOverlayCapabilitiesFromFile(malformedPath),
+      /target "caseRules" must use operation "set"/u,
     );
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -24,6 +24,12 @@ const DEFAULT_OVERLAY_CAPABILITIES_REGISTRY = {
       payloadType: 'role-array',
       target: 'roles',
     },
+    {
+      configPath: 'naming.caseRules',
+      operation: 'set',
+      payloadType: 'case-rules-object',
+      target: 'caseRules',
+    },
   ],
 };
 
@@ -570,6 +576,42 @@ test('unsupported config overlay paths remain ignored', () => {
   assert.deepEqual(withUnsupportedOverlay.roles, builtin.roles);
   assert.deepEqual(withUnsupportedOverlay.reportableExtensions, builtin.reportableExtensions);
   assert.deepEqual(withUnsupportedOverlay.summaryBuckets, builtin.summaryBuckets);
+  assert.deepEqual(withUnsupportedOverlay.caseRules, builtin.caseRules);
+});
+
+
+
+test('config overlay supports bounded case-rules set semantics', () => {
+  const result = resolveNamingRegistryInputs({
+    config: {
+      naming: {
+        caseRules: {
+          semanticName: { style: 'kebab-case' },
+        },
+      },
+    },
+  });
+
+  assert.equal(result.registrySource, 'config');
+  assert.deepEqual(result.caseRules, {
+    semanticName: { style: 'kebab-case' },
+  });
+});
+
+test('config overlay case-rules invalid semanticName.style throws deterministically', () => {
+  assert.throws(
+    () =>
+      resolveNamingRegistryInputs({
+        config: {
+          naming: {
+            caseRules: {
+              semanticName: { style: '' },
+            },
+          },
+        },
+      }),
+    /semanticName\.style must be a non-empty string/u,
+  );
 });
 
 test('throws when overlay capabilities registry is malformed', () => {


### PR DESCRIPTION
### Motivation

- Unify case-rules handling so builtin, optional custom, and config-overlay inputs share a single canonical validation/normalization path bounded to the existing `semanticName.style` surface. 
- Allow projects to optionally provide `_custom/case-rules.registry.custom.json` without changing runtime semantics or expanding case-style support. 
- Add a bounded, whole-surface config overlay for case rules so config can replace the case-rules object while preserving existing add-only overlay semantics for roles/extensions.

### Description

- Introduced `canonicalizeCaseRules` in `calculogic-validator/naming/src/registries/registry-state.logic.mjs` and routed builtin, custom (optional), and config-overlay inputs through it so all sources share the same shape/validation logic. 
- Added optional `_custom/case-rules.registry.custom.json` support with deterministic fallback to builtin `case-rules.registry.json` when the custom file is absent. 
- Extended overlay capability contract and loader (`naming-overlay-capabilities.registry.logic.mjs`) to support a new target `caseRules` with `operation: "set"` and `payloadType: "case-rules-object"`, and enforce target-specific operation/payload contracts. 
- Added builtin overlay capability entry `naming.caseRules:set` in `_builtin/overlay-capabilities.registry.json` and wired `applyConfigOverlay` (in `registry-state.logic.mjs`) to accept a bounded `set` payload that replaces the `caseRules` whole object when present. 
- Preserved runtime guardrails: the runtime converter (`toCaseRulesRuntime`) continues to accept only `semanticName.style = "kebab-case"` and unsupported styles still fail deterministically. 
- Updated and added tests to cover builtin resolution, custom override/fallback, config `caseRules` set semantics, invalid capability contracts, and runtime-style guardrail behavior, and updated spec doc `NamingValidatorSpec.md` to reflect the bounded overlay support.

### Testing

- Ran `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs` and it passed. 
- Ran `node --test calculogic-validator/naming/test/naming-case-rules-registry.test.mjs` and it passed. 
- Ran `node --test calculogic-validator/naming/test/naming-runtime-converters.test.mjs` and `node --test calculogic-validator/naming/test/naming-overlay-capabilities.registry.test.mjs` and both passed. 
- Ran the full test suite via `npm test` and it completed successfully with no failing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6c4090588331a9f003c0c1b6e4af)