### PR TITLE
test(validator): add conformance coverage for suite/report/config/naming contracts

### DIFF
--- a/calculogic-validator/naming/test/naming-missing-role.test.mjs
+++ b/calculogic-validator/naming/test/naming-missing-role.test.mjs
@@ -5,6 +5,8 @@ import { classifyPath } from '../src/naming-validator.host.mjs';
 test('classifies two-segment reportable filename as missing role', () => {
   const finding = classifyPath('src/App.tsx');
   assert.equal(finding.code, 'NAMING_MISSING_ROLE');
+  assert.equal(finding.classification, 'legacy-exception');
+  assert.equal(finding.severity, 'info');
 });
 
 test('keeps hyphen-appended role ambiguity precedence', () => {

--- a/calculogic-validator/naming/test/validate-naming-report-registry-meta.test.mjs
+++ b/calculogic-validator/naming/test/validate-naming-report-registry-meta.test.mjs
@@ -54,3 +54,29 @@ test('validate-naming bin report aligns envelope and includes registry metadata 
   assert.match(report.registrySource, /^(builtin|custom|config)$/u);
   assertRegistryDigestShape(report.registryDigests);
 });
+
+test('validate-naming with config includes configDigest and config-backed registry source metadata', () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--experimental-strip-types',
+      'calculogic-validator/scripts/validate-naming.mjs',
+      '--scope=system',
+      '--config=calculogic-validator/test/fixtures/validator-config.roles.contracts.json',
+    ],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(typeof report.configDigest, 'string');
+  assert.match(report.configDigest, digestPattern);
+  assert.equal(report.scopeSummary?.scope, report.scope);
+  assert.equal(report.scopeSummary?.findingsGenerated, report.findings.length);
+  assert.equal(typeof report.scopeContract?.description, 'string');
+
+  if (report.registrySource === 'config') {
+    assert.match(report.registryState, /^(builtin|custom)$/u);
+  }
+});

--- a/calculogic-validator/test/validate-tree.script.integration.test.mjs
+++ b/calculogic-validator/test/validate-tree.script.integration.test.mjs
@@ -77,3 +77,24 @@ test('validate-tree prints usage when npm args are not forwarded', () => {
   assert.match(result.stderr, /Detected npm argument forwarding issue/);
   assert.match(result.stderr, /Usage: npm run validate:tree --/);
 });
+
+test('validate-tree does not expose strict-mode toggling', () => {
+  const result = runValidateTree(repositoryRoot, ['--strict']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid argument: --strict/u);
+  assert.match(result.stderr, /Usage: npm run validate:tree --/u);
+});
+
+test('validate-tree accepts --config and includes configDigest in runner report envelope', () => {
+  const result = runValidateTree(repositoryRoot, [
+    '--scope=system',
+    '--config=calculogic-validator/test/fixtures/validator-config.extensions.contracts.json',
+  ]);
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.mode, 'report');
+  assert.equal(typeof report.configDigest, 'string');
+  assert.match(report.configDigest, /^[a-f0-9]{64}$/u);
+});

--- a/calculogic-validator/test/validator-exit-codes.test.mjs
+++ b/calculogic-validator/test/validator-exit-codes.test.mjs
@@ -14,6 +14,10 @@ const validateAllScriptPath = path.resolve(
   repositoryRoot,
   'calculogic-validator/scripts/validate-all.mjs',
 );
+const validateTreeScriptPath = path.resolve(
+  repositoryRoot,
+  'calculogic-validator/scripts/validate-tree.mjs',
+);
 
 const writeFixtureRepo = async (fixtureDir) => {
   await fs.mkdir(path.join(fixtureDir, 'src'), { recursive: true });
@@ -222,6 +226,52 @@ test('validate-all mirrors exit policy from aggregated findings', async () => {
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
+});
+
+test('validate-all strictness is CLI-driven and does not use config strictExit', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-exit-codes-'));
+  let configDir;
+
+  try {
+    await writeFixtureRepo(fixtureDir);
+
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-config-'));
+    const configPath = path.join(configDir, 'validator-config.strict-true.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ version: '0.1', strictExit: true }, null, 2),
+      'utf8',
+    );
+
+    const configOnlyResult = runNodeScript(validateAllScriptPath, [`--config=${configPath}`], fixtureDir);
+    assert.equal(configOnlyResult.status, 0);
+
+    const cliStrictResult = runNodeScript(
+      validateAllScriptPath,
+      ['--strict', `--config=${configPath}`],
+      fixtureDir,
+    );
+    assert.equal(cliStrictResult.status, 1);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    if (typeof configDir === 'string') {
+      await fs.rm(configDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('deferred mode labels are rejected as invalid CLI arguments', () => {
+  const namingResult = runNodeScript(namingScriptPath, ['--mode=soft-fail'], repositoryRoot);
+  const allResult = runNodeScript(validateAllScriptPath, ['--mode=hard-fail'], repositoryRoot);
+  const treeResult = runNodeScript(validateTreeScriptPath, ['--mode=correct'], repositoryRoot);
+
+  assert.equal(namingResult.status, 1);
+  assert.equal(allResult.status, 1);
+  assert.equal(treeResult.status, 1);
+
+  assert.match(namingResult.stderr, /Invalid argument: --mode=soft-fail/u);
+  assert.match(allResult.stderr, /Invalid argument: --mode=hard-fail/u);
+  assert.match(treeResult.stderr, /Invalid argument: --mode=correct/u);
 });
 
 test('validate-naming fails fast when npm script args are not forwarded', () => {

--- a/calculogic-validator/test/validator-report-schema.conformance.test.mjs
+++ b/calculogic-validator/test/validator-report-schema.conformance.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+const runScript = (scriptPath, args = []) =>
+  spawnSync(process.execPath, ['--experimental-strip-types', scriptPath, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+const assertIsoString = (value) => {
+  assert.equal(typeof value, 'string');
+  assert.ok(!Number.isNaN(Date.parse(value)));
+};
+
+test('validate-naming emits current slice report envelope and finding identifier contract', () => {
+  const result = runScript('calculogic-validator/scripts/validate-naming.mjs', ['--scope=system']);
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.mode, 'report');
+  assert.equal(report.validatorId, 'naming');
+  assert.equal(typeof report.toolVersion, 'string');
+  assert.equal(report.validatorVersion, report.toolVersion);
+  assert.ok(report.sourceSnapshot);
+  assert.equal(report.sourceSnapshot.source, 'fs');
+  assertIsoString(report.startedAt);
+  assertIsoString(report.endedAt);
+  assert.equal(typeof report.durationMs, 'number');
+  assert.equal(typeof report.scope, 'string');
+  assert.equal(typeof report.totalFilesScanned, 'number');
+  assert.ok(report.counts && typeof report.counts === 'object');
+  assert.ok(report.codeCounts && typeof report.codeCounts === 'object');
+  assert.ok(Array.isArray(report.findings));
+
+  for (const finding of report.findings) {
+    assert.equal(typeof finding.code, 'string');
+    assert.equal(finding.ruleId, undefined);
+  }
+});
+
+test('validate-all emits current runner report envelope and forwards configDigest', () => {
+  const result = runScript('calculogic-validator/scripts/validate-all.mjs', [
+    '--scope=system',
+    '--validators=naming',
+    '--config=calculogic-validator/test/fixtures/validator-config.roles.contracts.json',
+  ]);
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const report = JSON.parse(result.stdout);
+
+  assert.equal(report.version, '0.1.0');
+  assert.equal(report.mode, 'report');
+  assert.equal(report.validatorId, 'runner');
+  assert.equal(typeof report.toolVersion, 'string');
+  assert.equal(report.validatorVersion, report.toolVersion);
+  assert.equal(typeof report.configDigest, 'string');
+  assert.match(report.configDigest, /^[a-f0-9]{64}$/u);
+  assert.ok(report.sourceSnapshot);
+  assert.equal(report.sourceSnapshot.source, 'fs');
+  assertIsoString(report.startedAt);
+  assertIsoString(report.endedAt);
+  assert.equal(typeof report.durationMs, 'number');
+  assert.ok(Array.isArray(report.validators));
+  assert.equal(report.validators.length, 1);
+
+  const namingEntry = report.validators[0];
+  assert.equal(namingEntry.id, 'naming');
+  assert.equal(namingEntry.validatorId, 'naming');
+  assert.equal(typeof namingEntry.description, 'string');
+  assert.equal(typeof namingEntry.totalFilesScanned, 'number');
+  assert.ok(Array.isArray(namingEntry.findings));
+
+  for (const finding of namingEntry.findings) {
+    assert.equal(typeof finding.code, 'string');
+    assert.equal(finding.ruleId, undefined);
+  }
+});

--- a/calculogic-validator/test/validator-runner.test.mjs
+++ b/calculogic-validator/test/validator-runner.test.mjs
@@ -12,8 +12,12 @@ test('runner report includes naming validator in deterministic order', () => {
   const report = runValidatorRunner(process.cwd(), { scope: 'app' });
 
   assert.ok(report.version);
+  assert.equal(report.mode, 'report');
   assert.equal(report.validatorId, 'runner');
   assert.equal(report.sourceSnapshot?.source, 'fs');
+  assert.equal(typeof report.startedAt, 'string');
+  assert.equal(typeof report.endedAt, 'string');
+  assert.equal(typeof report.durationMs, 'number');
   assert.ok(Array.isArray(report.validators));
   assert.equal(report.validators.length, 2);
   assert.deepEqual(


### PR DESCRIPTION
### Motivation
- Lock the current canonical validator contracts (suite exit/strictness, report envelopes, config boundaries, naming metadata) with focused tests to prevent silent drift.
- Protect the corrected canonical docs as the authoritative current-contract sources without changing runtime behavior or enabling deferred features.
- Keep the change bounded to tests and minimal, deterministic assertions rather than broad runtime refactors or large snapshots.

### Description
- Added targeted conformance tests and small test extensions that assert current runtime/report/config/naming contract behavior without changing production code.
- New focused schema/envelope test file `calculogic-validator/test/validator-report-schema.conformance.test.mjs` validates slice and runner envelopes, timing fields, transitional `validatorVersion` alias, `configDigest` forwarding, and that findings emit `code` (not `ruleId`).
- Extended/added assertions in existing tests to cover exit/strictness and config boundaries (`calculogic-validator/test/validator-exit-codes.test.mjs`, `calculogic-validator/test/validate-tree.script.integration.test.mjs`, `calculogic-validator/test/validator-runner.test.mjs`).
- Strengthened naming-slice contract checks and config-backed metadata tests (`calculogic-validator/naming/test/validate-naming-report-registry-meta.test.mjs`, `calculogic-validator/naming/test/naming-missing-role.test.mjs`).
- Files changed: `calculogic-validator/test/validator-exit-codes.test.mjs`, `calculogic-validator/test/validate-tree.script.integration.test.mjs`, `calculogic-validator/test/validator-runner.test.mjs`, `calculogic-validator/test/validator-report-schema.conformance.test.mjs` (new), `calculogic-validator/naming/test/validate-naming-report-registry-meta.test.mjs`, `calculogic-validator/naming/test/naming-missing-role.test.mjs`.

### Testing
- Ran the new and updated tests together with: `node --test calculogic-validator/test/validator-exit-codes.test.mjs calculogic-validator/test/validate-tree.script.integration.test.mjs calculogic-validator/test/validator-runner.test.mjs calculogic-validator/test/validator-report-schema.conformance.test.mjs calculogic-validator/naming/test/validate-naming-report-registry-meta.test.mjs calculogic-validator/naming/test/naming-missing-role.test.mjs` and all tests passed successfully. 
- The test assertions exercise the following behaviors and passed: `mode` is `report`, `configDigest` forwarding, `validatorVersion`/`toolVersion` aliasing, findings `code` identifier surface, `validate:naming`/`validate:all` strictness resolution, `validate:tree` no `--strict` toggle, and rejection of deferred mode labels as invalid CLI args. 
- No runtime code changes or documentation wording edits were required; deferred features remain intentionally unimplemented and protected by tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7472cc03483318d6122c71d401c96)