### PR TITLE
test(tree): harden top-root registry loader edge-case coverage

### DIFF
--- a/calculogic-validator/test/tree-known-roots-registry.test.mjs
+++ b/calculogic-validator/test/tree-known-roots-registry.test.mjs
@@ -98,6 +98,76 @@ test('tree-known-roots registry fails clearly for invalid structured enums', () 
   );
 });
 
+test('tree-known-roots registry fails clearly for duplicate structured root metadata conflicts', () => {
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [
+          { root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: 'generic-builtin' },
+          { root: 'src', kind: 'semantic', ownershipSource: 'builtin', styleClass: 'generic-builtin' },
+        ],
+      }),
+    /duplicate topRoots entry for root "src" has conflicting metadata/u,
+  );
+
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [
+          { root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: 'generic-builtin' },
+          { root: 'src', kind: 'structural', ownershipSource: 'custom', styleClass: 'generic-builtin' },
+        ],
+      }),
+    /duplicate topRoots entry for root "src" has conflicting metadata/u,
+  );
+
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [
+          { root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: 'generic-builtin' },
+          { root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: 'semantic-custom' },
+        ],
+      }),
+    /duplicate topRoots entry for root "src" has conflicting metadata/u,
+  );
+});
+
+test('tree-known-roots registry fails clearly for empty or missing accepted shapes', () => {
+  assert.throws(
+    () => normalizeTreeKnownRootsRegistryPayload({ topRoots: [] }),
+    /topRoots must contain at least one entry/u,
+  );
+
+  assert.throws(
+    () => normalizeTreeKnownRootsRegistryPayload({ knownTopLevelDirectories: [] }),
+    /knownTopLevelDirectories must contain at least one entry/u,
+  );
+
+  assert.throws(
+    () => normalizeTreeKnownRootsRegistryPayload({ someOtherShape: [] }),
+    /expected topRoots array or knownTopLevelDirectories array/u,
+  );
+});
+
+test('tree-known-roots registry fails clearly for invalid optional styleClass', () => {
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: '' }],
+      }),
+    /topRoots\[0\]\.styleClass must be a non-empty string when provided/u,
+  );
+
+  assert.throws(
+    () =>
+      normalizeTreeKnownRootsRegistryPayload({
+        topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: 123 }],
+      }),
+    /topRoots\[0\]\.styleClass must be a non-empty string when provided/u,
+  );
+});
+
 test('tree-known-roots registry keeps known roots stable with structured repo-local semantic entries', () => {
   const normalized = normalizeTreeKnownRootsRegistryPayload({
     topRoots: EXPECTED_KNOWN_ROOTS.map((root) => ({


### PR DESCRIPTION
### Motivation

- The top-root registry loader `normalizeTreeKnownRootsRegistryPayload` already contains guardrails for missing/empty shapes, invalid enums, duplicate structured roots, and optional `styleClass`, but several error-paths lacked explicit test coverage.
- Harden the migration seam by adding focused tests that exercise duplicate structured-root metadata conflicts, empty/missing shape failures, and invalid optional `styleClass` handling so future changes remain deterministic.

### Description

- Added new edge-case tests to `calculogic-validator/test/tree-known-roots-registry.test.mjs` targeting `normalizeTreeKnownRootsRegistryPayload`.
- Added tests that assert duplicate structured-root conflicts throw when the same `root` has mismatched `kind`, `ownershipSource`, or `styleClass` metadata.
- Added tests that assert clear failures for empty structured shape (`topRoots: []`), empty flat shape (`knownTopLevelDirectories: []` with no structured shape), and payloads missing both accepted shapes.
- Added tests that assert `styleClass` validation fails when provided as an empty string or a non-string value.

### Testing

- Ran `node --test calculogic-validator/test/tree-known-roots-registry.test.mjs` and all new tests passed.
- Ran `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and the suite passed.
- Ran `npm test` and the full test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b383f9786c83319265d7529af7dafb)