### PR TITLE
Split tree core from shim diagnostics; add `findingContributors` composition seam

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -88,7 +88,8 @@ V0.1.6 introduces a suite-core scoped snapshot/input helper boundary and migrate
 
 - suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
 - tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
-- tree runtime remains slice-owned for findings and lazy content access over selected tree paths
+- tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`)
+- shim/content-backed diagnostics are composed from wiring as contributor callbacks so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
 
 Target behaviors in V0.1.2:

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -546,14 +546,22 @@ Report object SHOULD include:
 
 The runtime entrypoint expects prepared inputs from wiring/runtime adapters and must fail clearly when the contract is bypassed.
 
-Required prepared fields:
+Required prepared tree-core fields:
 
 - `selectedPaths` (array)
 - `topLevelDirectoryNames` (array)
 - `targets` (array)
-- `getFileContent(relativePath)` (function)
 
-Runtime must treat file content access as lazy and callable on demand by path, instead of requiring an eagerly materialized full-file map.
+Optional prepared diagnostic-composition fields:
+
+- `findingContributors` (array of contributor callbacks)
+
+Contributor callback contract:
+
+- receives the prepared tree-core inputs object
+- returns an array of tree findings (or an empty array)
+
+Tree-core runtime must not require file content access. File-content-backed diagnostics (for example shim detection) are composed by wiring through contributor callbacks and may use lazy staged reads internally.
 
 ---
 

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { collectShimCompatFindings } from './tree-shim-detection.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots.registry.logic.mjs';
 import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy.registry.logic.mjs';
 
@@ -166,16 +165,36 @@ const assertPreparedTreeInputs = (preparedInputs) => {
     preparedInputs &&
     Array.isArray(preparedInputs.selectedPaths) &&
     Array.isArray(preparedInputs.topLevelDirectoryNames) &&
-    Array.isArray(preparedInputs.targets) &&
-    typeof preparedInputs.getFileContent === 'function';
+    Array.isArray(preparedInputs.targets);
 
   if (hasPreparedRuntimeInputs) {
     return preparedInputs;
   }
 
   throw new Error(
-    'Tree runtime requires prepared inputs from wiring/runtime adapter: selectedPaths[], topLevelDirectoryNames[], targets[], and getFileContent(relativePath).',
+    'Tree runtime requires prepared tree-core inputs from wiring/runtime adapter: selectedPaths[], topLevelDirectoryNames[], and targets[].',
   );
+};
+
+const collectContributorFindings = (preparedInputs) => {
+  const { findingContributors } = preparedInputs;
+
+  if (!Array.isArray(findingContributors) || findingContributors.length === 0) {
+    return [];
+  }
+
+  return findingContributors.flatMap((contributor) => {
+    if (typeof contributor !== 'function') {
+      throw new Error('Tree runtime findingContributors must contain functions only.');
+    }
+
+    const contributedFindings = contributor(preparedInputs);
+    if (!Array.isArray(contributedFindings)) {
+      throw new Error('Tree runtime finding contributor must return an array of findings.');
+    }
+
+    return contributedFindings;
+  });
 };
 
 export const runTreeStructureAdvisor = (preparedInputs = {}) => {
@@ -185,7 +204,7 @@ export const runTreeStructureAdvisor = (preparedInputs = {}) => {
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
     ...collectValidatorOwnedOutsideTreeFindings(prepared.selectedPaths),
     ...collectOwnedSliceBoundaryDriftFindings(prepared.selectedPaths),
-    ...collectShimCompatFindings(prepared.selectedPaths, prepared.getFileContent),
+    ...collectContributorFindings(prepared),
   ].sort(sortByPathThenCode);
 
   return {

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -4,6 +4,7 @@ import {
   runTreeStructureAdvisor as runTreeStructureAdvisorRuntime,
   summarizeFindings,
 } from './tree-structure-advisor.logic.mjs';
+import { collectShimCompatFindings } from './tree-shim-detection.logic.mjs';
 import {
   collectSuiteScopedSnapshotInputs,
 } from '../../src/core/suite-scoped-snapshot-input.logic.mjs';
@@ -19,6 +20,10 @@ const WALK_EXCLUDED_DIRECTORIES = new Set([
   'dist',
   'node_modules',
 ]);
+
+
+const createShimFindingContributor = ({ selectedPaths, getFileContent }) => () =>
+  collectShimCompatFindings(selectedPaths, getFileContent);
 
 const collectTopLevelDirectoryNames = (repositoryRoot) =>
   fs
@@ -60,7 +65,12 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
     selectedPaths,
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: scopedSnapshotInputs.targets,
-    getFileContent,
+    findingContributors: [
+      createShimFindingContributor({
+        selectedPaths,
+        getFileContent,
+      }),
+    ],
   };
 };
 

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -824,20 +824,19 @@ test('tree-structure-advisor rejects invalid scope deterministically', async () 
   }
 });
 
-test('tree-structure-advisor prepared runtime contract rejects missing lazy content accessor', () => {
-  assert.throws(
-    () =>
-      runTreeStructureAdvisorRuntime({
-        scope: 'repo',
-        selectedPaths: [],
-        topLevelDirectoryNames: [],
-        targets: [],
-      }),
-    /getFileContent\(relativePath\)/u,
-  );
+test('tree-structure-advisor prepared runtime contract accepts tree-core inputs without contributors', () => {
+  const result = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: [],
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  assert.deepEqual(result.findings, []);
+  assert.equal(result.totalFilesScanned, 0);
 });
 
-test('tree-structure-advisor wiring provides lazy memoized content accessor and deterministic scope boundary error', async () => {
+test('tree-structure-advisor wiring composes shim contributor with lazy staged content reads', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-lazy-content-'));
 
   try {
@@ -851,18 +850,25 @@ test('tree-structure-advisor wiring provides lazy memoized content accessor and 
 
     const prepared = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'repo' });
 
-    assert.equal(typeof prepared.getFileContent, 'function');
-    assert.equal('fileContentsByPath' in prepared, false);
+    assert.equal(Array.isArray(prepared.findingContributors), true);
+    assert.equal(prepared.findingContributors.length, 1);
 
-    const selectedPath = 'src/compat/legacy-api.logic.mjs';
-    const firstRead = prepared.getFileContent(selectedPath);
-    await fs.writeFile(path.join(fixtureDir, selectedPath), 'export const changed = true\\n', 'utf8');
-    const secondRead = prepared.getFileContent(selectedPath);
+    const shimFindingsFirst = prepared.findingContributors[0](prepared);
+    assert.deepEqual(
+      shimFindingsFirst.filter((finding) => finding.path === 'src/compat/legacy-api.logic.mjs').map((finding) => finding.code),
+      ['TREE_SHIM_SURFACE_PRESENT'],
+    );
 
-    assert.equal(firstRead, secondRead);
-    assert.throws(
-      () => prepared.getFileContent('src/not-selected.logic.mjs'),
-      /Tree prepared getFileContent received out-of-scope path: src\/not-selected\.logic\.mjs/u,
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'compat', 'legacy-api.logic.mjs'),
+      'export const changed = true\\n',
+      'utf8',
+    );
+
+    const shimFindingsSecond = prepared.findingContributors[0](prepared);
+    assert.deepEqual(
+      shimFindingsSecond.filter((finding) => finding.path === 'src/compat/legacy-api.logic.mjs').map((finding) => finding.code),
+      ['TREE_SHIM_SURFACE_PRESENT'],
     );
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });


### PR DESCRIPTION
### Motivation
- Remove file-content dependency and direct shim import from the tree core so structural analysis can run without content access. 
- Provide a narrow, extraction-ready seam so shim diagnostics can be composed/removed later with minimal rewrite.

### Description
- Removed direct shim ownership from `tree-structure-advisor.logic.mjs` by deleting the `collectShimCompatFindings` import and `getFileContent` requirement, and by relaxing the prepared-input assertion to require only `selectedPaths`, `topLevelDirectoryNames`, and `targets`.
- Added an optional contributor seam to the core runtime: `findingContributors[]` callbacks and `collectContributorFindings(...)` that validate contributors return an array of findings and are flat-mapped into the final findings set.
- Moved shim composition to wiring: `tree-structure-advisor.wiring.mjs` now creates a `createShimFindingContributor` that closes over `selectedPaths` and the lazy `getFileContent` memo and injects it as `findingContributors` so staged reads remain intact.
- Updated tests in `tree/test/tree-structure-advisor.test.mjs` and docs/specs (`tree-structure-advisor-validator-spec.md`, `nl-config/cfg-treeStructureAdvisor.md`) to cover: core-only runtime behavior, wiring-level composition of shim diagnostics, and preservation of pass-through carveouts and thin re-export behavior.

### Testing
- Ran `npm test` and all test cases passed (`# pass 265 / # fail 0`).
- Ran `npm run validate:tree -- --scope=validator` and the tree validator report succeeded with no regressions.
- Ran `npm run validate:all -- --scope=validator`; run completed and produced the expected suite report, exiting non-zero due to pre-existing naming warnings in the repo (these warnings are not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b49922c2688331978156ca25350f9b)