### PR TITLE
docs(tree): clarify naming-signal consumption boundary in tree advisor spec

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -73,6 +73,28 @@ This validator treats **folders as scope roots** (host-like boundaries), and fil
 
 Goal: surface emergent patterns and recommend a structure that makes those patterns obvious.
 
+### Naming-signal consumption boundary
+
+Tree advisor may consume naming-shaped filename metadata as **structural signal input** for clustering and lane interpretation.
+
+Tree advisor may use these parsed naming-shaped signals when present:
+
+- `semanticName`
+- semantic family/group derived from `semanticName`
+- `role`
+- role category/status metadata
+
+Tree advisor does **not** re-own naming validity judgments. Naming validity remains owned by naming conventions/specs and the naming validator slice.
+
+Examples of naming validity judgments that tree advisor must not duplicate:
+
+- bad semantic case
+- missing role
+- deprecated role
+- hyphen-role ambiguity
+
+When usable naming-shaped metadata is unavailable, incomplete, or weak, tree advisor should reduce confidence and/or recommend running naming validation, rather than inventing naming-invalid findings inside tree output.
+
 Boundary note (canonical_target for this slice): tree validator ownership is under `calculogic-validator/tree/src/**`. Legacy flat suite-core paths such as `calculogic-validator/src/tree-structure-advisor.*.mjs` are compatibility wrappers only, not canonical ownership.
 
 ---


### PR DESCRIPTION
### Motivation
- Prevent the tree advisor from drifting into duplicate naming enforcement by clarifying the boundary between filename-derived structural signals and naming-validity ownership.
- Make explicit that tree analysis may rely on parsed filename metadata for clustering but must defer naming-invalid judgments to the naming validator slice.

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to add a new "Naming-signal consumption boundary" subsection under the Conceptual Model. 
- Documented the parsed naming-shaped signals tree may consume (`semanticName`, semantic family/group derived from `semanticName`, `role`, and role category/status). 
- Explicitly stated that naming validity judgments (for example: bad semantic case, missing role, deprecated role, hyphen-role ambiguity) remain owned by naming conventions/specs and the naming validator, and added guidance that tree should lower confidence or recommend a naming-validator pass when naming metadata is weak or unavailable.

### Testing
- Performed file content inspection and diff review of the updated spec section to verify the new subsection appears under Conceptual Model and contains the intended signals and ownership language. (`nl -ba calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md | sed -n '68,118p'`).
- Repository/patch validation (status and diff checks) and content review completed successfully with no runtime or behavioral changes introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c111a3c48331bea381ad56b09268)