### PR TITLE
chore(tree): align builtin known roots with intentional top-level peers

### DIFF
--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -18,6 +18,7 @@ const writeJson = async (filePath, value) => {
 const writeBaseFixtureRepo = async (fixtureDir) => {
   await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
   await fs.mkdir(path.join(fixtureDir, 'doc'), { recursive: true });
+  await fs.mkdir(path.join(fixtureDir, 'calculogic-doc-engine', 'src'), { recursive: true });
   await fs.mkdir(path.join(fixtureDir, 'calculogic-validator', 'src'), { recursive: true });
 
   await writeJson(path.join(fixtureDir, 'package.json'), {
@@ -26,6 +27,11 @@ const writeBaseFixtureRepo = async (fixtureDir) => {
   });
   await fs.writeFile(path.join(fixtureDir, 'src', 'app-shell.logic.ts'), 'export const app = true\n', 'utf8');
   await fs.writeFile(path.join(fixtureDir, 'doc', 'README.md'), '# fixture\n', 'utf8');
+  await fs.writeFile(
+    path.join(fixtureDir, 'calculogic-doc-engine', 'src', 'doc-engine.logic.mjs'),
+    'export const docEngine = true\n',
+    'utf8',
+  );
   await fs.writeFile(
     path.join(fixtureDir, 'calculogic-validator', 'src', 'naming-validator.logic.mjs'),
     'export const fixture = true\n',
@@ -67,9 +73,17 @@ test('tree-structure-advisor known roots come from bounded registry policy witho
       (finding) => finding.code === 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER' && finding.path === 'experiments',
     );
 
+    assert.equal(
+      result.findings.some(
+        (finding) =>
+          finding.code === 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER' && finding.path === 'calculogic-doc-engine',
+      ),
+      false,
+    );
     assert.ok(advisory);
     assert.deepEqual(advisory.details.knownRoots, [
       'bin',
+      'calculogic-doc-engine',
       'calculogic-validator',
       'doc',
       'docs',

--- a/calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json
@@ -1,6 +1,7 @@
 {
   "knownTopLevelDirectories": [
     "bin",
+    "calculogic-doc-engine",
     "calculogic-validator",
     "doc",
     "docs",

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -44,6 +44,7 @@ V0.1.x uses deterministic path-based signals only:
 
 1. **Top-level unexpected-folder advisory**
    - Emit info advisory for clearly unusual non-hidden top-level folders outside known repo shape.
+   - Builtin known-root baseline remains bounded/deterministic and includes stable current peers: `bin`, `calculogic-doc-engine`, `calculogic-validator`, `doc`, `docs`, `public`, `scripts`, `src`, `test`, `tools`.
 2. **Validator-owned-looking file outside validator tree**
    - Emit info advisory when filename/path signal strongly indicates validator ownership but file is outside `calculogic-validator/**`.
 


### PR DESCRIPTION
### Motivation
- Reduce TREE_UNEXPECTED_TOP_LEVEL_FOLDER false positives by aligning the builtin known-roots baseline with the repository's intentional top-level peers.
- Treat stable, intentionally-provisioned top-level directories as first-class known roots to reduce advisory noise and improve report trust.

### Description
- Add `calculogic-doc-engine` to the builtin `knownTopLevelDirectories` registry at `calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json` so it is no longer treated as unexpected.
- Update the test fixture in `calculogic-validator/test/tree-structure-advisor.test.mjs` to include `calculogic-doc-engine` in the baseline repo layout and add an assertion that it does not trigger `TREE_UNEXPECTED_TOP_LEVEL_FOLDER` while still verifying unknown peers (e.g. `experiments`) do.
- Add a short NL-first note to `doc/nl-config/cfg-treeStructureAdvisor.md` documenting the bounded builtin known-root baseline and its deterministic ordering.
- Keep all other tree heuristics, boundary-drift logic, naming, and scope behavior unchanged per constraints.

### Testing
- Ran the focused tree tests with `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and they passed.
- Ran the full suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a5a2485083318e70e5f1cd2e8439)