### PR TITLE
Add bounded structural class assignment for tree occurrence records

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -21,7 +21,7 @@ Canonical reading order for tree implementation work:
 
 ## 0.0 Version
 
-Current implementation target: **V0.1.6** (suite-scoped snapshot ownership split plus bounded occurrence-driven file-path adoption in tree core for validator-owned-outside-tree and owned-slice-boundary-drift structural helpers while preserving resolved-path findings output).
+Current implementation target: **V0.1.7** (bounded occurrence-level structural class assignment over tree occurrence records, consumed in tree-core occurrence-driven file reasoning while preserving resolved-path findings output).
 
 ## 1.0 Purpose
 
@@ -82,13 +82,14 @@ V0.1.x uses deterministic path-based signals only:
    - Runtimeish token/path-only matches remain info-level observability (`TREE_SHIM_SURFACE_PRESENT`) and do not emit debt-style `TREE_SHIM_OUTSIDE_COMPAT` unless thin re-export evidence exists.
 
 
-### 2.4 Input ownership split (V0.1.6)
+### 2.4 Input ownership split (V0.1.7)
 
-V0.1.6 introduces a suite-core scoped snapshot/input helper boundary and migrates tree as the first consumer:
+V0.1.7 introduces a suite-core scoped snapshot/input helper boundary and migrates tree as the first consumer:
 
 - suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
 - tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
 - tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`) and consumes occurrence-derived file-path reasoning input when `occurrenceSnapshot.occurrenceRecords` is available (bounded fallback to `selectedPaths` when occurrence snapshot is absent/malformed)
+- occurrence-driven file reasoning now carries bounded structural class metadata on occurrence records (`structuralClass`, `structuralKind`, repo-top known-root flags, scoped-root flag, subtree-partition candidate flag) for near-term tree-local interpretation
 - tree-run default contributor selection is owned by a dedicated assembly/wiring module so tree wiring only prepares tree-core inputs
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -1,4 +1,4 @@
-# Tree Structure Advisor Validator Spec (Report-Only Advisory, V0.1.6)
+# Tree Structure Advisor Validator Spec (Report-Only Advisory, V0.1.7)
 
 ## Purpose and Scope (Status: Current runtime behavior)
 
@@ -40,16 +40,16 @@ Status interpretation used in this document:
 
 ## Suite Contract Alignment (Status: Current runtime behavior)
 
-This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor V0.1.6 remains report-only even though additional policy modes exist suite-wide.
+This slice follows the shared suite contract in [`ValidatorSuite-Contracts-And-Modes.md`](../ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md): the validator suite is modular, configurable, policy-driven, and report-first by default. Tree advisor V0.1.7 remains report-only even though additional policy modes exist suite-wide.
 
-### In scope (V0.1.6 hardened subset)
+### In scope (V0.1.7 hardened subset)
 
 - Tree-core structural checks over prepared `selectedPaths` + `topLevelDirectoryNames` + `targets`
 - Optional contributor composition through `findingContributors[]` prepared by wiring/assembly
 - Shim/compat diagnostics attached through the tree contributor assembly default (`tree-shim-diagnostics`)
 - Report-only output with deterministic sorting and no filesystem mutation
 
-### Out of scope (V0.1.6)
+### Out of scope (V0.1.7)
 
 - Applying any filesystem changes (no auto-move, no auto-fix)
 - Enforcing a single “correct tree” (recommendations are heuristic + explainable)
@@ -525,6 +525,7 @@ Suggested codes (V0.0.1):
 
 - Tree core consumes **prepared tree-core inputs only** and fails closed when that contract is bypassed.
 - Tree core consumes occurrence-derived file records from `occurrenceSnapshot.occurrenceRecords` when available for bounded structural helpers (`TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE`, `TREE_OWNED_SLICE_BOUNDARY_DRIFT`) while keeping findings path output on resolved paths.
+- Occurrence-derived records are enriched with a bounded structural class interpretation layer (`structuralClass`, `structuralKind`, `isKnownTopRoot`, `isSemanticRoot`, `isStructuralRoot`, `isSubtreePartitionCandidate`, `isRepoTopOccurrence`, `isScopedRootOccurrence`) for tree-local reasoning substrate use; findings envelopes remain unchanged.
 - If occurrence snapshot is missing or malformed, tree core deterministically falls back to prepared `selectedPaths` for file-path reasoning.
 - Required prepared tree-core fields:
   - `selectedPaths` (array)

--- a/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
@@ -1,0 +1,82 @@
+const SUBTREE_PARTITION_CANDIDATE_NAMES = new Set(['assets', 'components', 'content', 'shared']);
+
+const buildTopRootKindByName = (treeKnownRoots) => {
+  const topRoots = Array.isArray(treeKnownRoots?.topRoots) ? treeKnownRoots.topRoots : [];
+
+  return new Map(
+    topRoots
+      .filter((entry) => entry && typeof entry.root === 'string' && typeof entry.kind === 'string')
+      .map((entry) => [entry.root, entry.kind]),
+  );
+};
+
+const isRepoTopOccurrencePath = (resolvedPath) =>
+  typeof resolvedPath === 'string' && resolvedPath.length > 0 && !resolvedPath.includes('/');
+
+const classifyWithTopRootMap = (occurrenceRecord, topRootKindByName) => {
+  if (!occurrenceRecord || typeof occurrenceRecord !== 'object') {
+    return {
+      structuralClass: 'unclassified',
+      structuralKind: 'unknown',
+      isRepoTopOccurrence: false,
+      isScopedRootOccurrence: false,
+      isKnownTopRoot: false,
+      isStructuralRoot: false,
+      isSemanticRoot: false,
+      isSubtreePartitionCandidate: false,
+    };
+  }
+
+  const resolvedPath = String(occurrenceRecord.resolvedPath ?? '');
+  const actualName = String(occurrenceRecord.actualName ?? '');
+  const occurrenceType = String(occurrenceRecord.occurrenceType ?? '');
+  const isRepoTopOccurrence = isRepoTopOccurrencePath(resolvedPath);
+  const isScopedRootOccurrence = occurrenceRecord.isScopedRoot === true;
+
+  const topRootKind = isRepoTopOccurrence ? topRootKindByName.get(actualName) : undefined;
+  const isStructuralRoot = topRootKind === 'structural';
+  const isSemanticRoot = topRootKind === 'semantic';
+  const isKnownTopRoot = isStructuralRoot || isSemanticRoot;
+
+  const isSubtreePartitionCandidate =
+    occurrenceType === 'folder' &&
+    !isRepoTopOccurrence &&
+    SUBTREE_PARTITION_CANDIDATE_NAMES.has(actualName);
+
+  let structuralClass = 'unclassified';
+  let structuralKind = 'unknown';
+
+  if (isStructuralRoot) {
+    structuralClass = 'repo-top-structural-root';
+    structuralKind = 'top-root-structural';
+  } else if (isSemanticRoot) {
+    structuralClass = 'repo-top-semantic-root';
+    structuralKind = 'semantic-root';
+  } else if (isSubtreePartitionCandidate) {
+    structuralClass = 'subtree-structural-partition-candidate';
+    structuralKind = 'subtree-partition';
+  }
+
+  return {
+    structuralClass,
+    structuralKind,
+    isRepoTopOccurrence,
+    isScopedRootOccurrence,
+    isKnownTopRoot,
+    isStructuralRoot,
+    isSemanticRoot,
+    isSubtreePartitionCandidate,
+  };
+};
+
+export const classifyTreeOccurrenceRecord = (occurrenceRecord, treeKnownRoots) =>
+  classifyWithTopRootMap(occurrenceRecord, buildTopRootKindByName(treeKnownRoots));
+
+export const classifyTreeOccurrenceRecords = ({ occurrenceRecords = [], treeKnownRoots } = {}) => {
+  const topRootKindByName = buildTopRootKindByName(treeKnownRoots);
+
+  return occurrenceRecords.map((occurrenceRecord) => ({
+    ...occurrenceRecord,
+    ...classifyWithTopRootMap(occurrenceRecord, topRootKindByName),
+  }));
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots.registry.logic.mjs';
 import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy.registry.logic.mjs';
+import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.logic.mjs';
 
 const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
 const TREE_SIGNAL_POLICY = getBuiltinTreeSignalPolicy();
@@ -143,7 +144,11 @@ const collectFileReasoningInput = (preparedInputs) => {
   const occurrenceRecords = occurrenceSnapshot?.occurrenceRecords;
 
   if (Array.isArray(occurrenceRecords)) {
-    const fileRecords = occurrenceRecords.filter(
+    const classifiedOccurrenceRecords = classifyTreeOccurrenceRecords({
+      occurrenceRecords,
+      treeKnownRoots: TREE_KNOWN_ROOTS,
+    });
+    const fileRecords = classifiedOccurrenceRecords.filter(
       (record) =>
         record &&
         record.occurrenceType === 'file' &&
@@ -156,6 +161,7 @@ const collectFileReasoningInput = (preparedInputs) => {
 
     return {
       source: 'occurrenceSnapshot',
+      occurrenceRecords: classifiedOccurrenceRecords,
       fileRecords,
       resolvedFilePaths,
     };

--- a/calculogic-validator/tree/test/tree-occurrence-classification.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classification.logic.mjs';
+import { prepareTreeOccurrenceSnapshot } from '../src/tree-occurrence-snapshot.logic.mjs';
+import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots.registry.logic.mjs';
+
+const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
+
+const classifySnapshot = (snapshot) =>
+  classifyTreeOccurrenceRecords({
+    occurrenceRecords: snapshot.occurrenceRecords,
+    treeKnownRoots: TREE_KNOWN_ROOTS,
+  });
+
+const byResolvedPath = (occurrenceRecords) =>
+  Object.fromEntries(occurrenceRecords.map((record) => [record.resolvedPath, record]));
+
+test('tree occurrence classification marks known repo-top structural roots deterministically', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['src/index.js'],
+    includeRoots: [],
+    targets: [],
+  });
+
+  const records = byResolvedPath(classifySnapshot(snapshot));
+
+  assert.equal(records.src.structuralClass, 'repo-top-structural-root');
+  assert.equal(records.src.structuralKind, 'top-root-structural');
+  assert.equal(records.src.isKnownTopRoot, true);
+  assert.equal(records.src.isStructuralRoot, true);
+  assert.equal(records.src.isSemanticRoot, false);
+});
+
+test('tree occurrence classification marks known repo-top semantic roots deterministically', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['calculogic-validator/src/index.mjs'],
+    includeRoots: [],
+    targets: [],
+  });
+
+  const records = byResolvedPath(classifySnapshot(snapshot));
+
+  assert.equal(records['calculogic-validator'].structuralClass, 'repo-top-semantic-root');
+  assert.equal(records['calculogic-validator'].structuralKind, 'semantic-root');
+  assert.equal(records['calculogic-validator'].isKnownTopRoot, true);
+  assert.equal(records['calculogic-validator'].isStructuralRoot, false);
+  assert.equal(records['calculogic-validator'].isSemanticRoot, true);
+});
+
+test('tree occurrence classification keeps repo-top class semantics stable across scoped rebasing', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
+    includeRoots: ['calculogic-validator'],
+    targets: [{ relPath: 'calculogic-validator/tree', kind: 'dir' }],
+  });
+
+  const records = byResolvedPath(classifySnapshot(snapshot));
+
+  assert.equal(records['calculogic-validator/tree'].isScopedRootOccurrence, true);
+  assert.equal(records['calculogic-validator/tree'].isRepoTopOccurrence, false);
+  assert.equal(records['calculogic-validator/tree'].structuralClass, 'unclassified');
+  assert.equal(records['calculogic-validator/tree'].structuralKind, 'unknown');
+});
+
+test('tree occurrence classification keeps repeated names distinct across depth and context', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['src/components/button.js', 'calculogic-validator/src/tree/components/rule.mjs'],
+    includeRoots: [],
+    targets: [],
+  });
+
+  const records = byResolvedPath(classifySnapshot(snapshot));
+
+  assert.equal(records['src/components'].structuralClass, 'subtree-structural-partition-candidate');
+  assert.equal(
+    records['calculogic-validator/src/tree/components'].structuralClass,
+    'subtree-structural-partition-candidate',
+  );
+  assert.notEqual(
+    records['src/components'].lineageSegments.join('/'),
+    records['calculogic-validator/src/tree/components'].lineageSegments.join('/'),
+  );
+});
+
+test('tree occurrence classification keeps unknown cases deterministic and bounded', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['experiments/notes.txt'],
+    includeRoots: [],
+    targets: [],
+  });
+
+  const records = byResolvedPath(classifySnapshot(snapshot));
+
+  assert.equal(records.experiments.structuralClass, 'unclassified');
+  assert.equal(records.experiments.structuralKind, 'unknown');
+  assert.equal(records.experiments.isKnownTopRoot, false);
+  assert.equal(records.experiments.isSubtreePartitionCandidate, false);
+});


### PR DESCRIPTION
### Motivation
- Introduce a small, deterministic structural-class interpretation layer on top of the stabilized occurrence snapshot so tree reasoning can start using bounded structural vocabulary without changing report surface or broadening to semantic/family logic.
- Keep the scope minimal and safe: operate on occurrence-level records, use only documented tree vocabulary, and avoid promoting these markers into global runtime grammar yet.

### Description
- Add a tree-local classifier at `calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs` that assigns `structuralClass` and `structuralKind` and deterministic boolean flags (`isRepoTopOccurrence`, `isScopedRootOccurrence`, `isKnownTopRoot`, `isStructuralRoot`, `isSemanticRoot`, `isSubtreePartitionCandidate`) using only builtin `topRoots` and a small, bounded subtree candidate set (`assets|components|content|shared`).
- Wire the classifier into the existing tree runtime path by classifying `occurrenceSnapshot.occurrenceRecords` inside `collectFileReasoningInput` (in `calculogic-validator/tree/src/tree-structure-advisor.logic.mjs`) and returning `occurrenceRecords` alongside `fileRecords`, while preserving current finding codes, resolved-path outputs, and external report envelope shape.
- Add unit tests at `calculogic-validator/tree/test/tree-occurrence-classification.test.mjs` that cover known repo-top structural roots, known semantic roots, scoped rebasing behavior, repeated-name distinctness across depths/contexts, and deterministic handling of unknown cases.
- Update NL/spec notes to V0.1.7 in `cfg-treeStructureAdvisor.md` and `tree-structure-advisor-validator-spec.md` to record the bounded occurrence-level class substrate and runtime-boundary wording (report semantics unchanged).

### Testing
- Ran `npm test` and all tests passed successfully (full test suite run completed).
- Ran `npm run validate:tree -- --scope=validator` and the tree validator executed successfully producing deterministic advisory findings.
- Ran `npm run validate:all -- --scope=validator` which completed; it returns exit code `2` under the repo's existing naming warn-policy but that outcome is unrelated to the new classification layer and expected under current naming warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58ac0fca483319d3bfa54267ddec4)