### PR TITLE
docs(suite): define suite-owned scope selection contract for slice and cross-slice validators

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -58,9 +58,13 @@ Current implementation policy:
 
 This is the current implementation policy and may later be generalized under suite modes (`soft-fail` / `hard-fail` / `correct` / `replace`), while detection remains unchanged.
 
-## 6) Shared scope vocabulary (Canonical)
+## 6) Suite-owned scope boundary contract (Canonical)
 
-Current supported scope names are:
+This section defines a bounded ownership contract for scope vocabulary and scoped input selection.
+
+### 6.1 Scope vocabulary is suite-owned
+
+Current canonical suite scope names are:
 
 - `repo`
 - `app`
@@ -68,7 +72,41 @@ Current supported scope names are:
 - `validator`
 - `system`
 
-Slices may implement scope-specific include/exclude details, but the scope vocabulary should remain consistent across suite docs and slice specs.
+These names are suite-owned vocabulary and should stay consistent across suite docs, slice specs, and runner/composed-validator docs.
+
+### 6.2 Scope selection is suite-owned
+
+Suite scope profiles own the shared scope-selection boundary, including:
+
+- `includeRoots`
+- `includeRootFiles`
+- shared scope intent
+
+Slice validators should start from this suite-owned scope selection layer instead of redefining base path collection locally.
+
+### 6.3 Slice-local meaning remains slice-owned
+
+After suite scope selection, each slice owns interpretation semantics for in-scope paths.
+
+Examples:
+
+- naming decides what in-scope paths mean for naming analysis
+- tree decides what in-scope paths mean for tree analysis
+
+Scope selection defines which paths are in play; it does not dictate slice interpretation semantics.
+
+### 6.4 Cross-slice validators use the same boundary
+
+Cross-slice validators should begin from the same suite-scoped snapshot/input boundary used by slices.
+
+Cross-slice composition logic may add additional composition rules after scope selection, but should not fork basic scope semantics unless explicitly documented as a suite contract extension.
+
+### 6.5 Guardrail
+
+Scope selection is not a dumping ground for slice heuristics.
+
+- suite scope answers: "which paths are in play"
+- slice or cross-slice logic answers: "what those paths mean"
 
 ## 7) Shared Report Envelope (Canonical)
 

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -184,6 +184,8 @@ Important metadata clarifications:
 
 ## Input Scope Profiles
 
+Tree advisor scope selection follows the suite-owned scope boundary contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md#6-suite-owned-scope-boundary-contract-canonical): suite owns canonical scope vocabulary and scoped input selection, and tree advisor applies tree-local interpretation after that shared boundary.
+
 Tree advisor scope selection should reuse the existing validator scope discovery model (repo/app/docs/validator/system), plus optional target filtering.
 
 - Default scope: `repo`


### PR DESCRIPTION
### Motivation

- Reduce ambiguity about who owns "scope" by documenting a single suite-owned selection boundary that slices and cross-slice validators must reuse.
- Align suite docs with current repo practice so slices consume a shared input snapshot and only apply slice-local interpretation.
- Prevent accidental scope reinvention in cross-slice workflows and future runner/composed validators by making the boundary explicit.

### Description

- Replaced the prior “Shared scope vocabulary” section in `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` with a new `Suite-owned scope boundary contract` and added bounded clauses `6.1`–`6.5` covering vocabulary, selection surfaces, slice-local meaning, cross-slice usage, and a guardrail.
- Declared the canonical suite scope names (`repo`, `app`, `docs`, `validator`, `system`) as suite-owned vocabulary and stated that `includeRoots` and `includeRootFiles` (and shared scope intent) are owned by the suite selection layer.
- Clarified that slices retain ownership of interpretation semantics (for example naming and tree meanings) after suite scope selection, and that cross-slice validators must begin from the same suite-scoped snapshot unless the suite contract is explicitly extended.
- Updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to explicitly reference and inherit the new suite-owned scope boundary before applying tree-local interpretation.

### Testing

- Ran `git diff --check` to ensure no whitespace or diff issues, which succeeded with no errors.
- Verified repository status and diff for the modified files with `git status --short` and `git diff -- <paths>`, confirming the two documentation files were updated as intended.
- Committed the changes locally (no runtime or code changes were performed) and validated the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a0073ae083318076f2d23c33c0ce)