### PR TITLE
docs(tree): define top-root classes and builtin vs custom root ownership

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -97,6 +97,43 @@ When usable naming-shaped metadata is unavailable, incomplete, or weak, tree adv
 
 Boundary note (canonical_target for this slice): tree validator ownership is under `calculogic-validator/tree/src/**`. Legacy flat suite-core paths such as `calculogic-validator/src/tree-structure-advisor.*.mjs` are compatibility wrappers only, not canonical ownership.
 
+## Top-Root Registry Classes and Ownership Boundary (Bounded Modeling Note)
+
+Classification: Informative
+
+This section clarifies modeling intent for tree root registries without changing current runtime behavior.
+
+### 1) Top-root classes
+
+- **Structural top roots**:
+  - generic surface-like roots such as `src`, `test`, `doc`, `docs`, `scripts`, `tools`, `public`, `bin`
+  - these are interpreted by tree as structural folder surfaces
+- **Semantic/custom-style top roots**:
+  - top roots that encode semantic/package identity or repo-local ownership style
+  - examples can include package-style roots used by a specific repository architecture
+
+### 2) Builtin vs custom ownership
+
+- Generic structural roots are appropriate builtin tree-owned defaults.
+- Semantic/custom-style roots may be valid and high-value, but are not automatically universal builtin truth.
+- Repo-specific roots used for dogfooding or implementation convenience may exist in current policy, but they should not automatically become permanent published-package builtins.
+
+### 3) Case/style distinction
+
+- Semantic/custom-style roots may follow naming-like style conventions.
+- This style signal does not make them filename roles.
+- Tree remains the owner of structural interpretation for folder roots.
+
+### 4) Future registry direction (modeling only)
+
+Future tree root registries may require metadata richer than a flat string list, for example:
+
+- root kind (`structural` vs `semantic`)
+- ownership/source (`builtin` vs `custom`)
+- style classification (`generic-builtin`, `custom-style`, or similar)
+
+This is a modeling direction note only, not an implementation claim for this version.
+
 ---
 
 ## Tree Addressing (Report-Only)


### PR DESCRIPTION
### Motivation
- Prevent repo-specific dogfooding roots from hardening into permanent builtin defaults by clarifying root-class distinctions and ownership intent in the tree advisor documentation.

### Description
- Added a new bounded modeling section `Top-Root Registry Classes and Ownership Boundary` to `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` that defines `structural` vs `semantic/custom-style` top roots. 
- Clarified `builtin` vs `custom` ownership guidance saying generic structural roots are appropriate builtin defaults while semantic/repo-local roots are valid but should not be auto-promoted to published-package builtins. 
- Documented a `case/style` distinction noting naming-style signals do not make folder roots into filename roles and retained that tree owns structural interpretation. 
- Added a future-facing modeling note that registries may need metadata beyond a flat string list (kind, ownership/source, style classification) while explicitly keeping this change docs-only and non-runtime.

### Testing
- Verified the doc change diff with `git diff -- calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` and inspected the updated file content. 
- Confirmed working-tree state with `git status --short` and committed the change with `git commit`, all commands completed successfully. 
- Created the PR entry via the repository tooling; this was a docs-only change with no runtime or validator behavior modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ccae5570833187835fed31ba1b4e)