### PR TITLE
docs(tree): normalize tree occurrence illustration marker/name/path split

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
@@ -178,41 +178,59 @@ D├─ src/
 
 ### Example Interpreted Occurrences
 
+Interpretation principle used below (Illustrative, tree-specific):
+
+- occurrence marker ≠ actual folder/file name,
+- marker identifies position/type within the illustrative lineage system,
+- actual name is the folder/file token resolved at that occurrence.
+
 - `A.1`
+  - Address: `A.1`
   - Occurrence type: `file occurrence`
-  - Label: `1`
+  - Occurrence marker: `1`
+  - Actual name: `LICENSE`
   - Resolved path: `calculogic-validator/LICENSE`
   - Meaning: first file occurrence directly under repo-root occurrence `A`.
 
 - `A.A`
+  - Address: `A.A`
   - Occurrence type: `folder occurrence`
-  - Label: `A`
+  - Occurrence marker: `A`
+  - Actual name: `doc`
   - Resolved path: `calculogic-validator/doc/`
-  - Meaning: first folder occurrence under repo-root occurrence `A` (the `doc` folder occurrence).
+  - Meaning: first folder occurrence under repo-root occurrence `A`.
 
 - `A.A.A`
+  - Address: `A.A.A`
   - Occurrence type: `folder occurrence`
-  - Label: `A`
+  - Occurrence marker: `A`
+  - Actual name: `ConventionRoutines`
   - Resolved path: `calculogic-validator/doc/ConventionRoutines/`
-  - Meaning: first folder occurrence under `calculogic-validator/doc/`, distinguished by lineage from other `A` labels.
+  - Meaning: first folder occurrence under `calculogic-validator/doc/`, distinguished by lineage from other `A` markers.
 
 - `A.D`
+  - Address: `A.D`
   - Occurrence type: `folder occurrence`
-  - Label: `D`
+  - Occurrence marker: `D`
+  - Actual name: `src`
   - Resolved path: `calculogic-validator/src/`
   - Meaning: fourth folder occurrence directly under repo-root occurrence `A`.
 
 - `A.D.A`
+  - Address: `A.D.A`
   - Occurrence type: `folder occurrence`
-  - Label: `A`
+  - Occurrence marker: `A`
+  - Actual name: `core`
   - Resolved path: `calculogic-validator/src/core/`
-  - Meaning: first folder occurrence under `calculogic-validator/src/`, showing reused letter labels remain lineage-scoped.
+  - Meaning: first folder occurrence under `calculogic-validator/src/`, showing reused letter markers remain lineage-scoped.
 
 - `A.D.A.3`
+  - Address: `A.D.A.3`
   - Occurrence type: `file occurrence`
-  - Label: `3`
+  - Occurrence marker: `3`
+  - Actual name: `validator-exit-code.logic.mjs`
   - Resolved path: `calculogic-validator/src/core/validator-exit-code.logic.mjs`
-  - Meaning: third file occurrence under `calculogic-validator/src/core/`, interpreted by parent chain plus file segment type.
+  - Meaning: third file occurrence under `calculogic-validator/src/core/`, interpreted by parent chain plus file-segment typing.
 
 ### Why This Illustration Matters
 
@@ -267,18 +285,19 @@ A simple illustrative notation may be used for examples:
 - folder lineage segments are alphabetic labels,
 - terminal file occurrence uses numeric segment typing.
 
-Example illustration only:
+Example illustration only (aligned with the concrete validator-tree style in this document):
 
-- Folder occurrence lineage: `R.calculogic-validator.naming.src`
-- Terminal file occurrence under that lineage: `R.calculogic-validator.naming.src.01`
+- Folder occurrence lineage: `A.D.A`
+- Terminal file occurrence under that lineage: `A.D.A.3`
 
 Interpretation of the example:
 
-- `R...src` identifies a folder occurrence,
-- `...src.01` identifies a file occurrence under that folder occurrence lineage,
+- `A.D.A` identifies a folder occurrence (marker chain resolves to `calculogic-validator/src/core/`),
+- `A.D.A.3` identifies a file occurrence under that same lineage (`validator-exit-code.logic.mjs`),
+- marker tokens (`A`, `D`, `3`) are occurrence markers in this illustrative system, not the actual folder/file names,
 - identity derives from lineage + terminal kind, not name-only.
 
-(Notation above is intentionally non-canonical and modeling-scoped in this document.)
+(Notation above remains intentionally non-canonical and modeling-scoped in this document.)
 
 ## Interpreted Occurrence Walkthrough for Repeated `src`
 


### PR DESCRIPTION
### Motivation
- Clarify the concrete validator-tree illustration so occurrence markers, actual names, and resolved paths are explicitly separated for reader clarity.
- Prevent conflation of illustrative occurrence markers (A, D, 1, 3) with actual folder/file tokens and reduce the sense of competing notation in the same section.

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md` in the **Concrete Validator Tree Illustration (Illustrative, Tree-Specific)** section to normalize interpreted entries into explicit fields: `Address`, `Occurrence type`, `Occurrence marker`, `Actual name`, `Resolved path`, and `Meaning`.
- Normalized the required example entries: `A.1` (LICENSE), `A.A` (doc), `A.A.A` (ConventionRoutines), `A.D` (src), `A.D.A` (core), and `A.D.A.3` (validator-exit-code.logic.mjs).
- Added a short interpretation principle note stating that occurrence markers are not actual folder/file names and that markers identify position/type in the illustrative lineage system.
- Aligned the later visual-deterministic notation example to the same validator-tree illustrative style (`A.D.A` / `A.D.A.3`) and retained explicit non-canonical/modeling-scoped wording to avoid presenting it as runtime grammar.

### Testing
- Performed a file inspection of the modified markdown using `sed`/`nl` to verify the new normalized lines and field ordering were present and correct (succeeded).
- Verified the concrete example entries now show explicit `Occurrence marker` vs `Actual name` vs `Resolved path` by line inspection (succeeded).
- No unit or runtime tests were applicable because this is a documentation-only change; no runtime behavior or parser was modified.

Tiny remaining ambiguity: the notation in this document remains explicitly modeling-scoped and non-canonical, so readers must still consult the deterministic structural addressing draft for any future grammar promotion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b523ce203c83319213ec1d0bb5bf56)