### PR TITLE
docs(naming): add validator-doc-realistic semantic-family example

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
@@ -241,6 +241,44 @@ Boundary note: these are naming-owned derived outputs from semantic-name interpr
 
 Classification: Normative
 
+### 9.1 Validator-doc-realistic example (`tree-occurrence-model-and-addressing-spec.md`)
+
+Example filename (validator-doc-realistic): `tree-occurrence-model-and-addressing-spec.md`
+
+- Intended semantic name (full semantic lane text): `tree-occurrence-model-and-addressing-spec`
+- Intended role form: docs role signal aligned to `spec` intent
+- Extension: `.md`
+- Ambiguity note (`-spec` vs `.spec`): this filename shape is realistic in current validator docs and can be interpreted as a compressed role-form signal (`-spec`) inside semantic text, rather than canonical dotted-role-slot form.
+
+Illustrative semantic-name interpretation snapshot (report-first phase):
+
+- `semanticName`: `tree-occurrence-model-and-addressing-spec`
+- `semanticTokens`: `[tree, occurrence, model, and, addressing, spec]`
+- `semanticFamily`: `tree-occurrence-model-and-addressing`
+- `familyRoot`: `tree` (repeated grouping anchor across related tree docs)
+- Candidate `familySubgroup` interpretations (ambiguity preserved):
+  - `occurrence-model`
+  - `addressing`
+  - `occurrence-model-and-addressing` (bounded combined alternative)
+- Candidate `relatedSemanticNames` (run-scoped and interpretation-dependent):
+  - `tree-structural-vocabulary-and-root-classification-spec`
+  - `tree-registry-definitions-and-relationships-spec`
+
+Connective-token note (`and`):
+
+- Connective tokens such as `and` may still be preserved in `semanticTokens`.
+- They may carry lower interpretive weight or connective meaning relative to domain anchors.
+- They should not automatically be promoted to dominant family anchors.
+
+Boundary reinforcement:
+
+- `semantic-family` remains inside semantic-name interpretation; it does not replace semantic-name.
+- `familyRoot`, `familySubgroup`, and `relatedSemanticNames` remain naming-owned derived outputs.
+- Those naming-owned outputs may later be handed to results first and tree later through cross-slice contracts.
+- Tree does not re-own semantic-family derivation in this model.
+
+Classification: Normative
+
 ## 10) Guardrails
 
 - Do not redesign naming runtime concepts already normalized today.


### PR DESCRIPTION
### Motivation
- Provide a realistic validator-doc example in the semantic-family spec so the contract is illustrated with the exact filename clusters the validator already emits.
- Clarify how `semanticName` tokenization, `familyRoot`, `familySubgroup`, `relatedSemanticNames`, and connective-token ambiguity are produced and preserved in a report-first naming interpretation.

### Description
- Added subsection `9.1 Validator-doc-realistic example` to `naming-semantic-family-and-interpretation-spec.md` using the exact example filename `tree-occurrence-model-and-addressing-spec.md` to show a real validator-doc pattern and the `-spec` vs `.spec` ambiguity.
- The example explicitly lists the intended semantic name (`tree-occurrence-model-and-addressing-spec`), intended role form (`spec` intent), extension (`.md`), and the ambiguity note that `-spec` can appear compressed inside the semantic-text rather than as a canonical dotted role slot.
- The illustrative snapshot documents `semanticName`, `semanticTokens` (`[tree, occurrence, model, and, addressing, spec]`), `semanticFamily` (`tree-occurrence-model-and-addressing`), `familyRoot` (`tree`), multiple candidate `familySubgroup` interpretations (`occurrence-model`, `addressing`, `occurrence-model-and-addressing`), and candidate `relatedSemanticNames` (`tree-structural-vocabulary-and-root-classification-spec`, `tree-registry-definitions-and-relationships-spec`).
- Added a bounded connective-token note explaining that tokens like `and` are preserved in `semanticTokens`, may carry lower interpretive weight vs domain anchors, and must not be automatically promoted to dominant family anchors, and reinforced that `semantic-family` and derived outputs remain naming-owned and report-first (tree-later) without changing ownership or runtime behavior.

### Testing
- Verified the file diff with `git diff` to ensure only `calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md` was changed and the new `9.1` subsection was appended, and the diff check succeeded.
- Verified repository status with `git status --short` to confirm the working tree change, and the check succeeded.
- Committed the change with `git commit` using message `docs(naming): add validator-doc-realistic semantic-family example`, and the commit succeeded.
- No automated unit or runtime tests were required because this is a documentation-only change and no runtime behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e0b140008331a5ae0ffb9e6679c5)