### PR TITLE
Clarify marker-vs-name repetition wording in tree occurrence model doc

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
@@ -254,7 +254,7 @@ Status boundary reminder:
 ### Why This Illustration Matters
 
 - The same actual name/token may appear in multiple `path occurrence` instances under different parent chains.
-- The same illustrative occurrence marker may also appear in different branches of the tree-specific notation.
+- The same illustrative occurrence marker may also appear under different parent lineages in the tree-specific notation.
 - Tree interpretation must distinguish `path occurrence` identity by lineage, not token only.
 - Tree interpretation must also distinguish `path occurrence` identity by lineage when occurrence markers are reused.
 - Repeated names such as multiple `src` occurrences under different parents are a motivating case for explicit occurrence addressing.

--- a/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
@@ -253,8 +253,10 @@ Status boundary reminder:
 
 ### Why This Illustration Matters
 
-- The same token/segment marker may appear multiple times under different parent chains.
+- The same actual name/token may appear in multiple `path occurrence` instances under different parent chains.
+- The same illustrative occurrence marker may also appear in different branches of the tree-specific notation.
 - Tree interpretation must distinguish `path occurrence` identity by lineage, not token only.
+- Tree interpretation must also distinguish `path occurrence` identity by lineage when occurrence markers are reused.
 - Repeated names such as multiple `src` occurrences under different parents are a motivating case for explicit occurrence addressing.
 
 ### Modeling Takeaway


### PR DESCRIPTION
### Motivation
- Tighten the wording in the **Why This Illustration Matters** subsection so it no longer conflates repeated actual names/tokens with repeated illustrative occurrence markers while preserving the lineage-based occurrence identity point.

### Description
- Edited `calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md` to replace the single compressed bullet with explicit lines: the original `- The same token/segment marker may appear multiple times under different parent chains.` was replaced by `- The same actual name/token may appear in multiple \`path occurrence\` instances under different parent chains.`, `- The same illustrative occurrence marker may also appear in different branches of the tree-specific notation.`, and an added explicit lineage statement `- Tree interpretation must also distinguish \`path occurrence\` identity by lineage when occurrence markers are reused.` (change visible around lines L254–L260).

### Testing
- Ran `git diff -- calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md`, inspected the updated region with `nl -ba calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md | sed -n '248,270p'`, and committed the change with `git commit`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b536d53ecc8331b94c3654203058e2)