### PR TITLE
Extract tree shim diagnostics contributor wiring module

### DIFF
--- a/calculogic-validator/tree/src/contributors/tree-shim-diagnostics.contributor.wiring.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-shim-diagnostics.contributor.wiring.mjs
@@ -1,0 +1,13 @@
+import { collectShimCompatFindings } from '../tree-shim-detection.logic.mjs';
+
+export const createTreeShimDiagnosticsContributor = ({ selectedPaths, getFileContent }) => {
+  if (!Array.isArray(selectedPaths)) {
+    throw new Error('Tree shim diagnostics contributor requires selectedPaths[] prepared input.');
+  }
+
+  if (typeof getFileContent !== 'function') {
+    throw new Error('Tree shim diagnostics contributor requires getFileContent(relativePath) prepared input.');
+  }
+
+  return () => collectShimCompatFindings(selectedPaths, getFileContent);
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -4,7 +4,9 @@ import {
   runTreeStructureAdvisor as runTreeStructureAdvisorRuntime,
   summarizeFindings,
 } from './tree-structure-advisor.logic.mjs';
-import { collectShimCompatFindings } from './tree-shim-detection.logic.mjs';
+import {
+  createTreeShimDiagnosticsContributor,
+} from './contributors/tree-shim-diagnostics.contributor.wiring.mjs';
 import {
   collectSuiteScopedSnapshotInputs,
 } from '../../src/core/suite-scoped-snapshot-input.logic.mjs';
@@ -20,10 +22,6 @@ const WALK_EXCLUDED_DIRECTORIES = new Set([
   'dist',
   'node_modules',
 ]);
-
-
-const createShimFindingContributor = ({ selectedPaths, getFileContent }) => () =>
-  collectShimCompatFindings(selectedPaths, getFileContent);
 
 const collectTopLevelDirectoryNames = (repositoryRoot) =>
   fs
@@ -66,7 +64,7 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: scopedSnapshotInputs.targets,
     findingContributors: [
-      createShimFindingContributor({
+      createTreeShimDiagnosticsContributor({
         selectedPaths,
         getFileContent,
       }),


### PR DESCRIPTION
### Motivation
- Decouple shim-detection composition from tree wiring so the tree wiring no longer knows shim internals while preserving the contributor-based tree-core boundary.  
- Prepare a clear, attachable shim contributor boundary to make future extraction a simple file-move + import-path change.

### Description
- Added a new shim contributor wiring module `calculogic-validator/tree/src/contributors/tree-shim-diagnostics.contributor.wiring.mjs` that validates a small prepared-input contract and returns a contributor closure invoking `collectShimCompatFindings(...)`.  
- Updated `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs` to stop importing `collectShimCompatFindings(...)` directly and to attach the shim contributor via `createTreeShimDiagnosticsContributor(...)`.  
- Removed the inline `createShimFindingContributor(...)` factory from tree wiring and kept wiring responsibilities limited to preparing `selectedPaths`, `targets`, `scope`, `topLevelDirectoryNames`, and the staged `getFileContent` accessor with in-scope guard + cache.  
- The shim contributor contract is explicit: prepared inputs must provide `selectedPaths` and `getFileContent` (the contributor module enforces these at creation time).

### Testing
- Ran `npm test` and the full test suite passed (`265` tests, `0` failures).  
- Ran `npm run validate:tree -- --scope=validator` and the tree validator completed and produced the expected report (including the shim observability finding).  
- Ran `npm run validate:all -- --scope=validator` which produced the combined report but exited with code `2` due to existing naming/tree advisory findings in the validator scope (report output was produced as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ae17fe188331b138db1801e982f8)