### PR TITLE
docs(tree): align spec code list with implemented owned-slice boundary drift advisory

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -439,7 +439,7 @@ Suggested codes (V0.0.1):
 - `TREE_SHARED_LANE_FIRST_PARTITION_PRESENT` (`info`)
 - `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` (`warn`/`info`)
 - `TREE_SHARED_SEMANTIC_ROOT_RECOMMENDED` (`warn`/`info`)
-- `TREE_OWNED_SLICE_BOUNDARY_DRIFT` (`warn`/`info`) — future advisory direction
+- `TREE_OWNED_SLICE_BOUNDARY_DRIFT` (`info`) — implemented in bounded deterministic form for conservative subtree-local growth signals under suite-core
 - `TREE_OWNED_SLICE_EXTRACTION_RECOMMENDED` (`warn`/`info`) — future advisory direction
 
 ---


### PR DESCRIPTION
### Motivation
- The tree spec contained an internal contradiction where `TREE_OWNED_SLICE_BOUNDARY_DRIFT` was described as implemented in the hardened V0.1.5 subset earlier but remained labeled future-facing in the "Finding / Code Set" list, creating avoidable spec drift.

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to mark `TREE_OWNED_SLICE_BOUNDARY_DRIFT` as `info` and describe it as "implemented in bounded deterministic form for conservative subtree-local growth signals under suite-core", while keeping `TREE_OWNED_SLICE_EXTRACTION_RECOMMENDED` as a future advisory direction.

### Testing
- Performed docs-only sanity checks by running `git diff --check` (no issues) and `rg -n "TREE_OWNED_SLICE_BOUNDARY_DRIFT|TREE_OWNED_SLICE_EXTRACTION_RECOMMENDED|Finding / Code Set"` to verify the updated lines, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa0ab0f1483319faa7cd61f8bead4)