### PR TITLE
perf(tree): lazily read tree advisor file content and harden runtime contract

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -454,6 +454,19 @@ Report object SHOULD include:
 - `addressing.hostBindings[]` (required)
 - `findings[]` (sorted deterministically)
 
+### Prepared runtime input contract (wiring/runtime boundary)
+
+The runtime entrypoint expects prepared inputs from wiring/runtime adapters and must fail clearly when the contract is bypassed.
+
+Required prepared fields:
+
+- `selectedPaths` (array)
+- `topLevelDirectoryNames` (array)
+- `targets` (array)
+- `getFileContent(relativePath)` (function)
+
+Runtime must treat file content access as lazy and callable on demand by path, instead of requiring an eagerly materialized full-file map.
+
 ---
 
 ## Determinism Requirements

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -7,6 +7,8 @@ import {
   runTreeStructureAdvisor,
   summarizeFindings,
 } from '../tree/src/tree-structure-advisor.host.mjs';
+import { prepareTreeStructureAdvisorInputs } from '../tree/src/tree-structure-advisor.wiring.mjs';
+import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../tree/src/tree-structure-advisor.logic.mjs';
 import { listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
 
 const writeJson = async (filePath, value) => {
@@ -477,6 +479,49 @@ test('tree-structure-advisor no-target behavior remains unchanged for findings',
     assert.deepEqual(withoutTargets.findings, explicitEmptyTargets.findings);
     assert.equal(withoutTargets.filters.isFiltered, false);
     assert.equal(explicitEmptyTargets.filters.isFiltered, false);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+
+test('tree-structure-advisor prepared runtime contract rejects missing lazy content accessor', () => {
+  assert.throws(
+    () =>
+      runTreeStructureAdvisorRuntime({
+        scope: 'repo',
+        selectedPaths: [],
+        topLevelDirectoryNames: [],
+        targets: [],
+      }),
+    /getFileContent\(relativePath\)/u,
+  );
+});
+
+test('tree-structure-advisor wiring provides lazy memoized content accessor', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-lazy-content-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'src', 'compat'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'compat', 'legacy-api.logic.mjs'),
+      "export * from '../../calculogic-validator/src/core/validator-runner.logic.mjs';\\n",
+      'utf8',
+    );
+
+    const prepared = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'repo' });
+
+    assert.equal(typeof prepared.getFileContent, 'function');
+    assert.equal('fileContentsByPath' in prepared, false);
+
+    const selectedPath = 'src/compat/legacy-api.logic.mjs';
+    const firstRead = prepared.getFileContent(selectedPath);
+    await fs.writeFile(path.join(fixtureDir, selectedPath), 'export const changed = true\\n', 'utf8');
+    const secondRead = prepared.getFileContent(selectedPath);
+
+    assert.equal(firstRead, secondRead);
+    assert.equal(prepared.getFileContent('src/not-selected.logic.mjs'), undefined);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }

--- a/calculogic-validator/tree/src/tree-shim-detection.logic.mjs
+++ b/calculogic-validator/tree/src/tree-shim-detection.logic.mjs
@@ -178,7 +178,7 @@ export const collectShimEvidence = (relativePath, rawContent) => {
   };
 };
 
-export const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
+export const collectShimCompatFindings = (paths, getFileContent) => {
   const findings = [];
 
   for (const relativePath of paths) {
@@ -187,7 +187,8 @@ export const collectShimCompatFindings = (paths, fileContentsByPath = {}) => {
       continue;
     }
 
-    const evidence = collectShimEvidence(relativePath, fileContentsByPath[relativePath]);
+    const rawContent = typeof getFileContent === 'function' ? getFileContent(relativePath) : undefined;
+    const evidence = collectShimEvidence(relativePath, rawContent);
     const hasWeakSignalOnly =
       !evidence.thinReexportShim &&
       (evidence.folderSignals.length > 0 || evidence.nameTokenSignals.length > 0);

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -85,15 +85,20 @@ export const summarizeFindings = (findings) => {
 };
 
 const assertPreparedTreeInputs = (preparedInputs) => {
-  if (
+  const hasPreparedRuntimeInputs =
     preparedInputs &&
     Array.isArray(preparedInputs.selectedPaths) &&
-    Array.isArray(preparedInputs.topLevelDirectoryNames)
-  ) {
+    Array.isArray(preparedInputs.topLevelDirectoryNames) &&
+    Array.isArray(preparedInputs.targets) &&
+    typeof preparedInputs.getFileContent === 'function';
+
+  if (hasPreparedRuntimeInputs) {
     return preparedInputs;
   }
 
-  throw new Error('Tree runtime requires prepared inputs from wiring/runtime adapter.');
+  throw new Error(
+    'Tree runtime requires prepared inputs from wiring/runtime adapter: selectedPaths[], topLevelDirectoryNames[], targets[], and getFileContent(relativePath).',
+  );
 };
 
 export const runTreeStructureAdvisor = (preparedInputs = {}) => {
@@ -102,7 +107,7 @@ export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const findings = [
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
     ...collectValidatorOwnedOutsideTreeFindings(prepared.selectedPaths),
-    ...collectShimCompatFindings(prepared.selectedPaths, prepared.fileContentsByPath),
+    ...collectShimCompatFindings(prepared.selectedPaths, prepared.getFileContent),
   ].sort(sortByPathThenCode);
 
   return {

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -97,19 +97,28 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
   const inScopePaths = sortPaths(new Set(scopedPaths));
   const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
   const selectedPaths = filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets);
-  const fileContentsByPath = Object.fromEntries(
-    selectedPaths.map((relativePath) => [
-      relativePath,
-      fs.readFileSync(path.resolve(repositoryRoot, relativePath), 'utf8'),
-    ]),
-  );
+  const contentByPathCache = new Map();
+  const selectedPathSet = new Set(selectedPaths);
+  const getFileContent = (relativePath) => {
+    if (!selectedPathSet.has(relativePath)) {
+      return undefined;
+    }
+
+    if (contentByPathCache.has(relativePath)) {
+      return contentByPathCache.get(relativePath);
+    }
+
+    const rawContent = fs.readFileSync(path.resolve(repositoryRoot, relativePath), 'utf8');
+    contentByPathCache.set(relativePath, rawContent);
+    return rawContent;
+  };
 
   return {
     scope: selectedScope,
     selectedPaths,
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: resolvedTargets.map((target) => target.relPath),
-    fileContentsByPath,
+    getFileContent,
   };
 };
 


### PR DESCRIPTION
### Motivation

- The tree advisor previously eagerly read every selected file into a `fileContentsByPath` map which wastes work and scales poorly for large tree slices.  
- The runtime input contract was underspecified: `assertPreparedTreeInputs(...)` did not validate that file-content access or `targets` were provided, leaving a boundary-hardening gap between wiring and runtime.

### Description

- Replace eager content map with lazy accessor: `prepareTreeStructureAdvisorInputs(...)` no longer builds `fileContentsByPath` and instead returns a memoized `getFileContent(relativePath)` function scoped to `selectedPaths` (in `tree-structure-advisor.wiring.mjs`).
- Harden runtime contract: `assertPreparedTreeInputs(...)` now requires `selectedPaths`, `topLevelDirectoryNames`, `targets`, and a `getFileContent` function and throws a deterministic error when missing (in `tree-structure-advisor.logic.mjs`).
- Adapt shim detection to use lazy access: `collectShimCompatFindings(...)` now accepts the `getFileContent` accessor and only reads file contents on demand (in `tree-shim-detection.logic.mjs`).
- Preserve behavior and outputs: findings codes, ordering, severity, and scope/target handling are preserved and unchanged; this is a wiring/runtime boundary improvement only.
- Tests and spec updated: added tests for runtime rejection when the lazy accessor is missing and for wiring-provided lazy memoized accessor behavior, and documented the prepared runtime contract in the validator spec (`tree-structure-advisor-validator-spec.md`).

### Testing

- Ran focused tree tests with `node --test calculogic-validator/test/**/*.test.mjs` and all tests passed.
- Ran full project test suite with `npm test` and all tests passed.
- New tests (runtime contract rejection and lazy accessor/memoization parity) were added and succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af91f12d0483318662fdb393518a8f)