### PR TITLE
Add initial tree occurrence snapshot substrate for deterministic occurrence identities

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs
@@ -1,0 +1,206 @@
+const POSIX_SEPARATOR = '/';
+
+const normalizeRelativePath = (relativePath) =>
+  String(relativePath ?? '')
+    .replaceAll('\\', POSIX_SEPARATOR)
+    .replace(/^\.\//u, '')
+    .replace(/\/$/u, '');
+
+const sortStrings = (values) => [...values].sort((left, right) => left.localeCompare(right));
+
+const isPathInsideDirectoryPath = (candidatePath, directoryPath) =>
+  candidatePath === directoryPath || candidatePath.startsWith(`${directoryPath}${POSIX_SEPARATOR}`);
+
+const toAlphabeticMarker = (index) => {
+  let marker = '';
+  let value = index + 1;
+
+  while (value > 0) {
+    const remainder = (value - 1) % 26;
+    marker = String.fromCharCode(97 + remainder) + marker;
+    value = Math.floor((value - 1) / 26);
+  }
+
+  return marker;
+};
+
+const normalizeTargetDescriptors = (targetDescriptors = []) => {
+  const normalized = [];
+
+  for (const targetDescriptor of targetDescriptors) {
+    if (typeof targetDescriptor === 'string') {
+      const relPath = normalizeRelativePath(targetDescriptor);
+      if (relPath && relPath !== '.') {
+        normalized.push({ relPath, kind: null });
+      }
+      continue;
+    }
+
+    const relPath = normalizeRelativePath(targetDescriptor?.relPath ?? '');
+    if (relPath && relPath !== '.') {
+      normalized.push({ relPath, kind: targetDescriptor?.kind ?? null });
+    }
+  }
+
+  const deduped = new Map();
+  for (const targetDescriptor of normalized) {
+    if (!deduped.has(targetDescriptor.relPath)) {
+      deduped.set(targetDescriptor.relPath, targetDescriptor);
+    }
+  }
+
+  return [...deduped.values()].sort((left, right) => left.relPath.localeCompare(right.relPath));
+};
+
+const buildScopeRoots = ({ selectedPaths, targets, includeRoots }) => {
+  if (targets.length > 0) {
+    return targets;
+  }
+
+  if (includeRoots.length > 0) {
+    return includeRoots.map((includeRoot) => ({ relPath: includeRoot, kind: 'dir' }));
+  }
+
+  const topLevelRoots = new Set(
+    selectedPaths.map((relativePath) => relativePath.split(POSIX_SEPARATOR)[0]).filter(Boolean),
+  );
+
+  return sortStrings(topLevelRoots).map((relPath) => ({ relPath, kind: 'dir' }));
+};
+
+const resolveScopeRootPathForNode = (resolvedPath, scopeRoots) => {
+  if (scopeRoots.length === 0) {
+    return '.';
+  }
+
+  const matchedRoots = scopeRoots
+    .filter((scopeRoot) => isPathInsideDirectoryPath(resolvedPath, scopeRoot.relPath))
+    .sort((left, right) => right.relPath.length - left.relPath.length || left.relPath.localeCompare(right.relPath));
+
+  if (matchedRoots.length > 0) {
+    return matchedRoots[0].relPath;
+  }
+
+  return scopeRoots[0].relPath;
+};
+
+const collectAllOccurrencePaths = (selectedPaths, scopeRoots) => {
+  const directoryPaths = new Set(scopeRoots.map((scopeRoot) => scopeRoot.relPath));
+  const filePaths = new Set();
+
+  for (const selectedPath of selectedPaths) {
+    filePaths.add(selectedPath);
+
+    const segments = selectedPath.split(POSIX_SEPARATOR);
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      directoryPaths.add(segments.slice(0, index + 1).join(POSIX_SEPARATOR));
+    }
+  }
+
+  return {
+    directoryPaths,
+    filePaths,
+  };
+};
+
+export const prepareTreeOccurrenceSnapshot = ({
+  selectedPaths = [],
+  targets = [],
+  includeRoots = [],
+} = {}) => {
+  const normalizedSelectedPaths = sortStrings(
+    selectedPaths.map((selectedPath) => normalizeRelativePath(selectedPath)).filter(Boolean),
+  );
+  const normalizedTargetDescriptors = normalizeTargetDescriptors(targets);
+  const normalizedIncludeRoots = sortStrings(
+    includeRoots.map((includeRoot) => normalizeRelativePath(includeRoot)).filter(Boolean),
+  );
+  const scopeRoots = buildScopeRoots({
+    selectedPaths: normalizedSelectedPaths,
+    targets: normalizedTargetDescriptors,
+    includeRoots: normalizedIncludeRoots,
+  });
+
+  const { directoryPaths, filePaths } = collectAllOccurrencePaths(normalizedSelectedPaths, scopeRoots);
+  const allPaths = sortStrings(new Set([...directoryPaths, ...filePaths]));
+
+  const recordsByPath = new Map();
+
+  for (const resolvedPath of allPaths) {
+    const occurrenceType = filePaths.has(resolvedPath) ? 'file' : 'folder';
+    const actualName = resolvedPath.includes(POSIX_SEPARATOR)
+      ? resolvedPath.slice(resolvedPath.lastIndexOf(POSIX_SEPARATOR) + 1)
+      : resolvedPath;
+    const scopeRootPath = resolveScopeRootPathForNode(resolvedPath, scopeRoots);
+    const lineageTail =
+      scopeRootPath === resolvedPath
+        ? []
+        : resolvedPath
+            .slice(scopeRootPath.length + 1)
+            .split(POSIX_SEPARATOR)
+            .filter(Boolean);
+    const lineageSegments = [scopeRootPath, ...lineageTail].filter(Boolean);
+
+    let parentResolvedPath = null;
+    if (resolvedPath !== scopeRootPath && resolvedPath.includes(POSIX_SEPARATOR)) {
+      const candidateParent = resolvedPath.slice(0, resolvedPath.lastIndexOf(POSIX_SEPARATOR));
+      if (candidateParent && isPathInsideDirectoryPath(candidateParent, scopeRootPath)) {
+        parentResolvedPath = candidateParent;
+      }
+    }
+
+    recordsByPath.set(resolvedPath, {
+      resolvedPath,
+      actualName,
+      occurrenceType,
+      parentResolvedPath,
+      depth: lineageSegments.length - 1,
+      scopeRootPath,
+      lineageSegments,
+      markerSegments: [],
+      occurrenceMarker: '',
+      isScopedRoot: resolvedPath === scopeRootPath,
+      isRepoTopOccurrence: lineageSegments.length === 1,
+    });
+  }
+
+  const childrenByParent = new Map();
+
+  for (const record of recordsByPath.values()) {
+    const parentKey = record.parentResolvedPath ?? '__ROOT__';
+    const parentChildren = childrenByParent.get(parentKey) ?? [];
+    parentChildren.push(record);
+    childrenByParent.set(parentKey, parentChildren);
+  }
+
+  for (const siblings of childrenByParent.values()) {
+    siblings.sort(
+      (left, right) =>
+        left.actualName.localeCompare(right.actualName) ||
+        left.occurrenceType.localeCompare(right.occurrenceType) ||
+        left.resolvedPath.localeCompare(right.resolvedPath),
+    );
+
+    let folderCounter = 0;
+    let fileCounter = 0;
+
+    for (const record of siblings) {
+      const marker =
+        record.occurrenceType === 'folder'
+          ? toAlphabeticMarker(folderCounter++)
+          : String(fileCounter++ + 1);
+      const parentSegments =
+        record.parentResolvedPath && recordsByPath.has(record.parentResolvedPath)
+          ? recordsByPath.get(record.parentResolvedPath).markerSegments
+          : [];
+
+      record.markerSegments = [...parentSegments, marker];
+      record.occurrenceMarker = record.markerSegments.join('.');
+    }
+  }
+
+  return {
+    scopeRoots: scopeRoots.map((scopeRoot) => scopeRoot.relPath),
+    occurrenceRecords: allPaths.map((resolvedPath) => recordsByPath.get(resolvedPath)),
+  };
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -9,6 +9,7 @@ import {
 import {
   collectSuiteScopedSnapshotInputs,
 } from '../../src/core/suite-scoped-snapshot-input.logic.mjs';
+import { prepareTreeOccurrenceSnapshot } from './tree-occurrence-snapshot.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
 const WALK_EXCLUDED_DIRECTORIES = new Set([
@@ -43,6 +44,11 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
   return {
     scope: scopedSnapshotInputs.scope,
     selectedPaths,
+    occurrenceSnapshot: prepareTreeOccurrenceSnapshot({
+      selectedPaths,
+      targets: scopedSnapshotInputs.targets,
+      includeRoots: scopedSnapshotInputs.includeRoots,
+    }),
     topLevelDirectoryNames: collectTopLevelDirectoryNames(repositoryRoot),
     targets: scopedSnapshotInputs.targets,
     findingContributors: collectDefaultTreeStructureAdvisorContributors({

--- a/calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeOccurrenceSnapshot } from '../src/tree-occurrence-snapshot.logic.mjs';
+import { prepareTreeStructureAdvisorInputs } from '../src/tree-structure-advisor.wiring.mjs';
+
+const byResolvedPath = (occurrenceRecords) =>
+  Object.fromEntries(occurrenceRecords.map((record) => [record.resolvedPath, record]));
+
+test('tree occurrence snapshot disambiguates repeated names by lineage', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: [
+      'calculogic-validator/src/core/runtime.mjs',
+      'calculogic-validator/naming/src/naming.logic.mjs',
+      'calculogic-validator/tree/src/tree.logic.mjs',
+    ],
+    targets: [],
+    includeRoots: ['calculogic-validator'],
+  });
+
+  const recordsByPath = byResolvedPath(snapshot.occurrenceRecords);
+  const srcRecords = ['calculogic-validator/src', 'calculogic-validator/naming/src', 'calculogic-validator/tree/src'].map(
+    (resolvedPath) => recordsByPath[resolvedPath],
+  );
+
+  assert.equal(srcRecords.every((record) => record.actualName === 'src'), true);
+  assert.equal(new Set(srcRecords.map((record) => record.occurrenceMarker)).size, 3);
+  assert.equal(
+    new Set(srcRecords.map((record) => record.lineageSegments.join('/'))).size,
+    3,
+  );
+});
+
+test('tree occurrence snapshot preserves deterministic lineage and depth', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs'],
+    targets: [],
+    includeRoots: ['calculogic-validator'],
+  });
+
+  const recordsByPath = byResolvedPath(snapshot.occurrenceRecords);
+
+  assert.deepEqual(recordsByPath['calculogic-validator/tree/src'].lineageSegments, [
+    'calculogic-validator',
+    'tree',
+    'src',
+  ]);
+  assert.equal(recordsByPath['calculogic-validator/tree/src'].depth, 2);
+  assert.equal(
+    recordsByPath['calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs']
+      .parentResolvedPath,
+    'calculogic-validator/tree/src/registries',
+  );
+});
+
+test('tree occurrence snapshot distinguishes folders and files from path structure', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
+    targets: [],
+    includeRoots: ['calculogic-validator'],
+  });
+
+  const recordsByPath = byResolvedPath(snapshot.occurrenceRecords);
+
+  assert.equal(recordsByPath['calculogic-validator/tree/src'].occurrenceType, 'folder');
+  assert.equal(
+    recordsByPath['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'].occurrenceType,
+    'file',
+  );
+  assert.match(recordsByPath['calculogic-validator/tree/src'].occurrenceMarker, /^[a-z]+(?:\.[a-z0-9]+)*$/u);
+  assert.match(
+    recordsByPath['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'].occurrenceMarker,
+    /^[a-z]+(?:\.[a-z0-9]+)*\.[0-9]+$/u,
+  );
+});
+
+test('tree occurrence snapshot rebases scoped lineage from targeted subtree roots', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
+    targets: [{ relPath: 'calculogic-validator/tree', kind: 'dir' }],
+    includeRoots: ['calculogic-validator'],
+  });
+
+  const recordsByPath = byResolvedPath(snapshot.occurrenceRecords);
+  const scopedRoot = recordsByPath['calculogic-validator/tree'];
+  const nestedSrc = recordsByPath['calculogic-validator/tree/src'];
+
+  assert.equal(scopedRoot.isScopedRoot, true);
+  assert.equal(scopedRoot.depth, 0);
+  assert.deepEqual(scopedRoot.lineageSegments, ['calculogic-validator/tree']);
+  assert.equal(nestedSrc.scopeRootPath, 'calculogic-validator/tree');
+  assert.deepEqual(nestedSrc.lineageSegments, ['calculogic-validator/tree', 'src']);
+  assert.equal(nestedSrc.depth, 1);
+});
+
+test('tree structure advisor wiring attaches occurrence snapshot with resolved paths', () => {
+  const prepared = prepareTreeStructureAdvisorInputs(process.cwd(), {
+    scope: 'validator',
+    targets: ['calculogic-validator/tree/src'],
+  });
+
+  assert.ok(prepared.occurrenceSnapshot);
+  assert.equal(Array.isArray(prepared.occurrenceSnapshot.occurrenceRecords), true);
+  assert.equal(
+    prepared.occurrenceSnapshot.occurrenceRecords.every(
+      (record) => typeof record.resolvedPath === 'string' && record.resolvedPath.length > 0,
+    ),
+    true,
+  );
+  assert.equal(prepared.selectedPaths.length > 0, true);
+  assert.equal(prepared.targets.includes('calculogic-validator/tree/src'), true);
+});


### PR DESCRIPTION
### Motivation
- Introduce a tree-local deterministic occurrence substrate so tree reasoning can operate on stable occurrence identities rather than token-only names. 
- Provide a bounded first-pass marker/addressing layer (sibling-local alphabetic folder markers and numeric file markers) for future tree reasoning without exposing marker grammar to users. 
- Keep all user-facing findings unchanged (continue to use resolved real paths) while preparing a clean input surface for later classification/addressing layers. 

### Description
- Added a new occurrence snapshot module `calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs` that builds deterministic occurrence records from prepared scoped paths and returns `{ scopeRoots, occurrenceRecords }`.
- Each occurrence record contains `resolvedPath`, `actualName`, `occurrenceType`, `parentResolvedPath`, `depth`, `scopeRootPath`, `lineageSegments`, `markerSegments`, `occurrenceMarker`, `isScopedRoot`, and `isRepoTopOccurrence`.
- Implemented scoped-root rebasing: scope roots are chosen from `targets` first, then `includeRoots`, then inferred top-level roots, and each node is bound to the most specific matching scope root so lineage/depth are computed relative to that scope root.
- Implemented deterministic sibling-local markers with alphabetic markers for folder siblings and numeric markers for file siblings, assigned deterministically by sorted sibling order, and integrated the snapshot into the tree wiring by attaching `occurrenceSnapshot` in `prepareTreeStructureAdvisorInputs` (wiring only; findings remain resolved-path based). 

### Testing
- Added `calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs` covering repeated-name disambiguation, lineage/depth + parent linkage, folder/file typing, scoped-root rebasing, and wiring attachment, and these tests pass. 
- Ran `npm test` successfully (full test suite passed). 
- Ran `node --test calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs` and `npm run validate:tree -- --scope=validator` successfully; `npm run validate:all -- --scope=validator` produced a non-zero exit only due to existing repository naming findings (report-mode), not changes from this slice.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55f0ffc0c83319d3aeabcc97309b3)