### PR TITLE
docs(naming): narrow semanticFamily in validator-doc example

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
@@ -264,8 +264,11 @@ Illustrative semantic-name interpretation snapshot (report-first phase):
 - Likely canonicalized semantic-name candidate: `tree-occurrence-model-and-addressing`
 - Canonicalized semantic tokens (after likely role-candidate separation): `[tree, occurrence, model, and, addressing]`
 - Role candidate (separated from semantic-family interpretation lane): `spec`
-- `semanticFamily`: `tree-occurrence-model-and-addressing`
-- `familyRoot`: `tree` (repeated grouping anchor across related tree docs)
+- Layering note:
+  - Full semantic-name candidate (`tree-occurrence-model-and-addressing`) remains the broad descriptive semantic lane.
+  - `semanticFamily` is the bounded grouping signal interpreted inside that semantic lane, not the lane repeated verbatim.
+- `semanticFamily`: `tree-occurrence-model` (bounded family grouping label, narrower than the full semantic-name candidate)
+- `familyRoot`: `tree` (dominant grouping anchor across related tree docs; narrower than `semanticFamily`)
 - Candidate `familySubgroup` interpretations (ambiguity preserved):
   - `occurrence-model`
   - `addressing`


### PR DESCRIPTION
### Motivation
- Clarify the validator-doc-realistic example so `semanticFamily` is shown as a bounded grouping signal inside the semantic-name lane instead of being modeled as the entire remaining semantic-name candidate.

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md` (section 9.1) to add an explicit layering note and to use a narrower `semanticFamily` value of `tree-occurrence-model`, while keeping the full semantic-name candidate as `tree-occurrence-model-and-addressing`, preserving `familyRoot` as `tree`, and retaining subgroup/related-name ambiguity and the existing `spec` role-candidate behavior.

### Testing
- Ran repository checks and file inspections (`git diff -- calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md`, `nl -ba calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md | sed -n '246,310p'`, `git show --stat --oneline HEAD`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e7a379dc833187d8265953fe4138)