### PR TITLE
test(naming): extract shared temp registry fixture helper

### DIFF
--- a/calculogic-validator/naming/test/naming-case-rules-registry.test.mjs
+++ b/calculogic-validator/naming/test/naming-case-rules-registry.test.mjs
@@ -48,87 +48,101 @@ const writeJson = (filePath, value) => {
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
 };
 
+const seedCaseRulesRegistryFixture = (
+  tempRoot,
+  {
+    includeCustomCaseRules = false,
+    customCaseRules = { semanticName: { style: 'kebab-case' } },
+  } = {},
+) => {
+  writeJson(path.join(tempRoot, 'registry-state.json'), {
+    schemaVersion: '1',
+    activeRegistry: 'custom',
+  });
+
+  writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+    categories: [{ category: 'architecture-support' }],
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+    rolesByCategory: {
+      'architecture-support': [{ role: 'host', status: 'active' }],
+    },
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
+    reportableExtensions: ['.ts'],
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), {
+    reportableRootFiles: ['package.json'],
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
+    classificationBuckets: ['canonical'],
+    secondaryBucketFamilies: ['codeCounts'],
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
+    missingRolePatterns: [
+      {
+        patternId: 'single-extension',
+        dotSegments: 2,
+        semanticSegmentIndex: 0,
+        extensionSegmentIndexes: [1],
+      },
+    ],
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), {
+    outcomes: {
+      canonical: {
+        code: 'NAMING_CANONICAL',
+        severity: 'info',
+        classification: 'canonical',
+        message: 'ok',
+        ruleRef: 'naming-spec',
+      },
+    },
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {
+    version: '1',
+    capabilities: [
+      {
+        configPath: 'naming.reportableExtensions',
+        operation: 'add',
+        payloadType: 'string-array',
+        target: 'reportableExtensions',
+      },
+      {
+        configPath: 'naming.roles',
+        operation: 'add',
+        payloadType: 'role-array',
+        target: 'roles',
+      },
+      {
+        configPath: 'naming.caseRules',
+        operation: 'set',
+        payloadType: 'case-rules-object',
+        target: 'caseRules',
+      },
+    ],
+  });
+  writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
+    semanticName: { style: 'kebab-case' },
+  });
+
+  writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
+    { role: 'host', category: 'architecture-support', status: 'active' },
+  ]);
+  writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
+
+  if (includeCustomCaseRules) {
+    writeJson(path.join(tempRoot, '_custom', 'case-rules.registry.custom.json'), customCaseRules);
+  }
+};
+
 test('custom case-rules file overrides builtin when present', () => {
   const tempRoot = makeTempRegistryRoot();
 
   try {
-    writeJson(path.join(tempRoot, 'registry-state.json'), {
-      schemaVersion: '1',
-      activeRegistry: 'custom',
-    });
-
-    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
-      categories: [{ category: 'architecture-support' }],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
-      rolesByCategory: {
-        'architecture-support': [{ role: 'host', status: 'active' }],
-      },
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
-      reportableExtensions: ['.ts'],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), {
-      reportableRootFiles: ['package.json'],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
-      classificationBuckets: ['canonical'],
-      secondaryBucketFamilies: ['codeCounts'],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
-      missingRolePatterns: [
-        {
-          patternId: 'single-extension',
-          dotSegments: 2,
-          semanticSegmentIndex: 0,
-          extensionSegmentIndexes: [1],
-        },
-      ],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), {
-      outcomes: {
-        canonical: {
-          code: 'NAMING_CANONICAL',
-          severity: 'info',
-          classification: 'canonical',
-          message: 'ok',
-          ruleRef: 'naming-spec',
-        },
-      },
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {
-      version: '1',
-      capabilities: [
-        {
-          configPath: 'naming.reportableExtensions',
-          operation: 'add',
-          payloadType: 'string-array',
-          target: 'reportableExtensions',
-        },
-        {
-          configPath: 'naming.roles',
-          operation: 'add',
-          payloadType: 'role-array',
-          target: 'roles',
-        },
-        {
-          configPath: 'naming.caseRules',
-          operation: 'set',
-          payloadType: 'case-rules-object',
-          target: 'caseRules',
-        },
-      ],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
-      semanticName: { style: 'kebab-case' },
-    });
-
-    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
-      { role: 'host', category: 'architecture-support', status: 'active' },
-    ]);
-    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
-    writeJson(path.join(tempRoot, '_custom', 'case-rules.registry.custom.json'), {
-      semanticName: { style: 'kebab-case' },
+    seedCaseRulesRegistryFixture(tempRoot, {
+      includeCustomCaseRules: true,
+      customCaseRules: { semanticName: { style: 'kebab-case' } },
     });
 
     const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
@@ -142,81 +156,7 @@ test('custom registry falls back to builtin case-rules when custom case-rules fi
   const tempRoot = makeTempRegistryRoot();
 
   try {
-    writeJson(path.join(tempRoot, 'registry-state.json'), {
-      schemaVersion: '1',
-      activeRegistry: 'custom',
-    });
-
-    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
-      categories: [{ category: 'architecture-support' }],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
-      rolesByCategory: {
-        'architecture-support': [{ role: 'host', status: 'active' }],
-      },
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), {
-      reportableExtensions: ['.ts'],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), {
-      reportableRootFiles: ['package.json'],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), {
-      classificationBuckets: ['canonical'],
-      secondaryBucketFamilies: ['codeCounts'],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), {
-      missingRolePatterns: [
-        {
-          patternId: 'single-extension',
-          dotSegments: 2,
-          semanticSegmentIndex: 0,
-          extensionSegmentIndexes: [1],
-        },
-      ],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), {
-      outcomes: {
-        canonical: {
-          code: 'NAMING_CANONICAL',
-          severity: 'info',
-          classification: 'canonical',
-          message: 'ok',
-          ruleRef: 'naming-spec',
-        },
-      },
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), {
-      version: '1',
-      capabilities: [
-        {
-          configPath: 'naming.reportableExtensions',
-          operation: 'add',
-          payloadType: 'string-array',
-          target: 'reportableExtensions',
-        },
-        {
-          configPath: 'naming.roles',
-          operation: 'add',
-          payloadType: 'role-array',
-          target: 'roles',
-        },
-        {
-          configPath: 'naming.caseRules',
-          operation: 'set',
-          payloadType: 'case-rules-object',
-          target: 'caseRules',
-        },
-      ],
-    });
-    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), {
-      semanticName: { style: 'kebab-case' },
-    });
-
-    writeJson(path.join(tempRoot, '_custom', 'roles.registry.custom.json'), [
-      { role: 'host', category: 'architecture-support', status: 'active' },
-    ]);
-    writeJson(path.join(tempRoot, '_custom', 'reportable-extensions.registry.custom.json'), ['.ts']);
+    seedCaseRulesRegistryFixture(tempRoot);
 
     const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
     assert.deepEqual(result.caseRules, { semanticName: { style: 'kebab-case' } });


### PR DESCRIPTION
### Motivation
- Two custom case-rules tests in `calculogic-validator/naming/test/naming-case-rules-registry.test.mjs` duplicated the same temp `_builtin` and base `_custom` registry setup, making the file noisier and harder to maintain.
- Centralize the common setup so each test only expresses the scenario-specific difference (custom case-rules present vs absent) while keeping behavior and assertions unchanged.

### Description
- Added a local helper `seedCaseRulesRegistryFixture(tempRoot, options)` in `calculogic-validator/naming/test/naming-case-rules-registry.test.mjs` that writes the shared `registry-state.json`, `_builtin` fixtures, and the base `_custom` fixtures.
- Kept `makeTempRegistryRoot` and `writeJson` unchanged and local to the test file as requested.
- Updated the two custom case-rules tests to call the helper with `includeCustomCaseRules: true` (and a `customCaseRules` payload) for the override scenario and to call the helper with defaults for the fallback scenario.
- No test assertions or runtime behavior were changed; the helper is confined to this test file and not extracted to shared utilities.

### Testing
- Ran the focused test file with `node --test calculogic-validator/naming/test/naming-case-rules-registry.test.mjs` and it passed all subtests.
- Ran the full test suite with `npm test` and observed all tests passing (no failures) for the repository test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6f9f8878833187931caa3a08027c)