### PR TITLE
refactor(tree): remove repo scope override and consume suite scope profiles uniformly

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -194,7 +194,7 @@ Tree advisor scope selection should reuse the existing validator scope discovery
 
 Target filtering applies after scope discovery and before analysis.
 
-Scope discovery for non-`repo` profiles must consume both scope-profile surfaces exposed by the shared runtime contract:
+Scope discovery for all profiles (including `repo`) must consume both scope-profile surfaces exposed by the shared runtime contract:
 
 - `includeRoots`: directory roots to walk recursively
 - `includeRootFiles`: explicit repository-root files to include when present

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -10,10 +10,77 @@ import {
 import { prepareTreeStructureAdvisorInputs } from '../tree/src/tree-structure-advisor.wiring.mjs';
 import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../tree/src/tree-structure-advisor.logic.mjs';
 import { listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
+import { getValidatorScopeProfile } from '../src/core/validator-scopes.runtime.mjs';
 
 const writeJson = async (filePath, value) => {
   await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
 };
+
+
+const collectExpectedPathsFromScopeProfile = async (fixtureDir, scope) => {
+  const profile = getValidatorScopeProfile(scope);
+
+  if (!profile) {
+    throw new Error(`Expected known scope profile: ${scope}`);
+  }
+
+  const collected = new Set();
+
+  for (const scopeRoot of profile.includeRoots) {
+    const absoluteRoot = path.join(fixtureDir, scopeRoot);
+
+    try {
+      const rootStat = await fs.stat(absoluteRoot);
+      if (!rootStat.isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    const walk = async (absoluteDirectoryPath) => {
+      const entries = await fs.readdir(absoluteDirectoryPath, { withFileTypes: true });
+      entries.sort((left, right) => left.name.localeCompare(right.name));
+
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          if (entry.name.startsWith('.') || entry.name === 'node_modules') {
+            continue;
+          }
+
+          await walk(path.join(absoluteDirectoryPath, entry.name));
+          continue;
+        }
+
+        collected.add(path.relative(fixtureDir, path.join(absoluteDirectoryPath, entry.name)).replace(/\\/gu, '/'));
+      }
+    };
+
+    await walk(absoluteRoot);
+  }
+
+  for (const rootFilePath of profile.includeRootFiles) {
+    const absolutePath = path.join(fixtureDir, rootFilePath);
+
+    if (path.dirname(absolutePath) !== fixtureDir) {
+      continue;
+    }
+
+    try {
+      const rootFileStat = await fs.stat(absolutePath);
+      if (!rootFileStat.isFile()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    collected.add(path.relative(fixtureDir, absolutePath).replace(/\\/gu, '/'));
+  }
+
+  return [...collected].sort((left, right) => left.localeCompare(right));
+};
+
 
 const writeBaseFixtureRepo = async (fixtureDir) => {
   await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
@@ -662,6 +729,42 @@ test('tree-structure-advisor root-file target filtering works for docs scope tar
     assert.equal(result.filters.isFiltered, true);
     assert.deepEqual(result.filters.targets, ['README.md']);
     assert.equal(result.totalFilesScanned, 1);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+
+test('tree-structure-advisor scope collection follows suite profiles uniformly, including repo', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-scope-uniform-suite-profile-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(path.join(fixtureDir, 'README.md'), '# root readme\n', 'utf8');
+    await fs.writeFile(path.join(fixtureDir, 'eslint.config.mjs'), 'export default []\n', 'utf8');
+    await fs.writeFile(path.join(fixtureDir, 'tsconfig.json'), '{"compilerOptions":{}}\n', 'utf8');
+
+    for (const scope of ['repo', 'docs', 'system']) {
+      const prepared = prepareTreeStructureAdvisorInputs(fixtureDir, { scope });
+      const expectedPaths = await collectExpectedPathsFromScopeProfile(fixtureDir, scope);
+
+      assert.deepEqual(prepared.selectedPaths, expectedPaths);
+    }
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor rejects invalid scope deterministically', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-invalid-scope-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    assert.throws(
+      () => prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'unknown-scope' }),
+      /Invalid scope profile: unknown-scope/u,
+    );
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -33,10 +33,6 @@ const getScopeCollectionProfile = (scope) => {
     throw new Error(`Invalid scope profile: ${selectedScope}`);
   }
 
-  if (selectedScope === 'repo') {
-    return { includeRoots: ['.'], includeRootFiles: [] };
-  }
-
   return {
     includeRoots: profile.includeRoots,
     includeRootFiles: profile.includeRootFiles,


### PR DESCRIPTION
### Motivation

- The validator suite contract centralizes scope selection and vocabulary at the suite level, so tree wiring must stop redefining `repo` semantics locally.
- Tree previously special-cased `repo` in `getScopeCollectionProfile(...)`, creating an ownership mismatch with the suite-owned scope profiles.

### Description

- Remove the tree-local `repo` override in `tree/src/tree-structure-advisor.wiring.mjs` so `getValidatorScopeProfile(...)` is consumed uniformly for all scopes and adapted into `includeRoots`/`includeRootFiles` only.
- Add a test helper and import `getValidatorScopeProfile(...)` in `test/tree-structure-advisor.test.mjs` and add focused tests that assert scope collection follows suite profiles for `repo`, `docs`, and `system` and that invalid scopes are rejected deterministically.
- Update the tree advisor spec `doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to clarify that all profiles (including `repo`) must consume both `includeRoots` and `includeRootFiles` from the suite-owned scope contract.
- This is an ownership-boundary cleanup only and preserves existing runtime behavior by consuming the suite profiles rather than re-defining `repo` locally.

### Testing

- Ran `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and the new/updated tree tests passed.
- Ran full suite with `npm test` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0aa04ae9c8331b292ee9edbaf6ea3)