### PR TITLE
feat(config): make naming.caseRules a first-class validator config surface

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
@@ -46,6 +46,7 @@ Allowed keys:
 
 - `reportableExtensions` (optional object)
 - `roles` (optional object)
+- `caseRules` (optional object)
 
 ### 4.3 `naming.reportableExtensions`
 
@@ -88,6 +89,8 @@ Unknown keys are rejected at:
 - `naming`
 - `naming.reportableExtensions`
 - `naming.roles`
+- `naming.caseRules`
+- `naming.caseRules.semanticName`
 - each `naming.roles.add[]` object
 
 Special case:
@@ -105,7 +108,8 @@ Runtime loading returns normalized config with deterministic shaping:
 - extension strings are trimmed.
 - extension additions are de-duplicated after trim (`Set` semantics).
 - `roles.add` entries are de-duplicated by trimmed `role` value; **first occurrence wins**.
-- `naming` is included in normalized output only when at least one supported naming addition list is present.
+- `naming` is included in normalized output only when at least one supported naming surface is present.
+- `naming.caseRules.semanticName.style` is retained (trimmed) when provided and valid.
 
 ## 7) Merge semantics in naming runtime
 
@@ -212,7 +216,22 @@ This behavior applies to:
 }
 ```
 
-### 9.5 Strict exit via config
+### 9.5 Case rules style override (current supported value)
+
+```json
+{
+  "version": "0.1",
+  "naming": {
+    "caseRules": {
+      "semanticName": {
+        "style": "kebab-case"
+      }
+    }
+  }
+}
+```
+
+### 9.6 Strict exit via config
 
 ```json
 {

--- a/calculogic-validator/src/core/config/validator-config.logic.mjs
+++ b/calculogic-validator/src/core/config/validator-config.logic.mjs
@@ -9,6 +9,7 @@ const VALID_ROLE_CATEGORIES = new Set([
   'deprecated',
 ]);
 const VALID_ROLE_STATUSES = new Set(['active', 'deprecated']);
+const VALID_SEMANTIC_NAME_STYLES = new Set(['kebab-case']);
 
 const fail = (message) => {
   throw new Error(`Invalid validator config: ${message}`);
@@ -56,8 +57,9 @@ const normalizeConfig = (config) => {
 
   const extensionAdditions = config?.naming?.reportableExtensions?.add;
   const roleAdditions = config?.naming?.roles?.add;
+  const semanticNameStyle = config?.naming?.caseRules?.semanticName?.style;
 
-  if (extensionAdditions || roleAdditions) {
+  if (extensionAdditions || roleAdditions || semanticNameStyle !== undefined) {
     normalized.naming = {};
   }
 
@@ -70,6 +72,14 @@ const normalizeConfig = (config) => {
   if (roleAdditions) {
     normalized.naming.roles = {
       add: normalizeRoleAdditions(roleAdditions),
+    };
+  }
+
+  if (semanticNameStyle !== undefined) {
+    normalized.naming.caseRules = {
+      semanticName: {
+        style: semanticNameStyle.trim(),
+      },
     };
   }
 
@@ -159,6 +169,43 @@ const validateRoleAdditions = (config) => {
   additions.forEach(validateRoleAdditionEntry);
 };
 
+const validateNamingCaseRules = (config) => {
+  const caseRules = config?.naming?.caseRules;
+  if (caseRules === undefined) {
+    return;
+  }
+
+  if (!caseRules || typeof caseRules !== 'object' || Array.isArray(caseRules)) {
+    fail('naming.caseRules must be an object when provided.');
+  }
+
+  assertOnlyKeys(caseRules, ['semanticName'], 'naming.caseRules');
+
+  const semanticName = caseRules.semanticName;
+  if (semanticName === undefined) {
+    return;
+  }
+
+  if (!semanticName || typeof semanticName !== 'object' || Array.isArray(semanticName)) {
+    fail('naming.caseRules.semanticName must be an object when provided.');
+  }
+
+  assertOnlyKeys(semanticName, ['style'], 'naming.caseRules.semanticName');
+
+  const style = semanticName.style;
+  if (style === undefined) {
+    return;
+  }
+
+  if (typeof style !== 'string' || style.trim().length === 0) {
+    fail('naming.caseRules.semanticName.style must be a non-empty string when provided.');
+  }
+
+  if (!VALID_SEMANTIC_NAME_STYLES.has(style.trim())) {
+    fail('naming.caseRules.semanticName.style must be "kebab-case".');
+  }
+};
+
 const validateConfig = (config) => {
   if (!config || typeof config !== 'object' || Array.isArray(config)) {
     fail('root must be an object.');
@@ -180,11 +227,12 @@ const validateConfig = (config) => {
       fail('naming must be an object when provided.');
     }
 
-    assertOnlyKeys(naming, ['reportableExtensions', 'roles'], 'naming');
+    assertOnlyKeys(naming, ['reportableExtensions', 'roles', 'caseRules'], 'naming');
   }
 
   validateReportableExtensionAdditions(config);
   validateRoleAdditions(config);
+  validateNamingCaseRules(config);
 };
 
 export const loadValidatorConfigFromFile = (configPath, { cwd = process.cwd() } = {}) => {

--- a/calculogic-validator/src/validator-config.schema.json
+++ b/calculogic-validator/src/validator-config.schema.json
@@ -74,6 +74,21 @@
               }
             }
           }
+        },
+        "caseRules": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "semanticName": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "style": {
+                  "const": "kebab-case"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/calculogic-validator/test/validator-config-schema-sync.test.mjs
+++ b/calculogic-validator/test/validator-config-schema-sync.test.mjs
@@ -13,3 +13,17 @@ test('validator config schema version const matches runtime contract version', (
 
   assert.equal(schema?.properties?.version?.const, VALIDATOR_CONFIG_VERSION);
 });
+
+
+test('validator config schema allows naming.caseRules.semanticName.style kebab-case only', () => {
+  const schemaPath = path.join(
+    process.cwd(),
+    'calculogic-validator/src/validator-config.schema.json',
+  );
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+
+  assert.equal(
+    schema?.properties?.naming?.properties?.caseRules?.properties?.semanticName?.properties?.style?.const,
+    'kebab-case',
+  );
+});

--- a/calculogic-validator/test/validator-config.case-rules.test.mjs
+++ b/calculogic-validator/test/validator-config.case-rules.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadValidatorConfigFromFile } from '../src/core/config/validator-config.logic.mjs';
+
+const writeTempConfig = (filename, payload) => {
+  const tempPath = path.join(process.cwd(), `calculogic-validator/test/fixtures/${filename}`);
+  fs.writeFileSync(tempPath, JSON.stringify(payload));
+  return tempPath;
+};
+
+test('accepts naming.caseRules.semanticName.style kebab-case and normalizes value', () => {
+  const tempPath = writeTempConfig('tmp-case-rules-valid-kebab-case.json', {
+    version: '0.1',
+    naming: {
+      caseRules: {
+        semanticName: {
+          style: ' kebab-case ',
+        },
+      },
+    },
+  });
+
+  try {
+    const config = loadValidatorConfigFromFile(tempPath, { cwd: '/' });
+    assert.deepEqual(config.naming?.caseRules, {
+      semanticName: {
+        style: 'kebab-case',
+      },
+    });
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
+test('rejects unsupported naming.caseRules.semanticName.style value', () => {
+  const tempPath = writeTempConfig('tmp-case-rules-invalid-style.json', {
+    version: '0.1',
+    naming: {
+      caseRules: {
+        semanticName: {
+          style: 'snake_case',
+        },
+      },
+    },
+  });
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(tempPath, { cwd: '/' }),
+      /Invalid validator config: naming\.caseRules\.semanticName\.style must be "kebab-case"\./u,
+    );
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});
+
+test('rejects unknown key under naming.caseRules', () => {
+  const tempPath = writeTempConfig('tmp-case-rules-unknown-key.json', {
+    version: '0.1',
+    naming: {
+      caseRules: {
+        semanticName: {
+          style: 'kebab-case',
+        },
+        extra: {},
+      },
+    },
+  });
+
+  try {
+    assert.throws(
+      () => loadValidatorConfigFromFile(tempPath, { cwd: '/' }),
+      /Invalid validator config: naming\.caseRules contains unknown key "extra"\./u,
+    );
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+});

--- a/doc/nl-config/cfg-namingValidator.md
+++ b/doc/nl-config/cfg-namingValidator.md
@@ -132,6 +132,8 @@ Naming validator supports optional runtime config input with deterministic JSON 
   - required `category` string, validated against `calculogic-validator/naming/src/registries/_builtin/categories.registry.json` `categories[].category`
   - required `status` from `active | deprecated`
   - optional `notes` string
+- optional `naming.caseRules.semanticName.style` string
+  - when provided, must be `kebab-case` for current runtime support
 
 Normalization and merge semantics for `naming.roles.add` are deterministic and additive-only:
 
@@ -171,6 +173,8 @@ Runtime and schema strictness are intentionally aligned. Unknown keys are reject
 - `naming`
 - `naming.reportableExtensions`
 - `naming.roles`
+- `naming.caseRules`
+- `naming.caseRules.semanticName`
 - each `naming.roles.add[]` entry object
 
 ### 2.7 Report metadata contract (V0.1.12)


### PR DESCRIPTION
### Motivation
- Resolve a contract mismatch where naming runtime and tests already accept `naming.caseRules` but the validator schema and loader rejected it. 
- Make the validator config contract deterministic and fail-fast for unsupported/unknown case-rule values to preserve trust in config validation. 

### Description
- Add `naming.caseRules` to the JSON schema in `calculogic-validator/src/validator-config.schema.json` with a bounded shape supporting only `semanticName.style` and `"kebab-case"` as the allowed value. 
- Extend runtime config validation in `calculogic-validator/src/core/config/validator-config.logic.mjs` to allow `naming.caseRules`, validate object shapes, enforce `semanticName.style` as a non-empty string, and reject unsupported styles early. 
- Extend `normalizeConfig(...)` to preserve `naming.caseRules.semanticName.style` (trimmed) in normalized output when provided. 
- Add focused tests `calculogic-validator/test/validator-config.case-rules.test.mjs` and a schema-sync assertion in `validator-config-schema-sync.test.mjs`, and update NL/spec docs to reflect the new contract. 

### Testing
- Ran the validator config tests with `node --test calculogic-validator/test/**/*.test.mjs` and the full test suite via `npm test`, and all tests passed. 
- New tests cover acceptance and normalization of `kebab-case`, rejection of unsupported styles like `snake_case`, and rejection of unknown keys under `naming.caseRules`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0959162e48331a77fa92b0eade9c3)