### PR TITLE
Stabilize ValidatorSpecs routing and references after ownership split

### DIFF
--- a/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
+++ b/calculogic-validator/doc/Indexes/ValidatorDocsIndex.md
@@ -2,6 +2,8 @@
 
 Purpose: quick routing map for validator documentation so readers can distinguish canonical contracts from drafts and implementation notes.
 
+Current `ValidatorSpecs` layout note: root-level files remain the stable canonical/shared entrypoints, while ownership-specialized supporting docs now live under `naming-owned/`, `tree-owned/`, `cross-cutting/`, and `suite-owned/`. Use the root entrypoints first, then drop into the ownership lane that matches the task.
+
 Authority labels used in this index:
 
 - **Canonical contract**: suite-wide normative contract; controls runtime-facing semantics within stated scope.

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg-inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg-inventory.md
@@ -21,7 +21,17 @@ It is intended to:
 - distinguish canonical authority from supporting, draft, and transitional materials,
 - provide a practical reading order for naming tasks,
 - record deterministic "stay put" vs "move/split/merge later" decisions,
-- reduce future setup/discovery friction without broad folder reorganization in this pass.
+- reduce future setup/discovery friction now that the ownership split is live, without proposing another broad folder reorganization.
+
+## Current Layout Snapshot
+
+Naming implementation discovery now follows a stable mixed-layout posture:
+
+- shared canonical entrypoints stay at `calculogic-validator/doc/ValidatorSpecs/` root when they are first-read cross-slice contracts,
+- naming-specialized supporting specs and routing metadata live under `calculogic-validator/doc/ValidatorSpecs/naming-owned/`,
+- cross-slice registry-model guidance lives under `calculogic-validator/doc/ValidatorSpecs/cross-cutting/` because its ownership is not naming-only.
+
+Use the root-level contract lane first, then continue into the naming-owned lane for supporting interpretation work.
 
 ## Canonical Reading Order (Naming Implementation Work)
 
@@ -77,7 +87,7 @@ Interpretation notes:
 - Keep `filename-case-and-interpretation-contract.md` at the `ValidatorSpecs` root because it is a shared contract lane used by multiple slices and already acts as a stable first-read contract surface.
 - Keep `naming-compatibility-inventory.md` outside the ownership buckets because it remains a cross-path transitional inventory rather than a validator-spec owner document.
 
-### Completed bounded move (this pass)
+### Completed bounded move (current layout)
 
 - Move naming-specialized supporting specs into `ValidatorSpecs/naming-owned/` so the naming-owned lane scans cleanly without disturbing canonical contract entrypoints.
 - Move `registry-model-and-slice-interaction-spec.md` into `ValidatorSpecs/cross-cutting/` because it constrains slice interaction and registry modeling across ownership boundaries rather than belonging purely to naming.

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md
@@ -97,7 +97,7 @@ Rules:
 - It remains secondary to canonical dominant role ownership.
 - It remains subordinate to explicit ownership grammar.
 
-For bounded semantic-family entities/definitions/relationships and run-scoped interpreted-signal framing, see `../naming-owned/naming-semantic-family-and-interpretation-spec.md`.
+For bounded semantic-family entities/definitions/relationships and run-scoped interpreted-signal framing, see `./naming-semantic-family-and-interpretation-spec.md`.
 
 This section documents a naming-owned interpretation lane whose runtime implementation is not yet activated in the current tranche.
 

--- a/calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md
@@ -19,9 +19,19 @@ It is intended to:
 - identify what documents currently exist for the tree implementation slice,
 - distinguish canonical runtime/spec authority from bounded normative supporting specs, supporting implementation guidance, draft references, and transitional metadata,
 - make explicit “stay put for now” vs “move/split/merge later” decisions,
-- reduce ambiguity for human maintainers and Codex task setup before any physical folder reorganization.
+- reduce ambiguity for human maintainers and Codex task setup now that the first ownership split has landed.
 
-Guardrail for this inventory pass: keep changes bounded to the tree NL/config note colocation move plus same-change-set cross-link updates (no broad folder reorganization).
+Guardrail for this stabilization pass: preserve the current physical layout, fix routing/discovery friction in place, and avoid proposing another broad folder reorganization.
+
+## Current Layout Snapshot
+
+Tree documentation discovery now follows a stable ownership split:
+
+- `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md` stays at the `ValidatorSpecs` root as the canonical tree slice entrypoint,
+- tree-specific supporting specs and routing metadata live under `calculogic-validator/doc/ValidatorSpecs/tree-owned/`,
+- the validator-owned tree NL/config note remains under `calculogic-validator/doc/ValidatorSpecs/nl-config/`.
+
+Read the root-level canonical tree spec first, then use the `tree-owned/` lane for supporting modeling/navigation material.
 
 ## Canonical Reading Order (Implementation Work)
 
@@ -53,13 +63,13 @@ Interpretation note:
 
 ## Reorg Recommendations (Bounded / First Move Completed)
 
-### Canonical now (do not relocate in this pass)
+### Canonical now (do not relocate in stabilization)
 
 - Keep suite contract in `ConventionRoutines` as validator-suite canonical authority.
 - Keep tree runtime spec in `ValidatorSpecs` as tree slice canonical authority.
 - Keep naming and naming-master docs in `ConventionRoutines` as cross-slice authorities consumed by tree.
 
-### Completed bounded move (this pass)
+### Completed bounded move (current layout)
 
 1. `doc/nl-config/cfg-treeStructureAdvisor.md` -> `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`
    - **Outcome:** completed earlier as a bounded colocation move with a tiny pointer stub left at the old path to preserve navigation continuity.


### PR DESCRIPTION
### Motivation
- Stabilize post-reorg routing and discovery for `calculogic-validator/doc/ValidatorSpecs/` so readers follow the new ownership buckets (`naming-owned/`, `tree-owned/`, `cross-cutting/`, `suite-owned/`) instead of a pre-bucket flat mental model.
- Remove remaining discovery friction and tighten one awkward same-lane link without doing any further physical moves or runtime changes.

### Description
- Clarified the canonical reading/navigation guidance by adding a brief `ValidatorSpecs` layout note to `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md` to explain root-level canonical entrypoints vs ownership lanes.
- Updated naming routing metadata in `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg-inventory.md` to add a `Current Layout Snapshot`, change move-status wording to reflect the landed layout, and emphasize using root entrypoints first.
- Updated tree routing metadata in `calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md` with a `Current Layout Snapshot`, stabilization guardrail wording, and normalized move-status language to the current layout posture.
- Tightened an awkward same-lane relative link in `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md` to point at the sibling `./naming-semantic-family-and-interpretation-spec.md` instead of a redundant parent-prefixed path.
- Files changed: `calculogic-validator/doc/Indexes/ValidatorDocsIndex.md`, `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg-inventory.md`, `calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md`, and `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation-spec.md`.

### Testing
- Ran repository pattern searches with `rg --fixed-strings` to look for stale pre-reorg flat `doc/ValidatorSpecs/...` references and confirmed no remaining exact old-path hits (searches succeeded with no unresolved stale matches).
- Validated relative Markdown links in the edited docs using a small Python check that extracts Markdown link targets and verifies they resolve, and all checked links resolved successfully (`All checked relative markdown links resolved.`).
- Re-ran targeted `rg` checks for the moved doc names (examples used in the acceptance criteria) and confirmed the repo no longer contains stale literal references to the old flat paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13fc3768833199493db954b6c31b)