### PR TITLE
design/refactor(core): define suite-scoped snapshot helper and migrate tree wiring

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -108,6 +108,23 @@ Scope selection is not a dumping ground for slice heuristics.
 - suite scope answers: "which paths are in play"
 - slice or cross-slice logic answers: "what those paths mean"
 
+### 6.6 Shared scoped snapshot/input helper boundary
+
+Suite-core owns a shared scoped snapshot/input helper boundary for suite scope profiles.
+
+Helper ownership includes:
+
+- reading suite scope profiles
+- applying `includeRoots`
+- applying `includeRootFiles`
+- normalized path collection
+- optional target filtering
+- deterministic sort/dedupe for selected path sets
+
+Guardrail: the helper does not own slice meaning. Slice runtimes remain responsible for interpreting in-scope paths.
+
+Cross-slice validators should start from this shared scoped snapshot/input layer before applying cross-slice interpretation rules.
+
 ## 7) Shared Report Envelope (Canonical)
 
 This document defines the suite-level shape contract. For the canonical full schema reference (including slice report vs runner report envelopes, finding baseline shape, and deterministic ordering rules), see [`ValidatorReportSchema-V0_1.md`](./ValidatorReportSchema-V0_1.md).

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -199,6 +199,8 @@ Scope discovery for all profiles (including `repo`) must consume both scope-prof
 - `includeRoots`: directory roots to walk recursively
 - `includeRootFiles`: explicit repository-root files to include when present
 
+Runtime collection should consume the suite-core shared scoped snapshot/input helper boundary (scope profile read + includeRoots/includeRootFiles collection + normalization + target filtering + deterministic sort/dedupe) before tree-local interpretation.
+
 Runtime collection must ignore missing declared root files, normalize collected root-file paths the same way as walked paths, then merge + deduplicate before target filtering.
 
 ---

--- a/calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs
+++ b/calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getValidatorScopeProfile, DEFAULT_VALIDATOR_SCOPE } from './validator-scopes.runtime.mjs';
+import {
+  normalizePath,
+  resolveScopedTargets,
+  filterScopedPathsByTargets,
+} from './scoped-target-paths.logic.mjs';
+
+const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
+
+const collectPathsFromScopeRoot = (
+  repositoryRoot,
+  scopeRoot,
+  { walkExcludedDirectories = new Set(), skipDotDirectories = true } = {},
+) => {
+  const absoluteRoot = path.resolve(repositoryRoot, scopeRoot);
+  if (!fs.existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  const rootStat = fs.statSync(absoluteRoot);
+  if (!rootStat.isDirectory()) {
+    return [];
+  }
+
+  const collected = [];
+
+  const walk = (absoluteDirectoryPath) => {
+    const entries = fs
+      .readdirSync(absoluteDirectoryPath, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (walkExcludedDirectories.has(entry.name)) {
+          continue;
+        }
+
+        if (skipDotDirectories && entry.name.startsWith('.')) {
+          continue;
+        }
+
+        walk(path.join(absoluteDirectoryPath, entry.name));
+        continue;
+      }
+
+      const relativeFilePath = normalizePath(
+        path.relative(repositoryRoot, path.join(absoluteDirectoryPath, entry.name)),
+      );
+      collected.push(relativeFilePath);
+    }
+  };
+
+  walk(absoluteRoot);
+  return collected;
+};
+
+const collectPathsFromRootFiles = (repositoryRoot, includeRootFiles) => {
+  const repositoryAbsoluteRoot = path.resolve(repositoryRoot);
+
+  return includeRootFiles.flatMap((rootFilePath) => {
+    const absolutePath = path.resolve(repositoryRoot, rootFilePath);
+
+    if (path.dirname(absolutePath) !== repositoryAbsoluteRoot || !fs.existsSync(absolutePath)) {
+      return [];
+    }
+
+    const rootFileStat = fs.statSync(absolutePath);
+    if (!rootFileStat.isFile()) {
+      return [];
+    }
+
+    return [normalizePath(path.relative(repositoryRoot, absolutePath))];
+  });
+};
+
+export const collectSuiteScopedPaths = (
+  repositoryRoot,
+  {
+    scope,
+    walkExcludedDirectories = new Set(),
+    skipDotDirectories = true,
+  } = {},
+) => {
+  const selectedScope = scope ?? DEFAULT_VALIDATOR_SCOPE;
+  const profile = getValidatorScopeProfile(selectedScope);
+
+  if (!profile) {
+    throw new Error(`Invalid scope profile: ${selectedScope}`);
+  }
+
+  const scopedPaths = profile.includeRoots.flatMap((scopeRoot) =>
+    collectPathsFromScopeRoot(repositoryRoot, scopeRoot, {
+      walkExcludedDirectories,
+      skipDotDirectories,
+    }),
+  );
+  const rootFilePaths = collectPathsFromRootFiles(repositoryRoot, profile.includeRootFiles);
+
+  return {
+    scope: selectedScope,
+    includeRoots: [...profile.includeRoots],
+    includeRootFiles: [...profile.includeRootFiles],
+    inScopePaths: sortPaths(new Set([...scopedPaths, ...rootFilePaths])),
+  };
+};
+
+export const collectSuiteScopedSnapshotInputs = (
+  repositoryRoot,
+  {
+    scope,
+    targets = [],
+    walkExcludedDirectories = new Set(),
+    skipDotDirectories = true,
+  } = {},
+) => {
+  const scopedCollection = collectSuiteScopedPaths(repositoryRoot, {
+    scope,
+    walkExcludedDirectories,
+    skipDotDirectories,
+  });
+  const resolvedTargets = resolveScopedTargets(repositoryRoot, targets);
+
+  return {
+    ...scopedCollection,
+    selectedPaths: filterScopedPathsByTargets(
+      repositoryRoot,
+      scopedCollection.inScopePaths,
+      resolvedTargets,
+    ),
+    targets: resolvedTargets.map((target) => target.relPath),
+  };
+};

--- a/calculogic-validator/test/suite-scoped-snapshot-input.test.mjs
+++ b/calculogic-validator/test/suite-scoped-snapshot-input.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { collectSuiteScopedSnapshotInputs } from '../src/core/suite-scoped-snapshot-input.logic.mjs';
+
+test('suite scoped snapshot helper collects scope roots and root files deterministically', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'suite-scoped-snapshot-docs-'));
+
+  try {
+    await fs.mkdir(path.join(fixtureDir, 'doc'), { recursive: true });
+    await fs.writeFile(path.join(fixtureDir, 'doc', 'README.md'), '# docs\n', 'utf8');
+    await fs.writeFile(path.join(fixtureDir, 'README.md'), '# root\n', 'utf8');
+
+    const snapshot = collectSuiteScopedSnapshotInputs(fixtureDir, { scope: 'docs' });
+
+    assert.equal(snapshot.scope, 'docs');
+    assert.deepEqual(snapshot.selectedPaths, ['doc/README.md', 'README.md']);
+    assert.equal(snapshot.targets.length, 0);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('suite scoped snapshot helper applies target filtering after scoped collection', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'suite-scoped-snapshot-targets-'));
+
+  try {
+    await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(fixtureDir, 'src', 'a.logic.ts'), 'export const a = true\n', 'utf8');
+    await fs.writeFile(path.join(fixtureDir, 'src', 'b.logic.ts'), 'export const b = true\n', 'utf8');
+
+    const snapshot = collectSuiteScopedSnapshotInputs(fixtureDir, {
+      scope: 'app',
+      targets: ['src/a.logic.ts'],
+    });
+
+    assert.deepEqual(snapshot.selectedPaths, ['src/a.logic.ts']);
+    assert.deepEqual(snapshot.targets, ['src/a.logic.ts']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -4,12 +4,9 @@ import {
   runTreeStructureAdvisor as runTreeStructureAdvisorRuntime,
   summarizeFindings,
 } from './tree-structure-advisor.logic.mjs';
-import { getValidatorScopeProfile } from '../../src/core/validator-scopes.runtime.mjs';
 import {
-  normalizePath,
-  resolveScopedTargets,
-  filterScopedPathsByTargets,
-} from '../../src/core/scoped-target-paths.logic.mjs';
+  collectSuiteScopedSnapshotInputs,
+} from '../../src/core/suite-scoped-snapshot-input.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
 const WALK_EXCLUDED_DIRECTORIES = new Set([
@@ -23,81 +20,6 @@ const WALK_EXCLUDED_DIRECTORIES = new Set([
   'node_modules',
 ]);
 
-const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
-
-const getScopeCollectionProfile = (scope) => {
-  const selectedScope = scope ?? 'repo';
-  const profile = getValidatorScopeProfile(selectedScope);
-
-  if (!profile) {
-    throw new Error(`Invalid scope profile: ${selectedScope}`);
-  }
-
-  return {
-    includeRoots: profile.includeRoots,
-    includeRootFiles: profile.includeRootFiles,
-  };
-};
-
-const collectPathsFromScopeRoot = (repositoryRoot, scopeRoot) => {
-  const absoluteRoot = path.resolve(repositoryRoot, scopeRoot);
-  if (!fs.existsSync(absoluteRoot)) {
-    return [];
-  }
-
-  const rootStat = fs.statSync(absoluteRoot);
-  if (!rootStat.isDirectory()) {
-    return [];
-  }
-
-  const collected = [];
-
-  const walk = (absoluteDirectoryPath) => {
-    const entries = fs
-      .readdirSync(absoluteDirectoryPath, { withFileTypes: true })
-      .sort((left, right) => left.name.localeCompare(right.name));
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        if (WALK_EXCLUDED_DIRECTORIES.has(entry.name) || entry.name.startsWith('.')) {
-          continue;
-        }
-
-        walk(path.join(absoluteDirectoryPath, entry.name));
-        continue;
-      }
-
-      const relativeFilePath = normalizePath(
-        path.relative(repositoryRoot, path.join(absoluteDirectoryPath, entry.name)),
-      );
-      collected.push(relativeFilePath);
-    }
-  };
-
-  walk(absoluteRoot);
-  return collected;
-};
-
-
-const collectPathsFromRootFiles = (repositoryRoot, includeRootFiles) => {
-  const repositoryAbsoluteRoot = path.resolve(repositoryRoot);
-
-  return includeRootFiles.flatMap((rootFilePath) => {
-    const absolutePath = path.resolve(repositoryRoot, rootFilePath);
-
-    if (path.dirname(absolutePath) !== repositoryAbsoluteRoot || !fs.existsSync(absolutePath)) {
-      return [];
-    }
-
-    const rootFileStat = fs.statSync(absolutePath);
-    if (!rootFileStat.isFile()) {
-      return [];
-    }
-
-    return [normalizePath(path.relative(repositoryRoot, absolutePath))];
-  });
-};
-
 const collectTopLevelDirectoryNames = (repositoryRoot) =>
   fs
     .readdirSync(repositoryRoot, { withFileTypes: true })
@@ -108,18 +30,13 @@ const collectTopLevelDirectoryNames = (repositoryRoot) =>
     .sort((left, right) => left.localeCompare(right));
 
 export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targets } = {}) => {
-  const selectedScope = scope ?? 'repo';
-  const scopeCollectionProfile = getScopeCollectionProfile(selectedScope);
-  const scopedPaths = scopeCollectionProfile.includeRoots.flatMap((scopeRoot) =>
-    collectPathsFromScopeRoot(repositoryRoot, scopeRoot),
-  );
-  const rootFilePaths = collectPathsFromRootFiles(
-    repositoryRoot,
-    scopeCollectionProfile.includeRootFiles,
-  );
-  const inScopePaths = sortPaths(new Set([...scopedPaths, ...rootFilePaths]));
-  const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
-  const selectedPaths = filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets);
+  const scopedSnapshotInputs = collectSuiteScopedSnapshotInputs(repositoryRoot, {
+    scope,
+    targets,
+    walkExcludedDirectories: WALK_EXCLUDED_DIRECTORIES,
+    skipDotDirectories: true,
+  });
+  const selectedPaths = scopedSnapshotInputs.selectedPaths;
   const contentByPathCache = new Map();
   const selectedPathSet = new Set(selectedPaths);
   const getFileContent = (relativePath) => {
@@ -139,10 +56,10 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
   };
 
   return {
-    scope: selectedScope,
+    scope: scopedSnapshotInputs.scope,
     selectedPaths,
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
-    targets: resolvedTargets.map((target) => target.relPath),
+    targets: scopedSnapshotInputs.targets,
     getFileContent,
   };
 };

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -63,14 +63,14 @@ V0.1.x uses deterministic path-based signals only:
    - Runtimeish token/path-only matches remain info-level observability (`TREE_SHIM_SURFACE_PRESENT`) and do not emit debt-style `TREE_SHIM_OUTSIDE_COMPAT` unless thin re-export evidence exists.
 
 
-### 2.4 Input ownership split (V0.1.2)
+### 2.4 Input ownership split (V0.1.6)
 
-V0.1.2 aligns tree with naming input ownership discipline:
+V0.1.6 introduces a suite-core scoped snapshot/input helper boundary and migrates tree as the first consumer:
 
-- wiring resolves scope profile and validates target paths
-- wiring prepares scoped path inventory and target-filtered selected paths
-- wiring prepares top-level directory inventory used by repo-scope top-level advisory checks
-- runtime consumes prepared inputs only and emits deterministic findings/summary-compatible output
+- suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
+- tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
+- tree runtime remains slice-owned for findings and lazy content access over selected tree paths
+- naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
 
 Target behaviors in V0.1.2:
 


### PR DESCRIPTION
### Motivation

- Establish a clear suite-owned boundary for scope/profile-driven path selection so slices start from a single deterministic collection layer.
- Share normalized, deduped, target-filtered scoped inputs across slices to avoid duplicated includeRoots/includeRootFiles handling and sorting logic.
- Migrate `tree` as the first consumer of this shared boundary while keeping slice-local interpretation (findings, lazy content access, and naming semantics) unchanged.

### Description

- Add `collectSuiteScopedPaths` and `collectSuiteScopedSnapshotInputs` in `calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs` to centralize scope profile read, `includeRoots` walking, `includeRootFiles` inclusion, normalization, target resolving, and deterministic sort/dedupe.
- Migrate tree wiring to consume the new helper by updating `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs` to call `collectSuiteScopedSnapshotInputs` and preserve tree-local responsibilities like top-level directory inventory and lazy `getFileContent` accessor.
- Update documentation and NL/specs to record the boundary and ownership split in `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`, `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`, and `doc/nl-config/cfg-treeStructureAdvisor.md`.
- Add focused tests `calculogic-validator/test/suite-scoped-snapshot-input.test.mjs` to validate deterministic collection and that target filtering is applied after scoped collection, while leaving existing tree and cross-slice behavior unchanged.

### Testing

- Ran `node --test test/suite-scoped-snapshot-input.test.mjs test/tree-structure-advisor.test.mjs test/cross-slice-deterministic-invariants.test.mjs` in `calculogic-validator` and all tests passed (34 tests for tree suite + helper tests completed without failures).
- Verified deterministic ordering and target-filter behavior via the new helper tests and preserved tree wiring runtime contract in existing tree tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b24e4ac88331bd1d6d2ebef17346)