### PR TITLE
docs(naming): clarify role-candidate handling in semantic-family example

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
@@ -245,15 +245,25 @@ Classification: Normative
 
 Example filename (validator-doc-realistic): `tree-occurrence-model-and-addressing-spec.md`
 
-- Intended semantic name (full semantic lane text): `tree-occurrence-model-and-addressing-spec`
-- Intended role form: docs role signal aligned to `spec` intent
-- Extension: `.md`
-- Ambiguity note (`-spec` vs `.spec`): this filename shape is realistic in current validator docs and can be interpreted as a compressed role-form signal (`-spec`) inside semantic text, rather than canonical dotted-role-slot form.
+- Observed filename form: `tree-occurrence-model-and-addressing-spec.md`
+- Likely canonicalized interpretation candidate:
+  - semantic-name candidate: `tree-occurrence-model-and-addressing`
+  - role candidate: `spec`
+  - extension: `.md`
+- Disambiguation note (no explicit dotted role slot present):
+  - This observed filename does not already expose explicit canonical `.<role>.<ext>` ownership.
+  - `spec` matches a known role token, so it is a strong candidate for intended role ownership rather than being casually left inside semantic-family interpretation.
+  - This ambiguity is therefore preserved and surfaced as likely role ownership intent.
+- Explicit-role contrast:
+  - If the file were `tree-occurrence-model-and-addressing.spec.md`, `.spec` would remain canonical role authority.
+  - In that explicit-slot case, any additional role-like token remaining inside semantic-name text would be interpreted as semantic content by default.
 
 Illustrative semantic-name interpretation snapshot (report-first phase):
 
-- `semanticName`: `tree-occurrence-model-and-addressing-spec`
-- `semanticTokens`: `[tree, occurrence, model, and, addressing, spec]`
+- Observed semantic lane tokens: `[tree, occurrence, model, and, addressing, spec]`
+- Likely canonicalized semantic-name candidate: `tree-occurrence-model-and-addressing`
+- Canonicalized semantic tokens (after likely role-candidate separation): `[tree, occurrence, model, and, addressing]`
+- Role candidate (separated from semantic-family interpretation lane): `spec`
 - `semanticFamily`: `tree-occurrence-model-and-addressing`
 - `familyRoot`: `tree` (repeated grouping anchor across related tree docs)
 - Candidate `familySubgroup` interpretations (ambiguity preserved):
@@ -273,6 +283,7 @@ Connective-token note (`and`):
 Boundary reinforcement:
 
 - `semantic-family` remains inside semantic-name interpretation; it does not replace semantic-name.
+- For this shape, semantic-family reasoning applies to the semantic-name portion that remains after the likely role candidate (`spec`) is separated.
 - `familyRoot`, `familySubgroup`, and `relatedSemanticNames` remain naming-owned derived outputs.
 - Those naming-owned outputs may later be handed to results first and tree later through cross-slice contracts.
 - Tree does not re-own semantic-family derivation in this model.


### PR DESCRIPTION
### Motivation
- The `validator-doc-realistic` example in `naming-semantic-family-and-interpretation-spec.md` softened the role-like `spec` token and therefore did not reflect the current disambiguation contract. 
- The doc must show that when there is no explicit dotted `.<role>.<ext>` slot, a matching known role token inside the observed filename is a strong candidate for intended role ownership. 
- The example should still preserve semantic-family reasoning applied to the remaining semantic-name portion after likely role separation.

### Description
- Updated the `9.1 Validator-doc-realistic example` for `tree-occurrence-model-and-addressing-spec.md` to explicitly separate the observed filename form from a likely canonicalized interpretation candidate. 
- Added exact observed-vs-canonicalized wording: observed filename form: `tree-occurrence-model-and-addressing-spec.md`; likely canonicalized interpretation candidate: semantic-name `tree-occurrence-model-and-addressing`, role candidate `spec`, extension `.md`. 
- Tightened disambiguation language to state that because no explicit `.<role>.<ext>` slot is present and because `spec` matches a known role token, `spec` is a strong likely role-ownership candidate; and added an explicit contrast note that if the file were `tree-occurrence-model-and-addressing.spec.md` the `.spec` dotted slot would remain canonical authority. 
- Preserved semantic-family framing by showing semantic-family reasoning applies to the semantic-name portion after the likely role candidate is separated, and maintained ownership boundary language for `familyRoot`/`familySubgroup`/`relatedSemanticNames`.

### Testing
- Ran content inspections and searches to validate the edit location and wording with `rg -n` and `sed -n`, which reported the updated section as expected (succeeded). 
- Verified the repository diff with `git diff` and committed the change with `git commit`, confirming the file `calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md` was updated (succeeded). 
- No runtime tests were required because this is a documentation-only clarification and no behavior or registry changes were made (N/A).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e4b7a4648331830bf9449c34d2cc)