### PR TITLE
Extract tree contributor assembly from wiring

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -89,6 +89,7 @@ V0.1.6 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
 - tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
 - tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`)
+- tree-run default contributor selection is owned by a dedicated assembly/wiring module so tree wiring only prepares tree-core inputs
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
 
@@ -131,6 +132,7 @@ Each finding follows existing report conventions:
 - Canonical tree slice boundary lives at:
   - `calculogic-validator/tree/src/tree-structure-advisor.host.mjs`
   - `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs`
+  - `calculogic-validator/tree/src/tree-structure-advisor-contributors.assembly.wiring.mjs`
   - `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs`
   - shim evidence/runtime helpers: `calculogic-validator/tree/src/tree-shim-detection.logic.mjs`
   - optional contracts surface: `calculogic-validator/tree/src/tree-structure-advisor.contracts.mjs`

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -561,7 +561,7 @@ Contributor callback contract:
 - receives the prepared tree-core inputs object
 - returns an array of tree findings (or an empty array)
 
-Tree-core runtime must not require file content access. File-content-backed diagnostics (for example shim detection) are composed by wiring through contributor callbacks and may use lazy staged reads internally.
+Tree-core runtime must not require file content access. File-content-backed diagnostics (for example shim detection) are composed through contributor callbacks selected by tree-run assembly wiring and may use lazy staged reads internally.
 
 ---
 

--- a/calculogic-validator/tree/src/tree-structure-advisor-contributors.assembly.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor-contributors.assembly.wiring.mjs
@@ -1,0 +1,11 @@
+import {
+  attachTreeShimDiagnosticsContributor,
+} from './contributors/tree-shim-diagnostics.contributor.wiring.mjs';
+
+export const collectDefaultTreeStructureAdvisorContributors = ({ repositoryRoot, selectedPaths }) => [
+  attachTreeShimDiagnosticsContributor({
+    repositoryRoot,
+    selectedPaths,
+  }),
+];
+

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -4,8 +4,8 @@ import {
   summarizeFindings,
 } from './tree-structure-advisor.logic.mjs';
 import {
-  attachTreeShimDiagnosticsContributor,
-} from './contributors/tree-shim-diagnostics.contributor.wiring.mjs';
+  collectDefaultTreeStructureAdvisorContributors,
+} from './tree-structure-advisor-contributors.assembly.wiring.mjs';
 import {
   collectSuiteScopedSnapshotInputs,
 } from '../../src/core/suite-scoped-snapshot-input.logic.mjs';
@@ -45,12 +45,10 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
     selectedPaths,
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: scopedSnapshotInputs.targets,
-    findingContributors: [
-      attachTreeShimDiagnosticsContributor({
-        repositoryRoot,
-        selectedPaths,
-      }),
-    ],
+    findingContributors: collectDefaultTreeStructureAdvisorContributors({
+      repositoryRoot,
+      selectedPaths,
+    }),
   };
 };
 


### PR DESCRIPTION
### Motivation
- Remove the last tree-local composition policy so tree wiring only prepares tree-core inputs while contributor selection is decided at an explicit assembly boundary. 
- Avoid `tree-structure-advisor.wiring.mjs` being the policy point for cross-slice concerns (shim diagnostics) so shim-owned logic keeps its own prep and attachment. 

### Description
- Add `calculogic-validator/tree/src/tree-structure-advisor-contributors.assembly.wiring.mjs` which returns the default `findingContributors` for a normal tree run and imports shim attachment helpers. 
- Update `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs` to stop importing `attachTreeShimDiagnosticsContributor` directly and to call `collectDefaultTreeStructureAdvisorContributors(...)` after preparing tree-core inputs (`selectedPaths`, `topLevelDirectoryNames`, `targets`). 
- Update docs to reflect the new assembly boundary in `cfg-treeStructureAdvisor.md` and clarify the wiring/runtime contract in `tree-structure-advisor-validator-spec.md`. 

### Testing
- Ran `npm test` and the full test suite passed (265 tests, 0 failures). 
- Ran `npm run validate:tree -- --scope=validator` and the tree run completed showing the same shim finding behavior as before. 
- Ran `npm run validate:all -- --scope=validator` which executed successfully and produced the expected report (exits non-zero due to existing naming warnings in validator scope, not impacted by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c6d8823c8331aee11e7d3ed75553)