### PR TITLE
refactor(tree): add structured top-root dual-read registry support

### DIFF
--- a/calculogic-validator/test/tree-known-roots-registry.test.mjs
+++ b/calculogic-validator/test/tree-known-roots-registry.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { normalizeTreeKnownRootsRegistryPayload } from '../tree/src/registries/tree-known-roots.registry.logic.mjs';
+
+const EXPECTED_KNOWN_ROOTS = [
+  'bin',
+  'calculogic-doc-engine',
+  'calculogic-validator',
+  'doc',
+  'docs',
+  'public',
+  'scripts',
+  'src',
+  'test',
+  'tools',
+];
+
+test('tree-known-roots registry supports flat-only payloads', () => {
+  const normalized = normalizeTreeKnownRootsRegistryPayload({
+    knownTopLevelDirectories: EXPECTED_KNOWN_ROOTS,
+  });
+
+  assert.deepEqual([...normalized.knownTopLevelDirectories], EXPECTED_KNOWN_ROOTS);
+  assert.equal(normalized.topRoots[0].root, 'bin');
+  assert.equal(normalized.topRoots[0].kind, 'structural');
+  assert.equal(normalized.topRoots[0].ownershipSource, 'builtin');
+});
+
+test('tree-known-roots registry supports structured-only payloads', () => {
+  const normalized = normalizeTreeKnownRootsRegistryPayload({
+    topRoots: [
+      {
+        root: 'src',
+        kind: 'structural',
+        ownershipSource: 'builtin',
+        styleClass: 'generic-builtin',
+      },
+      {
+        root: 'calculogic-validator',
+        kind: 'semantic',
+        ownershipSource: 'custom',
+        styleClass: 'custom-style',
+      },
+      {
+        root: 'calculogic-doc-engine',
+        kind: 'semantic',
+        ownershipSource: 'custom',
+      },
+    ],
+  });
+
+  assert.deepEqual([...normalized.knownTopLevelDirectories], [
+    'calculogic-doc-engine',
+    'calculogic-validator',
+    'src',
+  ]);
+  assert.deepEqual(
+    normalized.topRoots.map((entry) => entry.root),
+    ['calculogic-doc-engine', 'calculogic-validator', 'src'],
+  );
+});
+
+test('tree-known-roots registry uses structured precedence for dual-shape payloads', () => {
+  const normalized = normalizeTreeKnownRootsRegistryPayload({
+    topRoots: [
+      {
+        root: 'src',
+        kind: 'structural',
+        ownershipSource: 'builtin',
+      },
+      {
+        root: 'calculogic-validator',
+        kind: 'semantic',
+        ownershipSource: 'custom',
+      },
+    ],
+    knownTopLevelDirectories: ['src', 'tools', 'legacy-root'],
+  });
+
+  assert.deepEqual([...normalized.knownTopLevelDirectories], ['calculogic-validator', 'src']);
+});
+
+test('tree-known-roots registry fails clearly for invalid structured enums', () => {
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [{ root: 'src', kind: 'invalid', ownershipSource: 'builtin' }],
+      }),
+    /topRoots\[0\]\.kind must be one of structural\|semantic/u,
+  );
+
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'invalid' }],
+      }),
+    /topRoots\[0\]\.ownershipSource must be one of builtin\|custom/u,
+  );
+});
+
+test('tree-known-roots registry keeps known roots stable with structured repo-local semantic entries', () => {
+  const normalized = normalizeTreeKnownRootsRegistryPayload({
+    topRoots: EXPECTED_KNOWN_ROOTS.map((root) => ({
+      root,
+      kind:
+        root === 'calculogic-validator' || root === 'calculogic-doc-engine' ? 'semantic' : 'structural',
+      ownershipSource:
+        root === 'calculogic-validator' || root === 'calculogic-doc-engine' ? 'custom' : 'builtin',
+      styleClass:
+        root === 'calculogic-validator' || root === 'calculogic-doc-engine'
+          ? 'custom-style'
+          : 'generic-builtin',
+    })),
+  });
+
+  assert.deepEqual([...normalized.knownTopLevelDirectories], EXPECTED_KNOWN_ROOTS);
+});

--- a/calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json
@@ -1,4 +1,66 @@
 {
+  "topRoots": [
+    {
+      "root": "bin",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "calculogic-doc-engine",
+      "kind": "semantic",
+      "ownershipSource": "custom",
+      "styleClass": "custom-style"
+    },
+    {
+      "root": "calculogic-validator",
+      "kind": "semantic",
+      "ownershipSource": "custom",
+      "styleClass": "custom-style"
+    },
+    {
+      "root": "doc",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "docs",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "public",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "scripts",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "src",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "test",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    },
+    {
+      "root": "tools",
+      "kind": "structural",
+      "ownershipSource": "builtin",
+      "styleClass": "generic-builtin"
+    }
+  ],
   "knownTopLevelDirectories": [
     "bin",
     "calculogic-doc-engine",

--- a/calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs
+++ b/calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs
@@ -7,22 +7,38 @@ export const BUILTIN_TREE_KNOWN_ROOTS_REGISTRY_PATH = fileURLToPath(
   new URL('tree-known-roots.registry.json', BUILTIN_REGISTRY_ROOT),
 );
 
+const TOP_ROOT_KIND_VALUES = new Set(['structural', 'semantic']);
+const TOP_ROOT_OWNERSHIP_SOURCE_VALUES = new Set(['builtin', 'custom']);
+
 let cachedBuiltinTreeKnownRoots = null;
 
-const loadBuiltinTreeKnownRoots = () => {
-  const payload = JSON.parse(fs.readFileSync(BUILTIN_TREE_KNOWN_ROOTS_REGISTRY_PATH, 'utf8'));
-
-  if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid builtin tree-known-roots registry: expected object payload.');
+const compareTopRoots = (left, right) => {
+  const rootDiff = left.root.localeCompare(right.root);
+  if (rootDiff !== 0) {
+    return rootDiff;
   }
 
-  if (!Array.isArray(payload.knownTopLevelDirectories)) {
+  const kindDiff = left.kind.localeCompare(right.kind);
+  if (kindDiff !== 0) {
+    return kindDiff;
+  }
+
+  const ownershipDiff = left.ownershipSource.localeCompare(right.ownershipSource);
+  if (ownershipDiff !== 0) {
+    return ownershipDiff;
+  }
+
+  return (left.styleClass ?? '').localeCompare(right.styleClass ?? '');
+};
+
+const validateLegacyKnownTopLevelDirectories = (knownTopLevelDirectories) => {
+  if (!Array.isArray(knownTopLevelDirectories)) {
     throw new Error(
-      'Invalid builtin tree-known-roots registry: missing knownTopLevelDirectories array.',
+      'Invalid builtin tree-known-roots registry: knownTopLevelDirectories must be an array when provided.',
     );
   }
 
-  payload.knownTopLevelDirectories.forEach((directoryName, index) => {
+  knownTopLevelDirectories.forEach((directoryName, index) => {
     if (typeof directoryName !== 'string' || directoryName.length === 0) {
       throw new Error(
         `Invalid builtin tree-known-roots registry: knownTopLevelDirectories[${index}] must be a non-empty string.`,
@@ -30,9 +46,128 @@ const loadBuiltinTreeKnownRoots = () => {
     }
   });
 
+  return [...new Set(knownTopLevelDirectories)].sort((left, right) => left.localeCompare(right));
+};
+
+const normalizeStructuredTopRoots = (topRoots) => {
+  if (!Array.isArray(topRoots)) {
+    throw new Error('Invalid builtin tree-known-roots registry: topRoots must be an array when provided.');
+  }
+
+  const normalized = topRoots.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Invalid builtin tree-known-roots registry: topRoots[${index}] must be an object.`);
+    }
+
+    if (typeof entry.root !== 'string' || entry.root.length === 0) {
+      throw new Error(`Invalid builtin tree-known-roots registry: topRoots[${index}].root must be a non-empty string.`);
+    }
+
+    if (!TOP_ROOT_KIND_VALUES.has(entry.kind)) {
+      throw new Error(
+        `Invalid builtin tree-known-roots registry: topRoots[${index}].kind must be one of structural|semantic.`,
+      );
+    }
+
+    if (!TOP_ROOT_OWNERSHIP_SOURCE_VALUES.has(entry.ownershipSource)) {
+      throw new Error(
+        `Invalid builtin tree-known-roots registry: topRoots[${index}].ownershipSource must be one of builtin|custom.`,
+      );
+    }
+
+    if (
+      typeof entry.styleClass !== 'undefined'
+      && (typeof entry.styleClass !== 'string' || entry.styleClass.length === 0)
+    ) {
+      throw new Error(
+        `Invalid builtin tree-known-roots registry: topRoots[${index}].styleClass must be a non-empty string when provided.`,
+      );
+    }
+
+    return {
+      root: entry.root,
+      kind: entry.kind,
+      ownershipSource: entry.ownershipSource,
+      ...(typeof entry.styleClass === 'string' ? { styleClass: entry.styleClass } : {}),
+    };
+  });
+
+  const sorted = [...normalized].sort(compareTopRoots);
+  const deduped = [];
+
+  for (const candidate of sorted) {
+    const previous = deduped.at(-1);
+
+    if (!previous || previous.root !== candidate.root) {
+      deduped.push(candidate);
+      continue;
+    }
+
+    const hasMetadataMismatch =
+      previous.kind !== candidate.kind
+      || previous.ownershipSource !== candidate.ownershipSource
+      || (previous.styleClass ?? '') !== (candidate.styleClass ?? '');
+
+    if (hasMetadataMismatch) {
+      throw new Error(
+        `Invalid builtin tree-known-roots registry: duplicate topRoots entry for root "${candidate.root}" has conflicting metadata.`,
+      );
+    }
+  }
+
+  return deduped;
+};
+
+export const normalizeTreeKnownRootsRegistryPayload = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Invalid builtin tree-known-roots registry: expected object payload.');
+  }
+
+  const hasStructuredTopRoots = typeof payload.topRoots !== 'undefined';
+  const hasLegacyKnownTopLevelDirectories = typeof payload.knownTopLevelDirectories !== 'undefined';
+
+  if (!hasStructuredTopRoots && !hasLegacyKnownTopLevelDirectories) {
+    throw new Error(
+      'Invalid builtin tree-known-roots registry: expected topRoots array or knownTopLevelDirectories array.',
+    );
+  }
+
+  const normalizedLegacyKnownTopLevelDirectories = hasLegacyKnownTopLevelDirectories
+    ? validateLegacyKnownTopLevelDirectories(payload.knownTopLevelDirectories)
+    : [];
+
+  const normalizedStructuredTopRoots = hasStructuredTopRoots
+    ? normalizeStructuredTopRoots(payload.topRoots)
+    : [];
+
+  if (hasStructuredTopRoots && normalizedStructuredTopRoots.length === 0) {
+    throw new Error('Invalid builtin tree-known-roots registry: topRoots must contain at least one entry.');
+  }
+
+  if (!hasStructuredTopRoots && normalizedLegacyKnownTopLevelDirectories.length === 0) {
+    throw new Error(
+      'Invalid builtin tree-known-roots registry: knownTopLevelDirectories must contain at least one entry.',
+    );
+  }
+
+  const canonicalTopRoots = hasStructuredTopRoots
+    ? normalizedStructuredTopRoots
+    : normalizedLegacyKnownTopLevelDirectories.map((root) => ({
+      root,
+      kind: 'structural',
+      ownershipSource: 'builtin',
+    }));
+
   return {
-    knownTopLevelDirectories: new Set(payload.knownTopLevelDirectories),
+    topRoots: canonicalTopRoots,
+    knownTopLevelDirectories: new Set(canonicalTopRoots.map((entry) => entry.root)),
   };
+};
+
+const loadBuiltinTreeKnownRoots = () => {
+  const payload = JSON.parse(fs.readFileSync(BUILTIN_TREE_KNOWN_ROOTS_REGISTRY_PATH, 'utf8'));
+
+  return normalizeTreeKnownRootsRegistryPayload(payload);
 };
 
 export const getBuiltinTreeKnownRoots = () => {


### PR DESCRIPTION
### Motivation
- Move the tree top-root registry toward the documented structured transition shape while preserving backward compatibility with the existing flat `knownTopLevelDirectories[]` payload.
- Provide deterministic runtime normalization so tree analysis consumes a single canonical model during the migration window.

### Description
- Added a loader/normalizer `normalizeTreeKnownRootsRegistryPayload` that accepts `topRoots[]` (structured) and/or `knownTopLevelDirectories[]` (legacy) and resolves them into a canonical runtime model containing `topRoots` and `knownTopLevelDirectories` (a `Set`).
- Implemented bounded validation for structured entries (fields: `root`, `kind` enum `structural|semantic`, `ownershipSource` enum `builtin|custom`, optional `styleClass`), deterministic sort/dedupe, and duplicate-entry metadata conflict detection.
- Enforced structured-shape precedence when both shapes are present (structured `topRoots[]` becomes canonical) while keeping legacy flat-shape compatibility if structured data is absent.
- Files changed: `calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs`, `calculogic-validator/tree/src/registries/_builtin/tree-known-roots.registry.json`, and added tests in `calculogic-validator/test/tree-known-roots-registry.test.mjs`; no tree-finding or naming semantics were expanded.

### Testing
- Ran the focused loader tests with `node --test calculogic-validator/test/tree-known-roots-registry.test.mjs` together with the existing tree advisor tests using `node --test calculogic-validator/test/tree-structure-advisor.test.mjs`, and they passed (all subtests OK).
- Ran the full suite with `npm test` and observed all tests passing (TAP output indicates 260 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b368f4ab308331b8643914b941f27c)