### PR TITLE
Refactor tree runtime to use a single occurrence-derived reasoning substrate

### DIFF
--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -137,40 +137,35 @@ const collectOwnedSliceBoundaryDriftFindings = (paths) => {
 };
 
 
-const collectOccurrenceDerivedFileReasoningInput = (preparedInputs) => {
+const collectFileReasoningInput = (preparedInputs) => {
   const occurrenceSnapshot = preparedInputs?.occurrenceSnapshot;
 
-  if (!occurrenceSnapshot || !Array.isArray(occurrenceSnapshot.occurrenceRecords)) {
-    return null;
+  const occurrenceRecords = occurrenceSnapshot?.occurrenceRecords;
+
+  if (Array.isArray(occurrenceRecords)) {
+    const fileRecords = occurrenceRecords.filter(
+      (record) =>
+        record &&
+        record.occurrenceType === 'file' &&
+        typeof record.resolvedPath === 'string' &&
+        record.resolvedPath.length > 0,
+    );
+    const resolvedFilePaths = [...new Set(fileRecords.map((record) => record.resolvedPath))].sort((left, right) =>
+      left.localeCompare(right),
+    );
+
+    return {
+      source: 'occurrenceSnapshot',
+      fileRecords,
+      resolvedFilePaths,
+    };
   }
-
-  const fileRecords = occurrenceSnapshot.occurrenceRecords.filter(
-    (record) =>
-      record &&
-      record.occurrenceType === 'file' &&
-      typeof record.resolvedPath === 'string' &&
-      record.resolvedPath.length > 0,
-  );
-
-  const uniqueResolvedFilePaths = [...new Set(fileRecords.map((record) => record.resolvedPath))].sort((left, right) =>
-    left.localeCompare(right),
-  );
 
   return {
-    fileRecords,
-    resolvedFilePaths: uniqueResolvedFilePaths,
-    recordsByResolvedPath: new Map(fileRecords.map((record) => [record.resolvedPath, record])),
+    source: 'selectedPaths-fallback',
+    fileRecords: [],
+    resolvedFilePaths: preparedInputs.selectedPaths,
   };
-};
-
-const collectSelectedPathsForReasoning = (preparedInputs) => {
-  const occurrenceDerivedFileReasoningInput = collectOccurrenceDerivedFileReasoningInput(preparedInputs);
-
-  if (occurrenceDerivedFileReasoningInput) {
-    return occurrenceDerivedFileReasoningInput.resolvedFilePaths;
-  }
-
-  return preparedInputs.selectedPaths;
 };
 
 const incrementCounter = (counts, key) => {
@@ -236,17 +231,13 @@ const collectContributorFindings = (preparedInputs) => {
 
 export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const prepared = assertPreparedTreeInputs(preparedInputs);
-
-  const occurrenceDerivedFileReasoningInput = collectOccurrenceDerivedFileReasoningInput(prepared);
-  const selectedPathsForReasoning = collectSelectedPathsForReasoning(prepared);
-  const pathsForOwnedSliceBoundaryDriftReasoning = occurrenceDerivedFileReasoningInput
-    ? occurrenceDerivedFileReasoningInput.resolvedFilePaths
-    : prepared.selectedPaths;
+  const fileReasoningInput = collectFileReasoningInput(prepared);
+  const selectedPathsForReasoning = fileReasoningInput.resolvedFilePaths;
 
   const findings = [
     ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
     ...collectValidatorOwnedOutsideTreeFindings(selectedPathsForReasoning),
-    ...collectOwnedSliceBoundaryDriftFindings(pathsForOwnedSliceBoundaryDriftReasoning),
+    ...collectOwnedSliceBoundaryDriftFindings(selectedPathsForReasoning),
     ...collectContributorFindings(prepared),
   ].sort(sortByPathThenCode);
 

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -825,6 +825,43 @@ test('tree-structure-advisor rejects invalid scope deterministically', async () 
 });
 
 
+
+
+test('tree-structure-advisor computes occurrence-derived file reasoning input once per runtime run', () => {
+  let occurrenceRecordReads = 0;
+  const occurrenceSnapshot = {};
+
+  Object.defineProperty(occurrenceSnapshot, 'occurrenceRecords', {
+    get() {
+      occurrenceRecordReads += 1;
+      return [
+        {
+          resolvedPath: 'src/validator-runner.logic.mjs',
+          occurrenceType: 'file',
+        },
+      ];
+    },
+  });
+
+  const result = runTreeStructureAdvisorRuntime({
+    scope: 'repo',
+    selectedPaths: ['doc/README.md'],
+    occurrenceSnapshot,
+    topLevelDirectoryNames: [],
+    targets: [],
+  });
+
+  assert.equal(occurrenceRecordReads, 1);
+  assert.equal(result.totalFilesScanned, 1);
+  assert.equal(
+    result.findings.some(
+      (finding) =>
+        finding.code === 'TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE' &&
+        finding.path === 'src/validator-runner.logic.mjs',
+    ),
+    true,
+  );
+});
 test('tree-structure-advisor consumes occurrence snapshot file records for validator-owned outside-tree reasoning', () => {
   const fromOccurrenceSnapshot = runTreeStructureAdvisorRuntime({
     scope: 'repo',


### PR DESCRIPTION
### Motivation
- Remove duplicated reasoning-input plumbing so occurrence-derived file reasoning is computed once and consumed consistently by tree runtime. 
- Make the occurrence-derived substrate shape explicit and intentional to simplify downstream reasoning and reduce dead shape. 
- Preserve all current findings behavior, resolved-path outputs, and report shape while centralizing fallback for malformed/missing occurrence snapshots.

### Description
- Introduced a single canonical helper `collectFileReasoningInput(preparedInputs)` that returns `{ source, fileRecords, resolvedFilePaths }` and centralizes the fallback to `selectedPaths` when the occurrence snapshot is absent or malformed. 
- Replaced the old split helpers (`collectOccurrenceDerivedFileReasoningInput` + `collectSelectedPathsForReasoning`) with `collectFileReasoningInput` and updated runtime usage so both outside-tree and boundary-drift checks consume `resolvedFilePaths`. 
- Removed the unused `recordsByResolvedPath` field from the reasoning substrate to avoid dead shape. 
- Updated tests and added a regression test ensuring the occurrence snapshot is read exactly once per runtime run. 
- Files changed: `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs` and `calculogic-validator/tree/test/tree-structure-advisor.test.mjs`.

### Testing
- Ran `npm test` and all tests passed (`277` tests, `0` failing). 
- Ran `npm run validate:tree -- --scope=validator` which completed successfully and returned the expected tree report. 
- Ran `npm run validate:all -- --scope=validator`; the validator run completed and emitted reports but returned non-zero due to pre-existing naming findings in report mode (not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b579f4d2d883319aa83fa2f7350a25)