### PR TITLE
Add generated validator report example refresh pipeline

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -128,3 +128,26 @@ Optional fields currently emitted by slices:
 - `validatorVersion` is a compatibility alias currently emitted alongside `toolVersion`.
 - Runner and slice reports use `configDigest`; any `configFingerprint` wording is deferred/planning only.
 - Fix-plan output fields (`suggestedFix[]`, `appliedFix[]` at envelope level) are deferred/planning only and are not part of the current emitted envelope.
+
+## 9) Current generated examples (illustrative)
+
+Classification: **Illustrative**
+
+Current-runtime report examples are generated from live validator entrypoints and checked in at:
+
+- `calculogic-validator/test/fixtures/report-examples/validate-naming.system.report.example.json`
+- `calculogic-validator/test/fixtures/report-examples/validate-all.system.naming.report.example.json`
+
+Refresh workflow:
+
+```bash
+node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.mjs
+```
+
+Normalization policy for these examples is intentionally bounded for deterministic repo artifacts:
+
+- normalize `startedAt`, `endedAt`, and `durationMs`
+- normalize `sourceSnapshot.gitHeadSha`
+- normalize `sourceSnapshot.diagnostics` dirty/changed counters
+
+Contract-significant fields remain runtime-faithful (for example `mode`, `validatorId`, `toolVersion`/`validatorVersion`, summary and findings structures).

--- a/calculogic-validator/scripts/generate-validator-report-examples.mjs
+++ b/calculogic-validator/scripts/generate-validator-report-examples.mjs
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { resolveRepositoryRoot } from '../src/core/repository-root.logic.mjs';
+
+const EXAMPLES_DIRECTORY = 'calculogic-validator/test/fixtures/report-examples';
+
+const replaceUnstableSourceSnapshot = (sourceSnapshot) => {
+  if (!sourceSnapshot || typeof sourceSnapshot !== 'object') {
+    return sourceSnapshot;
+  }
+
+  const normalized = {
+    ...sourceSnapshot,
+  };
+
+  if (typeof normalized.gitHeadSha === 'string') {
+    normalized.gitHeadSha = '<git-head-sha>';
+  }
+
+  if (normalized.diagnostics && typeof normalized.diagnostics === 'object') {
+    normalized.diagnostics = {
+      isDirty: false,
+      changedCount: 0,
+      untrackedCount: 0,
+    };
+  }
+
+  return normalized;
+};
+
+const normalizeReport = (report) => ({
+  ...report,
+  startedAt: '<iso-startedAt>',
+  endedAt: '<iso-endedAt>',
+  durationMs: 0,
+  sourceSnapshot: replaceUnstableSourceSnapshot(report.sourceSnapshot),
+});
+
+const runValidatorScript = (repositoryRoot, scriptPath, args) => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', scriptPath, ...args],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (![0, 1, 2].includes(result.status)) {
+    throw new Error(result.stderr || `Command failed with status ${result.status}`);
+  }
+
+  return JSON.parse(result.stdout);
+};
+
+const writeExample = (outputPath, report) => {
+  fs.writeFileSync(outputPath, `${JSON.stringify(normalizeReport(report), null, 2)}\n`, 'utf8');
+};
+
+const parseArgs = (argv) => {
+  const outDirArgument = argv.find((argument) => argument.startsWith('--out-dir='));
+  if (!outDirArgument) {
+    return {};
+  }
+
+  return {
+    outDir: outDirArgument.slice('--out-dir='.length),
+  };
+};
+
+export const generateValidatorReportExamples = ({ repositoryRoot, outputDirectory }) => {
+  const namingReport = runValidatorScript(repositoryRoot, 'calculogic-validator/scripts/validate-naming.mjs', [
+    '--scope=system',
+  ]);
+
+  const runnerReport = runValidatorScript(repositoryRoot, 'calculogic-validator/scripts/validate-all.mjs', [
+    '--scope=system',
+    '--validators=naming',
+  ]);
+
+  fs.mkdirSync(outputDirectory, { recursive: true });
+
+  writeExample(path.join(outputDirectory, 'validate-naming.system.report.example.json'), namingReport);
+  writeExample(path.join(outputDirectory, 'validate-all.system.naming.report.example.json'), runnerReport);
+};
+
+const runAsScript = () => {
+  const repositoryRoot = resolveRepositoryRoot();
+  const parsed = parseArgs(process.argv.slice(2));
+  const outputDirectory = path.resolve(
+    repositoryRoot,
+    parsed.outDir ?? EXAMPLES_DIRECTORY,
+  );
+
+  generateValidatorReportExamples({ repositoryRoot, outputDirectory });
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runAsScript();
+}

--- a/calculogic-validator/test/fixtures/report-examples/validate-all.system.naming.report.example.json
+++ b/calculogic-validator/test/fixtures/report-examples/validate-all.system.naming.report.example.json
@@ -1,0 +1,134 @@
+{
+  "version": "0.1.0",
+  "mode": "report",
+  "scope": "system",
+  "validatorId": "runner",
+  "toolVersion": "0.1.0",
+  "validatorVersion": "0.1.0",
+  "sourceSnapshot": {
+    "source": "fs",
+    "gitRef": "HEAD",
+    "gitHeadSha": "<git-head-sha>",
+    "diagnostics": {
+      "isDirty": false,
+      "changedCount": 0,
+      "untrackedCount": 0
+    }
+  },
+  "startedAt": "<iso-startedAt>",
+  "endedAt": "<iso-endedAt>",
+  "durationMs": 0,
+  "validators": [
+    {
+      "id": "naming",
+      "validatorId": "naming",
+      "description": "Filename naming validator (report-mode).",
+      "scope": "system",
+      "totalFilesScanned": 7,
+      "counts": {
+        "canonical": 0,
+        "allowed-special-case": 7,
+        "legacy-exception": 0,
+        "invalid-ambiguous": 0
+      },
+      "codeCounts": {
+        "NAMING_ALLOWED_SPECIAL_CASE": 7
+      },
+      "specialCaseTypeCounts": {
+        "ecosystem-required": 7
+      },
+      "warningRoleStatusCounts": {},
+      "warningRoleCategoryCounts": {},
+      "findings": [
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "eslint.config.mjs",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        },
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "package-lock.json",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        },
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "package.json",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        },
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "tsconfig.app.json",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        },
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "tsconfig.json",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        },
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "tsconfig.node.json",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        },
+        {
+          "code": "NAMING_ALLOWED_SPECIAL_CASE",
+          "severity": "info",
+          "path": "vite.config.ts",
+          "classification": "allowed-special-case",
+          "message": "Filename matches an allowed reserved/special-case pattern.",
+          "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+          "details": {
+            "specialCaseType": "ecosystem-required"
+          }
+        }
+      ],
+      "meta": {
+        "registry": {
+          "registryState": "builtin",
+          "registrySource": "builtin",
+          "registryDigests": {
+            "builtin": "6ccd841392efca3462f440f27abc5a2a915b704f2beef49790d80b618d693c43",
+            "custom": "8d5ccfbe4cc90cf86d4b03abcc68e003d7f6f05b7508eb241c9b8d49ac29dd8f",
+            "resolved": "6ccd841392efca3462f440f27abc5a2a915b704f2beef49790d80b618d693c43"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/calculogic-validator/test/fixtures/report-examples/validate-naming.system.report.example.json
+++ b/calculogic-validator/test/fixtures/report-examples/validate-naming.system.report.example.json
@@ -1,0 +1,145 @@
+{
+  "mode": "report",
+  "validatorId": "naming",
+  "toolVersion": "0.1.0",
+  "validatorVersion": "0.1.0",
+  "sourceSnapshot": {
+    "source": "fs",
+    "gitRef": "HEAD",
+    "gitHeadSha": "<git-head-sha>",
+    "diagnostics": {
+      "isDirty": false,
+      "changedCount": 0,
+      "untrackedCount": 0
+    }
+  },
+  "registryState": "builtin",
+  "registrySource": "builtin",
+  "registryDigests": {
+    "builtin": "6ccd841392efca3462f440f27abc5a2a915b704f2beef49790d80b618d693c43",
+    "custom": "8d5ccfbe4cc90cf86d4b03abcc68e003d7f6f05b7508eb241c9b8d49ac29dd8f",
+    "resolved": "6ccd841392efca3462f440f27abc5a2a915b704f2beef49790d80b618d693c43"
+  },
+  "startedAt": "<iso-startedAt>",
+  "endedAt": "<iso-endedAt>",
+  "durationMs": 0,
+  "scope": "system",
+  "totalFilesScanned": 7,
+  "filters": {
+    "isFiltered": false
+  },
+  "scopeSummary": {
+    "scope": "system",
+    "reportableFilesInScope": 7,
+    "findingsGenerated": 7
+  },
+  "scopeContract": {
+    "description": "System/tooling files scan (root package/tsconfig/eslint/vite files).",
+    "includeRoots": [],
+    "includeRootFiles": [
+      "eslint.config.js",
+      "eslint.config.mjs",
+      "package-lock.json",
+      "package.json",
+      "tsconfig.app.json",
+      "tsconfig.json",
+      "tsconfig.node.json",
+      "vite.config.js",
+      "vite.config.mjs",
+      "vite.config.ts"
+    ]
+  },
+  "counts": {
+    "canonical": 0,
+    "allowed-special-case": 7,
+    "legacy-exception": 0,
+    "invalid-ambiguous": 0
+  },
+  "codeCounts": {
+    "NAMING_ALLOWED_SPECIAL_CASE": 7
+  },
+  "specialCaseTypeCounts": {
+    "ecosystem-required": 7
+  },
+  "warningRoleStatusCounts": {},
+  "warningRoleCategoryCounts": {},
+  "findings": [
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "eslint.config.mjs",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    },
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "package-lock.json",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    },
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "package.json",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    },
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "tsconfig.app.json",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    },
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "tsconfig.json",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    },
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "tsconfig.node.json",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    },
+    {
+      "code": "NAMING_ALLOWED_SPECIAL_CASE",
+      "severity": "info",
+      "path": "vite.config.ts",
+      "classification": "allowed-special-case",
+      "message": "Filename matches an allowed reserved/special-case pattern.",
+      "ruleRef": "calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#allowed-special-cases-and-reserved-filenames-v12",
+      "details": {
+        "specialCaseType": "ecosystem-required"
+      }
+    }
+  ]
+}

--- a/calculogic-validator/test/validator-report-examples-generation.test.mjs
+++ b/calculogic-validator/test/validator-report-examples-generation.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const runExampleGenerator = (outDir) =>
+  spawnSync(
+    process.execPath,
+    [
+      '--experimental-strip-types',
+      'calculogic-validator/scripts/generate-validator-report-examples.mjs',
+      `--out-dir=${outDir}`,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    },
+  );
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+const assertCommonEnvelope = (report) => {
+  assert.equal(report.mode, 'report');
+  assert.equal(report.startedAt, '<iso-startedAt>');
+  assert.equal(report.endedAt, '<iso-endedAt>');
+  assert.equal(report.durationMs, 0);
+  assert.ok(report.sourceSnapshot && typeof report.sourceSnapshot === 'object');
+
+  if (typeof report.sourceSnapshot.gitHeadSha === 'string') {
+    assert.equal(report.sourceSnapshot.gitHeadSha, '<git-head-sha>');
+  }
+
+  if (report.sourceSnapshot.diagnostics) {
+    assert.deepEqual(report.sourceSnapshot.diagnostics, {
+      isDirty: false,
+      changedCount: 0,
+      untrackedCount: 0,
+    });
+  }
+};
+
+test('validator report example generator emits deterministic naming and runner examples', () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'validator-report-examples-'));
+
+  const result = runExampleGenerator(outDir);
+  assert.equal(result.status, 0, result.stderr);
+
+  const namingFile = path.join(outDir, 'validate-naming.system.report.example.json');
+  const runnerFile = path.join(outDir, 'validate-all.system.naming.report.example.json');
+
+  assert.ok(fs.existsSync(namingFile));
+  assert.ok(fs.existsSync(runnerFile));
+
+  const namingReport = readJson(namingFile);
+  const runnerReport = readJson(runnerFile);
+
+  assertCommonEnvelope(namingReport);
+  assert.equal(namingReport.validatorId, 'naming');
+  assert.ok(Array.isArray(namingReport.findings));
+
+  assertCommonEnvelope(runnerReport);
+  assert.equal(runnerReport.validatorId, 'runner');
+  assert.ok(Array.isArray(runnerReport.validators));
+  assert.equal(runnerReport.validators.length, 1);
+  assert.equal(runnerReport.validators[0].validatorId, 'naming');
+
+  const secondResult = runExampleGenerator(outDir);
+  assert.equal(secondResult.status, 0, secondResult.stderr);
+
+  const namingReportSecond = readJson(namingFile);
+  const runnerReportSecond = readJson(runnerFile);
+
+  assert.deepEqual(namingReportSecond, namingReport);
+  assert.deepEqual(runnerReportSecond, runnerReport);
+});
+
+test('checked-in generated report examples match current generator output', () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'validator-report-examples-checked-in-'));
+
+  const result = runExampleGenerator(outDir);
+  assert.equal(result.status, 0, result.stderr);
+
+  const generatedNaming = readJson(path.join(outDir, 'validate-naming.system.report.example.json'));
+  const generatedRunner = readJson(path.join(outDir, 'validate-all.system.naming.report.example.json'));
+
+  const checkedInNaming = readJson(
+    'calculogic-validator/test/fixtures/report-examples/validate-naming.system.report.example.json',
+  );
+  const checkedInRunner = readJson(
+    'calculogic-validator/test/fixtures/report-examples/validate-all.system.naming.report.example.json',
+  );
+
+  assert.deepEqual(checkedInNaming, generatedNaming);
+  assert.deepEqual(checkedInRunner, generatedRunner);
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "report:tree:app": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-app -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=app",
     "report:tree:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=docs",
     "report:tree:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=validator",
-    "report:tree:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-system -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=system"
+    "report:tree:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-system -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.mjs --scope=system",
+    "report:examples:validator": "node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.mjs"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation

- Restore concrete current-runtime report examples for the validator schema without reintroducing hand-maintained drift by generating artifacts from real entrypoints. 
- Keep examples small, deterministic, and owned by the validator area so they remain illustrative rather than authoritative. 
- Provide an easy refresh workflow and lightweight tests to keep examples aligned with runtime behavior.

### Description

- Add a generator script `calculogic-validator/scripts/generate-validator-report-examples.mjs` that invokes runtime entrypoints (`validate-naming` and `validate-all`), captures their JSON stdout, applies bounded normalization, and writes artifacts.
- Write generated example artifacts into `calculogic-validator/test/fixtures/report-examples/` as:
  - `validate-naming.system.report.example.json`
  - `validate-all.system.naming.report.example.json`
- Normalize only unstable runtime fields for determinism: `startedAt`, `endedAt`, `durationMs`, `sourceSnapshot.gitHeadSha`, and `sourceSnapshot.diagnostics` counters; leave contract-significant fields (for example `mode`, `validatorId`, `toolVersion`/`validatorVersion`, summaries and findings) intact.
- Add a bounded test `calculogic-validator/test/validator-report-examples-generation.test.mjs` that verifies generation succeeds, output parses, normalized envelope expectations hold, generator is deterministic on repeated runs, and checked-in examples match freshly generated output.
- Update `calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md` with a short "Current generated examples" (Classification: Illustrative) section linking to the new artifacts and showing the refresh command: `node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.mjs`.
- Add a convenience npm script `report:examples:validator` that runs the generator.

### Testing

- Ran the generator directly with `node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.mjs`, which completed successfully. 
- Ran the new and existing tests together with `node --test --experimental-strip-types calculogic-validator/test/validator-report-examples-generation.test.mjs calculogic-validator/test/validator-report-schema.conformance.test.mjs`, and all tests passed (4 subtests; no failures).
- The test suite validates: generator exit status is `0`, produced files exist and parse, normalized fields match expectations, generator output is stable across repeated runs, and checked-in fixtures match generated output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82d8ace4083318b19afaa927d1922)