### PR TITLE
Add tree-owned test glob to npm test and normalize tree slice test location

### DIFF
--- a/calculogic-validator/tree/test/tree-known-roots-registry.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-registry.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { normalizeTreeKnownRootsRegistryPayload } from '../tree/src/registries/tree-known-roots.registry.logic.mjs';
+import { normalizeTreeKnownRootsRegistryPayload } from '../src/registries/tree-known-roots.registry.logic.mjs';
 
 const EXPECTED_KNOWN_ROOTS = [
   'bin',

--- a/calculogic-validator/tree/test/tree-signal-policy.registry.test.mjs
+++ b/calculogic-validator/tree/test/tree-signal-policy.registry.test.mjs
@@ -7,7 +7,7 @@ import {
   BUILTIN_SHIM_DETECTION_SIGNALS_REGISTRY_PATH,
   BUILTIN_VALIDATOR_OWNED_SIGNALS_REGISTRY_PATH,
   loadBuiltinTreeSignalPolicy,
-} from '../tree/src/registries/tree-signal-policy.registry.logic.mjs';
+} from '../src/registries/tree-signal-policy.registry.logic.mjs';
 
 test('tree signal policy loader compiles validator-owned basename matchers deterministically', () => {
   const policy = loadBuiltinTreeSignalPolicy();

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -6,12 +6,12 @@ import { test } from 'node:test';
 import {
   runTreeStructureAdvisor,
   summarizeFindings,
-} from '../tree/src/tree-structure-advisor.host.mjs';
-import { prepareTreeStructureAdvisorInputs } from '../tree/src/tree-structure-advisor.wiring.mjs';
-import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../tree/src/tree-structure-advisor.logic.mjs';
-import { collectShimCompatFindings } from '../tree/src/tree-shim-detection.logic.mjs';
-import { listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
-import { getValidatorScopeProfile } from '../src/core/validator-scopes.runtime.mjs';
+} from '../src/tree-structure-advisor.host.mjs';
+import { prepareTreeStructureAdvisorInputs } from '../src/tree-structure-advisor.wiring.mjs';
+import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../src/tree-structure-advisor.logic.mjs';
+import { collectShimCompatFindings } from '../src/tree-shim-detection.logic.mjs';
+import { listRegisteredValidators } from '../../src/core/validator-registry.knowledge.mjs';
+import { getValidatorScopeProfile } from '../../src/core/validator-scopes.runtime.mjs';
 
 const writeJson = async (filePath, value) => {
   await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
@@ -384,7 +384,7 @@ test('tree-structure-advisor does not treat public index entrypoint barrel as sh
       [
         "export * from './core/validator-runner.logic.mjs';",
         "export * as naming from '../naming/src/naming-validator.host.mjs';",
-        "export * as treeStructureAdvisor from '../tree/src/tree-structure-advisor.host.mjs';",
+        "export * as treeStructureAdvisor from '../src/tree-structure-advisor.host.mjs';",
       ].join('\n'),
       'utf8',
     );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node --test --experimental-strip-types test/**/*.test.mjs calculogic-doc-engine/test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs calculogic-validator/naming/test/**/*.test.mjs",
+    "test": "node --test --experimental-strip-types test/**/*.test.mjs calculogic-doc-engine/test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs calculogic-validator/naming/test/**/*.test.mjs calculogic-validator/tree/test/**/*.test.mjs",
     "validate:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs",
     "validate:all": "node --experimental-strip-types calculogic-validator/scripts/validate-all.mjs",
     "health:validator": "node --experimental-strip-types calculogic-validator/scripts/validator-health-check.host.mjs",


### PR DESCRIPTION
### Motivation
- Ensure tree-owned tests are executed by the repository-level `npm test` so the tree slice is protected by the same CI test surface as naming and doc-engine.
- Normalize tree slice test locations to the slice-owned root so tree shim/advisor tests are discoverable and owned consistently under `calculogic-validator/tree/`.

### Description
- Updated the root test script in `package.json` to include the tree-owned glob `calculogic-validator/tree/test/**/*.test.mjs` while keeping existing globs unchanged (`test/**`, `calculogic-doc-engine/test/**`, `calculogic-validator/test/**`, and `calculogic-validator/naming/test/**`).
- Moved tree tests into the tree slice test root: `calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, `calculogic-validator/tree/test/tree-signal-policy.registry.test.mjs`, and `calculogic-validator/tree/test/tree-known-roots-registry.test.mjs`.
- Adjusted relative imports inside the moved tests to resolve from the new location (tree-local imports now use `../src/...` and suite-core imports use `../../src/core/...`).
- Kept the change focused to including the new test glob and relocating tree-owned tests without refactoring the test runner or broadening other globs.

### Testing
- Ran `npm test` (invokes `node --test --experimental-strip-types test/**/*.test.mjs calculogic-doc-engine/test/**/*.test.mjs calculogic-validator/test/**/*.test.mjs calculogic-validator/naming/test/**/*.test.mjs calculogic-validator/tree/test/**/*.test.mjs`) and the full suite completed successfully.
- All tests passed: `# pass 265` and `# fail 0` as reported by the test run.
- Verified tree-owned tests executed as part of the run (tree-structure-advisor and tree registry tests appear in the output and passed).
- Confirmed no existing naming/doc-engine/validator test globs were altered other than adding the tree test glob to the root `test` script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4912f81c883319c1295c269268a4b)