### PR TITLE
docs(validator): clarify non-canonical middle-layer headings

### DIFF
--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -42,7 +42,9 @@ Authority labels used in this index:
 - `doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`
   **Authority:** canonical slice spec (tree). **Intended use:** normative tree-slice runtime/spec behavior for diagnostics and snapshot-driven structure checks.
 
-## 4) Supporting implementation guidance (non-canonical runtime authority)
+## 4) Non-canonical implementation/spec guidance
+
+### 4.1 Bounded normative supporting specs
 
 - `doc/ValidatorSpecs/filename-case-and-interpretation-contract.md`
   **Authority:** bounded normative supporting spec. **Intended use:** shared filename interpretation/case-policy contract lane for cross-slice alignment; defer primary runtime authority to suite contract + slice specs.
@@ -55,6 +57,8 @@ Authority labels used in this index:
 
 - `doc/ValidatorSpecs/registry-model-and-slice-interaction-spec.md`
   **Authority:** bounded normative supporting spec. **Intended use:** suite-level registry model/interaction constraints for implementation design and ownership boundaries; defer primary runtime authority to canonical contracts/slice specs.
+
+### 4.2 Supporting implementation guidance
 
 - `doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`
   **Authority:** supporting implementation guidance. **Intended use:** tree NL/config implementation context and sequencing notes; defer runtime authority to suite contract + tree slice spec.


### PR DESCRIPTION
### Motivation
- The validator docs index grouped both "bounded normative supporting specs" and lighter "supporting implementation guidance" under a single coarse heading which made the section-level label weaker than the item-level authority labels, so a minimal structural polish was needed to restore clarity and scanability.

### Description
- Updated `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to replace `## 4) Supporting implementation guidance (non-canonical runtime authority)` with a broader parent heading `## 4) Non-canonical implementation/spec guidance` and added two subsections `### 4.1 Bounded normative supporting specs` and `### 4.2 Supporting implementation guidance`, while preserving all existing entries and authority labels and making no other doc or taxonomy changes.

### Testing
- Ran repository sanity checks and review commands (`git status`, `git diff` on the changed file, and `rg` to verify the new headings) and committed the change; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b725148db4833182e3f89a6b62b42c)