### PR TITLE
docs(validator): update naming interpretation hardening inventory for bounded caseRules integration

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingInterpretationHardening-TransitionalInventory.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingInterpretationHardening-TransitionalInventory.md
@@ -22,7 +22,7 @@ The goal is ownership clarity and hardening ROI for the next naming-first pass, 
 | Explicit role-slot authority over incidental role-like tokens | **Partially implemented** | Canonical parse + role checks exist; role-like semantic/folder override behavior is contract-defined but not yet fully locked as dedicated disambiguation behavior/tests for all edge patterns. |
 | Optional semantic-family / semantic-group interpretation | **Intentionally out of scope for now** | Contract marks this as optional; no mandatory runtime lane required in current tranche. |
 | Folder-token context as contextual (not canonical authority by default) | **Partially implemented** | Folder context is used as scope/traversal input for walking/reporting mechanics. Folder-token interpretation remains a separate interpretation lane (contextual by default and non-overriding vs an explicit role slot), and that lane is not yet fully hard-locked as a dedicated behavior matrix. |
-| Lane-aware case policy surface (shared concept) | **Partially implemented (semantic-name baseline implemented)** | Semantic-name case policy baseline is registry-resolved and prepared-runtime-backed today; lane-specific policy expansion (for additional interpretation lanes) remains future-facing/partial. |
+| Lane-aware case policy surface (shared concept) | **Partially implemented (semantic-name baseline + bounded optional registry integration implemented)** | Semantic-name case policy baseline is registry-resolved and prepared-runtime-backed today, and bounded optional registry integration is now exercised for `caseRules` on that semantic-name surface. Lane-specific policy expansion for additional interpretation lanes remains future-facing/partial. |
 | Suite-owned implementation pairing rule (shared impl must have slice consumer) | **Already implemented (architecture guardrail)** | Current naming/runtime boundaries already reflect slice-owned enforcement with suite contracts; no speculative suite-only implementation is required in this tranche. |
 
 ### 2.2 `naming-semantic-name-and-role-disambiguation-spec.md` (naming specialization)
@@ -35,7 +35,7 @@ The goal is ownership clarity and hardening ROI for the next naming-first pass, 
 | Role-like tokens in semantic name treated as semantic by default when explicit role exists | **Partially implemented** | Contract exists; behavior is covered indirectly by existing parser/role checks, but dedicated disambiguation scenarios remain a hardening target. |
 | Role-like folder tokens remain contextual by default | **Partially implemented** | Contract exists; folder context is currently used operationally for scoped traversal/reporting, while folder-token meaning as an interpretation lane (contextual and non-overriding vs explicit role slot) is not yet expressed as a dedicated, test-locked disambiguation matrix. |
 | Ambiguity signaling allowed without ownership reassignment | **Already implemented (baseline), hardening recommended** | Ambiguity signaling exists (for example hyphen-appended role ambiguity). Additional disambiguation classes should be broadened before registry expansion. |
-| Naming-case application points beyond current semantic case checks | **Partially implemented (semantic-name baseline implemented)** | Naming currently applies a prepared semantic-name case-policy baseline sourced from registry payload and runtime preparation; additional lane-aware policy surfaces remain a later hardening step. |
+| Naming-case application points beyond current semantic case checks | **Partially implemented (semantic-name baseline + bounded optional registry integration implemented)** | Naming currently applies a prepared semantic-name case-policy baseline sourced from registry payload and runtime preparation, and bounded optional registry integration is now proven for `caseRules` on that surface. Additional lane-aware policy surfaces remain a later hardening step. |
 | Optional semantic-family-style interpretation | **Intentionally out of scope for now** | Optional by contract; no mandatory runtime addition needed in this tranche. |
 
 ### 2.3 `registry-model-and-slice-interaction-spec.md` (suite-level registry ownership model)
@@ -57,8 +57,9 @@ The goal is ownership clarity and hardening ROI for the next naming-first pass, 
 | Explicit role-slot authority rule text | **Suite-shared contract only** (consumed by naming slice) |
 | Naming disambiguation behavior for semantic/folder role-like tokens | **Naming-slice implementation** |
 | Ambiguity findings and naming-slice disambiguation diagnostics | **Naming-slice implementation** |
-| Semantic-name case style policy currently in builtin case-rules payload | **Builtin registry payload (implemented baseline)** |
-| Potential lane-aware case-policy expansion metadata (future) | **Builtin registry candidate** (after behavior hardening) |
+| Semantic-name case style policy currently in `caseRules` payload | **Registry payload (implemented baseline: builtin, optional custom, or bounded config overlay)** |
+| Bounded optional registry integration for semantic-name `caseRules` | **Naming-slice implementation + registry-state preparation (implemented, bounded)** |
+| Potential broader lane-aware case-policy expansion metadata (future) | **Registry payload candidate** (only after behavior lock + ownership clarity) |
 | Registry-state selection, normalization, digesting, converter prep | **Code-owned loader/converter mechanism (registry-state + runtime preparation)** |
 | Canonical filename parsing (`<semantic>.<role>.<ext>` and extension handling) | **Code-owned runtime/parser/disambiguation mechanic** |
 | Folder traversal/scoped collection mechanics | **Code-owned runtime/parser/disambiguation mechanic** |
@@ -68,7 +69,7 @@ The goal is ownership clarity and hardening ROI for the next naming-first pass, 
 
 ### 4.1 Policy surfaces that are valid builtin-registry candidates
 
-- Lane policy metadata (for example the implemented semantic-name case style baseline; later lane-aware case policy metadata once behavior is stable).
+- Lane policy metadata (for example the implemented semantic-name case style baseline and bounded optional `caseRules` integration for semantic-name; later broader lane-aware metadata only once behavior is stable).
 - Vocabulary/state payloads (roles/categories/status, finding policy mappings, allowed special-case classifications, summary-bucket policy).
 - Optional future disambiguation policy toggles **only** when they express bounded policy choices rather than parser algorithm flow.
 
@@ -79,7 +80,7 @@ The goal is ownership clarity and hardening ROI for the next naming-first pass, 
 - Traversal and scoped path-collection mechanics.
 - Runtime normalization/converter mechanics that compile payload shapes into executable runtime state.
 
-Guardrail: do not push parser/disambiguation/traversal engines into registries; registry payloads own policy data, converter/runtime preparation owns style-to-pattern compilation, and naming rule/helper code consumes prepared runtime state for deterministic enforcement.
+Guardrail: do not push parser/disambiguation/traversal engines into registries; registry payloads may originate from builtin, optional custom, or bounded config-overlay sources for supported surfaces, converter/runtime preparation owns normalization and style-to-pattern compilation, and naming rule/helper code consumes prepared runtime state for deterministic enforcement.
 
 ## 5) Recommended bounded implementation order (naming interpretation hardening tranche)
 
@@ -89,8 +90,9 @@ Guardrail: do not push parser/disambiguation/traversal engines into registries; 
 2. **Lane-aware case-policy surfaces second**
    - Keep parser/disambiguation mechanics code-owned.
    - Add only bounded policy surfaces that clearly belong in naming builtin registries.
-3. **Optional registry integration third (only after behavior clarity)**
-   - Integrate additional registry-backed policy metadata only where behavior is already test-locked and ownership is unambiguous.
+3. **Optional registry integration third (bounded step now exercised for semantic-name `caseRules`)**
+   - Bounded optional registry integration is now proven for semantic-name `caseRules`.
+   - Any broader registry-backed lane policy integration remains future-facing and should proceed only where behavior is test-locked and ownership is unambiguous.
 
 Tranche note: this is naming-first hardening, but better deterministic filename interpretation should improve downstream tree-validator signal quality indirectly.
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
@@ -114,7 +114,7 @@ Naming-slice specialization may define how shared case-policy surfaces apply to:
 
 Current runtime boundary for this specialization:
 
-- Implemented baseline: prepared semantic-name lane case-policy application.
+- Implemented baseline: prepared semantic-name lane case-policy application, including bounded optional registry integration for semantic-name `caseRules`.
 - Future/optional expansion: additional family/group/folder lane-aware policy remains future-facing and is not required by the current runtime contract.
 
 Case-policy guardrail:


### PR DESCRIPTION
### Motivation
- Prevent documentation drift by reflecting that the semantic-name case-policy baseline now exercises a bounded optional registry integration for `caseRules`, and to tighten ownership/guardrail language without changing runtime behavior.

### Description
- Updated `calculogic-validator/doc/ConventionRoutines/NamingInterpretationHardening-TransitionalInventory.md` to state that the semantic-name lane case policy is registry-resolved and that a bounded optional registry integration for `caseRules` is now exercised, while keeping broader lane expansion future-facing. 
- Tightened ownership and guardrail wording to clarify registry payload origins (`builtin`, optional custom, or bounded config overlay) while preserving that normalization/converter/runtime preparation and parser/disambiguation mechanics remain code-owned. 
- Revised sequencing language to mark bounded registry integration for semantic-name `caseRules` as proven and to require behavior lock + ownership clarity before any broader registry-backed lane expansion. 
- Made a minimal, consistency-only wording update in `calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md` to mention the bounded optional `caseRules` integration in the semantic-name baseline, without broadening the runtime contract.

### Testing
- Ran `git diff --check` to validate whitespace/patch hygiene, which succeeded.
- Changes were committed locally (`docs(validator): harden naming-case registry integration inventory`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af71f730e48331b1c79c0a617821b5)