### PR TITLE
Move shim content-access prep into shim diagnostics attachment helper

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -89,7 +89,7 @@ V0.1.6 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
 - tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
 - tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`)
-- shim/content-backed diagnostics are composed from wiring as contributor callbacks so tree-core runtime does not require file-content access
+- shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
 
 Target behaviors in V0.1.2:

--- a/calculogic-validator/tree/src/contributors/tree-shim-diagnostics.contributor.wiring.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-shim-diagnostics.contributor.wiring.mjs
@@ -1,13 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { collectShimCompatFindings } from '../tree-shim-detection.logic.mjs';
 
-export const createTreeShimDiagnosticsContributor = ({ selectedPaths, getFileContent }) => {
-  if (!Array.isArray(selectedPaths)) {
-    throw new Error('Tree shim diagnostics contributor requires selectedPaths[] prepared input.');
+export const attachTreeShimDiagnosticsContributor = ({ repositoryRoot, selectedPaths }) => {
+  if (typeof repositoryRoot !== 'string' || repositoryRoot.length === 0) {
+    throw new Error('Tree shim diagnostics attachment requires repositoryRoot prepared input.');
   }
 
-  if (typeof getFileContent !== 'function') {
-    throw new Error('Tree shim diagnostics contributor requires getFileContent(relativePath) prepared input.');
+  if (!Array.isArray(selectedPaths)) {
+    throw new Error('Tree shim diagnostics attachment requires selectedPaths[] prepared input.');
   }
+
+  const contentByPathCache = new Map();
+  const selectedPathSet = new Set(selectedPaths);
+  const getFileContent = (relativePath) => {
+    if (!selectedPathSet.has(relativePath)) {
+      throw new Error(
+        `Tree shim diagnostics getFileContent received out-of-scope path: ${relativePath}`,
+      );
+    }
+
+    if (contentByPathCache.has(relativePath)) {
+      return contentByPathCache.get(relativePath);
+    }
+
+    const rawContent = fs.readFileSync(path.resolve(repositoryRoot, relativePath), 'utf8');
+    contentByPathCache.set(relativePath, rawContent);
+    return rawContent;
+  };
 
   return () => collectShimCompatFindings(selectedPaths, getFileContent);
 };

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import {
   runTreeStructureAdvisor as runTreeStructureAdvisorRuntime,
   summarizeFindings,
 } from './tree-structure-advisor.logic.mjs';
 import {
-  createTreeShimDiagnosticsContributor,
+  attachTreeShimDiagnosticsContributor,
 } from './contributors/tree-shim-diagnostics.contributor.wiring.mjs';
 import {
   collectSuiteScopedSnapshotInputs,
@@ -40,23 +39,6 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
     skipDotDirectories: true,
   });
   const selectedPaths = scopedSnapshotInputs.selectedPaths;
-  const contentByPathCache = new Map();
-  const selectedPathSet = new Set(selectedPaths);
-  const getFileContent = (relativePath) => {
-    if (!selectedPathSet.has(relativePath)) {
-      throw new Error(
-        `Tree prepared getFileContent received out-of-scope path: ${relativePath}`,
-      );
-    }
-
-    if (contentByPathCache.has(relativePath)) {
-      return contentByPathCache.get(relativePath);
-    }
-
-    const rawContent = fs.readFileSync(path.resolve(repositoryRoot, relativePath), 'utf8');
-    contentByPathCache.set(relativePath, rawContent);
-    return rawContent;
-  };
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -64,9 +46,9 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: scopedSnapshotInputs.targets,
     findingContributors: [
-      createTreeShimDiagnosticsContributor({
+      attachTreeShimDiagnosticsContributor({
+        repositoryRoot,
         selectedPaths,
-        getFileContent,
       }),
     ],
   };


### PR DESCRIPTION
### Motivation
- Reduce tree wiring responsibility so it only prepares tree-core inputs and no longer builds shim-specific file-content readers or guards. 
- Centralize shim content-access needs (lazy reads, caching, selected-path guard) with the shim diagnostics attachment so the shim contributor fully owns its content-access contract. 

### Description
- Moved lazy `getFileContent(relativePath)` creation, selected-path out-of-scope guard, and per-path content cache from `tree-structure-advisor.wiring.mjs` into a new shim-owned attachment helper `attachTreeShimDiagnosticsContributor` in `contributors/tree-shim-diagnostics.contributor.wiring.mjs`. 
- Updated `prepareTreeStructureAdvisorInputs` to prepare only tree-core inputs (`scope`, `selectedPaths`, `topLevelDirectoryNames`, `targets`) and to attach the shim diagnostics via `attachTreeShimDiagnosticsContributor({ repositoryRoot, selectedPaths })` instead of inlining reader logic. 
- Kept staged/lazy content-read behavior and caching semantics intact by implementing the same read-on-demand semantics inside the shim attachment helper and passing a `getFileContent` reader into `collectShimCompatFindings`. 
- Files changed: `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs`, `calculogic-validator/tree/src/contributors/tree-shim-diagnostics.contributor.wiring.mjs`, and `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`. 

### Testing
- Ran `npm test` and the full test suite passed (265 tests, 0 failures). 
- Ran `npm run validate:tree -- --scope=validator` and it completed successfully with expected findings. 
- Ran `npm run validate:all -- --scope=validator` which executed correctly but returned exit code 2 due to existing naming warnings in the validator scope report (report execution itself succeeded as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ba8869508331a6a330f1d8066410)