### PR TITLE
Clarify semantic-family wording: presence vs implementation ownership

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
+++ b/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
@@ -37,12 +37,12 @@ The semantic name is a high-priority filename interpretation lane directly below
 - Semantic name materially influences interpretation and diagnostics.
 - Semantic name does **not** override an explicit canonical dominant role slot.
 
-### 3.3 Optional semantic-family / semantic-group interpretation
+### 3.3 Semantic-family / semantic-group interpretation when filename shape supports it
 
-Semantic-family-like interpretation may exist and can be useful, but it is optional in this contract.
+Semantic-family-like interpretation is part of the intended naming-owned filename interpretation lane, but it only applies when filename shape exposes semantic-family/group structure.
 
-- It is not required as a structural lane for contract validity.
-- Slices may adopt it where ROI and domain semantics justify it.
+- Semantic-family/group presence is not required as a structural lane for contract validity in every filename.
+- Cross-slice contracts may reference it when naming exposes those outputs and ROI/domain semantics justify downstream use, while naming remains the primary derivation owner.
 
 ### 3.4 Folder-token context
 
@@ -61,7 +61,7 @@ Minimum precedence order:
 
 1. explicit canonical role slot
 2. semantic name lane
-3. optional semantic-family / semantic-group interpretation
+3. semantic-family / semantic-group interpretation when filename shape supports it
 4. folder-token context
 
 Deterministic precedence rule:
@@ -173,7 +173,7 @@ Classification: Normative
 
 - No runtime behavior changes in this task.
 - No requirement to implement all case lanes immediately.
-- No requirement to make semantic-family interpretation mandatory.
+- No requirement to make semantic-family/group presence mandatory in every filename shape.
 - No requirement to flatten naming logic into suite-core in this task.
 - No file renames/moves and no registry payload changes in this task.
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
@@ -2,7 +2,7 @@
 
 - **Classification:** Normative
 - **Applies to:** Naming-slice semantic-name interpretation extensions.
-- **Status:** Active for documentation-first modeling; runtime implementation deferred.
+- **Status:** Active for documentation-first modeling; semantic-family derivation remains an intended naming-owned implementation lane, but runtime activation in the current tranche is deferred.
 - **Authority posture note:** Bounded normative supporting spec for naming interpretation modeling; does not supersede primary canonical naming authorities.
 
 ## 1) Purpose
@@ -45,7 +45,7 @@ Current naming interpretation already provides bounded disambiguation hints in `
 
 Current baseline is already defined by existing specs:
 
-- shared filename interpretation precedence and optional semantic-family lane framing,
+- shared filename interpretation precedence and semantic-family lane framing that may or may not apply depending on semantic-name shape,
 - naming-slice semantic-name + role-token disambiguation framing,
 - suite-level registry model and normalization/resolution ownership boundaries.
 
@@ -53,7 +53,7 @@ Current baseline is already defined by existing specs:
 
 This spec adds a bounded interpretation vocabulary layer that was not yet explicitly defined:
 
-- first bounded naming entities for semantic-family interpretation,
+- first bounded naming entities for semantic-family interpretation when semantic-name shape supports that interpretation,
 - first bounded relationship types between those entities,
 - run-scoped normalized signal guidance for report/results consumption.
 
@@ -84,7 +84,7 @@ Classification: Normative
 
 Descriptive filename lane content already parsed below the canonical dominant role slot. It carries domain meaning and may contain role-like or category-adjacent vocabulary, without becoming a second canonical role declaration.
 
-`semantic-name` remains the full semantic lane before any role/ext interpretation and before any optional family/subgroup interpretation.
+`semantic-name` remains the full semantic lane before any role/ext interpretation and before any family/subgroup interpretation that may or may not apply for a given semantic-name shape.
 
 ### 4.2 `semantic-token`
 
@@ -171,7 +171,7 @@ Guardrail: this spec intentionally does not over-commit exact runtime field name
 
 ### 6.1 Bounded semantic-family interpretation grammar notes (report-first)
 
-Interpretation in this phase may apply bounded grammar-like guidance for semantic-family normalization.
+Interpretation in this phase may apply bounded grammar-like guidance for semantic-family normalization when the semantic-name shape supports family/subgroup interpretation.
 
 Connector-token guidance:
 
@@ -190,7 +190,7 @@ Descriptor-token guidance:
 
 Future policy direction (deferred):
 
-- These interpretation rules may later live in naming-owned semantic-family interpretation policy, registry-backed interpretation surfaces, and customizable commands/overrides.
+- These interpretation rules may later live in naming-owned semantic-family interpretation policy, registry-backed interpretation surfaces, and customizable commands/overrides once this intended naming-owned lane reaches later runtime/report maturity.
 - That policy/customization expansion is intentionally deferred until customization commands are no longer deferred and report maturity is stronger.
 
 Ownership clarification (naming-owned derived outputs):
@@ -219,16 +219,16 @@ Classification: Normative
 
 Current maturity boundary remains unchanged:
 
-- warn/error/strict/plan/fix behavior for semantic-family is deferred,
-- semantic-family interpretation is report-first in this phase,
+- warn/error/strict/plan/fix behavior for semantic-family is not implemented in the current runtime tranche yet,
+- semantic-family interpretation remains structurally important and report-first in this phase,
 - results/reporting is the first intended consumer,
-- tree runtime consumption is deferred until implementation maturity justifies it.
+- tree runtime consumption is not activated in this tranche yet and remains deferred until naming-owned implementation maturity justifies it.
 
 Results-first, tree-later handoff clarification:
 
 - Results/reporting consumes naming-owned semantic-family outputs first.
-- Tree consumption is later and explicitly deferred in this tranche.
-- Tree may later consume `semanticFamily`/`familyRoot`/`familySubgroup`/`relatedSemanticNames` for semantic-folder expectations or grouping reasoning.
+- Tree consumption is later and explicitly deferred in this tranche; that timing deferment does not make semantic-family derivation conceptually optional.
+- Tree may later consume `semanticFamily`/`familyRoot`/`familySubgroup`/`relatedSemanticNames` for semantic-folder expectations or grouping reasoning once naming emits those outputs.
 - Tree must not derive semantic-family independently as a competing source.
 
 Classification: Normative
@@ -237,9 +237,9 @@ Classification: Normative
 
 Future boundary contract:
 
-- naming owns semantic-family derivation,
-- tree may later consume prepared family/root/subgroup signals,
-- such signals may later help tree reason about expected semantic folders/subtrees,
+- naming owns semantic-family derivation as an intended implementation lane for later runtime/report/results maturity,
+- tree may later consume prepared family/root/subgroup signals produced by naming-owned derivation,
+- such signals may later help tree reason about expected semantic folders/subtrees, and tree behavior depends on naming providing them rather than re-deriving them,
 - tree must not independently derive semantic-family as a competing source of truth.
 
 Interpretation posture alignment:
@@ -315,7 +315,7 @@ Boundary reinforcement:
 - For this shape, semantic-family reasoning applies to the semantic-name portion that remains after the likely role candidate (`spec`) is separated.
 - `familyRoot`, `familySubgroup`, and `relatedSemanticNames` remain naming-owned derived outputs.
 - Those naming-owned outputs may later be handed to results first and tree later through cross-slice contracts.
-- Tree does not re-own semantic-family derivation in this model.
+- Tree does not re-own semantic-family derivation in this model and must remain downstream of naming-owned outputs.
 
 Classification: Normative
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md
@@ -37,7 +37,7 @@ Naming-slice interpretation precedence follows deterministic order:
 
 1. canonical dominant role slot
 2. semantic name lane
-3. optional semantic-family-style interpretation
+3. semantic-family-style interpretation when semantic-name shape supports it
 4. folder context
 
 Interpretation guardrail:
@@ -86,20 +86,20 @@ However, ambiguity signaling must not reinterpret or reassign explicit canonical
 
 Classification: Normative
 
-## 6) Optional Semantic-Family-Style Interpretation
+## 6) Semantic-Family-Style Interpretation When Shape Supports It
 
-Semantic-family-style grouping is an optional interpretation capability inside or around semantic naming.
+Semantic-family-style grouping is an intended naming-owned interpretation capability inside semantic naming, but it only applies when the semantic-name shape supports that interpretation.
 
 Rules:
 
-- It is not a required structural filename lane.
-- It may later be inferred, declared, or registry-assisted.
+- Semantic-family presence is not a required structural filename lane in every filename shape.
+- It may later be inferred, declared, or registry-assisted through naming-owned derivation.
 - It remains secondary to canonical dominant role ownership.
 - It remains subordinate to explicit ownership grammar.
 
 For bounded semantic-family entities/definitions/relationships and run-scoped interpreted-signal framing, see `../naming-owned/naming-semantic-family-and-interpretation-spec.md`.
 
-This section remains an interpretation option, not a mandatory runtime requirement.
+This section documents a naming-owned interpretation lane whose runtime implementation is not yet activated in the current tranche.
 
 Classification: Normative
 
@@ -113,13 +113,13 @@ Naming-slice specialization may define how shared case-policy surfaces apply to:
 
 - semantic-name lane text,
 - semantic-name token segments,
-- optional semantic-family-style segments,
+- semantic-family-style segments when the semantic-name shape exposes them,
 - role token segments in the explicit canonical role slot.
 
 Current runtime boundary for this specialization:
 
 - Implemented baseline: prepared semantic-name lane case-policy application, including bounded optional registry integration for semantic-name `caseRules`.
-- Future/optional expansion: additional family/group/folder lane-aware policy remains future-facing and is not required by the current runtime contract.
+- Future runtime expansion: additional family/group/folder lane-aware policy remains future-facing and is not required by the current runtime contract yet.
 
 Case-policy guardrail:
 
@@ -137,7 +137,7 @@ Classification: Illustrative
 
 - Canonical role: `contracts` (from explicit `.contracts.ts` slot)
 - Semantic name: `naming-role-matrix`
-- Optional semantic-family-style interpretation: `naming` family with `role-matrix` semantic grouping (optional)
+- Semantic-family-style interpretation when shape-supported: `naming` family with `role-matrix` semantic grouping
 - Why role-like tokens are not reclassified: explicit role slot already owns canonical role; `role` inside semantic name is descriptive text.
 
 ### 8.2 Role-like folder token with explicit role slot
@@ -146,7 +146,7 @@ Path example: `validators/host/naming-role-index.logic.mjs`
 
 - Canonical role: `logic` (from explicit `.logic.mjs` slot)
 - Semantic name: `naming-role-index`
-- Optional semantic-family-style interpretation: `naming` family with `role-index` grouping (optional)
+- Semantic-family-style interpretation when shape-supported: `naming` family with `role-index` grouping
 - Folder context: `host` is role-like but contextual in this interpretation lane
 - Why role-like tokens are not reclassified: explicit role slot remains authority; folder token and semantic-name token are contextual/semantic.
 
@@ -156,7 +156,7 @@ Filename example: `role-catalog-family-map.contracts.mjs`
 
 - Canonical role: `contracts`
 - Semantic name: `role-catalog-family-map`
-- Optional semantic-family-style interpretation: `catalog` or `family-map` grouping (optional and policy-dependent)
+- Semantic-family-style interpretation when shape-supported: `catalog` or `family-map` grouping (policy-dependent)
 - Why role-like tokens are not reclassified: `role` token is semantic reference content; explicit `.contracts.mjs` slot remains canonical ownership declaration.
 
 ## 9) Ambiguity Handling
@@ -179,7 +179,7 @@ Inherited shared concepts (not redefined here):
 
 - canonical dominant role slot as authoritative ownership lane,
 - semantic name as a major lane directly below canonical role,
-- optional semantic-family/semantic-group lane concept,
+- semantic-family/semantic-group lane concept when the semantic-name shape exposes it,
 - folder-token contextual interpretation,
 - shared case-policy contract surface.
 
@@ -187,7 +187,7 @@ Naming-slice-specific specialization in this spec:
 
 - how naming slice interprets semantic-name lane content,
 - default disambiguation behavior for role-like tokens in semantic/folder context,
-- optional semantic-family-style interpretation framing in naming slice,
+- semantic-family-style interpretation framing in naming slice when shape-supported,
 - naming-slice application points for shared case-policy surfaces.
 
 Classification: Normative
@@ -197,7 +197,7 @@ Classification: Normative
 This spec does not:
 
 - change runtime behavior,
-- require a mandatory semantic-family lane,
+- require semantic-family presence in every filename shape,
 - redefine suite-level core nouns,
 - finalize all future registry shapes,
 - rename files, move files, or mutate registry payloads.

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -90,7 +90,7 @@ Tree advisor may consume naming-shaped filename metadata as **structural signal 
 Tree advisor may use these parsed naming-shaped signals when present:
 
 - `semanticName`
-- semantic family/group derived from `semanticName`
+- semantic family/group outputs derived by naming from `semanticName`
 - `role`
 - role category/status metadata
 
@@ -280,12 +280,12 @@ V0.0.1 uses deterministic heuristics that are explainable in findings.
 
 ### 1) Semantic family cohesion
 
-Detect when a semantic family (shared `<semantic-name>` prefix) is scattered across too many unrelated folders.
+Detect when a naming-derived semantic family signal is scattered across too many unrelated folders.
 
 Example family keys:
 
 - exact semantic name: `validator-config`
-- configured “family prefix rule” (optional): `naming-rule-*` → family `naming-rule`
+- configured family-prefix rule when enabled: `naming-rule-*` → family `naming-rule`
 
 ### 2) Lane purity / entropy
 
@@ -363,7 +363,7 @@ Detect (deterministic):
 - A shared root is one of a configured set (V0.0.1 default example: `src/shared`).
 - The shared root contains lane-first partitions as immediate child folders (examples):
   - `logic`, `knowledge`, `results`, `build`, `build-style`, `results-style`, `tests`, `docs`
-- A semantic family (derived from parsed `<semantic-name>`) appears under >= 2 distinct lane-first partitions within that shared root.
+- A semantic family output supplied by naming (derived from parsed `<semantic-name>`) appears under >= 2 distinct lane-first partitions within that shared root.
 - Guardrail: only recommend when the family has >= 2 files (reduces churn/noise).
 
 Recommend (advisory):


### PR DESCRIPTION
### Motivation
- Fix ambiguous wording that made `semantic-family` sound like an optional implementation rather than an optionally-present filename segment while preserving the current runtime-deferred status.
- Ensure naming remains the authoritative owner of semantic-family derivation and that tree is described strictly as a downstream consumer, not an independent derivation source.

### Description
- Tightened the primary semantic-family spec so “optional” refers to the presence/shape of semantic-family structure in a filename and not to the conceptual/ownership importance of semantic-family derivation, and clarified that the naming-owned derivation lane is intended but not yet activated in the current runtime tranche. (file: `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md`)
- Updated naming disambiguation language to consistently state that semantic-family/style interpretation applies only when the `semantic-name` shape supports it and that its runtime implementation is not yet activated in this tranche. (file: `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md`)
- Adjusted the suite-level filename contract so “optional” no longer implies optional implementation ownership and now documents that semantic-family/group presence may be absent for some filename shapes while naming remains the primary derivation owner when present. (file: `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md`)
- Made bounded alignment edits in the tree advisor spec to state that tree consumes naming-derived semantic-family outputs (when supplied) rather than deriving semantic-family independently, and clarified that tree consumption is deferred until naming emits those outputs. (file: `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md`)
- Files changed: `naming-semantic-family-and-interpretation-spec.md`, `naming-semantic-name-and-role-disambiguation-spec.md`, `filename-case-and-interpretation-contract.md`, `tree-structure-advisor-validator-spec.md`; changes are limited wording clarifications only (no runtime or structural changes).

### Testing
- Ran targeted search checks to confirm ambiguous phrasing was removed or replaced with shape-dependent/maturity wording using pattern searches for prior ambiguous phrases; the search results validated the replacements succeeded.
- Ran `git diff --check` and inspected the diffs to ensure no trailing whitespace or obvious formatting errors; the check succeeded with no issues.
- Verified working-tree status to ensure only the intended spec files were modified; only the four docs listed above were changed and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba03798e648331a5a384567ba57846)