### PR TITLE
feat(tree): emit owned-slice boundary drift advisory for validator-owned growth under suite-core

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -37,6 +37,7 @@ This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-M
   - normalization of repeated validator-subtree scaffolds (for future validators)
 - Shim/compat advisory hardening with bounded evidence precedence and intentional pass-through carveouts, including package/public barrel pass-through (`calculogic-validator/src/index.mjs`) with `export * from`, `export * as <name> from`, and optional `export { ... } from` forms
 - Weak token/path-only shim observability may suppress detector-implementation modules inside `calculogic-validator/tree/src/` when `shim` appears only as part of the detector semantic name (for example `*shim-detection*`) and no thin re-export evidence exists
+- Bounded owned-slice boundary drift advisory under suite-core: emit `TREE_OWNED_SLICE_BOUNDARY_DRIFT` only for deterministic, conservative subtree-local growth signals under `calculogic-validator/src/**` while preserving explicit shared-infra/compat/public-entry carveouts
 
 ### Out of scope (V0.1.5)
 

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -375,6 +375,122 @@ test('tree-structure-advisor flags validator-owned-looking file outside validato
   }
 });
 
+
+test('tree-structure-advisor boundary drift keeps suite-core shared infra carveouts quiet', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-boundary-shared-infra-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'naming'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'naming', 'naming-validator.logic.mjs'),
+      'export const namingCore = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'core', 'naming', 'naming-validator.wiring.mjs'),
+      'export const namingWiring = true\n',
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some((finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor emits owned-slice boundary drift for clear subsystem growth under suite-core', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-boundary-drift-owned-growth-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'tree-structure-advisor'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(
+        fixtureDir,
+        'calculogic-validator',
+        'src',
+        'tree-structure-advisor',
+        'tree-structure-advisor.logic.mjs',
+      ),
+      'export const treeLogic = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(
+        fixtureDir,
+        'calculogic-validator',
+        'src',
+        'tree-structure-advisor',
+        'tree-structure-advisor.wiring.mjs',
+      ),
+      'export const treeWiring = true\n',
+      'utf8',
+    );
+
+    const first = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const second = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+    const firstDriftFindings = first.findings.filter(
+      (finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT',
+    );
+    const secondDriftFindings = second.findings.filter(
+      (finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT',
+    );
+
+    assert.equal(firstDriftFindings.length, 1);
+    assert.deepEqual(firstDriftFindings, secondDriftFindings);
+    assert.equal(firstDriftFindings[0].path, 'calculogic-validator/src/tree-structure-advisor/');
+    assert.deepEqual(firstDriftFindings[0].details.matchedOwnedSignalPaths, [
+      'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.logic.mjs',
+      'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.wiring.mjs',
+    ]);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor boundary drift preserves compat and public-entry carveouts', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-boundary-drift-carveouts-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src', 'compat'), { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'compat', 'legacy-validator.logic.mjs'),
+      'export const compatLogic = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'compat', 'legacy-validator.wiring.mjs'),
+      'export const compatWiring = true\n',
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(fixtureDir, 'calculogic-validator', 'src', 'index.mjs'),
+      "export * from './core/validator-runner.logic.mjs';\n",
+      'utf8',
+    );
+
+    const result = runTreeStructureAdvisor(fixtureDir, { scope: 'repo' });
+
+    assert.equal(
+      result.findings.some((finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor directory target narrows analyzed paths/findings', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-target-dir-'));
 

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -6,6 +6,21 @@ import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy.regi
 const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
 const TREE_SIGNAL_POLICY = getBuiltinTreeSignalPolicy();
 
+const VALIDATOR_SUITE_CORE_ROOT = 'calculogic-validator/src/';
+const SUITE_CORE_BOUNDARY_DRIFT_CARVEOUT_PREFIXES = [
+  'calculogic-validator/src/core/',
+  'calculogic-validator/src/compat/',
+  'calculogic-validator/src/registries/',
+];
+const SUITE_CORE_BOUNDARY_DRIFT_CARVEOUT_EXACT_PATHS = new Set([
+  'calculogic-validator/src/index.mjs',
+  'calculogic-validator/src/validator-config.schema.json',
+]);
+const SUITE_CORE_BOUNDARY_DRIFT_OWNED_SUBSYSTEM_MIN_FILES = 2;
+
+const BOUNDARY_DRIFT_BASENAME_SIGNAL_MATCHER =
+  /(?:\.host\.|\.wiring\.|\.logic\.|\.knowledge\.|\.contracts\.|\.runtime\.|registry|registries)/u;
+
 const sortByPathThenCode = (left, right) => {
   const byPath = left.path.localeCompare(right.path);
   if (byPath !== 0) {
@@ -60,6 +75,68 @@ const collectValidatorOwnedOutsideTreeFindings = (paths) =>
       },
     }));
 
+const isBoundaryDriftCarveoutPath = (relativePath) =>
+  SUITE_CORE_BOUNDARY_DRIFT_CARVEOUT_EXACT_PATHS.has(relativePath) ||
+  SUITE_CORE_BOUNDARY_DRIFT_CARVEOUT_PREFIXES.some((prefix) => relativePath.startsWith(prefix));
+
+const collectOwnedSliceBoundaryDriftFindings = (paths) => {
+  const filesBySuiteCoreSubtree = new Map();
+
+  for (const relativePath of paths) {
+    if (!relativePath.startsWith(VALIDATOR_SUITE_CORE_ROOT)) {
+      continue;
+    }
+
+    if (isBoundaryDriftCarveoutPath(relativePath)) {
+      continue;
+    }
+
+    const suffix = relativePath.slice(VALIDATOR_SUITE_CORE_ROOT.length);
+    const [topLevelSegment] = suffix.split('/');
+    if (!topLevelSegment || topLevelSegment.includes('.')) {
+      continue;
+    }
+
+    const siblingPaths = filesBySuiteCoreSubtree.get(topLevelSegment) ?? [];
+    siblingPaths.push(relativePath);
+    filesBySuiteCoreSubtree.set(topLevelSegment, siblingPaths);
+  }
+
+  return Array.from(filesBySuiteCoreSubtree.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([topLevelSegment, siblingPaths]) => {
+      const matchedOwnedSignals = siblingPaths
+        .filter((candidatePath) =>
+          BOUNDARY_DRIFT_BASENAME_SIGNAL_MATCHER.test(path.posix.basename(candidatePath)),
+        )
+        .sort((left, right) => left.localeCompare(right));
+
+      if (matchedOwnedSignals.length < SUITE_CORE_BOUNDARY_DRIFT_OWNED_SUBSYSTEM_MIN_FILES) {
+        return [];
+      }
+
+      return [
+        {
+          code: 'TREE_OWNED_SLICE_BOUNDARY_DRIFT',
+          severity: 'info',
+          path: `${VALIDATOR_SUITE_CORE_ROOT}${topLevelSegment}/`,
+          classification: 'advisory-structure',
+          message:
+            'Likely validator-owned subsystem growth is accumulating under suite-core calculogic-validator/src/** rather than an owned slice root.',
+          ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md',
+          details: {
+            suiteCoreRoot: VALIDATOR_SUITE_CORE_ROOT,
+            observedSubtree: topLevelSegment,
+            matchedOwnedSignalPaths: matchedOwnedSignals,
+            threshold: {
+              minOwnedSignalFiles: SUITE_CORE_BOUNDARY_DRIFT_OWNED_SUBSYSTEM_MIN_FILES,
+            },
+          },
+        },
+      ];
+    });
+};
+
 const incrementCounter = (counts, key) => {
   counts[key] = (counts[key] ?? 0) + 1;
 };
@@ -107,6 +184,7 @@ export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const findings = [
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
     ...collectValidatorOwnedOutsideTreeFindings(prepared.selectedPaths),
+    ...collectOwnedSliceBoundaryDriftFindings(prepared.selectedPaths),
     ...collectShimCompatFindings(prepared.selectedPaths, prepared.getFileContent),
   ].sort(sortByPathThenCode);
 


### PR DESCRIPTION
### Motivation
- Detect conservative, deterministic signs of validator-owned subsystem growth accumulating inside the shared suite-core area `calculogic-validator/src/**` so the tree advisor can warn about avoidable future extraction/shim debt. 
- Preserve existing public-entry and shared-infra carveouts and keep the advisory report-only to avoid forcing any moves.

### Description
- Added a bounded detection pass in `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs` that groups files under `calculogic-validator/src/<subtree>/`, ignores explicit carveouts (`src/core/**`, `src/compat/**`, `src/registries/**`, `src/index.mjs`, `src/validator-config.schema.json`), and emits a deterministic `TREE_OWNED_SLICE_BOUNDARY_DRIFT` advisory when a subtree contains at least `2` validator-owned-local signal files (conservative threshold). 
- Matching uses a deterministic basename signal matcher (`.host.`, `.wiring.`, `.logic.`, `.knowledge.`, `registry`/`registries`, etc.) and sorts matched paths in the finding details for stable output. 
- Integrated the new collector into the existing findings pipeline so existing findings and shim/compat carveouts are preserved. 
- Updated the validator spec `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to document the bounded V0.1.5 behavior and added focused tests in `calculogic-validator/test/tree-structure-advisor.test.mjs` exercising carveouts, positive detection, and determinism.

### Testing
- Ran the focused slice tests with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and all tests in that file passed. 
- Ran the full suite with `npm test` and the entire test suite passed without failures. 
- New/modified automated tests added: boundary-carveout non-flagging, owned-subsystem-flagging under `calculogic-validator/src/**`, carveout preservation for public-entry/compat, and deterministic repeatability for the new advisory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af9cc122408331ae9b6badcfedff8a)