### PR TITLE
tree: adopt occurrence-derived input for owned-slice boundary drift helper

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -21,7 +21,7 @@ Canonical reading order for tree implementation work:
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.5** (shim evidence hardening with robust public-entrypoint barrel carveout coverage for `export *`, `export * as <name>`, and optional `export { ... } from` pass-through forms while preserving thin re-export shim detection).
+Current implementation target: **V0.1.6** (suite-scoped snapshot ownership split plus bounded occurrence-driven file-path adoption in tree core for validator-owned-outside-tree and owned-slice-boundary-drift structural helpers while preserving resolved-path findings output).
 
 ## 1.0 Purpose
 
@@ -88,7 +88,7 @@ V0.1.6 introduces a suite-core scoped snapshot/input helper boundary and migrate
 
 - suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
 - tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
-- tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`)
+- tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`) and consumes occurrence-derived file-path reasoning input when `occurrenceSnapshot.occurrenceRecords` is available (bounded fallback to `selectedPaths` when occurrence snapshot is absent/malformed)
 - tree-run default contributor selection is owned by a dedicated assembly/wiring module so tree wiring only prepares tree-core inputs
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -1,4 +1,4 @@
-# Tree Structure Advisor Validator Spec (Report-Only Advisory, V0.1.5)
+# Tree Structure Advisor Validator Spec (Report-Only Advisory, V0.1.6)
 
 ## Purpose and Scope (Status: Current runtime behavior)
 
@@ -40,16 +40,16 @@ Status interpretation used in this document:
 
 ## Suite Contract Alignment (Status: Current runtime behavior)
 
-This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor V0.1.5 remains report-only even though additional policy modes exist suite-wide.
+This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor V0.1.6 remains report-only even though additional policy modes exist suite-wide.
 
-### In scope (V0.1.5 hardened subset)
+### In scope (V0.1.6 hardened subset)
 
 - Tree-core structural checks over prepared `selectedPaths` + `topLevelDirectoryNames` + `targets`
 - Optional contributor composition through `findingContributors[]` prepared by wiring/assembly
 - Shim/compat diagnostics attached through the tree contributor assembly default (`tree-shim-diagnostics`)
 - Report-only output with deterministic sorting and no filesystem mutation
 
-### Out of scope (V0.1.5)
+### Out of scope (V0.1.6)
 
 - Applying any filesystem changes (no auto-move, no auto-fix)
 - Enforcing a single “correct tree” (recommendations are heuristic + explainable)
@@ -524,6 +524,8 @@ Suggested codes (V0.0.1):
 ### Runtime boundary
 
 - Tree core consumes **prepared tree-core inputs only** and fails closed when that contract is bypassed.
+- Tree core consumes occurrence-derived file records from `occurrenceSnapshot.occurrenceRecords` when available for bounded structural helpers (`TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE`, `TREE_OWNED_SLICE_BOUNDARY_DRIFT`) while keeping findings path output on resolved paths.
+- If occurrence snapshot is missing or malformed, tree core deterministically falls back to prepared `selectedPaths` for file-path reasoning.
 - Required prepared tree-core fields:
   - `selectedPaths` (array)
   - `topLevelDirectoryNames` (array)

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -137,23 +137,37 @@ const collectOwnedSliceBoundaryDriftFindings = (paths) => {
 };
 
 
-const collectSelectedPathRecordsFromOccurrenceSnapshot = (occurrenceSnapshot) => {
+const collectOccurrenceDerivedFileReasoningInput = (preparedInputs) => {
+  const occurrenceSnapshot = preparedInputs?.occurrenceSnapshot;
+
   if (!occurrenceSnapshot || !Array.isArray(occurrenceSnapshot.occurrenceRecords)) {
     return null;
   }
 
-  return occurrenceSnapshot.occurrenceRecords.filter(
-    (record) => record && record.occurrenceType === 'file' && typeof record.resolvedPath === 'string',
+  const fileRecords = occurrenceSnapshot.occurrenceRecords.filter(
+    (record) =>
+      record &&
+      record.occurrenceType === 'file' &&
+      typeof record.resolvedPath === 'string' &&
+      record.resolvedPath.length > 0,
   );
+
+  const uniqueResolvedFilePaths = [...new Set(fileRecords.map((record) => record.resolvedPath))].sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+  return {
+    fileRecords,
+    resolvedFilePaths: uniqueResolvedFilePaths,
+    recordsByResolvedPath: new Map(fileRecords.map((record) => [record.resolvedPath, record])),
+  };
 };
 
 const collectSelectedPathsForReasoning = (preparedInputs) => {
-  const selectedPathRecords = collectSelectedPathRecordsFromOccurrenceSnapshot(preparedInputs.occurrenceSnapshot);
+  const occurrenceDerivedFileReasoningInput = collectOccurrenceDerivedFileReasoningInput(preparedInputs);
 
-  if (selectedPathRecords) {
-    return selectedPathRecords
-      .map((record) => record.resolvedPath)
-      .sort((left, right) => left.localeCompare(right));
+  if (occurrenceDerivedFileReasoningInput) {
+    return occurrenceDerivedFileReasoningInput.resolvedFilePaths;
   }
 
   return preparedInputs.selectedPaths;
@@ -223,12 +237,16 @@ const collectContributorFindings = (preparedInputs) => {
 export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const prepared = assertPreparedTreeInputs(preparedInputs);
 
+  const occurrenceDerivedFileReasoningInput = collectOccurrenceDerivedFileReasoningInput(prepared);
   const selectedPathsForReasoning = collectSelectedPathsForReasoning(prepared);
+  const pathsForOwnedSliceBoundaryDriftReasoning = occurrenceDerivedFileReasoningInput
+    ? occurrenceDerivedFileReasoningInput.resolvedFilePaths
+    : prepared.selectedPaths;
 
   const findings = [
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
     ...collectValidatorOwnedOutsideTreeFindings(selectedPathsForReasoning),
-    ...collectOwnedSliceBoundaryDriftFindings(prepared.selectedPaths),
+    ...collectOwnedSliceBoundaryDriftFindings(pathsForOwnedSliceBoundaryDriftReasoning),
     ...collectContributorFindings(prepared),
   ].sort(sortByPathThenCode);
 

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -853,6 +853,132 @@ test('tree-structure-advisor consumes occurrence snapshot file records for valid
   assert.equal(fromOccurrenceSnapshot.totalFilesScanned, 1);
 });
 
+
+
+test('tree-structure-advisor consumes occurrence-derived file paths for owned-slice boundary drift reasoning', () => {
+  const fromOccurrenceSnapshot = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: ['doc/README.md'],
+    occurrenceSnapshot: {
+      scopeRoots: ['calculogic-validator'],
+      occurrenceRecords: [
+        {
+          resolvedPath: 'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.logic.mjs',
+          occurrenceType: 'file',
+        },
+        {
+          resolvedPath: 'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.wiring.mjs',
+          occurrenceType: 'file',
+        },
+      ],
+    },
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  const withoutOccurrenceSnapshot = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: [
+      'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.logic.mjs',
+      'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.wiring.mjs',
+    ],
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  const fromSnapshotBoundaryDrift = fromOccurrenceSnapshot.findings.filter(
+    (finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT',
+  );
+  const fromSelectedPathsBoundaryDrift = withoutOccurrenceSnapshot.findings.filter(
+    (finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT',
+  );
+
+  assert.deepEqual(fromSnapshotBoundaryDrift, fromSelectedPathsBoundaryDrift);
+  assert.equal(fromSnapshotBoundaryDrift.length, 1);
+});
+
+test('tree-structure-advisor occurrence-derived boundary drift reasoning remains stable for repeated-name subtree paths', () => {
+  const result = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: ['doc/README.md'],
+    occurrenceSnapshot: {
+      scopeRoots: ['calculogic-validator'],
+      occurrenceRecords: [
+        {
+          resolvedPath: 'calculogic-validator/src/src-helper/src-helper.logic.mjs',
+          occurrenceType: 'file',
+        },
+        {
+          resolvedPath: 'calculogic-validator/src/src-helper/src-helper.wiring.mjs',
+          occurrenceType: 'file',
+        },
+      ],
+    },
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  const driftFinding = result.findings.find((finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT');
+
+  assert.ok(driftFinding);
+  assert.equal(driftFinding.path, 'calculogic-validator/src/src-helper/');
+  assert.deepEqual(driftFinding.details.matchedOwnedSignalPaths, [
+    'calculogic-validator/src/src-helper/src-helper.logic.mjs',
+    'calculogic-validator/src/src-helper/src-helper.wiring.mjs',
+  ]);
+});
+
+test('tree-structure-advisor occurrence-derived boundary drift reasoning remains stable for rebased scope roots', () => {
+  const result = runTreeStructureAdvisorRuntime({
+    scope: 'validator',
+    selectedPaths: ['doc/README.md'],
+    occurrenceSnapshot: {
+      scopeRoots: ['calculogic-validator/tree'],
+      occurrenceRecords: [
+        {
+          resolvedPath: 'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.logic.mjs',
+          occurrenceType: 'file',
+          scopeRootPath: 'calculogic-validator/tree',
+          isScopeTopOccurrence: false,
+        },
+        {
+          resolvedPath: 'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.wiring.mjs',
+          occurrenceType: 'file',
+          scopeRootPath: 'calculogic-validator/tree',
+          isScopeTopOccurrence: false,
+        },
+      ],
+    },
+    topLevelDirectoryNames: [],
+    targets: ['calculogic-validator/tree'],
+  });
+
+  const driftFinding = result.findings.find((finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT');
+
+  assert.ok(driftFinding);
+  assert.equal(driftFinding.path, 'calculogic-validator/src/tree-structure-advisor/');
+});
+
+test('tree-structure-advisor falls back to selectedPaths when occurrence snapshot is malformed', () => {
+  const result = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: [
+      'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.logic.mjs',
+      'calculogic-validator/src/tree-structure-advisor/tree-structure-advisor.wiring.mjs',
+    ],
+    occurrenceSnapshot: {
+      occurrenceRecords: 'malformed',
+    },
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  assert.equal(
+    result.findings.some((finding) => finding.code === 'TREE_OWNED_SLICE_BOUNDARY_DRIFT'),
+    true,
+  );
+});
+
 test('tree-structure-advisor prepared runtime contract accepts tree-core inputs without contributors', () => {
   const result = runTreeStructureAdvisorRuntime({
     scope: 'repo',


### PR DESCRIPTION
### Motivation
- Move one more bounded structural helper to consume the occurrence snapshot substrate so tree reasoning is less split between raw `selectedPaths` and occurrence-derived records while preserving resolved-path findings.
- Target the owned-slice boundary-drift helper because it is structural/path-based and high-ROI to convert without widening scope.

### Description
- Added a small bounded helper `collectOccurrenceDerivedFileReasoningInput(preparedInputs)` that reads `preparedInputs.occurrenceSnapshot.occurrenceRecords` and returns `{ fileRecords, resolvedFilePaths, recordsByResolvedPath }` (deduped & sorted resolved file paths).
- Converted the owned-slice drift usage so `collectOwnedSliceBoundaryDriftFindings(...)` now consumes occurrence-derived `resolvedFilePaths` when available and otherwise falls back to the original `selectedPaths` (behavior and finding shape unchanged).
- Files changed: `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs`, `calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`, and `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`.
- Tests: added tree tests asserting parity between occurrence-driven and `selectedPaths`-driven boundary-drift findings, stability for repeated-name subtree paths, rebased scope-root behavior, and malformed-snapshot fallback behavior.
- Fallback choice: bounded fallback to `selectedPaths` when the occurrence snapshot is missing or malformed (explicit, fail-closed avoided for this slice).
- Next-step nits: reuse the occurrence-derived shape once per run path to avoid recomputation, and convert one additional bounded helper before considering structural class assignment.

### Testing
- Ran `npm test` and the full test suite passed (all tree tests including the new cases succeeded).
- Ran `npm run validate:tree -- --scope=validator` and the tree validator run succeeded and produced the expected advisory output.
- Ran `npm run validate:all -- --scope=validator` which exits non-zero due to existing naming-slice advisory findings (expected in report mode) and not due to runtime failures from these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b574b0f6108331950e7e5eb0a34117)