### PR TITLE
refactor(tree): harden getFileContent scope boundary checks

### DIFF
--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -498,7 +498,7 @@ test('tree-structure-advisor prepared runtime contract rejects missing lazy cont
   );
 });
 
-test('tree-structure-advisor wiring provides lazy memoized content accessor', async () => {
+test('tree-structure-advisor wiring provides lazy memoized content accessor and deterministic scope boundary error', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-lazy-content-'));
 
   try {
@@ -521,7 +521,10 @@ test('tree-structure-advisor wiring provides lazy memoized content accessor', as
     const secondRead = prepared.getFileContent(selectedPath);
 
     assert.equal(firstRead, secondRead);
-    assert.equal(prepared.getFileContent('src/not-selected.logic.mjs'), undefined);
+    assert.throws(
+      () => prepared.getFileContent('src/not-selected.logic.mjs'),
+      /Tree prepared getFileContent received out-of-scope path: src\/not-selected\.logic\.mjs/u,
+    );
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -101,7 +101,9 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
   const selectedPathSet = new Set(selectedPaths);
   const getFileContent = (relativePath) => {
     if (!selectedPathSet.has(relativePath)) {
-      return undefined;
+      throw new Error(
+        `Tree prepared getFileContent received out-of-scope path: ${relativePath}`,
+      );
     }
 
     if (contentByPathCache.has(relativePath)) {


### PR DESCRIPTION
### Motivation
- Harden the wiring boundary so out-of-scope file access via the lazy `getFileContent(relativePath)` accessor fails deterministically instead of returning `undefined` to avoid ambiguous runtime behavior.
- Preserve existing lazy-read and memoization semantics for valid selected paths while limiting the change strictly to boundary hardening with no broad behavior expansion.

### Description
- Changed `prepareTreeStructureAdvisorInputs` in `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs` so `getFileContent(relativePath)` throws `Error('Tree prepared getFileContent received out-of-scope path: ...')` for paths not in `selectedPaths` while keeping the `contentByPathCache` and lazy read path intact.
- Updated the focused test in `calculogic-validator/test/tree-structure-advisor.test.mjs` to assert that in-scope reads still succeed, repeated reads remain memoized/consistent, and out-of-scope reads throw the deterministic error.
- Kept all other wiring, tree-finding, and registry behaviors unchanged and limited the modification to the accessor boundary.

### Testing
- Ran the focused test file with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and all tests passed (20 tests, 0 failures).
- The updated test verifies in-scope reads, memoization on repeated reads, and deterministic throwing on out-of-scope reads, and those assertions succeeded during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af968ccc648331bb7e45be98a6067e)