### PR TITLE
docs(tree): align tree documentation map authority taxonomy

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md
@@ -17,7 +17,7 @@ This document provides one bounded, implementation-facing navigation map for tre
 It is intended to:
 
 - identify what documents currently exist for the tree implementation slice,
-- distinguish canonical runtime/spec authority from supporting references,
+- distinguish canonical runtime/spec authority from bounded normative supporting specs, supporting implementation guidance, draft references, and transitional metadata,
 - make explicit “stay put for now” vs “move/split/merge later” decisions,
 - reduce ambiguity for human maintainers and Codex task setup before any physical folder reorganization.
 
@@ -35,20 +35,21 @@ Use this sequence for tree implementation tasks (runtime, wiring, contracts, or 
 
 Interpretation note:
 
-- Runtime behavior authority should come from suite contract + tree spec.
-- NL/config note is implementation-context guidance that mirrors status labeling and reading order for this slice.
-- This map is navigation metadata and ownership guidance only; it does not redefine runtime behavior.
+- Runtime/spec authority comes from the suite canonical contract and the tree canonical slice spec.
+- Cross-slice naming docs consumed by tree remain canonical within naming-owned scope; tree consumes them as bounded supporting authority for naming-signal boundaries, not as tree-owned runtime authority.
+- NL/config note is supporting implementation guidance; draft references are bounded and non-final outside explicitly closed draft scope.
+- This map is transitional inventory metadata and ownership guidance only; it does not redefine runtime/spec behavior.
 
 ## Inventory (Bounded Set)
 
 | Document | Document role | Status classification | Audience / usage | Path decision | Action recommendation |
 |---|---|---|---|---|---|
-| `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` | Suite contract (canonical authority for shared validator vocabulary/modes/scope boundary) | Current runtime behavior + current implementation policy + limited future advisory direction notes | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path | **Keep** |
-| `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` | Canonical spec for tree slice runtime behavior and bounded tree modeling guidance | Mixed: current runtime behavior, current implementation guidance, current architectural/modeling guidance, bounded modeling note, future advisory direction, dogfooding/current-repo reality | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path (already under `ValidatorSpecs`, implementation-facing) | **Keep** |
-| `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` | Supporting convention/spec boundary for naming-signal consumption by tree advisor | Current runtime behavior and current implementation guidance for naming slice; supports tree interpretation boundaries | Runtime implementation, architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
-| `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md` | NL/config implementation note for tree slice | Current implementation guidance + deferred behavior (future advisory direction) + dogfooding/current-repo reality examples | Runtime implementation, Codex task context, historical/reference context for implementation sequencing | **Now colocated** under `ValidatorSpecs/nl-config` with pointer stub retained at the prior repo-root NL path | **Keep** (validator-owned supporting implementation guidance) |
-| `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` | Supporting convention (canonical authority for filename grammar + role/category/status taxonomy) | Current architectural/modeling guidance and governance vocabulary; runtime subset enforcement is delegated to naming slice | Architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
-| `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` | Bounded modeling note source for report-only tree-address grammar alignment | Draft-bounded modeling guidance (not full runtime enforcement contract for tree slice) | Architecture/modeling, supporting context only, historical/deferred decision reference | **Stay put** at current path | **Reference only** |
+| `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` | Suite contract (shared validator vocabulary/modes/scope boundary) | **Canonical contract** | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path | **Keep** |
+| `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` | Tree slice runtime/spec authority with bounded modeling notes | **Canonical slice spec** | Runtime implementation, architecture/modeling, Codex task context | **Stay put** at current path (already under `ValidatorSpecs`, implementation-facing) | **Keep** |
+| `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` | Naming slice runtime/spec authority consumed by tree for naming-signal boundary interpretation | **Canonical slice spec** (cross-slice supporting authority for tree tasks) | Runtime implementation, architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
+| `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md` | Tree NL/config implementation note | **Supporting implementation guidance** | Runtime implementation, Codex task context, historical/reference context for implementation sequencing | **Now colocated** under `ValidatorSpecs/nl-config` with pointer stub retained at the prior repo-root NL path | **Keep** (validator-owned supporting implementation guidance) |
+| `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` | Naming grammar/taxonomy authority consumed by tree for filename/role vocabulary boundaries | **Canonical contract** (cross-slice naming authority) | Architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
+| `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` | Bounded draft reference for report-only tree-address grammar alignment | **Draft** (bounded modeling guidance) | Architecture/modeling, supporting context only, historical/deferred decision reference | **Stay put** at current path | **Reference only** |
 
 ## Reorg Recommendations (Bounded / First Move Completed)
 


### PR DESCRIPTION
### Motivation

- The tree documentation map used coarser "supporting references" wording and mixed status wording that made authority posture less scannable against the refined validator-doc taxonomy. This change tightens authority language to avoid ambiguity while keeping the map transitional and non-canonical. 

### Description

- Updated `calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md` to replace coarse supporting wording with explicit middle-layer categories such as `Canonical contract`, `Canonical slice spec`, `Bounded normative supporting spec`, `Supporting implementation guidance`, and `Draft` where it improves clarity. 
- Tightened the interpretation/routing note so it states that runtime/spec authority comes from the suite `canonical contract` and the tree `canonical slice spec`, and clarified that cross-slice naming docs remain canonical within naming-owned scope but are only consumed as bounded supporting authority by the tree map. 
- Rewrote the Inventory table classification column to use consistent, scannable authority labels instead of mixing runtime state, modeling notes, and posture prose. 
- Kept the change strictly documentation-only and limited in scope to where distinctions genuinely improved clarity; did not change `ValidatorDocsIndex.md` or other tree-side content beyond small posture clarification in the tree map. 

Files changed:
- `calculogic-validator/doc/ValidatorSpecs/tree-documentation-map-and-reorg-inventory.md`

Scope notes:
- The tree side required the middle-layer distinction only partially: applied where it materially improved scanability and authority clarity, not full parity with naming-side split. Broader cross-slice taxonomy cleanup was intentionally deferred as out-of-scope. 

### Testing

- Ran repository checks and diffs: `git diff --check` (no problems reported), `git status --short`, and `git diff` for the modified file; all checks succeeded. 
- Verified the file was added to the index and committed via `git commit` (commit created). 
- No runtime/unit tests were necessary because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b727e859f483318984cf0e2397ed7f)