### PR TITLE
docs(tree): normalize authority terminology and add explicit backlinks

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -6,6 +6,12 @@ Status labeling for this NL/config note:
 - **Deferred Behavior** = future advisory direction, not shipped runtime behavior.
 - Repo-shape examples are current-repo implementation reality, not universal published builtin requirements.
 
+Navigation backlinks:
+
+- Tree validator spec (runtime authority): [`calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`](../tree-structure-advisor-validator-spec.md)
+- Tree documentation map (navigation metadata): [`calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md`](../tree-documentation-map-and-reorg-inventory.md)
+- Pointer stub at prior path: [`doc/nl-config/cfg-treeStructureAdvisor.md`](../../../../doc/nl-config/cfg-treeStructureAdvisor.md)
+
 Canonical reading order for tree implementation work:
 
 1. `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md`

--- a/calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md
@@ -7,7 +7,7 @@ This document provides one bounded, implementation-facing navigation map for tre
 It is intended to:
 
 - identify what documents currently exist for the tree implementation slice,
-- distinguish canonical_source implementation guidance from supporting references,
+- distinguish canonical authority implementation guidance from supporting references,
 - make explicit “stay put for now” vs “move/split/merge later” decisions,
 - reduce ambiguity for human maintainers and Codex task setup before any physical folder reorganization.
 
@@ -27,25 +27,25 @@ Interpretation note:
 
 - Runtime behavior authority should come from suite contract + tree spec.
 - NL/config note is implementation-context guidance that mirrors status labeling and reading order for this slice.
-- This map is a navigation/ownership layer and does not redefine runtime behavior.
+- This map is navigation metadata and ownership guidance only; it does not redefine runtime behavior.
 
 ## Inventory (Bounded Set)
 
 | Document | Document role | Status classification | Audience / usage | Path decision | Action recommendation |
 |---|---|---|---|---|---|
-| `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` | Suite contract (canonical_source for shared validator vocabulary/modes/scope boundary) | Current runtime behavior + current implementation policy + limited future advisory direction notes | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path | **Keep** |
+| `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` | Suite contract (canonical authority for shared validator vocabulary/modes/scope boundary) | Current runtime behavior + current implementation policy + limited future advisory direction notes | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path | **Keep** |
 | `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` | Canonical spec for tree slice runtime behavior and bounded tree modeling guidance | Mixed: current runtime behavior, current implementation guidance, current architectural/modeling guidance, bounded modeling note, future advisory direction, dogfooding/current-repo reality | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path (already under `ValidatorSpecs`, implementation-facing) | **Keep** |
 | `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` | Supporting convention/spec boundary for naming-signal consumption by tree advisor | Current runtime behavior and current implementation guidance for naming slice; supports tree interpretation boundaries | Runtime implementation, architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
 | `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md` | NL/config implementation note for tree slice | Current implementation guidance + deferred behavior (future advisory direction) + dogfooding/current-repo reality examples | Runtime implementation, Codex task context, historical/reference context for implementation sequencing | **Now colocated** under `ValidatorSpecs/nl-config` with pointer stub retained at the prior repo-root NL path | **Keep** (validator-owned supporting implementation guidance) |
-| `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` | Supporting convention (canonical_source for filename grammar + role/category/status taxonomy) | Current architectural/modeling guidance and governance vocabulary; runtime subset enforcement is delegated to naming slice | Architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
+| `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` | Supporting convention (canonical authority for filename grammar + role/category/status taxonomy) | Current architectural/modeling guidance and governance vocabulary; runtime subset enforcement is delegated to naming slice | Architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
 | `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` | Bounded modeling note source for report-only tree-address grammar alignment | Draft-bounded modeling guidance (not full runtime enforcement contract for tree slice) | Architecture/modeling, supporting context only, historical/deferred decision reference | **Stay put** at current path | **Reference only** |
 
 ## Reorg Recommendations (Bounded / First Move Completed)
 
 ### Canonical now (do not relocate in this pass)
 
-- Keep suite contract in `ConventionRoutines` as validator-suite canonical_source.
-- Keep tree runtime spec in `ValidatorSpecs` as tree slice canonical_source.
+- Keep suite contract in `ConventionRoutines` as validator-suite canonical authority.
+- Keep tree runtime spec in `ValidatorSpecs` as tree slice canonical authority.
 - Keep naming and naming-master docs in `ConventionRoutines` as cross-slice authorities consumed by tree.
 
 ### Completed bounded move (this pass)
@@ -64,7 +64,7 @@ Interpretation note:
 
 ## Guardrails for Future Folder Moves
 
-1. **No behavior change via path move.** Any move must preserve canonical_source authority and reading order semantics.
+1. **No behavior change via path move.** Any move must preserve canonical authority and reading order semantics.
 2. **Move in bounded phases.** First add pointer/wrapper or backlink docs, then move content, then retire wrappers after references are updated.
 3. **Preserve deterministic references.** Update all cross-links in suite/tree/naming/NL docs in the same change set as any move.
 4. **Do not collapse ownership boundaries.** Suite-wide contracts remain suite-owned; tree slice behavior remains tree-spec-owned.
@@ -72,6 +72,6 @@ Interpretation note:
 
 ## Maintenance Notes
 
-- Update this inventory whenever a tree-adjacent canonical_source document is added, superseded, or repathed.
+- Update this inventory whenever a tree-adjacent canonical authority document is added, superseded, or repathed.
 - For tree task setup, this inventory is an index and should be used before ad hoc doc discovery.
-- If runtime behavior conflicts appear, defer to suite contract and tree spec canonical_source docs; treat this map as navigational metadata.
+- If runtime behavior conflicts appear, defer to suite contract and tree spec canonical authority docs; treat this map as navigational metadata.

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -29,6 +29,7 @@ Read these first before tree implementation work (runtime, wiring, or contracts)
 2. Tree validator spec (this document): runtime behavior + bounded modeling notes
 3. Naming boundary context: [`NamingValidatorSpec.md`](../ConventionRoutines/NamingValidatorSpec.md)
 4. Tree NL/config implementation note: [`calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`](./nl-config/cfg-treeStructureAdvisor.md)
+5. Tree documentation map (navigation metadata): [`tree-documentation-map-and-reorg-inventory.md`](./tree-documentation-map-and-reorg-inventory.md)
 
 Status interpretation used in this document:
 

--- a/doc/nl-config/cfg-treeStructureAdvisor.md
+++ b/doc/nl-config/cfg-treeStructureAdvisor.md
@@ -4,4 +4,4 @@ Canonical path moved to:
 
 - `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`
 
-This stub is retained intentionally as a bounded redirect/backlink to preserve existing reading-path navigation.
+This stub is retained intentionally as a bounded redirect/backlink to preserve existing reading-path navigation. The validator-owned file under `calculogic-validator/doc/ValidatorSpecs/nl-config/` is the canonical location for this NL/config note.


### PR DESCRIPTION
### Motivation

- Normalize wording in the tree documentation map and nearby docs to reduce vocabulary drift between navigation metadata and authoritative runtime specs.
- Make navigation between the moved NL/config note, the tree spec, the documentation map, and the old pointer stub explicit to lower friction for human readers and AI tooling.
- Keep the change bounded to docs-only terminology and backlink clarity without moving files or changing runtime behavior.

### Description

- Replaced `canonical_source` phrasing with `canonical authority` and aligned related wording in `calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md`. 
- Strengthened the map interpretation note to state it is navigation metadata and ownership guidance, not a runtime authority. 
- Added explicit navigation backlinks in `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md` pointing to the tree spec, the tree documentation map, and the prior-path pointer stub. 
- Added a symmetric reading-path backlink from `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` to the tree documentation map and clarified the pointer stub `doc/nl-config/cfg-treeStructureAdvisor.md` to state the validator-owned `ValidatorSpecs/nl-config` file is the canonical location.

### Testing

- Searched for the old token with `rg -n "canonical_source"` across the targeted tree docs and confirmed no remaining matches in the updated files. 
- Verified reading-path references with `rg -n "doc/nl-config/cfg-treeStructureAdvisor.md|calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md"` and confirmed links point to the new `ValidatorSpecs/nl-config` path. 
- Ran `git diff --check` to validate whitespace/conflict hygiene and observed no issues. 
- Confirmed the following docs were updated: `calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md`, `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`, `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`, and `doc/nl-config/cfg-treeStructureAdvisor.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b33f1293008331a52135a13fbaa9f7)