### PR TITLE
Implement naming semantic-family derivation and report aggregates (report-first tranche)

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -313,7 +313,7 @@ Report object includes (canonical current contract for naming slice output):
 - `filters`
 - `scopeSummary`
 - `scopeContract`
-- summary count objects (`counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`)
+- summary count objects (`counts`, `codeCounts`, `specialCaseTypeCounts`, `warningRoleStatusCounts`, `warningRoleCategoryCounts`, `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`)
 - `findings`
 
 When `--config=<path>` is supplied, report metadata may include:
@@ -323,20 +323,18 @@ When `--config=<path>` is supplied, report metadata may include:
 - `registrySource`
 - `registryDigests`
 
-### Semantic-family report surfaces (future/current-tranche direction)
+### Semantic-family report surfaces (current emitted behavior)
 
-Current runtime contract remains the emitted surface listed above. This spec does **not** claim that semantic-family-derived report fields are already emitted today.
+Current naming runtime now emits bounded naming-owned semantic-family report surfaces in two layers:
 
-When later naming-owned semantic-family reporting is implemented, slice-specific optional report surfaces may include:
-
-- per-file derived details when emitted from naming interpretation, such as `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, `relatedSemanticNames`, and ambiguity/split markers
-- run-level aggregate naming observations such as `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts`
+- per-file derived details in `finding.details` when the semantic-name shape supports deterministic semantic-family interpretation, currently including `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, and run-scoped `relatedSemanticNames` when another same-family semantic name is observed in the run
+- run-level aggregate naming observations in the report envelope: `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts`
 
 Boundary clarifications:
 
 - these are naming-owned observed report surfaces, not shared registry declarations
 - aggregate counts represent what a naming run observed after derivation; they are not policy truth by themselves
-- results/report interpretation may use them once emitted
+- current runtime only emits these derived details when the semantic-name shape supports bounded deterministic interpretation; it does not force every filename to have family outputs
 - tree may later consume naming-owned emitted surfaces rather than deriving semantic-family independently
 - later custom-registry work may review recurring observations as candidate evidence for additions, overlays, or pinning, but registry truth must still be declared through a separate policy/customization lane
 

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -42,6 +42,9 @@ Current naming CLI output includes:
 - `specialCaseTypeCounts` (object)
 - `warningRoleStatusCounts` (object)
 - `warningRoleCategoryCounts` (object)
+- `familyRootCounts` (object; naming-observed derived family-root counts for this run)
+- `familySubgroupCounts` (object; naming-observed derived family-subgroup counts for this run)
+- `semanticFamilyCounts` (object; naming-observed derived semantic-family counts for this run)
 - `findings` (array)
 
 ### Optional / transitional fields
@@ -52,11 +55,11 @@ Current naming CLI output includes:
 - `registrySource` (`"builtin" | "custom" | "config"`)
 - `registryDigests` (object `{ builtin, custom, resolved }`)
 
-Slice-specific future-facing note (bounded, non-claiming):
+Slice-specific note (current naming emitted behavior):
 
-- Some slices may later document additional optional report surfaces before they become part of the canonical emitted contract.
-- For naming specifically, semantic-family-derived per-file details and aggregate observations (for example `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`) remain slice-specific optional/future-facing surfaces until runtime emission is actually shipped.
-- Observed aggregate fields, if/when emitted by a slice, are report observations rather than automatic registry/policy declarations.
+- Naming now emits bounded semantic-family-derived per-file details inside `finding.details` when the semantic-name shape supports deterministic derivation. Current derived fields include `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, and run-scoped `relatedSemanticNames` when observed.
+- Naming now also emits `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` at the slice-report top level.
+- These aggregate fields are report observations rather than automatic registry/policy declarations.
 
 ## 4) Canonical current contract: Runner Report Envelope
 
@@ -98,7 +101,7 @@ Entry-level optional fields:
   - `meta.filters` (object; present when target filtering is active)
   - `meta.registry` (object; present when slice exposes registry metadata)
 
-Runner currently passes through deterministic slice summary fields in addition to `counts` (for example naming `codeCounts` and tree `codeCounts`).
+Runner currently passes through deterministic slice summary fields in addition to `counts` (for example naming `codeCounts`, `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`, and tree `codeCounts`).
 
 ## 6) Canonical current contract: Finding Object Baseline
 

--- a/calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs
@@ -50,6 +50,9 @@ export const buildNamingValidatorReport = ({
     specialCaseTypeCounts: summary.specialCaseTypeCounts,
     warningRoleStatusCounts: summary.warningRoleStatusCounts,
     warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
+    familyRootCounts: summary.familyRootCounts,
+    familySubgroupCounts: summary.familySubgroupCounts,
+    semanticFamilyCounts: summary.semanticFamilyCounts,
     findings,
   };
 };

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -18,6 +18,10 @@ import { hasHyphenAppendedRoleAmbiguity } from './rules/naming-rule-check-hyphen
 import { isCanonicalSemanticName } from './rules/naming-rule-check-semantic-case.logic.mjs';
 import { deriveDisambiguationHints } from './rules/naming-rule-derive-disambiguation-hints.logic.mjs';
 import {
+  deriveSemanticFamilyDetails,
+  attachRelatedSemanticNames,
+} from './rules/naming-rule-derive-semantic-family.logic.mjs';
+import {
   getRoleMetadata,
   isDeprecatedRole,
   isUnknownOrInactiveRole,
@@ -368,6 +372,9 @@ export const classifyPath = (
       });
     }
 
+    const semanticFamilyDetails = deriveSemanticFamilyDetails({
+      semanticName: parsed.semanticName,
+    });
     const disambiguationHints = deriveDisambiguationHints({
       normalizedPath,
       parsed,
@@ -382,6 +389,7 @@ export const classifyPath = (
         ...parsed,
         roleStatus: roleMetadata.status,
         roleCategory: roleMetadata.category,
+        ...(semanticFamilyDetails ?? {}),
         ...(disambiguationHints ? { disambiguation: disambiguationHints } : {}),
       },
     });
@@ -425,13 +433,15 @@ export const runNamingValidator = (preparedInputs = {}) => {
     preparedInputs.findingPolicyRuntime,
   );
   const caseRulesRuntime = assertPreparedCaseRulesRuntime(preparedInputs.caseRulesRuntime);
-  const findings = selectedPaths.map((pathname) =>
-    classifyPath(
-      pathname,
-      namingRolesRuntime,
-      missingRolePatternsRuntime,
-      findingPolicyRuntime,
-      caseRulesRuntime,
+  const findings = attachRelatedSemanticNames(
+    selectedPaths.map((pathname) =>
+      classifyPath(
+        pathname,
+        namingRolesRuntime,
+        missingRolePatternsRuntime,
+        findingPolicyRuntime,
+        caseRulesRuntime,
+      ),
     ),
   );
 
@@ -475,6 +485,10 @@ export const summarizeFindings = (findings, summaryBucketsRuntime) => {
     summaryBuckets.secondaryBucketFamilies.map((bucketFamily) => [bucketFamily, {}]),
   );
 
+  secondaryCountsByFamily.familyRootCounts ??= {};
+  secondaryCountsByFamily.familySubgroupCounts ??= {};
+  secondaryCountsByFamily.semanticFamilyCounts ??= {};
+
   const incrementSecondaryFamilyCounter = (bucketFamily, counterKey) => {
     if (!secondaryCountsByFamily[bucketFamily]) {
       return;
@@ -498,6 +512,18 @@ export const summarizeFindings = (findings, summaryBucketsRuntime) => {
     if (finding.severity === 'warn' && finding.details?.roleCategory) {
       incrementSecondaryFamilyCounter('warningRoleCategoryCounts', finding.details.roleCategory);
     }
+
+    if (finding.details?.familyRoot) {
+      incrementSecondaryFamilyCounter('familyRootCounts', finding.details.familyRoot);
+    }
+
+    if (finding.details?.familySubgroup) {
+      incrementSecondaryFamilyCounter('familySubgroupCounts', finding.details.familySubgroup);
+    }
+
+    if (finding.details?.semanticFamily) {
+      incrementSecondaryFamilyCounter('semanticFamilyCounts', finding.details.semanticFamily);
+    }
   }
 
   return {
@@ -506,5 +532,8 @@ export const summarizeFindings = (findings, summaryBucketsRuntime) => {
     specialCaseTypeCounts: sortCountObject(secondaryCountsByFamily.specialCaseTypeCounts ?? {}),
     warningRoleStatusCounts: sortCountObject(secondaryCountsByFamily.warningRoleStatusCounts ?? {}),
     warningRoleCategoryCounts: sortCountObject(secondaryCountsByFamily.warningRoleCategoryCounts ?? {}),
+    familyRootCounts: sortCountObject(secondaryCountsByFamily.familyRootCounts ?? {}),
+    familySubgroupCounts: sortCountObject(secondaryCountsByFamily.familySubgroupCounts ?? {}),
+    semanticFamilyCounts: sortCountObject(secondaryCountsByFamily.semanticFamilyCounts ?? {}),
   };
 };

--- a/calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs
+++ b/calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs
@@ -1,0 +1,103 @@
+export const CONNECTOR_TOKENS = new Set(['and', 'or', 'with']);
+
+const splitSemanticTokens = (semanticName) =>
+  semanticName.split(/[-.]/u).map((token) => token.trim()).filter(Boolean);
+
+const toSortedUnique = (values) => Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+
+const deriveFamilyGrouping = (semanticTokens) => {
+  const hasConnectorToken = semanticTokens.slice(1).some((token) => CONNECTOR_TOKENS.has(token));
+
+  if (hasConnectorToken) {
+    return {
+      semanticFamily: semanticTokens[0],
+      familyRoot: semanticTokens[0],
+      familySubgroupTokens: semanticTokens.slice(1),
+    };
+  }
+
+  if (semanticTokens.length >= 4) {
+    return {
+      semanticFamily: semanticTokens.slice(0, 2).join('-'),
+      familyRoot: semanticTokens[0],
+      familySubgroupTokens: semanticTokens.slice(1, -1),
+    };
+  }
+
+  return {
+    semanticFamily: semanticTokens[0],
+    familyRoot: semanticTokens[0],
+    familySubgroupTokens: semanticTokens.slice(1),
+  };
+};
+
+export const deriveSemanticFamilyDetails = ({ semanticName }) => {
+  const semanticTokens = splitSemanticTokens(semanticName);
+
+  if (semanticTokens.length < 2) {
+    return null;
+  }
+
+  const grouping = deriveFamilyGrouping(semanticTokens);
+  const familySubgroup = grouping.familySubgroupTokens.length > 0
+    ? grouping.familySubgroupTokens.join('-')
+    : undefined;
+
+  return {
+    semanticTokens,
+    semanticFamily: grouping.semanticFamily,
+    familyRoot: grouping.familyRoot,
+    ...(familySubgroup ? { familySubgroup } : {}),
+  };
+};
+
+export const attachRelatedSemanticNames = (findings) => {
+  const semanticNamesByFamily = new Map();
+
+  for (const finding of findings) {
+    const semanticFamily = finding.details?.semanticFamily;
+    const semanticName = finding.details?.semanticName;
+
+    if (!semanticFamily || !semanticName) {
+      continue;
+    }
+
+    if (!semanticNamesByFamily.has(semanticFamily)) {
+      semanticNamesByFamily.set(semanticFamily, []);
+    }
+
+    semanticNamesByFamily.get(semanticFamily).push(semanticName);
+  }
+
+  const relatedSemanticNamesByFamily = new Map(
+    Array.from(semanticNamesByFamily.entries(), ([semanticFamily, semanticNames]) => [
+      semanticFamily,
+      toSortedUnique(semanticNames),
+    ]),
+  );
+
+  return findings.map((finding) => {
+    const semanticFamily = finding.details?.semanticFamily;
+    const semanticName = finding.details?.semanticName;
+
+    if (!semanticFamily || !semanticName) {
+      return finding;
+    }
+
+    const relatedSemanticNames = (relatedSemanticNamesByFamily.get(semanticFamily) ?? []).filter(
+      (candidateSemanticName) => candidateSemanticName !== semanticName,
+    );
+
+    if (relatedSemanticNames.length === 0) {
+      return finding;
+    }
+
+    return {
+      ...finding,
+      details: {
+        ...finding.details,
+        relatedSemanticNames,
+      },
+    };
+  });
+};

--- a/calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs
+++ b/calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  deriveSemanticFamilyDetails,
+  attachRelatedSemanticNames,
+} from '../src/rules/naming-rule-derive-semantic-family.logic.mjs';
+import { summarizeFindings } from '../src/naming-validator.host.mjs';
+
+test('derives bounded semantic-family details for supported list-like semantic-name shapes', () => {
+  assert.deepEqual(deriveSemanticFamilyDetails({ semanticName: 'order-payment-refund-reconcile' }), {
+    semanticTokens: ['order', 'payment', 'refund', 'reconcile'],
+    semanticFamily: 'order-payment',
+    familyRoot: 'order',
+    familySubgroup: 'payment-refund',
+  });
+});
+
+test('derives connector-aware subgroup details without promoting connectors to family roots', () => {
+  assert.deepEqual(
+    deriveSemanticFamilyDetails({ semanticName: 'tree-occurrence-model-and-addressing' }),
+    {
+      semanticTokens: ['tree', 'occurrence', 'model', 'and', 'addressing'],
+      semanticFamily: 'tree',
+      familyRoot: 'tree',
+      familySubgroup: 'occurrence-model-and-addressing',
+    },
+  );
+});
+
+test('derives bounded subgroup details for shorter supported semantic-name shapes', () => {
+  assert.deepEqual(deriveSemanticFamilyDetails({ semanticName: 'naming-role-index' }), {
+    semanticTokens: ['naming', 'role', 'index'],
+    semanticFamily: 'naming',
+    familyRoot: 'naming',
+    familySubgroup: 'role-index',
+  });
+});
+
+test('does not derive semantic-family details for unsupported single-token semantic-name shapes', () => {
+  assert.equal(deriveSemanticFamilyDetails({ semanticName: 'tree' }), null);
+});
+
+test('attaches related semantic names by observed semantic-family clusters only', () => {
+  const findings = attachRelatedSemanticNames([
+    {
+      path: 'a',
+      details: {
+        semanticName: 'naming-role-index',
+        semanticFamily: 'naming',
+      },
+    },
+    {
+      path: 'b',
+      details: {
+        semanticName: 'naming-role-matrix',
+        semanticFamily: 'naming',
+      },
+    },
+    {
+      path: 'c',
+      details: {
+        semanticName: 'tree-occurrence-model-and-addressing',
+        semanticFamily: 'tree',
+      },
+    },
+  ]);
+
+  assert.deepEqual(findings[0].details.relatedSemanticNames, ['naming-role-matrix']);
+  assert.deepEqual(findings[1].details.relatedSemanticNames, ['naming-role-index']);
+  assert.equal(findings[2].details.relatedSemanticNames, undefined);
+});
+
+test('summary emits deterministic semantic-family observation counts from derived details', () => {
+  const summary = summarizeFindings([
+    {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      severity: 'info',
+      details: {
+        familyRoot: 'tree',
+        familySubgroup: 'occurrence-model-and-addressing',
+        semanticFamily: 'tree',
+      },
+    },
+    {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      severity: 'info',
+      details: {
+        familyRoot: 'naming',
+        familySubgroup: 'role-index',
+        semanticFamily: 'naming',
+      },
+    },
+    {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      severity: 'info',
+      details: {
+        familyRoot: 'naming',
+        familySubgroup: 'role-matrix',
+        semanticFamily: 'naming',
+      },
+    },
+  ]);
+
+  assert.deepEqual(summary.familyRootCounts, {
+    naming: 2,
+    tree: 1,
+  });
+  assert.deepEqual(summary.familySubgroupCounts, {
+    'occurrence-model-and-addressing': 1,
+    'role-index': 1,
+    'role-matrix': 1,
+  });
+  assert.deepEqual(summary.semanticFamilyCounts, {
+    naming: 2,
+    tree: 1,
+  });
+});

--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -9,6 +9,7 @@ import {
   parseCanonicalName,
   collectRepositoryPaths,
   summarizeFindings,
+  runNamingValidator,
 } from '../src/naming-validator.host.mjs';
 
 test('parse canonical filename with simple extension', () => {
@@ -152,6 +153,51 @@ disambiguationPrecedenceCases.forEach(({ name, inputPath, expected }) => {
       assert.equal(finding.suggestedFix, expected.suggestedFix);
     }
   });
+});
+
+
+
+test('classifies canonical file with semantic-family derived details when shape is supported', () => {
+  const finding = classifyPath('src/order-payment-refund-reconcile.logic.mjs');
+
+  assert.equal(finding.classification, 'canonical');
+  assert.equal(finding.code, 'NAMING_CANONICAL');
+  assert.deepEqual(finding.details?.semanticTokens, ['order', 'payment', 'refund', 'reconcile']);
+  assert.equal(finding.details?.semanticFamily, 'order-payment');
+  assert.equal(finding.details?.familyRoot, 'order');
+  assert.equal(finding.details?.familySubgroup, 'payment-refund');
+});
+
+test('runNamingValidator attaches run-scoped related semantic names without coupling tree runtime', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-semantic-family-run-'));
+
+  try {
+    fs.mkdirSync(path.join(tempRoot, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tempRoot, 'src', 'naming-role-index.logic.mjs'), 'export const index = 1;\n');
+    fs.writeFileSync(path.join(tempRoot, 'src', 'naming-role-matrix.logic.mjs'), 'export const matrix = 1;\n');
+    fs.writeFileSync(path.join(tempRoot, 'src', 'tree.logic.mjs'), 'export const tree = 1;\n');
+
+    const result = runNamingValidator(tempRoot, { scope: 'app', targets: ['src'] });
+    const report = {
+      ...result,
+      ...summarizeFindings(result.findings),
+    };
+    const indexFinding = report.findings.find((finding) => finding.path === 'src/naming-role-index.logic.mjs');
+    const matrixFinding = report.findings.find((finding) => finding.path === 'src/naming-role-matrix.logic.mjs');
+    const treeFinding = report.findings.find((finding) => finding.path === 'src/tree.logic.mjs');
+
+    assert.deepEqual(indexFinding?.details?.relatedSemanticNames, ['naming-role-matrix']);
+    assert.deepEqual(matrixFinding?.details?.relatedSemanticNames, ['naming-role-index']);
+    assert.equal(treeFinding?.details?.relatedSemanticNames, undefined);
+    assert.deepEqual(report.familyRootCounts, { naming: 2 });
+    assert.deepEqual(report.familySubgroupCounts, {
+      'role-index': 1,
+      'role-matrix': 1,
+    });
+    assert.deepEqual(report.semanticFamilyCounts, { naming: 2 });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test('classifies semantic-name casing violation as invalid-ambiguous', () => {
@@ -333,6 +379,9 @@ test('summary keeps default classification buckets and empty secondary families 
   assert.deepEqual(summary.specialCaseTypeCounts, {});
   assert.deepEqual(summary.warningRoleStatusCounts, {});
   assert.deepEqual(summary.warningRoleCategoryCounts, {});
+  assert.deepEqual(summary.familyRootCounts, {});
+  assert.deepEqual(summary.familySubgroupCounts, {});
+  assert.deepEqual(summary.semanticFamilyCounts, {});
 });
 
 test('summary preserves deterministic ordering and warning facet behavior', () => {
@@ -378,4 +427,7 @@ test('summary preserves deterministic ordering and warning facet behavior', () =
     'architecture-support': 1,
     documentation: 1,
   });
+  assert.deepEqual(summary.familyRootCounts, {});
+  assert.deepEqual(summary.familySubgroupCounts, {});
+  assert.deepEqual(summary.semanticFamilyCounts, {});
 });

--- a/calculogic-validator/test/fixtures/report-examples/validate-all.system.naming.report.example.json
+++ b/calculogic-validator/test/fixtures/report-examples/validate-all.system.naming.report.example.json
@@ -39,6 +39,9 @@
       },
       "warningRoleStatusCounts": {},
       "warningRoleCategoryCounts": {},
+      "familyRootCounts": {},
+      "familySubgroupCounts": {},
+      "semanticFamilyCounts": {},
       "findings": [
         {
           "code": "NAMING_ALLOWED_SPECIAL_CASE",

--- a/calculogic-validator/test/fixtures/report-examples/validate-naming.system.report.example.json
+++ b/calculogic-validator/test/fixtures/report-examples/validate-naming.system.report.example.json
@@ -63,6 +63,9 @@
   },
   "warningRoleStatusCounts": {},
   "warningRoleCategoryCounts": {},
+  "familyRootCounts": {},
+  "familySubgroupCounts": {},
+  "semanticFamilyCounts": {},
   "findings": [
     {
       "code": "NAMING_ALLOWED_SPECIAL_CASE",

--- a/calculogic-validator/test/validator-report-schema.conformance.test.mjs
+++ b/calculogic-validator/test/validator-report-schema.conformance.test.mjs
@@ -32,6 +32,9 @@ test('validate-naming emits current slice report envelope and finding identifier
   assert.equal(typeof report.totalFilesScanned, 'number');
   assert.ok(report.counts && typeof report.counts === 'object');
   assert.ok(report.codeCounts && typeof report.codeCounts === 'object');
+  assert.ok(report.familyRootCounts && typeof report.familyRootCounts === 'object');
+  assert.ok(report.familySubgroupCounts && typeof report.familySubgroupCounts === 'object');
+  assert.ok(report.semanticFamilyCounts && typeof report.semanticFamilyCounts === 'object');
   assert.ok(Array.isArray(report.findings));
 
   for (const finding of report.findings) {
@@ -70,6 +73,9 @@ test('validate-all emits current runner report envelope and forwards configDiges
   assert.equal(namingEntry.validatorId, 'naming');
   assert.equal(typeof namingEntry.description, 'string');
   assert.equal(typeof namingEntry.totalFilesScanned, 'number');
+  assert.ok(namingEntry.familyRootCounts && typeof namingEntry.familyRootCounts === 'object');
+  assert.ok(namingEntry.familySubgroupCounts && typeof namingEntry.familySubgroupCounts === 'object');
+  assert.ok(namingEntry.semanticFamilyCounts && typeof namingEntry.semanticFamilyCounts === 'object');
   assert.ok(Array.isArray(namingEntry.findings));
 
   for (const finding of namingEntry.findings) {


### PR DESCRIPTION
### Motivation

- Provide a bounded naming-owned implementation for semantic-family derivation so naming remains the single derivation owner when semantic-name shapes support it. 
- Surface per-file semantic-family signals in the existing naming report (report-first) and add deterministic run-level aggregate observations for downstream visibility. 
- Preserve the observation vs policy boundary so aggregates are reported as run-scoped evidence only and do not change registry/policy truth or tree behavior in this tranche.

### Description

- Added a naming-owned derivation helper at `naming/src/rules/naming-rule-derive-semantic-family.logic.mjs` that deterministically derives `semanticTokens`, `semanticFamily`, `familyRoot`, and `familySubgroup` for supported semantic-name shapes and exposes `attachRelatedSemanticNames` to compute run-scoped `relatedSemanticNames` clusters. 
- Wired derivation into the existing interpretation flow by calling `deriveSemanticFamilyDetails(...)` inside `classifyPath(...)` and emitting derived per-file fields inside the existing `finding.details` object to avoid creating a separate per-file manifest. 
- Implemented run-level deterministic aggregates in `summarizeFindings(...)` by counting observed `familyRoot`, `familySubgroup`, and `semanticFamily` values and added `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` to the naming report builder (`naming/src/cli/naming-report-builder.logic.mjs`) and runner passthrough. 
- Updated documentation to reflect current emitted reality by editing `doc/ConventionRoutines/NamingValidatorSpec.md` and `doc/ConventionRoutines/ValidatorReportSchema-V0_1.md`, refreshed checked-in report examples, and added focused tests at `naming/test/naming-semantic-family-derivation.test.mjs` and updates to `naming/test/naming-validator.test.mjs` and schema conformance tests to validate the new surfaces. 
- Kept scope bounded and deferred further work: no registry pinning/overlays, no policy enforcement from counts, no tree-side consumption or re-derivation, and ambiguity/split-family policy expansion is intentionally out of scope for this tranche.

### Testing

- Ran the focused unit/integration tests with `node --test calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs calculogic-validator/naming/test/naming-validator.test.mjs calculogic-validator/test/validator-report-schema.conformance.test.mjs calculogic-validator/test/validator-report-examples-generation.test.mjs` and all tests passed. 
- Executed the naming script `node --experimental-strip-types calculogic-validator/scripts/validate-naming.mjs --scope=system` which produced a valid naming report including the new aggregate fields. 
- Regenerated report examples with `node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.mjs` and refreshed the checked-in example fixtures successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba41a38c90833187ca3aeb48e9dea9)