### PR TITLE
Lock canonical validator docs to current runtime/report/config behavior

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -114,7 +114,7 @@ Parsing assumptions:
 
 ## Input Scope Profiles (V0.1.2)
 
-V0.1.2 implements deterministic scope profiles selected by CLI.
+V0.1.2 implements deterministic scope profiles selected by CLI, using suite-owned scope-profile runtime data.
 
 Scope profile ownership model for this slice:
 
@@ -301,18 +301,27 @@ Rule ID note (canonical linkage):
 - map `code` to canonical `ruleId` for suite-wide contracts and future slice alignment
 - canonical contract reference: [`ValidatorRuleIds-Contract.md`](./ValidatorRuleIds-Contract.md)
 
-Report object includes:
+Report object includes (canonical current contract for naming slice output):
 
 - `mode`
+- `validatorId`
+- `toolVersion` (plus transitional `validatorVersion` alias)
+- `sourceSnapshot`
+- `startedAt` / `endedAt` / `durationMs`
 - `scope`
 - `totalFilesScanned`
-- summary count objects
+- `filters`
+- `scopeSummary`
+- `scopeContract`
+- summary count objects (`counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`)
 - `findings`
 
-When `--config=<path>` is supplied, report metadata may also include:
+When `--config=<path>` is supplied, report metadata may include:
 
 - `configDigest`
-  - emitted by the CLI when config input is active
+- `registryState`
+- `registrySource`
+- `registryDigests`
 
 ### Special-case subtype metadata
 
@@ -336,11 +345,12 @@ When a canonical-like parse resolves to a known deprecated role (currently `view
   - optional `deprecationNote`
 - validator does not auto-map deprecated role to modern roles (manual migration required)
 
-## Finding / Error Codes (V0.1.2)
+## Finding / Error Codes (V0.1.2 current runtime set)
 
 - `NAMING_CANONICAL`
 - `NAMING_ALLOWED_SPECIAL_CASE`
 - `NAMING_LEGACY_EXCEPTION`
+- `NAMING_MISSING_ROLE`
 - `NAMING_UNKNOWN_ROLE`
 - `NAMING_DEPRECATED_ROLE`
 - `NAMING_BAD_SEMANTIC_CASE`
@@ -361,7 +371,7 @@ Naming V0.1.7 currently implements:
   - invalid CLI usage (e.g., unknown `--scope`) exits `1`
 
 `--strict` in this naming slice is an exit-policy modifier, not a separate detection mode. See [`ValidatorSuite-Contracts-And-Modes.md`](./ValidatorSuite-Contracts-And-Modes.md) for canonical policy framing.
-When both CLI and config are present, CLI `--strict` has precedence for strict-exit resolution.
+When both CLI and config are present, CLI `--strict` has precedence for strict-exit resolution. Config-only strict exit is currently `strictExit=true` with no CLI `--strict` required.
 
 Suite policy options are shared contracts but deferred for naming implementation:
 

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -2,34 +2,32 @@
 
 ## 1) Purpose and Scope (Canonical)
 
-This document is the **canonical** reference for Calculogic Validator report JSON structure.
+This document is the **canonical current contract** for Calculogic Validator report JSON structure.
 
-It explicitly defines both report envelopes used today:
+It defines both envelopes emitted in current runtime:
 
-- **Slice Report** (single-slice CLI output, for example `validate:naming`)
-- **Runner Report** (multi-slice CLI output, for example `validate:all`)
-
-Where implementation-specific naming currently differs, this schema records current emitted keys and notes canonical alignment.
+- **Slice Report** (single-slice CLI output, currently `validate:naming`)
+- **Runner Report** (runner/composed output, currently `validate:all` and `validate:tree`)
 
 ## 2) Terms
 
-- **Report Envelope**: the top-level JSON object emitted by a validator command.
-- **Slice**: one validator domain/module (for example `naming`, later `tree`).
+- **Report Envelope**: top-level JSON object emitted by a validator command.
+- **Slice**: one validator domain/module (for example `naming`, `tree-structure-advisor`).
 - **Runner**: orchestrator that executes one or more slices and emits a multi-slice report.
 - **Finding**: one deterministic diagnostic record produced by a slice.
 - **Summary**: deterministic aggregate counts and rollups for findings.
-- **SourceSnapshot**: reproducibility metadata about the scanned source state.
-- **Config Digest / Fingerprint**: stable digest/fingerprint of resolved config used for the run.
+- **SourceSnapshot**: reproducibility metadata about scanned source state.
+- **Config Digest**: stable digest of resolved config used for the run.
 
-## 3) Canonical: Slice Report Envelope
+## 3) Canonical current contract: Slice Report Envelope
 
-The slice report envelope is the canonical shape for single-slice output. Current naming CLI output must include these fields:
+Current naming CLI output includes:
 
-### Required fields
+### Required fields (current implementation)
 
-- `mode` (string; currently `"report"`)
-- `validatorId` (string; for naming slice: `"naming"`)
-- `toolVersion` (string when tool version is resolved)
+- `mode` (string; current value: `"report"`)
+- `validatorId` (string; naming value: `"naming"`)
+- `toolVersion` (string)
 - `sourceSnapshot` (object)
 - `startedAt` (ISO-8601 datetime string)
 - `endedAt` (ISO-8601 datetime string)
@@ -37,31 +35,31 @@ The slice report envelope is the canonical shape for single-slice output. Curren
 - `scope` (string)
 - `totalFilesScanned` (number)
 - `filters` (object)
-- `counts` (object)
-- `findings` (array of finding objects)
+- `scopeSummary` (object)
+- `scopeContract` (object)
+- `counts` (object; classification-bucket counts)
+- `codeCounts` (object)
+- `specialCaseTypeCounts` (object)
+- `warningRoleStatusCounts` (object)
+- `warningRoleCategoryCounts` (object)
+- `findings` (array)
 
 ### Optional / transitional fields
 
-- `validatorVersion` (string; currently emitted alongside `toolVersion` for compatibility)
-- `configDigest` (string; present when config is supplied)
-- `scopeSummary` (object; deterministic slice summary)
-- `scopeContract` (object; deterministic scope metadata)
-- `codeCounts` (object; naming transitional summary key)
-- `specialCaseTypeCounts` (object; naming-specific summary key)
-- `warningRoleStatusCounts` (object; naming-specific summary key)
-- `warningRoleCategoryCounts` (object; naming-specific summary key)
-- `registryState` (`"builtin" | "custom"`; optional registry-state metadata)
-- `registrySource` (`"builtin" | "custom" | "config"`; optional resolved source metadata)
-- `registryDigests` (object `{ builtin, custom, resolved }`; optional digest transparency metadata)
+- `validatorVersion` (string; currently emitted alongside `toolVersion`)
+- `configDigest` (string; emitted when config is supplied)
+- `registryState` (`"builtin" | "custom"`)
+- `registrySource` (`"builtin" | "custom" | "config"`)
+- `registryDigests` (object `{ builtin, custom, resolved }`)
 
-## 4) Canonical: Runner Report Envelope
+## 4) Canonical current contract: Runner Report Envelope
 
-The runner report envelope is the canonical shape for multi-slice output. Current runner output must include these fields:
+Current runner output includes:
 
 ### Required fields
 
-- `version` (string; report contract version)
-- `mode` (string; currently `"report"`)
+- `version` (string; current value from `CALCULOGIC_VALIDATOR_REPORT_VERSION`, currently `"0.1.0"`)
+- `mode` (string; current value: `"report"`)
 - `validatorId` (string; `"runner"`)
 - `sourceSnapshot` (object)
 - `startedAt` (ISO-8601 datetime string)
@@ -71,157 +69,62 @@ The runner report envelope is the canonical shape for multi-slice output. Curren
 
 ### Optional fields
 
-- `scope` (string; when a scoped run is requested)
+- `scope` (string; emitted when scope is provided)
 - `toolVersion` (string)
-- `validatorVersion` (string; currently emitted alongside `toolVersion` for compatibility)
-- `configDigest` (string; when config is supplied)
+- `validatorVersion` (string; transitional/current compatibility field)
+- `configDigest` (string)
 
-## 5) Canonical: Runner `validators[]` Entry
+## 5) Canonical current contract: Runner `validators[]` Entry
 
-Each `validators[]` entry must include:
+Each entry includes:
 
-- `id` (string; runner registry id)
+- `id` (string; registry id)
 - `validatorId` (string; slice id)
 - `description` (string)
-- `findings` (array; possibly empty)
+- `scope` (string)
+- `totalFilesScanned` (number)
+- `findings` (array)
 
 Entry-level optional fields:
 
-- `scope` (string)
-- `totalFilesScanned` (number)
 - `counts` (object)
 - `meta` (object)
-  - `meta.filters` (object; present when runner forwards active target filtering metadata)
-  - `meta.registry` (object; present when slice exposes registry-state metadata, e.g. naming)
+  - `meta.filters` (object; present when target filtering is active)
+  - `meta.registry` (object; present when slice exposes registry metadata)
 
-Pass-through summary keys are allowed (for example naming summary keys beyond `counts`), but they must be deterministic and documented by the corresponding slice spec.
+Runner currently passes through deterministic slice summary fields in addition to `counts` (for example naming `codeCounts` and tree `codeCounts`).
 
-## 6) Canonical: Finding Object Shape (Suite-wide baseline)
+## 6) Canonical current contract: Finding Object Baseline
 
-Suite-wide minimum finding shape:
+Suite-wide minimum finding baseline in current runtime:
 
-- `ruleId` (string; canonical stable identifier, see `ValidatorRuleIds-Contract.md`)
-- `severity` (`info` | `warn` | `error`)
-- `path` (normalized repo-relative path using `/`)
+- `severity` (`info` | `warn`)
+- `path` (normalized repo-relative path with `/` separators)
 - `message` (string)
-- `details` (optional object)
-- `ruleRef` (optional repo-local rule/spec pointer string)
-- `suggestedFix` (optional object; plan-only where applicable)
+- `classification` (string)
+- `ruleRef` (string)
 
-Transitional note: naming currently emits `code`. Until migration is complete, treat `code` as the effective `ruleId`.
+Current/transitional identifier mapping:
+
+- Naming and tree currently emit `code` as the stable finding identifier.
+- Canonical suite rule-id authority remains `ValidatorRuleIds-Contract.md`.
+- `ruleId` is deferred/planning for report payload migration; until then `code` is the current emitted identifier.
+
+Optional fields currently emitted by slices:
+
+- `details` (object)
+- `suggestedFix` (string; naming policy metadata)
 
 ## 7) Determinism Rules (Canonical)
 
-- Normalize all reported file paths to `/` separators.
-- Sort findings by:
-  1. `path` ascending,
-  2. `ruleId` ascending (or transitional `code`),
-  3. stable tie-breakers (for example deterministic message/details ordering).
-- Sort `targets` input lists before persistence/emission.
-- Keep count/summary object key order deterministic when serialized (stable stringify is recommended for digest/comparison workflows).
+- Normalize reported file paths to `/` separators.
+- Keep selected path sets deterministic via sort/dedupe before classification.
+- Sort finding arrays deterministically in slice runtime output.
+- Sort aggregate summary object keys deterministically where runtime emits sorted breakdowns.
 - Same inputs + same resolved config => identical report payload.
 
-## 8) Examples (matching current implementation)
+## 8) Transitional/current mapping notes
 
-### 8.1 Slice report example (`validate:naming`)
-
-```json
-{
-  "mode": "report",
-  "validatorId": "naming",
-  "toolVersion": "0.1.7",
-  "validatorVersion": "0.1.7",
-  "configDigest": "sha256:abc123",
-  "sourceSnapshot": {
-    "source": "fs",
-    "gitRef": "HEAD"
-  },
-  "startedAt": "2026-01-10T12:00:00.000Z",
-  "endedAt": "2026-01-10T12:00:00.120Z",
-  "durationMs": 120,
-  "scope": "app",
-  "totalFilesScanned": 42,
-  "filters": {
-    "isFiltered": true,
-    "targets": ["src/buildsurface", "src/shared"]
-  },
-  "scopeSummary": {
-    "scope": "app",
-    "reportableFilesInScope": 42,
-    "findingsGenerated": 2
-  },
-  "scopeContract": {
-    "description": "Application source files",
-    "includeRoots": ["src"],
-    "includeRootFiles": []
-  },
-  "counts": {
-    "info": 1,
-    "warn": 1,
-    "total": 2
-  },
-  "codeCounts": {
-    "NAMING_CANONICAL": 1,
-    "NAMING_UNKNOWN_ROLE": 1
-  },
-  "specialCaseTypeCounts": {
-    "barrel": 0
-  },
-  "warningRoleStatusCounts": {
-    "active": 1
-  },
-  "warningRoleCategoryCounts": {
-    "architecture-support": 1
-  },
-  "findings": [
-    {
-      "code": "NAMING_UNKNOWN_ROLE",
-      "severity": "warn",
-      "path": "src/shared/user-widget.thing.ts",
-      "classification": "invalid-ambiguous",
-      "message": "Unknown role token 'thing'.",
-      "ruleRef": "calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md#finding--error-codes"
-    }
-  ]
-}
-```
-
-### 8.2 Runner report example (`validate:all`)
-
-```json
-{
-  "version": "0.1",
-  "mode": "report",
-  "scope": "repo",
-  "validatorId": "runner",
-  "toolVersion": "0.1.7",
-  "validatorVersion": "0.1.7",
-  "configDigest": "sha256:abc123",
-  "sourceSnapshot": {
-    "source": "fs",
-    "gitRef": "HEAD"
-  },
-  "startedAt": "2026-01-10T12:00:00.000Z",
-  "endedAt": "2026-01-10T12:00:00.300Z",
-  "durationMs": 300,
-  "validators": [
-    {
-      "id": "naming",
-      "validatorId": "naming",
-      "description": "Filename naming validator",
-      "scope": "repo",
-      "totalFilesScanned": 420,
-      "counts": {
-        "info": 410,
-        "warn": 10,
-        "total": 420
-      },
-      "codeCounts": {
-        "NAMING_CANONICAL": 410,
-        "NAMING_UNKNOWN_ROLE": 10
-      },
-      "findings": []
-    }
-  ]
-}
-```
+- `validatorVersion` is a compatibility alias currently emitted alongside `toolVersion`.
+- Runner and slice reports use `configDigest`; any `configFingerprint` wording is deferred/planning only.
+- Fix-plan output fields (`suggestedFix[]`, `appliedFix[]` at envelope level) are deferred/planning only and are not part of the current emitted envelope.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md
@@ -8,7 +8,7 @@ Status labeling note for this document:
 
 ## 1) Identity and Vocabulary (Canonical)
 
-Calculogic Validator is a modular, configurable, policy-driven validator suite. It is report-first by default and can optionally escalate findings via soft-fail/hard-fail policies or execute deterministic fix plans (correct/replace) when explicitly enabled.
+Calculogic Validator is a modular, configurable, policy-driven validator suite. **Current implementation policy** is report-mode execution with policy-derived exit behavior. Shared suite mode vocabulary also includes deferred policy/fix modes (`soft-fail`, `hard-fail`, `correct`, `replace`) as canonical contract terms, but those modes are not yet implemented as executable runtime modes.
 
 Canonical terms:
 
@@ -23,10 +23,10 @@ Canonical terms:
 Suite-wide policies over the same findings:
 
 - `report`: report findings first; exit behavior may still be policy-driven.
-- `soft-fail`: report findings and fail only under configured soft-fail thresholds/scope gates.
-- `hard-fail`: report findings and fail deterministically on configured hard-fail conditions.
-- `correct`: execute explicitly allowed safe fix plans in addition to reporting.
-- `replace`: execute explicitly allowed structural fix plans in addition to reporting.
+- `soft-fail`: deferred/planning-only mode label for threshold/gate-based failure policy.
+- `hard-fail`: deferred/planning-only mode label for deterministic hard-fail policy.
+- `correct`: deferred/planning-only mode label for explicitly allowed safe fix-plan execution.
+- `replace`: deferred/planning-only mode label for explicitly allowed structural fix-plan execution.
 
 Normative rule:
 
@@ -58,9 +58,15 @@ For canonical loader → converter → runtime ownership boundaries (including w
 Current implementation policy:
 
 - any `warn` findings => exit `2`
-- when no `warn` findings exist, `--strict` with any `legacy-exception` findings => exit `1`
+- when no `warn` findings exist, effective strict mode with any `legacy-exception` findings => exit `1`
 - otherwise => exit `0`
 - invalid CLI usage => exit `1`
+
+Strictness resolution in current implementation:
+
+- `validate:naming`: effective strict mode is enabled by CLI `--strict` or config `strictExit=true`.
+- `validate:all`: effective strict mode is enabled by CLI `--strict`.
+- `validate:tree`: does not currently expose strict-mode toggling.
 
 This is the current implementation policy and may later be generalized under suite modes (`soft-fail` / `hard-fail` / `correct` / `replace`), while detection remains unchanged.
 
@@ -133,38 +139,23 @@ Guardrail: the helper does not own slice meaning. Slice runtimes remain responsi
 
 Cross-slice validators should start from this shared scoped snapshot/input layer before applying cross-slice interpretation rules.
 
-## 7) Shared Report Envelope (Canonical)
+## 7) Shared report-envelope boundary (Canonical + transitional/current mapping)
 
-This document defines the suite-level shape contract. For the canonical full schema reference (including slice report vs runner report envelopes, finding baseline shape, and deterministic ordering rules), see [`ValidatorReportSchema-V0_1.md`](./ValidatorReportSchema-V0_1.md).
+Suite-level envelope authority is intentionally minimal here. Primary schema authority is [`ValidatorReportSchema-V0_1.md`](./ValidatorReportSchema-V0_1.md).
 
-Each validator slice should emit a stable high-level report envelope:
+Canonical suite-level boundary:
 
-- `validatorId`
-- `validatorVersion`
-- `mode`
-- `scope`
-- `targets[]` (optional)
-- `sourceSnapshot` (snapshot metadata only: filesystem state and/or git reference such as `HEAD`; dirty/untracked diagnostics are metadata)
-- `configFingerprint` (hash/fingerprint of resolved config)
-- `summary` (stable counts)
-- `findings[]` (deterministically sorted)
-- `suggestedFix[]` (optional; when fix planning is enabled)
-- `appliedFix[]` (optional; only when fixes are actually executed)
+- successful report runs emit structured JSON to `stdout`
+- envelope includes validator identity, report mode, reproducibility metadata, timing metadata, and deterministic findings payloads
+- runner envelope (`validatorId: "runner"`) composes deterministic per-slice entries under `validators[]`
 
-`sourceSnapshot` values are environment metadata for reproducibility and comparison, not naming roles and not detection categories.
+Current implementation mapping note:
 
-This contract is intentionally shape-level so slices can add deterministic details while preserving suite-wide comparability.
+- current emitted config digest field is `configDigest`
+- `validatorVersion` is emitted as a transitional compatibility alias with `toolVersion`
+- envelope-level fix-plan arrays are deferred/planning only and are not currently emitted
 
-### Current report mapping (naming slice)
-
-Canonical envelope is the stable suite contract; some slices currently emit equivalent fields under different names until runner unification.
-
-- `validatorVersion` → `toolVersion`
-- `validatorId` → `validatorId`
-- `configFingerprint` → `configDigest`
-- `summary` → `counts` + `codeCounts` (plus deterministic naming-specific breakdowns such as `specialCaseTypeCounts` and warning-category/status counts)
-- `findings[]` → `findings[]`
-- `sourceSnapshot` → `sourceSnapshot`
+`sourceSnapshot` remains reproducibility metadata only (`source`, optional git ref/sha and diagnostics), not semantic finding content.
 
 ## 8) Shared Determinism Rules (Canonical)
 

--- a/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/validator-config-spec.md
@@ -8,7 +8,7 @@ The naming validator remains **report-first** for detection and findings emissio
 
 ## 1) Purpose
 
-This spec defines the canonical validator config contract for current naming-validator usage. The config provides strict, deterministic input for registry shaping (reportable extension additions and role metadata additions) and reproducible report metadata.
+This spec defines the canonical validator config contract for current suite runtime behavior. The config provides strict, deterministic input for naming registry shaping (reportable extension additions, role metadata additions, case-rules style) and reproducible report metadata.
 
 ## 2) Versioning
 
@@ -120,7 +120,7 @@ Current naming wiring applies normalized config additively:
 - active roles are derived from merged metadata where `status === "active"`.
 - role suffix list is derived from merged role keys sorted by descending string length.
 
-## 8) CLI consumption
+## 8) CLI consumption (current implementation policy)
 
 Config flag (exact form):
 
@@ -132,7 +132,12 @@ Current failure modes when config is supplied:
 - cannot parse JSON → error
 - invalid config shape/content → error
 
-When a valid config is supplied, naming reports may include:
+Current runtime support boundaries:
+
+- `validate:naming` and `validate:all` load/validate/normalize config and forward naming-supported surfaces.
+- `validate:tree` currently accepts `--config` and computes `configDigest` but does not apply tree-specific config semantics yet (deferred/planning for tree config surfaces).
+
+When a valid config is supplied, emitted reports may include:
 
 - `configDigest`
 
@@ -142,11 +147,6 @@ Strict-exit resolution for naming CLI uses existing exit-policy semantics:
 - Otherwise, effective strictness is `true` when `config.strictExit === true`.
 - Otherwise, effective strictness is `false`.
 - Report JSON is emitted before exit code is derived/applied.
-
-This behavior applies to:
-
-- `calculogic-validator/scripts/validate-naming.mjs`
-- `calculogic-validator/bin/calculogic-validate-naming.mjs`
 
 ## 9) Valid examples
 


### PR DESCRIPTION
### Motivation
- Reduce documentation drift by aligning canonical validator docs with the actual emitted runtime/report/config behavior rather than letting planning language read like shipped behavior. 
- Keep the docs authoritative for suite-level contract, report schema, config contract, and naming-slice behavior while marking deferred/planning features explicitly.

### Description
- `ValidatorSuite-Contracts-And-Modes.md`: tightened mode vocabulary to show non-report modes (`soft-fail`, `hard-fail`, `correct`, `replace`) as deferred/planning-only and documented the current exit/strictness resolution per CLI (`validate:naming`, `validate:all`, `validate:tree`).
- `ValidatorReportSchema-V0_1.md`: rewrote to a canonical current-contract view that lists the actual slice and runner fields currently emitted, clarifies the finding baseline and transitional `code`→`ruleId` mapping, and documents deterministic ordering expectations and transitional mapping notes.
- `validator-config-spec.md`: clarified that config is a canonical contract for current runtime surfaces, documented which CLIs load/apply naming-supported config (`validate:naming`, `validate:all`) and that tree accepts `--config` but tree-specific config semantics remain deferred; preserved strictness/normalization rules.
- `NamingValidatorSpec.md`: updated the naming-slice report contract to include currently emitted fields (registry metadata surfaces), added the missing `NAMING_MISSING_ROLE` finding code to the runtime set, and tightened strict-exit wording so CLI precedence and `strictExit` config behavior are explicit; marked deferred items where appropriate.

### Testing
- Ran targeted validator tests: `node --test calculogic-validator/test/validator-exit-codes.test.mjs calculogic-validator/test/validator-config-strictness.test.mjs calculogic-validator/test/validator-runner.test.mjs` and observed all tests passed (22/22).
- An initial attempt to run the same tests via `cd calculogic-validator && node --test test/validator-exit-codes.test.mjs test/validator-config-strictness.test.mjs test/validator-runner.test.mjs` failed due to an invocation/working-directory path issue (not related to doc edits), so the successful full-path run above is the validated result.
- No runtime code changes were made; this is documentation-only and tests confirm no behavioral regressions in the covered exit/config/runner test surfaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b734328b148331aeb54c087bfc427c)