### PR TITLE
docs(tree): add concrete validator tree occurrence illustration

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
@@ -105,7 +105,7 @@ Therefore, tree must interpret **occurrences**, not names alone.
 
 Repeated folder names can appear under different parents and at different depths.
 
-Example set:
+Example occurrence set:
 
 - `calculogic-validator/src`
 - `calculogic-validator/naming/src`
@@ -116,6 +116,118 @@ All three terminal tokens are `src`, but tree modeling must treat them as three 
 Required statement:
 
 - Same token + different lineage => different occurrence identity.
+
+## Concrete Validator Tree Illustration (Illustrative, Tree-Specific)
+
+### Status Note (Scope and Authority)
+
+This section is a concrete **illustrative tree-occurrence** example for this document.
+
+- Letters represent **folder occurrences**.
+- Numbers represent **file occurrences**.
+- This notation is **tree-specific modeling guidance** scoped to this doc.
+- It is **not** declared canonical runtime grammar in this pass.
+- It does **not** replace `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md`.
+
+### Concrete Tree Excerpt
+
+`A` = `calculogic-validator/`
+
+```text
+A: calculogic-validator/
+1├─ LICENSE
+2├─ README.md
+3├─ package.json
+A├─ doc/
+│ A├─ ConventionRoutines/
+│ B├─ ValidatorSpecs/
+│ C└─ Indexes/
+B├─ bin/
+│ 1├─ calculogic-validate.mjs
+│ 2├─ calculogic-validate-naming.mjs
+│ 3└─ calculogic-validator-health.mjs
+C├─ scripts/
+│ 1├─ validate-all.mjs
+│ 2├─ validate-naming.mjs
+│ 3├─ validator-health-check.host.mjs
+│ 4├─ report-capture-verify.mjs
+│ 5└─ report-capture-summarize.mjs
+D├─ src/
+│ 1├─ index.mjs
+│ 2├─ validator-config.schema.json
+│ A├─ core/
+│ │ 1├─ repository-root.logic.mjs
+│ │ 2├─ npm-arg-forwarding-guard.logic.mjs
+│ │ 3├─ validator-exit-code.logic.mjs
+│ │ A├─ cli/
+│ │ │ 1├─ validator-cli-output.logic.mjs
+│ │ │ 2├─ validator-cli-scopes.logic.mjs
+│ │ │ 3├─ validator-cli-targets.logic.mjs
+│ │ │ 4└─ validator-cli-usage.logic.mjs
+│ │ 4├─ validator-report.contracts.mjs
+│ │ 5├─ validator-report-meta.logic.mjs
+│ │ 6├─ validator-runner.logic.mjs
+│ │ 7├─ validator-registry.knowledge.mjs
+│ │ 8├─ validator-scopes.runtime.mjs
+│ │ 9├─ validator-root-files.knowledge.mjs
+│ │ 10└─ source-snapshot.logic.mjs
+│ B└─ config/
+│   1├─ validator-config.contracts.mjs
+│   2└─ validator-config.logic.mjs
+```
+
+### Example Interpreted Occurrences
+
+- `A.1`
+  - Occurrence type: `file occurrence`
+  - Label: `1`
+  - Resolved path: `calculogic-validator/LICENSE`
+  - Meaning: first file occurrence directly under repo-root occurrence `A`.
+
+- `A.A`
+  - Occurrence type: `folder occurrence`
+  - Label: `A`
+  - Resolved path: `calculogic-validator/doc/`
+  - Meaning: first folder occurrence under repo-root occurrence `A` (the `doc` folder occurrence).
+
+- `A.A.A`
+  - Occurrence type: `folder occurrence`
+  - Label: `A`
+  - Resolved path: `calculogic-validator/doc/ConventionRoutines/`
+  - Meaning: first folder occurrence under `calculogic-validator/doc/`, distinguished by lineage from other `A` labels.
+
+- `A.D`
+  - Occurrence type: `folder occurrence`
+  - Label: `D`
+  - Resolved path: `calculogic-validator/src/`
+  - Meaning: fourth folder occurrence directly under repo-root occurrence `A`.
+
+- `A.D.A`
+  - Occurrence type: `folder occurrence`
+  - Label: `A`
+  - Resolved path: `calculogic-validator/src/core/`
+  - Meaning: first folder occurrence under `calculogic-validator/src/`, showing reused letter labels remain lineage-scoped.
+
+- `A.D.A.3`
+  - Occurrence type: `file occurrence`
+  - Label: `3`
+  - Resolved path: `calculogic-validator/src/core/validator-exit-code.logic.mjs`
+  - Meaning: third file occurrence under `calculogic-validator/src/core/`, interpreted by parent chain plus file segment type.
+
+### Why This Illustration Matters
+
+- The same token/segment marker may appear multiple times under different parent chains.
+- Tree interpretation must distinguish `path occurrence` identity by lineage, not token only.
+- Repeated names such as multiple `src` occurrences under different parents are a motivating case for explicit occurrence addressing.
+
+### Modeling Takeaway
+
+Tree determinism requires both:
+
+1. structural vocabulary/root-partition classification, and
+2. occurrence addressing/lineage identity.
+
+Neither layer is sufficient alone for reliable interpreted tree occurrence modeling.
 
 ## Tree-Specific Occurrence Addressing Guidance (Modeling Direction)
 
@@ -218,4 +330,3 @@ This document is modeling-first and intentionally non-disruptive to current runt
 1. Define a small tree-local address example registry (documentation-only) that exercises repeated-name scenarios across top-root and subtree contexts.
 2. Add a traceability table mapping each interpreted occurrence field to current tree findings payload fields and explicit "missing today" markers.
 3. Open a bounded alignment note with the deterministic structural addressing draft for any grammar decisions needed before runtime adoption.
-


### PR DESCRIPTION
### Motivation

- Provide a concrete, tree-scoped example that makes occurrence identity explicit through lineage so readers can see how repeated folder/file names are disambiguated.
- Show folder-vs-file segment typing and how an address resolves to a concrete validator path to clarify the tree occurrence model examples.
- Keep the notation clearly scoped as illustrative tree-specific modeling guidance and avoid implying any immediate runtime grammar change.

### Description

- Added a new section `Concrete Validator Tree Illustration (Illustrative, Tree-Specific)` to `calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md` with an explicit status/authority note that letters = `folder occurrence`, numbers = `file occurrence`, and the notation is non-canonical modeling guidance. 
- Inserted the concrete tree excerpt rooted at `A = calculogic-validator/` that includes repo-root files plus `doc/` (with `ConventionRoutines/`, `ValidatorSpecs/`, `Indexes/`), `bin/`, `scripts/`, `src/`, `src/core/`, `src/core/cli/`, and `src/config/` examples. 
- Added interpreted occurrence bullets for `A.1`, `A.A`, `A.A.A`, `A.D`, `A.D.A`, and `A.D.A.3` describing occurrence type, label, resolved path, and a short meaning statement, and corrected the important mapping that `A.A` resolves to `calculogic-validator/doc/` and `A.A.A` resolves to `calculogic-validator/doc/ConventionRoutines/`. 
- Normalized one wording instance from “Example set” to `Example occurrence set` for terminology consistency and left a small nit noted in-doc where a different illustrative notation (`R...`) coexists but remains explicitly non-canonical.

### Testing

- Verified the file contents with `sed -n '1,360p' calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md`, which printed the updated section successfully. (succeeded)
- Checked presence of required example addresses and lineage wording with `rg` for `A.1`, `A.A`, `A.A.A`, `A.D`, `A.D.A`, `A.D.A.3`, `Concrete Validator Tree Illustration`, and `canonical runtime grammar`, which found the expected lines. (succeeded)
- Staged and committed the change with `git add` and `git commit -m "docs(tree): add concrete validator occurrence illustration"`, producing a successful commit. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52176a2b88331bc48bca4b91f753e)