### PR TITLE
Harden tree occurrence snapshot scope/target semantics and attach bounded runtime usage

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md
@@ -328,6 +328,24 @@ Status boundary:
 - It is not declared as canonical runtime grammar in this pass.
 - Promotion to canonical runtime/addressing rules requires explicit follow-up adoption work.
 
+
+### Runtime alignment notes for current substrate hardening
+
+The current tree occurrence snapshot runtime aligns to this document's illustration as follows:
+
+- Folder occurrence markers are generated as uppercase alphabetic segments (`A`, `B`, ..., `AA`, ...).
+- File occurrence markers remain numeric sibling counters (`1`, `2`, ...).
+- Snapshot records use `isScopeTopOccurrence` (scoped-root-relative semantics) instead of `isRepoTopOccurrence`.
+
+Scoped target rebasing behavior used by runtime snapshot generation:
+
+- directory targets: the targeted directory path is used as the scoped-root rebase anchor,
+- file targets: the containing directory is used as the scoped-root rebase anchor,
+- file targets are not treated as directory lineage roots.
+
+This keeps tree-local occurrence reasoning deterministic while preserving resolved-path findings output.
+
+
 ### Visual deterministic notation (documentation example)
 
 A simple illustrative notation may be used for examples:

--- a/calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs
@@ -8,8 +8,13 @@ const normalizeRelativePath = (relativePath) =>
 
 const sortStrings = (values) => [...values].sort((left, right) => left.localeCompare(right));
 
-const isPathInsideDirectoryPath = (candidatePath, directoryPath) =>
-  candidatePath === directoryPath || candidatePath.startsWith(`${directoryPath}${POSIX_SEPARATOR}`);
+const isPathInsideDirectoryPath = (candidatePath, directoryPath) => {
+  if (directoryPath === '' || directoryPath === '.') {
+    return true;
+  }
+
+  return candidatePath === directoryPath || candidatePath.startsWith(`${directoryPath}${POSIX_SEPARATOR}`);
+};
 
 const toAlphabeticMarker = (index) => {
   let marker = '';
@@ -17,7 +22,7 @@ const toAlphabeticMarker = (index) => {
 
   while (value > 0) {
     const remainder = (value - 1) % 26;
-    marker = String.fromCharCode(97 + remainder) + marker;
+    marker = String.fromCharCode(65 + remainder) + marker;
     value = Math.floor((value - 1) / 26);
   }
 
@@ -52,9 +57,43 @@ const normalizeTargetDescriptors = (targetDescriptors = []) => {
   return [...deduped.values()].sort((left, right) => left.relPath.localeCompare(right.relPath));
 };
 
+const inferTargetKind = (targetDescriptor, selectedPathSet) => {
+  if (targetDescriptor.kind === 'file' || targetDescriptor.kind === 'dir') {
+    return targetDescriptor.kind;
+  }
+
+  const hasNestedMatch = [...selectedPathSet].some((selectedPath) =>
+    selectedPath.startsWith(`${targetDescriptor.relPath}${POSIX_SEPARATOR}`),
+  );
+
+  if (hasNestedMatch) {
+    return 'dir';
+  }
+
+  return selectedPathSet.has(targetDescriptor.relPath) ? 'file' : 'dir';
+};
+
+const toScopeRootPath = (targetDescriptor, selectedPathSet) => {
+  const targetKind = inferTargetKind(targetDescriptor, selectedPathSet);
+
+  if (targetKind === 'dir') {
+    return targetDescriptor.relPath;
+  }
+
+  if (!targetDescriptor.relPath.includes(POSIX_SEPARATOR)) {
+    return '.';
+  }
+
+  return targetDescriptor.relPath.slice(0, targetDescriptor.relPath.lastIndexOf(POSIX_SEPARATOR));
+};
+
 const buildScopeRoots = ({ selectedPaths, targets, includeRoots }) => {
   if (targets.length > 0) {
-    return targets;
+    const selectedPathSet = new Set(selectedPaths);
+    const targetScopeRoots = sortStrings(
+      new Set(targets.map((targetDescriptor) => toScopeRootPath(targetDescriptor, selectedPathSet))),
+    );
+    return targetScopeRoots.map((relPath) => ({ relPath, kind: 'dir' }));
   }
 
   if (includeRoots.length > 0) {
@@ -85,7 +124,7 @@ const resolveScopeRootPathForNode = (resolvedPath, scopeRoots) => {
 };
 
 const collectAllOccurrencePaths = (selectedPaths, scopeRoots) => {
-  const directoryPaths = new Set(scopeRoots.map((scopeRoot) => scopeRoot.relPath));
+  const directoryPaths = new Set(scopeRoots.map((scopeRoot) => scopeRoot.relPath).filter((scopeRoot) => scopeRoot !== '.'));
   const filePaths = new Set();
 
   for (const selectedPath of selectedPaths) {
@@ -101,6 +140,22 @@ const collectAllOccurrencePaths = (selectedPaths, scopeRoots) => {
     directoryPaths,
     filePaths,
   };
+};
+
+const buildLineageSegments = (resolvedPath, scopeRootPath) => {
+  if (scopeRootPath === '.') {
+    return resolvedPath.split(POSIX_SEPARATOR).filter(Boolean);
+  }
+
+  const lineageTail =
+    scopeRootPath === resolvedPath
+      ? []
+      : resolvedPath
+          .slice(scopeRootPath.length + 1)
+          .split(POSIX_SEPARATOR)
+          .filter(Boolean);
+
+  return [scopeRootPath, ...lineageTail].filter(Boolean);
 };
 
 export const prepareTreeOccurrenceSnapshot = ({
@@ -132,14 +187,7 @@ export const prepareTreeOccurrenceSnapshot = ({
       ? resolvedPath.slice(resolvedPath.lastIndexOf(POSIX_SEPARATOR) + 1)
       : resolvedPath;
     const scopeRootPath = resolveScopeRootPathForNode(resolvedPath, scopeRoots);
-    const lineageTail =
-      scopeRootPath === resolvedPath
-        ? []
-        : resolvedPath
-            .slice(scopeRootPath.length + 1)
-            .split(POSIX_SEPARATOR)
-            .filter(Boolean);
-    const lineageSegments = [scopeRootPath, ...lineageTail].filter(Boolean);
+    const lineageSegments = buildLineageSegments(resolvedPath, scopeRootPath);
 
     let parentResolvedPath = null;
     if (resolvedPath !== scopeRootPath && resolvedPath.includes(POSIX_SEPARATOR)) {
@@ -160,7 +208,7 @@ export const prepareTreeOccurrenceSnapshot = ({
       markerSegments: [],
       occurrenceMarker: '',
       isScopedRoot: resolvedPath === scopeRootPath,
-      isRepoTopOccurrence: lineageSegments.length === 1,
+      isScopeTopOccurrence: lineageSegments.length === 1,
     });
   }
 

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -136,6 +136,29 @@ const collectOwnedSliceBoundaryDriftFindings = (paths) => {
     });
 };
 
+
+const collectSelectedPathRecordsFromOccurrenceSnapshot = (occurrenceSnapshot) => {
+  if (!occurrenceSnapshot || !Array.isArray(occurrenceSnapshot.occurrenceRecords)) {
+    return null;
+  }
+
+  return occurrenceSnapshot.occurrenceRecords.filter(
+    (record) => record && record.occurrenceType === 'file' && typeof record.resolvedPath === 'string',
+  );
+};
+
+const collectSelectedPathsForReasoning = (preparedInputs) => {
+  const selectedPathRecords = collectSelectedPathRecordsFromOccurrenceSnapshot(preparedInputs.occurrenceSnapshot);
+
+  if (selectedPathRecords) {
+    return selectedPathRecords
+      .map((record) => record.resolvedPath)
+      .sort((left, right) => left.localeCompare(right));
+  }
+
+  return preparedInputs.selectedPaths;
+};
+
 const incrementCounter = (counts, key) => {
   counts[key] = (counts[key] ?? 0) + 1;
 };
@@ -200,16 +223,18 @@ const collectContributorFindings = (preparedInputs) => {
 export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const prepared = assertPreparedTreeInputs(preparedInputs);
 
+  const selectedPathsForReasoning = collectSelectedPathsForReasoning(prepared);
+
   const findings = [
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
-    ...collectValidatorOwnedOutsideTreeFindings(prepared.selectedPaths),
+    ...collectValidatorOwnedOutsideTreeFindings(selectedPathsForReasoning),
     ...collectOwnedSliceBoundaryDriftFindings(prepared.selectedPaths),
     ...collectContributorFindings(prepared),
   ].sort(sortByPathThenCode);
 
   return {
     findings,
-    totalFilesScanned: prepared.selectedPaths.length,
+    totalFilesScanned: selectedPathsForReasoning.length,
     scope: prepared.scope ?? 'repo',
     filters: {
       isFiltered: prepared.targets.length > 0,

--- a/calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs
@@ -24,10 +24,7 @@ test('tree occurrence snapshot disambiguates repeated names by lineage', () => {
 
   assert.equal(srcRecords.every((record) => record.actualName === 'src'), true);
   assert.equal(new Set(srcRecords.map((record) => record.occurrenceMarker)).size, 3);
-  assert.equal(
-    new Set(srcRecords.map((record) => record.lineageSegments.join('/'))).size,
-    3,
-  );
+  assert.equal(new Set(srcRecords.map((record) => record.lineageSegments.join('/'))).size, 3);
 });
 
 test('tree occurrence snapshot preserves deterministic lineage and depth', () => {
@@ -46,13 +43,12 @@ test('tree occurrence snapshot preserves deterministic lineage and depth', () =>
   ]);
   assert.equal(recordsByPath['calculogic-validator/tree/src'].depth, 2);
   assert.equal(
-    recordsByPath['calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs']
-      .parentResolvedPath,
+    recordsByPath['calculogic-validator/tree/src/registries/tree-known-roots.registry.logic.mjs'].parentResolvedPath,
     'calculogic-validator/tree/src/registries',
   );
 });
 
-test('tree occurrence snapshot distinguishes folders and files from path structure', () => {
+test('tree occurrence snapshot distinguishes folders and files from path structure with uppercase folder markers', () => {
   const snapshot = prepareTreeOccurrenceSnapshot({
     selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
     targets: [],
@@ -66,10 +62,10 @@ test('tree occurrence snapshot distinguishes folders and files from path structu
     recordsByPath['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'].occurrenceType,
     'file',
   );
-  assert.match(recordsByPath['calculogic-validator/tree/src'].occurrenceMarker, /^[a-z]+(?:\.[a-z0-9]+)*$/u);
+  assert.match(recordsByPath['calculogic-validator/tree/src'].occurrenceMarker, /^[A-Z]+(?:\.[A-Z0-9]+)*$/u);
   assert.match(
     recordsByPath['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'].occurrenceMarker,
-    /^[a-z]+(?:\.[a-z0-9]+)*\.[0-9]+$/u,
+    /^[A-Z]+(?:\.[A-Z0-9]+)*\.[0-9]+$/u,
   );
 });
 
@@ -85,11 +81,28 @@ test('tree occurrence snapshot rebases scoped lineage from targeted subtree root
   const nestedSrc = recordsByPath['calculogic-validator/tree/src'];
 
   assert.equal(scopedRoot.isScopedRoot, true);
+  assert.equal(scopedRoot.isScopeTopOccurrence, true);
   assert.equal(scopedRoot.depth, 0);
   assert.deepEqual(scopedRoot.lineageSegments, ['calculogic-validator/tree']);
   assert.equal(nestedSrc.scopeRootPath, 'calculogic-validator/tree');
   assert.deepEqual(nestedSrc.lineageSegments, ['calculogic-validator/tree', 'src']);
   assert.equal(nestedSrc.depth, 1);
+});
+
+test('tree occurrence snapshot file targets rebase from containing folder and avoid file-root lineage', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
+    targets: [{ relPath: 'calculogic-validator/tree/src/tree-structure-advisor.logic.mjs', kind: 'file' }],
+    includeRoots: ['calculogic-validator'],
+  });
+
+  const recordsByPath = byResolvedPath(snapshot.occurrenceRecords);
+  const fileRecord = recordsByPath['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'];
+
+  assert.deepEqual(snapshot.scopeRoots, ['calculogic-validator/tree/src']);
+  assert.equal(fileRecord.scopeRootPath, 'calculogic-validator/tree/src');
+  assert.equal(fileRecord.isScopedRoot, false);
+  assert.deepEqual(fileRecord.lineageSegments, ['calculogic-validator/tree/src', 'tree-structure-advisor.logic.mjs']);
 });
 
 test('tree structure advisor wiring attaches occurrence snapshot with resolved paths', () => {

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -824,6 +824,35 @@ test('tree-structure-advisor rejects invalid scope deterministically', async () 
   }
 });
 
+
+test('tree-structure-advisor consumes occurrence snapshot file records for validator-owned outside-tree reasoning', () => {
+  const fromOccurrenceSnapshot = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
+    occurrenceSnapshot: {
+      scopeRoots: ['src'],
+      occurrenceRecords: [
+        {
+          resolvedPath: 'src/validator-runner.logic.mjs',
+          occurrenceType: 'file',
+        },
+      ],
+    },
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  const withoutOccurrenceSnapshot = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: ['src/validator-runner.logic.mjs'],
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  assert.deepEqual(fromOccurrenceSnapshot.findings, withoutOccurrenceSnapshot.findings);
+  assert.equal(fromOccurrenceSnapshot.totalFilesScanned, 1);
+});
+
 test('tree-structure-advisor prepared runtime contract accepts tree-core inputs without contributors', () => {
   const result = runTreeStructureAdvisorRuntime({
     scope: 'repo',


### PR DESCRIPTION
### Motivation
- Fix immediate runtime/doc drift and ambiguous fields in the new tree occurrence substrate so tree reasoning can safely consume it. 
- Make scoped-root/target rebasing explicit and deterministic for file vs directory targets. 
- Prove the occurrence snapshot is consumable by wiring it into one small, bounded reasoning path without changing user-facing findings. 

### Description
- Normalized folder occurrence marker generation to uppercase alphabetic markers by changing `toAlphabeticMarker` and matching tests to the doc examples (runtime aligned to docs). The file changed is `calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs`. 
- Replaced the misleading `isRepoTopOccurrence` field with `isScopeTopOccurrence` and updated construction/consumers accordingly in the occurrence snapshot; final occurrence record fields include `resolvedPath`, `actualName`, `occurrenceType`, `parentResolvedPath`, `depth`, `scopeRootPath`, `lineageSegments`, `markerSegments`, `occurrenceMarker`, `isScopedRoot`, and `isScopeTopOccurrence`. Change in `calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs`. 
- Hardened target rebasing: added `inferTargetKind`/`toScopeRootPath` helpers so directory targets remain directory scope roots and file targets rebase to their containing directory (file targets are not treated as directory lineage roots); scope-root `.` handling also made explicit. Changes in `calculogic-validator/tree/src/tree-occurrence-snapshot.logic.mjs` and tests. 
- Attached snapshot to a bounded reasoning path: added `collectSelectedPathRecordsFromOccurrenceSnapshot` and `collectSelectedPathsForReasoning` and made `runTreeStructureAdvisor` consume snapshot file-records for `collectValidatorOwnedOutsideTreeFindings` (falling back to `selectedPaths`), preserving resolved-path outputs; change in `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs`. 
- Tests: updated and extended tree-owned tests to assert uppercase markers, repeated-name disambiguation, scoped-root rebasing, `isScopeTopOccurrence` semantics, file-target vs folder-target behavior, and a parity assertion that consuming snapshot records preserves the existing findings outcome; test files changed are `calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs` and `calculogic-validator/tree/test/tree-structure-advisor.test.mjs`. 
- Documentation: added a small runtime-alignment note to `calculogic-validator/doc/ValidatorSpecs/tree-occurrence-model-and-addressing-spec.md` to record the marker-case and target-rebasing decisions so modeling and runtime are explicit. 

### Testing
- Ran `npm test` and the full suite passed (`272` tests ran and passed). 
- Ran `node --test` on the modified tree tests: `calculogic-validator/tree/test/tree-occurrence-snapshot.test.mjs` and `calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, both passed. 
- Ran `npm run validate:tree -- --scope=validator` and saw the validator run successfully. 
- Ran `npm run validate:all -- --scope=validator` and verified expected validator-suite exit behavior (the suite produced findings and returned the expected non-zero exit status for naming warnings as part of normal validation). 
- All new/updated tree-owned tests exercising marker case, scoped rebasing, file-vs-folder target behavior, renamed field semantics, and the bounded consumption path passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56f4252708331b407655ff6e04d1c)