### PR TITLE
Refine naming-doc middle-layer authority classifications

### DIFF
--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -6,6 +6,7 @@ Authority labels used in this index:
 
 - **Canonical contract**: suite-wide normative contract; controls runtime-facing semantics within stated scope.
 - **Canonical slice spec**: slice-owned normative behavior/spec authority.
+- **Bounded normative supporting spec**: active normative/spec guidance for a bounded lane; non-primary authority that must defer to canonical contracts/slice specs.
 - **Supporting implementation guidance**: implementation context only; does not redefine runtime authority.
 - **Draft**: governance-in-progress or scoped draft assumptions; non-final authority outside explicitly closed scope.
 - **Audit**: snapshot verification artifact; records findings at a point in time.
@@ -42,6 +43,18 @@ Authority labels used in this index:
   **Authority:** canonical slice spec (tree). **Intended use:** normative tree-slice runtime/spec behavior for diagnostics and snapshot-driven structure checks.
 
 ## 4) Supporting implementation guidance (non-canonical runtime authority)
+
+- `doc/ValidatorSpecs/filename-case-and-interpretation-contract.md`
+  **Authority:** bounded normative supporting spec. **Intended use:** shared filename interpretation/case-policy contract lane for cross-slice alignment; defer primary runtime authority to suite contract + slice specs.
+
+- `doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md`
+  **Authority:** bounded normative supporting spec. **Intended use:** naming semantic-name vs role-token disambiguation interpretation guidance; supports implementation and modeling without replacing canonical slice authority.
+
+- `doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md`
+  **Authority:** bounded normative supporting spec. **Intended use:** active documentation-first semantic-family modeling tranche for naming interpretation; runtime behavior remains governed by canonical authorities unless implemented.
+
+- `doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`
+  **Authority:** bounded normative supporting spec. **Intended use:** suite-level registry model/interaction constraints for implementation design and ownership boundaries; defer primary runtime authority to canonical contracts/slice specs.
 
 - `doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`
   **Authority:** supporting implementation guidance. **Intended use:** tree NL/config implementation context and sequencing notes; defer runtime authority to suite contract + tree slice spec.

--- a/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
+++ b/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
@@ -8,6 +8,8 @@ This contract is intentionally shape-level and cross-slice oriented. It does **n
 
 Classification: Normative
 
+Authority posture note: This is a bounded normative supporting spec in naming documentation maps; it remains a shared contract lane and does not replace primary canonical naming authorities.
+
 ## 2) Scope and Ownership Boundary
 
 - This is a **suite-level shared-contract** document.

--- a/calculogic-validator/doc/ValidatorSpecs/naming-documentation-map-and-reorg-inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-documentation-map-and-reorg-inventory.md
@@ -42,7 +42,8 @@ Use this sequence for naming implementation tasks (runtime behavior, wiring/cont
 Interpretation notes:
 
 - Runtime/spec authority comes from the suite contract, naming slice spec, and explicit canonical contracts.
-- Supporting and transitional docs provide implementation context and migration routing; they do not redefine canonical behavior.
+- Bounded normative supporting specs provide active interpretation/model constraints for their lane, but they do not supersede primary canonical authorities.
+- Repo-local supporting implementation notes and transitional inventories provide local context/routing only; they do not redefine canonical behavior.
 - This map is navigation metadata only.
 
 ## Inventory (Bounded Naming-Adjacent Set)
@@ -53,10 +54,10 @@ Interpretation notes:
 | `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` | Naming-slice runtime/spec authority | **Canonical slice spec** | Naming runtime behavior/spec implementation and validation | **Stay put** | **Keep** |
 | `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` | Naming grammar/taxonomy authority (filename grammar + role/category/status vocabulary) | **Canonical contract** (cross-slice naming authority) | Naming taxonomy/governance, classification semantics, change-control | **Stay put** | **Keep** |
 | `calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md` | Validator config semantics authority | **Canonical contract** (config) | Config modeling, schema/runtime strictness, merge/normalization behavior | **Stay put** | **Keep** |
-| `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md` | Shared filename interpretation and case-policy contract surface | **Supporting implementation guidance** for naming routing in this map | Cross-slice interpretation vocabulary, implementation alignment context | **Stay put** | **Reference only** |
-| `calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md` | Naming interpretation spec for semantic-name vs role disambiguation | **Supporting implementation guidance** | Naming interpretation implementation tasks and bounded design alignment | **Stay put** | **Keep; split later only if scanability degrades materially** |
-| `calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md` | Naming interpretation spec for semantic-family semantics | **Supporting implementation guidance** | Naming interpretation implementation tasks and bounded design alignment | **Stay put** | **Keep; do not merge into master list authority** |
-| `calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md` | Naming registry model and slice interaction reference | **Supporting implementation guidance** | Wiring/modeling decisions and slice-boundary context | **Stay put** | **Keep; consider later split by concern only if document growth harms scanability** |
+| `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md` | Shared filename interpretation and case-policy contract surface | **Bounded normative supporting spec** (shared contract lane; non-primary canonical authority in this map) | Cross-slice interpretation vocabulary, implementation alignment context | **Stay put** | **Reference and maintain as bounded supporting contract lane** |
+| `calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md` | Naming interpretation spec for semantic-name vs role disambiguation | **Bounded normative supporting spec** | Naming interpretation implementation tasks and bounded design alignment | **Stay put** | **Keep; split later only if scanability degrades materially** |
+| `calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md` | Naming interpretation spec for semantic-family semantics | **Bounded normative supporting spec** (active for documentation-first modeling) | Naming interpretation implementation tasks and bounded design alignment | **Stay put** | **Keep; do not merge into master list authority** |
+| `calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md` | Naming registry model and slice interaction reference | **Bounded normative supporting spec** (suite-level model constraints) | Wiring/modeling decisions and slice-boundary context | **Stay put** | **Keep; consider later split by concern only if document growth harms scanability** |
 | `doc/nl-config/cfg-namingValidator.md` | Repo-local naming NL/config note | **Supporting implementation guidance** (repo-local/external to validator-owned canonical set) | Implementation sequencing/context for local repo tasks | **Stay put** | **Reference only** |
 | `calculogic-validator/doc/naming-compatibility-inventory.md` | Naming migration/compatibility snapshot | **Transitional inventory** | Migration context, retirements, follow-up hardening routing | **Stay put** | **Keep as transitional inventory** |
 | `calculogic-validator/doc/ValidatorSpecs/naming-documentation-map-and-reorg-inventory.md` | Naming routing and bounded reorg map | **Transitional inventory** | First-stop navigation for naming documentation and ownership decisions | **Stay put** | **Keep and maintain** |
@@ -72,7 +73,7 @@ Interpretation notes:
 - Keep `ValidatorSuite-Contracts-And-Modes.md` as suite-owned canonical authority in `ConventionRoutines`.
 - Keep `NamingValidatorSpec.md` as naming-slice canonical runtime/spec authority in `ConventionRoutines`.
 - Keep `FileNamingMasterList-V1_1.md` as canonical naming grammar/taxonomy authority in `ConventionRoutines`.
-- Keep naming interpretation specs and registry interaction spec in `ValidatorSpecs` as implementation-facing supporting specs.
+- Keep naming interpretation specs and registry interaction spec in `ValidatorSpecs` as bounded normative supporting specs (implementation-facing, non-primary canonical).
 - Keep transitional inventories (`naming-compatibility-inventory.md` and this map) as transitional artifacts, not canonical behavior authorities.
 
 ### Reference-only posture

--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md
@@ -3,6 +3,7 @@
 - **Classification:** Normative
 - **Applies to:** Naming-slice semantic-name interpretation extensions.
 - **Status:** Active for documentation-first modeling; runtime implementation deferred.
+- **Authority posture note:** Bounded normative supporting spec for naming interpretation modeling; does not supersede primary canonical naming authorities.
 
 ## 1) Purpose
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md
@@ -10,6 +10,8 @@ In this scope, semantic name is treated as a major naming interpretation lane di
 
 Classification: Normative
 
+Authority posture note: This is a bounded normative supporting spec for naming interpretation specialization; it does not supersede primary canonical naming authorities.
+
 ## 2) Relationship to Shared Contract and Ownership
 
 Inherited shared concepts come from:

--- a/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md
@@ -3,6 +3,7 @@
 - **Classification:** Normative
 - **Applies to:** Calculogic validator suite registry modeling and cross-slice registry interaction.
 - **Status:** Active suite-level contract.
+- **Authority posture note:** Bounded normative supporting spec for slice modeling/interaction in naming documentation maps; does not supersede primary canonical naming authorities.
 
 ## Purpose
 


### PR DESCRIPTION
### Motivation

- The existing naming documentation map used a single broad “Supporting implementation guidance” bucket for several interpretation/spec docs, which understates the active normative posture of some of those docs.
- The goal was to sharpen the middle-layer taxonomy to distinguish bounded normative/spec guidance from lightweight repo-local notes and transitional inventories while preserving canonical authority boundaries and avoiding broad reorg.

### Description

- Introduced a tighter middle-layer label, **"Bounded normative supporting spec"**, and added it where interpretation/model docs are normative within a bounded lane but non-primary versus canonical authorities.
- Updated the naming map and index to reflect the refined classification, and added short authority-posture notes at the top of the affected spec files to align wording without changing substantive content.
- Files changed: `calculogic-validator/doc/ValidatorSpecs/naming-documentation-map-and-reorg-inventory.md`, `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md`, `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md`, `calculogic-validator/doc/ValidatorSpecs/naming-semantic-name-and-role-disambiguation-spec.md`, `calculogic-validator/doc/ValidatorSpecs/naming-semantic-family-and-interpretation-spec.md`, and `calculogic-validator/doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`.
- Reclassified docs and rationale: `filename-case-and-interpretation-contract.md` (suite-shared normative lane; stronger than casual support), `naming-semantic-name-and-role-disambiguation-spec.md` (naming-slice interpretation specialization; normative but non-primary), `naming-semantic-family-and-interpretation-spec.md` (active documentation-first normative tranche; bounded modeling), and `registry-model-and-slice-interaction-spec.md` (suite-level model constraints useful to implementation/design); all were moved from generic "Supporting implementation guidance" to **Bounded normative supporting spec** to better express their posture while deferring primary authority to canonical contracts/slice specs.
- Preserved guardrails: canonical authority (suite contract, naming slice spec, FileNamingMasterList) remains unchanged, repo-local `cfg-namingValidator.md` stays as weaker supporting-implementation note, and transitional inventories remain explicitly non-canonical.

### Testing

- Ran repository checks: `git diff --check` completed with no whitespace/errors, and `git status --short` shows the intended documentation files modified; both checks succeeded.
- This is a documentation-only change set with no runtime or behavior modifications, so no runtime or unit tests were required or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b711e3bf1c8331959e8ab25c22f931)