### PR TITLE
docs: clarify naming-owned semantic-family report surfaces

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -323,6 +323,23 @@ When `--config=<path>` is supplied, report metadata may include:
 - `registrySource`
 - `registryDigests`
 
+### Semantic-family report surfaces (future/current-tranche direction)
+
+Current runtime contract remains the emitted surface listed above. This spec does **not** claim that semantic-family-derived report fields are already emitted today.
+
+When later naming-owned semantic-family reporting is implemented, slice-specific optional report surfaces may include:
+
+- per-file derived details when emitted from naming interpretation, such as `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, `relatedSemanticNames`, and ambiguity/split markers
+- run-level aggregate naming observations such as `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts`
+
+Boundary clarifications:
+
+- these are naming-owned observed report surfaces, not shared registry declarations
+- aggregate counts represent what a naming run observed after derivation; they are not policy truth by themselves
+- results/report interpretation may use them once emitted
+- tree may later consume naming-owned emitted surfaces rather than deriving semantic-family independently
+- later custom-registry work may review recurring observations as candidate evidence for additions, overlays, or pinning, but registry truth must still be declared through a separate policy/customization lane
+
 ### Special-case subtype metadata
 
 V0.1.2 keeps top-level classification `allowed-special-case` and includes deterministic subtype metadata in `details.specialCaseType`:

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -52,6 +52,12 @@ Current naming CLI output includes:
 - `registrySource` (`"builtin" | "custom" | "config"`)
 - `registryDigests` (object `{ builtin, custom, resolved }`)
 
+Slice-specific future-facing note (bounded, non-claiming):
+
+- Some slices may later document additional optional report surfaces before they become part of the canonical emitted contract.
+- For naming specifically, semantic-family-derived per-file details and aggregate observations (for example `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`) remain slice-specific optional/future-facing surfaces until runtime emission is actually shipped.
+- Observed aggregate fields, if/when emitted by a slice, are report observations rather than automatic registry/policy declarations.
+
 ## 4) Canonical current contract: Runner Report Envelope
 
 Current runner output includes:

--- a/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
+++ b/calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md
@@ -43,6 +43,7 @@ Semantic-family-like interpretation is part of the intended naming-owned filenam
 
 - Semantic-family/group presence is not required as a structural lane for contract validity in every filename.
 - Cross-slice contracts may reference it when naming exposes those outputs and ROI/domain semantics justify downstream use, while naming remains the primary derivation owner.
+- Any aggregate counts derived from semantic-family interpretation are naming-owned report observations when emitted, not automatic registry declarations.
 
 ### 3.4 Folder-token context
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
@@ -150,26 +150,44 @@ Classification: Normative
 
 Phase guidance:
 
+- semantic-family/group presence may or may not be present in a filename shape,
+- when filename shape does support semantic-family interpretation, naming remains the derivation owner,
 - semantic-family is interpreted first from current naming interpretation context,
 - normalized during the validator run,
 - temporarily held in runtime/report/results context,
 - not yet authoritative declared registry truth,
 - later custom registry/overlay work may declare, override, or pin meanings.
 
-Conceptual signal candidates for this phase (concept-first, field-name-flexible):
-
-- `semanticName`
-- `semanticTokens`
-- `semanticFamily`
-- `familyRoot`
-- `familySubgroup`
-- `relatedSemanticNames`
-- `ambiguityFlags`
-- `splitFamilyFlags`
-
 Guardrail: this spec intentionally does not over-commit exact runtime field names in this tranche.
 
-### 6.1 Bounded semantic-family interpretation grammar notes (report-first)
+### 6.1 Intended report/output layers (bounded next-tranche direction)
+
+The intended naming-owned report surfaces for semantic-family work are separated into bounded layers so observation does not get confused with policy.
+
+1. **Per-file derived outputs** capture naming's filename-level interpretation when the semantic-name shape supports it. Conceptual candidates in this layer include:
+   - `semanticName`
+   - `semanticTokens`
+   - `semanticFamily`
+   - `familyRoot`
+   - `familySubgroup`
+   - `relatedSemanticNames`
+   - ambiguity markers such as `ambiguityFlags`
+   - split markers such as `splitFamilyFlags`
+2. **Run-level aggregate observations** summarize what a naming run observed across files after derivation. Conceptual candidates in this layer include:
+   - `familyRootCounts`
+   - `familySubgroupCounts`
+   - `semanticFamilyCounts`
+3. **Later candidate-policy direction** may use recurring observed roots/subgroups/families as evidence for future custom-registry additions, overlays, or pinning. The report itself does **not** declare registry membership or convert an observed count into policy truth.
+
+Observation/policy boundary for this tranche:
+
+- per-file derived outputs are naming-owned interpreted results,
+- aggregate count surfaces are naming-owned observed run statistics,
+- `familyRootCounts.tree = 12` means the naming run observed 12 files whose derived `familyRoot` was `tree`,
+- that observation does **not** mean `tree` is now a declared registry root or registry-approved family,
+- later customization/registry work may review these observations as candidate evidence, but policy declaration remains a separate later ownership lane.
+
+### 6.2 Bounded semantic-family interpretation grammar notes (report-first)
 
 Interpretation in this phase may apply bounded grammar-like guidance for semantic-family normalization when the semantic-name shape supports family/subgroup interpretation.
 
@@ -191,6 +209,8 @@ Descriptor-token guidance:
 Future policy direction (deferred):
 
 - These interpretation rules may later live in naming-owned semantic-family interpretation policy, registry-backed interpretation surfaces, and customizable commands/overrides once this intended naming-owned lane reaches later runtime/report maturity.
+- Recurring aggregate observations such as `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` may later be reviewed as candidate evidence for what should be added, pinned, or overridden in a custom registry.
+- Those observed counts remain report evidence only; they do **not** become registry truth unless a later policy/customization surface explicitly declares them.
 - That policy/customization expansion is intentionally deferred until customization commands are no longer deferred and report maturity is stronger.
 
 Ownership clarification (naming-owned derived outputs):
@@ -229,6 +249,7 @@ Results-first, tree-later handoff clarification:
 - Results/reporting consumes naming-owned semantic-family outputs first.
 - Tree consumption is later and explicitly deferred in this tranche; that timing deferment does not make semantic-family derivation conceptually optional.
 - Tree may later consume `semanticFamily`/`familyRoot`/`familySubgroup`/`relatedSemanticNames` for semantic-folder expectations or grouping reasoning once naming emits those outputs.
+- Tree may later consume naming-owned aggregate observations such as `familyRootCounts`/`familySubgroupCounts`/`semanticFamilyCounts` only as report context, not as tree-owned policy declaration.
 - Tree must not derive semantic-family independently as a competing source.
 
 Classification: Normative
@@ -239,6 +260,7 @@ Future boundary contract:
 
 - naming owns semantic-family derivation as an intended implementation lane for later runtime/report/results maturity,
 - tree may later consume prepared family/root/subgroup signals produced by naming-owned derivation,
+- tree may later consume naming-owned aggregate observations as downstream context when useful,
 - such signals may later help tree reason about expected semantic folders/subtrees, and tree behavior depends on naming providing them rather than re-deriving them,
 - tree must not independently derive semantic-family as a competing source of truth.
 

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator-spec.md
@@ -101,6 +101,7 @@ When naming-derived signal input is explicitly wired in later, intended consumab
 
 - `semanticName`
 - semantic family/group outputs derived by naming from `semanticName`
+- naming-owned aggregate observations such as `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` when/if naming later emits them
 - `role`
 - role category/status metadata
 
@@ -113,7 +114,7 @@ Examples of naming validity judgments that tree advisor must not duplicate:
 - deprecated role
 - hyphen-role ambiguity
 
-When usable naming-shaped metadata is unavailable, incomplete, or not yet wired into tree runtime, tree advisor should reduce confidence and/or recommend running naming validation rather than inventing naming-invalid findings inside tree output.
+When usable naming-shaped metadata is unavailable, incomplete, or not yet wired into tree runtime, tree advisor should reduce confidence and/or recommend running naming validation rather than inventing naming-invalid findings inside tree output. Naming-owned aggregate observations are downstream evidence only and do not let tree declare registry truth on its own.
 
 Boundary note (canonical_target for this slice): tree validator ownership is under `calculogic-validator/tree/src/**`. Legacy flat suite-core paths such as `calculogic-validator/src/tree-structure-advisor.*.mjs` are compatibility wrappers only, not canonical ownership.
 


### PR DESCRIPTION
### Motivation
- Move the semantic-family modeling from documentation-only framing toward a naming-owned, naming-first report surface while preserving that runtime emission is deferred in this tranche. 
- Make the ownership/consumption boundary explicit so naming is the derivation owner, tree becomes a later consumer, and aggregate counts are treated as observations not registry truth. 
- Keep the change documentation-only: no runtime behavior, no reorg, and no registry or tree implementation changes are made.

### Description
- Tighten `naming-semantic-family-and-interpretation-spec.md` to explicitly separate intended naming-owned report/output layers into per-file derived outputs (for example `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, `relatedSemanticNames`, ambiguity/split markers), run-level aggregate observations (for example `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`), and a later candidate-policy direction that may use recurring observations as evidence. 
- Extend `NamingValidatorSpec.md` with a bounded “future/current-tranche direction” section that honestly makes room for optional slice-specific semantic-family per-file fields and run-level aggregate fields when implemented (and emphasizes that these fields are not claimed as currently emitted). 
- Make a small, non-claiming alignment note in `ValidatorReportSchema-V0_1.md` that slice-specific optional/future-facing fields may exist before being promoted to the canonical emitted contract, and that observed aggregate fields are report observations not automatic registry/policy declarations. 
- Add minimal boundary-preserving wording in `filename-case-and-interpretation-contract.md` and `tree-structure-advisor-validator-spec.md` so the shared contract and tree guidance consistently state that naming derives semantic-family signals, tree may later consume naming-owned outputs (including aggregates) as context only, and observed counts do not equal registry truth.

### Testing
- Ran `git diff --check` to validate there are no whitespace/indexing issues and it completed with no errors. 
- Ran `git status --short` to confirm the intended docs were staged/committed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba32f012e8833187cec97a5102f52e)