### PR TITLE
feat(tree): respect includeRootFiles in tree scope collection

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -192,6 +192,13 @@ Tree advisor scope selection should reuse the existing validator scope discovery
 
 Target filtering applies after scope discovery and before analysis.
 
+Scope discovery for non-`repo` profiles must consume both scope-profile surfaces exposed by the shared runtime contract:
+
+- `includeRoots`: directory roots to walk recursively
+- `includeRootFiles`: explicit repository-root files to include when present
+
+Runtime collection must ignore missing declared root files, normalize collected root-file paths the same way as walked paths, then merge + deduplicate before target filtering.
+
 ---
 
 ## Analysis Heuristics (Deterministic)

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -601,6 +601,58 @@ test('tree-structure-advisor no-target behavior remains unchanged for findings',
 });
 
 
+
+test('tree-structure-advisor docs scope includes declared root README when present', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-scope-docs-root-file-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(path.join(fixtureDir, 'README.md'), '# root readme\n', 'utf8');
+
+    const prepared = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'docs' });
+
+    assert.deepEqual(prepared.selectedPaths, ['doc/README.md', 'README.md']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor system scope includes present root files and ignores missing declarations', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-scope-system-root-files-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(path.join(fixtureDir, 'eslint.config.mjs'), 'export default []\n', 'utf8');
+    await fs.writeFile(path.join(fixtureDir, 'tsconfig.json'), '{"compilerOptions":{}}\n', 'utf8');
+
+    const prepared = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'system' });
+
+    assert.deepEqual(prepared.selectedPaths, ['eslint.config.mjs', 'package.json', 'tsconfig.json']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor root-file target filtering works for docs scope target', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-scope-docs-target-root-file-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(path.join(fixtureDir, 'README.md'), '# root readme\n', 'utf8');
+
+    const result = runTreeStructureAdvisor(fixtureDir, {
+      scope: 'docs',
+      targets: ['README.md'],
+    });
+
+    assert.equal(result.filters.isFiltered, true);
+    assert.deepEqual(result.filters.targets, ['README.md']);
+    assert.equal(result.totalFilesScanned, 1);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor prepared runtime contract rejects missing lazy content accessor', () => {
   assert.throws(
     () =>

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -25,7 +25,7 @@ const WALK_EXCLUDED_DIRECTORIES = new Set([
 
 const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
 
-const getScopeRoots = (scope) => {
+const getScopeCollectionProfile = (scope) => {
   const selectedScope = scope ?? 'repo';
   const profile = getValidatorScopeProfile(selectedScope);
 
@@ -34,10 +34,13 @@ const getScopeRoots = (scope) => {
   }
 
   if (selectedScope === 'repo') {
-    return ['.'];
+    return { includeRoots: ['.'], includeRootFiles: [] };
   }
 
-  return profile.includeRoots;
+  return {
+    includeRoots: profile.includeRoots,
+    includeRootFiles: profile.includeRootFiles,
+  };
 };
 
 const collectPathsFromScopeRoot = (repositoryRoot, scopeRoot) => {
@@ -79,6 +82,26 @@ const collectPathsFromScopeRoot = (repositoryRoot, scopeRoot) => {
   return collected;
 };
 
+
+const collectPathsFromRootFiles = (repositoryRoot, includeRootFiles) => {
+  const repositoryAbsoluteRoot = path.resolve(repositoryRoot);
+
+  return includeRootFiles.flatMap((rootFilePath) => {
+    const absolutePath = path.resolve(repositoryRoot, rootFilePath);
+
+    if (path.dirname(absolutePath) !== repositoryAbsoluteRoot || !fs.existsSync(absolutePath)) {
+      return [];
+    }
+
+    const rootFileStat = fs.statSync(absolutePath);
+    if (!rootFileStat.isFile()) {
+      return [];
+    }
+
+    return [normalizePath(path.relative(repositoryRoot, absolutePath))];
+  });
+};
+
 const collectTopLevelDirectoryNames = (repositoryRoot) =>
   fs
     .readdirSync(repositoryRoot, { withFileTypes: true })
@@ -90,11 +113,15 @@ const collectTopLevelDirectoryNames = (repositoryRoot) =>
 
 export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targets } = {}) => {
   const selectedScope = scope ?? 'repo';
-  const scopeRoots = getScopeRoots(selectedScope);
-  const scopedPaths = scopeRoots.flatMap((scopeRoot) =>
+  const scopeCollectionProfile = getScopeCollectionProfile(selectedScope);
+  const scopedPaths = scopeCollectionProfile.includeRoots.flatMap((scopeRoot) =>
     collectPathsFromScopeRoot(repositoryRoot, scopeRoot),
   );
-  const inScopePaths = sortPaths(new Set(scopedPaths));
+  const rootFilePaths = collectPathsFromRootFiles(
+    repositoryRoot,
+    scopeCollectionProfile.includeRootFiles,
+  );
+  const inScopePaths = sortPaths(new Set([...scopedPaths, ...rootFilePaths]));
   const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
   const selectedPaths = filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets);
   const contentByPathCache = new Map();


### PR DESCRIPTION
### Motivation
- The tree advisor wiring previously only walked `includeRoots` from scope profiles and ignored `includeRootFiles`, making tree scope collection incomplete relative to the shared scope-profile contract.
- Builtin scope profiles expose both `includeRoots` and `includeRootFiles` (used by docs and system profiles), so the advisor must honor both to provide correct scope inputs without changing heuristics or findings.

### Description
- Use `getValidatorScopeProfile(...)` to read the full scope profile via a new `getScopeCollectionProfile(...)` helper and preserve `repo` fallback behavior as `{ includeRoots: ['.'], includeRootFiles: [] }`.
- Add `collectPathsFromRootFiles(...)` which only returns existing repository-root files, normalizes returned paths, and ignores missing or non-root declarations.
- Merge normalized root-file paths with directory-walk results, then sort and deduplicate the combined set before applying target filtering so determinism, stable sorting, and deduplication are preserved.
- No changes to findings, heuristics, registries, naming, or tree heuristics were introduced; change is limited to input collection and test/spec clarity.

### Testing
- Added focused tests asserting that docs scope includes `README.md`, system scope includes present root system files and ignores missing declarations, and that `--target` filtering works when the target is a root file; these tests live in `calculogic-validator/test/tree-structure-advisor.test.mjs`.
- Ran `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and observed all tests in that file passed.
- Ran the full suite via `npm test` and observed the test run completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b099f22a8083318dddec7aee36867e)