### PR TITLE
Stage tree shim content reads behind deterministic candidates

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -68,7 +68,7 @@ V0.1.x uses deterministic path-based signals only:
    - Emit info advisory when filename/path signal strongly indicates validator ownership but file is outside `calculogic-validator/**`.
 
 3. **Shim/compat surface advisory (hardened evidence precedence, V0.1.5)**
-   - Collects deterministic shim evidence per file with bounded fields:
+   - Collects deterministic shim evidence with staged evaluation (path/surface/token-first; content reads only for deterministic shim candidates) and bounded fields:
      - `artifactSurface` (`quality|docs|examples|fixtures|runtimeish`)
      - folder token signals, basename token signals
      - `thinReexportShim`, `canonicalTargetPath`, `reexportTargetCount`

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -52,7 +52,7 @@ This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-M
   - consolidation of scattered semantic families
   - separation of mixed lanes where mixing predicts growth pain
   - normalization of repeated validator-subtree scaffolds (for future validators)
-- Shim/compat advisory hardening with bounded evidence precedence and intentional pass-through carveouts, including package/public barrel pass-through (`calculogic-validator/src/index.mjs`) with `export * from`, `export * as <name> from`, and optional `export { ... } from` forms
+- Shim/compat advisory hardening with staged evidence precedence (path/surface/token-first, content reads only for deterministic shim candidates) and intentional pass-through carveouts, including package/public barrel pass-through (`calculogic-validator/src/index.mjs`) with `export * from`, `export * as <name> from`, and optional `export { ... } from` forms
 - Weak token/path-only shim observability may suppress detector-implementation modules inside `calculogic-validator/tree/src/` when `shim` appears only as part of the detector semantic name (for example `*shim-detection*`) and no thin re-export evidence exists
 - Bounded owned-slice boundary drift advisory under suite-core: emit `TREE_OWNED_SLICE_BOUNDARY_DRIFT` only for deterministic, conservative subtree-local growth signals under `calculogic-validator/src/**` while preserving explicit shared-infra/compat/public-entry carveouts
 

--- a/calculogic-validator/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/test/tree-structure-advisor.test.mjs
@@ -9,6 +9,7 @@ import {
 } from '../tree/src/tree-structure-advisor.host.mjs';
 import { prepareTreeStructureAdvisorInputs } from '../tree/src/tree-structure-advisor.wiring.mjs';
 import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../tree/src/tree-structure-advisor.logic.mjs';
+import { collectShimCompatFindings } from '../tree/src/tree-shim-detection.logic.mjs';
 import { listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
 import { getValidatorScopeProfile } from '../src/core/validator-scopes.runtime.mjs';
 
@@ -431,6 +432,59 @@ test('tree-structure-advisor does not flag normal non-shim files for shim findin
   }
 });
 
+
+
+test('tree shim detection stages content reads and skips non-candidate runtime files', () => {
+  const selectedPaths = [
+    'src/app-shell.logic.ts',
+    'src/compat/legacy-api.logic.mjs',
+    'src/bridge-runtime.logic.mjs',
+  ];
+  const readCalls = [];
+  const contentByPath = new Map([
+    [
+      'src/compat/legacy-api.logic.mjs',
+      "export * from '../../calculogic-validator/src/core/validator-runner.logic.mjs';\n",
+    ],
+    ['src/bridge-runtime.logic.mjs', 'export const bridge = true\n'],
+  ]);
+
+  const findings = collectShimCompatFindings(selectedPaths, (relativePath) => {
+    readCalls.push(relativePath);
+    return contentByPath.get(relativePath) ?? 'export const noop = true\n';
+  });
+
+  assert.deepEqual(readCalls, ['src/compat/legacy-api.logic.mjs', 'src/bridge-runtime.logic.mjs']);
+  assert.equal(readCalls.includes('src/app-shell.logic.ts'), false);
+  assert.deepEqual(
+    findings.filter((finding) => finding.path === 'src/compat/legacy-api.logic.mjs').map((finding) => finding.code),
+    ['TREE_SHIM_SURFACE_PRESENT'],
+  );
+  assert.deepEqual(
+    findings.filter((finding) => finding.path === 'src/bridge-runtime.logic.mjs').map((finding) => finding.code),
+    ['TREE_SHIM_SURFACE_PRESENT'],
+  );
+});
+
+test('tree shim detection emits outside-compat warning only for thin re-export evidence outside compat', () => {
+  const selectedPaths = [
+    'src/bridge-runtime.logic.mjs',
+    'src/compat/legacy-api.logic.mjs',
+    'src/validator-runner.logic.mjs',
+  ];
+  const contentByPath = new Map([
+    ['src/bridge-runtime.logic.mjs', 'export const bridge = true\n'],
+    ['src/compat/legacy-api.logic.mjs', "export * from '../../calculogic-validator/src/core/validator-runner.logic.mjs';\n"],
+    ['src/validator-runner.logic.mjs', "export * from '../calculogic-validator/src/core/validator-runner.logic.mjs';\n"],
+  ]);
+
+  const findings = collectShimCompatFindings(selectedPaths, (relativePath) => contentByPath.get(relativePath));
+  const outsideCompatCodes = findings
+    .filter((finding) => finding.code === 'TREE_SHIM_OUTSIDE_COMPAT')
+    .map((finding) => finding.path);
+
+  assert.deepEqual(outsideCompatCodes, ['src/validator-runner.logic.mjs']);
+});
 test('tree-structure-advisor flags validator-owned-looking file outside validator tree', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-misplaced-'));
 

--- a/calculogic-validator/tree/src/tree-shim-detection.logic.mjs
+++ b/calculogic-validator/tree/src/tree-shim-detection.logic.mjs
@@ -59,6 +59,27 @@ export const collectPathShimSignals = (relativePath) => {
   };
 };
 
+const isDeterministicShimContentCandidate = (relativePath, pathSignals) => {
+  if (pathSignals.insideCompatSurface) {
+    return true;
+  }
+
+  if (pathSignals.folderSignals.length > 0 || pathSignals.basenameTokens.length > 0) {
+    return true;
+  }
+
+  const basename = path.posix.basename(relativePath);
+  if (basename.includes('.host.')) {
+    return true;
+  }
+
+  if (TREE_SIGNAL_POLICY.validatorOwnedBasenameSignalMatchers.some(({ matcher }) => matcher.test(basename))) {
+    return true;
+  }
+
+  return relativePath === 'calculogic-validator/src/index.mjs';
+};
+
 export const parseThinReexportShim = (rawContent) => {
   if (typeof rawContent !== 'string') {
     return null;
@@ -178,6 +199,35 @@ export const collectShimEvidence = (relativePath, rawContent) => {
   };
 };
 
+const collectPathOnlyShimEvidence = (relativePath) => {
+  const shimSignals = collectPathShimSignals(relativePath);
+  const basenameTokens = tokenizeBasename(path.posix.basename(relativePath));
+
+  return {
+    surface: inferArtifactSurface(relativePath),
+    folderSignals: shimSignals.folderSignals,
+    nameTokenSignals: shimSignals.basenameTokens,
+    insideCompatSurface: shimSignals.insideCompatSurface,
+    shouldReadContent: isDeterministicShimContentCandidate(relativePath, shimSignals),
+    isShimDetectorImplementationModule:
+      relativePath.startsWith('calculogic-validator/tree/src/') &&
+      basenameTokens.includes('shim') &&
+      basenameTokens.some((token) => TREE_SIGNAL_POLICY.shimDetectorImplementationTokens.has(token)),
+  };
+};
+
+const collectContentBackedShimEvidence = (relativePath, rawContent) => {
+  const thinReexportSignal = parseThinReexportShim(rawContent);
+
+  return {
+    thinReexportShim: thinReexportSignal !== null,
+    canonicalTargetPath: thinReexportSignal?.canonicalTargetPath,
+    reexportTargetCount: thinReexportSignal?.reexportTargetCount ?? 0,
+    isCanonicalHostPassThrough: detectCanonicalHostPassThrough(relativePath, thinReexportSignal),
+    isPublicEntryPointPassThrough: detectPublicEntrypointPassThrough(relativePath, rawContent),
+  };
+};
+
 export const collectShimCompatFindings = (paths, getFileContent) => {
   const findings = [];
 
@@ -187,8 +237,25 @@ export const collectShimCompatFindings = (paths, getFileContent) => {
       continue;
     }
 
-    const rawContent = typeof getFileContent === 'function' ? getFileContent(relativePath) : undefined;
-    const evidence = collectShimEvidence(relativePath, rawContent);
+    const pathEvidence = collectPathOnlyShimEvidence(relativePath);
+
+    let contentEvidence = {
+      thinReexportShim: false,
+      canonicalTargetPath: undefined,
+      reexportTargetCount: 0,
+      isCanonicalHostPassThrough: false,
+      isPublicEntryPointPassThrough: false,
+    };
+
+    if (pathEvidence.shouldReadContent && typeof getFileContent === 'function') {
+      const rawContent = getFileContent(relativePath);
+      contentEvidence = collectContentBackedShimEvidence(relativePath, rawContent);
+    }
+
+    const evidence = {
+      ...pathEvidence,
+      ...contentEvidence,
+    };
     const hasWeakSignalOnly =
       !evidence.thinReexportShim &&
       (evidence.folderSignals.length > 0 || evidence.nameTokenSignals.length > 0);


### PR DESCRIPTION
### Motivation
- Reduce the cost of shim detection by avoiding broad `getFileContent` reads and making shim detection truly staged so path/surface/token signals are checked before any content read. 
- Preserve existing advisory semantics (`TREE_SHIM_SURFACE_PRESENT`, `TREE_SHIM_OUTSIDE_COMPAT`) and intentional pass-through carveouts while keeping the `getFileContent(relativePath)` boundary lazy and cached.

### Description
- Split evidence collection into a path-only layer and a content-backed layer and added `collectPathOnlyShimEvidence`, `collectContentBackedShimEvidence`, and `isDeterministicShimContentCandidate` to enforce staged reads. 
- Only call `getFileContent(relativePath)` when `isDeterministicShimContentCandidate` returns true, otherwise decide non-candidate paths from path/surface/token signals alone. 
- Kept thin re-export detection and pass-through carveouts (canonical `*.host.*->*.wiring.*`, public entrypoint `calculogic-validator/src/index.mjs`, and shim-detector implementation module suppression) and preserved existing finding generation logic. 
- Files changed: `calculogic-validator/tree/src/tree-shim-detection.logic.mjs`, `calculogic-validator/test/tree-structure-advisor.test.mjs`, `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`, and `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`.

### Testing
- Ran unit tests with `npm test` and all validator test suites passed locally after adjustments including the new shim-focused tests. 
- Executed the slice-specific runtime test `node --test calculogic-validator/test/tree-structure-advisor.test.mjs` and the shim staging tests passed. 
- Ran `npm run validate:tree -- --scope=validator` and observed the tree validator producing expected (clean) output, and ran `npm run validate:all -- --scope=validator` which returns exit code 2 only due to pre-existing naming `warn` findings while the tree validator output remained correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4881bc21c8331b188c3a1ab38fd9e)