### PR TITLE
Tighten naming semantic-family evidence semantics

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -327,13 +327,25 @@ When `--config=<path>` is supplied, report metadata may include:
 
 Current naming runtime now emits bounded naming-owned semantic-family report surfaces in two layers:
 
-- per-file derived details in `finding.details` when the semantic-name shape supports deterministic semantic-family interpretation, currently including `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, and run-scoped `relatedSemanticNames` when another same-family semantic name is observed in the run
+- per-file derived details in `finding.details` when the semantic-name shape supports deterministic semantic-family interpretation, currently including `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, optional `ambiguityFlags`, optional `splitFamilyFlags`, and run-scoped `relatedSemanticNames` when another same-family peer is observed in the run
 - run-level aggregate naming observations in the report envelope: `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts`
+
+Aggregate inclusion rule (explicit current runtime behavior):
+
+- only findings classified as `canonical` and carrying a complete naming-derived semantic-family observation (`semanticName`, `semanticFamily`, `familyRoot`) contribute to `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`, `relatedSemanticNames`, and split-family observation markers
+- invalid, deprecated, missing-role, special-case, or other non-canonical findings never contribute semantic-family aggregates even if a caller manually injects similar-looking fields into `details`
+- this keeps aggregate counts aligned to trustworthy naming evidence instead of “any finding with family-looking fields”
+
+Marker semantics (bounded, observational, non-policy):
+
+- `ambiguityFlags` mark bounded cases where current deterministic interpretation required a heuristic family boundary choice; current runtime emits `family-boundary-heuristic` for connector-free semantic names with four or more tokens
+- `splitFamilyFlags` mark bounded run-scoped divergence where one observed `familyRoot` maps to multiple observed `semanticFamily` values; current runtime emits `family-root-observed-multiple-families`
+- `relatedSemanticNames` is retained and now means same-`semanticFamily` peer semantic names observed in the current run's canonical evidence set, sorted deterministically; it is not a registry declaration or a generic semantic-relatedness engine
 
 Boundary clarifications:
 
 - these are naming-owned observed report surfaces, not shared registry declarations
-- aggregate counts represent what a naming run observed after derivation; they are not policy truth by themselves
+- aggregate counts represent what a naming run observed after canonical-evidence inclusion; they are not policy truth by themselves
 - current runtime only emits these derived details when the semantic-name shape supports bounded deterministic interpretation; it does not force every filename to have family outputs
 - tree may later consume naming-owned emitted surfaces rather than deriving semantic-family independently
 - later custom-registry work may review recurring observations as candidate evidence for additions, overlays, or pinning, but registry truth must still be declared through a separate policy/customization lane

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -57,9 +57,11 @@ Current naming CLI output includes:
 
 Slice-specific note (current naming emitted behavior):
 
-- Naming now emits bounded semantic-family-derived per-file details inside `finding.details` when the semantic-name shape supports deterministic derivation. Current derived fields include `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, and run-scoped `relatedSemanticNames` when observed.
+- Naming now emits bounded semantic-family-derived per-file details inside `finding.details` when the semantic-name shape supports deterministic derivation. Current derived fields include `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, optional `ambiguityFlags`, optional `splitFamilyFlags`, and run-scoped `relatedSemanticNames` when observed.
+- `relatedSemanticNames` means same-`semanticFamily` peer semantic names observed in the current run's canonical semantic-family evidence set; it is intentionally narrower than generic semantic relatedness.
 - Naming now also emits `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` at the slice-report top level.
-- These aggregate fields are report observations rather than automatic registry/policy declarations.
+- Aggregate inclusion is explicit: only `canonical` findings with complete naming-derived semantic-family evidence (`semanticName`, `semanticFamily`, `familyRoot`) contribute to these report-level family count objects.
+- These aggregate fields and per-file markers are report observations rather than automatic registry/policy declarations.
 
 ## 4) Canonical current contract: Runner Report Envelope
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
@@ -2,7 +2,7 @@
 
 - **Classification:** Normative
 - **Applies to:** Naming-slice semantic-name interpretation extensions.
-- **Status:** Active for documentation-first modeling; semantic-family derivation remains an intended naming-owned implementation lane, but runtime activation in the current tranche is deferred.
+- **Status:** Active for bounded naming-owned runtime/report behavior in the current tranche; semantic-family derivation is implemented as report-first observation, while tree consumption remains deferred.
 - **Authority posture note:** Bounded normative supporting spec for naming interpretation modeling; does not supersede primary canonical naming authorities.
 
 ## 1) Purpose
@@ -15,7 +15,7 @@ This pass:
 2. adds a bounded definitions-and-relationships interpretation layer,
 3. defines semantic-family as a run-scoped interpreted signal for report-first outputs.
 
-This spec is documentation/modeling only. It does not change runtime behavior in this task.
+This spec documents the current bounded naming-owned runtime/report behavior for semantic-family interpretation in this tranche.
 
 Classification: Normative
 
@@ -183,7 +183,8 @@ Observation/policy boundary for this tranche:
 
 - per-file derived outputs are naming-owned interpreted results,
 - aggregate count surfaces are naming-owned observed run statistics,
-- `familyRootCounts.tree = 12` means the naming run observed 12 files whose derived `familyRoot` was `tree`,
+- current aggregate inclusion is explicit: only findings classified as `canonical` with complete naming-derived semantic-family evidence (`semanticName`, `semanticFamily`, `familyRoot`) contribute to aggregate family counts or run-scoped peer/split observation maps,
+- `familyRootCounts.tree = 12` means the naming run observed 12 canonical-evidence files whose derived `familyRoot` was `tree`,
 - that observation does **not** mean `tree` is now a declared registry root or registry-approved family,
 - later customization/registry work may review these observations as candidate evidence, but policy declaration remains a separate later ownership lane.
 
@@ -232,6 +233,8 @@ Cross-slice boundary clarification:
 - Cross-slice contracts define what results/tree may consume.
 - Cross-slice contracts do **not** re-own derivation logic.
 - `familyRoot`, `familySubgroup`, and `relatedSemanticNames` are not cross-slice owned; they are naming-owned outputs with later cross-slice utility.
+- `relatedSemanticNames` remains the current field name for bounded churn reasons and now means same-`semanticFamily` peer semantic names observed within the current run's canonical evidence set; it is intentionally not a generic semantic-relatedness claim.
+- Current runtime `ambiguityFlags` and `splitFamilyFlags` are bounded observational markers: `family-boundary-heuristic` records a deterministic but not-confidently-singular boundary choice for connector-free 4+ token semantic names, and `family-root-observed-multiple-families` records that one observed `familyRoot` mapped to multiple observed `semanticFamily` values in the run.
 
 Classification: Normative
 

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -20,6 +20,7 @@ import { deriveDisambiguationHints } from './rules/naming-rule-derive-disambigua
 import {
   deriveSemanticFamilyDetails,
   attachRelatedSemanticNames,
+  isSemanticFamilyEvidenceFinding,
 } from './rules/naming-rule-derive-semantic-family.logic.mjs';
 import {
   getRoleMetadata,
@@ -513,15 +514,13 @@ export const summarizeFindings = (findings, summaryBucketsRuntime) => {
       incrementSecondaryFamilyCounter('warningRoleCategoryCounts', finding.details.roleCategory);
     }
 
-    if (finding.details?.familyRoot) {
+    if (isSemanticFamilyEvidenceFinding(finding)) {
       incrementSecondaryFamilyCounter('familyRootCounts', finding.details.familyRoot);
-    }
 
-    if (finding.details?.familySubgroup) {
-      incrementSecondaryFamilyCounter('familySubgroupCounts', finding.details.familySubgroup);
-    }
+      if (finding.details.familySubgroup) {
+        incrementSecondaryFamilyCounter('familySubgroupCounts', finding.details.familySubgroup);
+      }
 
-    if (finding.details?.semanticFamily) {
       incrementSecondaryFamilyCounter('semanticFamilyCounts', finding.details.semanticFamily);
     }
   }

--- a/calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs
+++ b/calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs
@@ -1,5 +1,15 @@
 export const CONNECTOR_TOKENS = new Set(['and', 'or', 'with']);
 
+export const SEMANTIC_FAMILY_EVIDENCE_CLASSIFICATIONS = new Set(['canonical']);
+
+export const SEMANTIC_FAMILY_AMBIGUITY_FLAGS = Object.freeze({
+  FAMILY_BOUNDARY_HEURISTIC: 'family-boundary-heuristic',
+});
+
+export const SEMANTIC_FAMILY_SPLIT_FLAGS = Object.freeze({
+  ROOT_HAS_MULTIPLE_FAMILIES: 'family-root-observed-multiple-families',
+});
+
 const splitSemanticTokens = (semanticName) =>
   semanticName.split(/[-.]/u).map((token) => token.trim()).filter(Boolean);
 
@@ -31,6 +41,25 @@ const deriveFamilyGrouping = (semanticTokens) => {
   };
 };
 
+const deriveAmbiguityFlags = ({ semanticTokens }) => {
+  if (semanticTokens.length >= 4 && !semanticTokens.slice(1).some((token) => CONNECTOR_TOKENS.has(token))) {
+    return [SEMANTIC_FAMILY_AMBIGUITY_FLAGS.FAMILY_BOUNDARY_HEURISTIC];
+  }
+
+  return [];
+};
+
+const withSortedUniqueFlags = (details, fieldName, flags) => {
+  if (flags.length === 0) {
+    return details;
+  }
+
+  return {
+    ...details,
+    [fieldName]: toSortedUnique(flags),
+  };
+};
+
 export const deriveSemanticFamilyDetails = ({ semanticName }) => {
   const semanticTokens = splitSemanticTokens(semanticName);
 
@@ -43,61 +72,90 @@ export const deriveSemanticFamilyDetails = ({ semanticName }) => {
     ? grouping.familySubgroupTokens.join('-')
     : undefined;
 
-  return {
+  return withSortedUniqueFlags({
     semanticTokens,
     semanticFamily: grouping.semanticFamily,
     familyRoot: grouping.familyRoot,
     ...(familySubgroup ? { familySubgroup } : {}),
-  };
+  }, 'ambiguityFlags', deriveAmbiguityFlags({ semanticTokens }));
 };
 
-export const attachRelatedSemanticNames = (findings) => {
+export const isSemanticFamilyEvidenceFinding = (finding) =>
+  SEMANTIC_FAMILY_EVIDENCE_CLASSIFICATIONS.has(finding.classification) &&
+  typeof finding.details?.semanticName === 'string' &&
+  typeof finding.details?.semanticFamily === 'string' &&
+  typeof finding.details?.familyRoot === 'string';
+
+const buildSemanticFamilyObservationMaps = (findings) => {
   const semanticNamesByFamily = new Map();
+  const semanticFamiliesByRoot = new Map();
 
   for (const finding of findings) {
-    const semanticFamily = finding.details?.semanticFamily;
-    const semanticName = finding.details?.semanticName;
-
-    if (!semanticFamily || !semanticName) {
+    if (!isSemanticFamilyEvidenceFinding(finding)) {
       continue;
     }
+
+    const { semanticFamily, semanticName, familyRoot } = finding.details;
 
     if (!semanticNamesByFamily.has(semanticFamily)) {
       semanticNamesByFamily.set(semanticFamily, []);
     }
 
     semanticNamesByFamily.get(semanticFamily).push(semanticName);
+
+    if (!semanticFamiliesByRoot.has(familyRoot)) {
+      semanticFamiliesByRoot.set(familyRoot, []);
+    }
+
+    semanticFamiliesByRoot.get(familyRoot).push(semanticFamily);
   }
 
-  const relatedSemanticNamesByFamily = new Map(
-    Array.from(semanticNamesByFamily.entries(), ([semanticFamily, semanticNames]) => [
-      semanticFamily,
-      toSortedUnique(semanticNames),
-    ]),
-  );
+  return {
+    relatedSemanticNamesByFamily: new Map(
+      Array.from(semanticNamesByFamily.entries(), ([semanticFamily, semanticNames]) => [
+        semanticFamily,
+        toSortedUnique(semanticNames),
+      ]),
+    ),
+    semanticFamiliesByRoot: new Map(
+      Array.from(semanticFamiliesByRoot.entries(), ([familyRoot, semanticFamilies]) => [
+        familyRoot,
+        toSortedUnique(semanticFamilies),
+      ]),
+    ),
+  };
+};
+
+export const attachRelatedSemanticNames = (findings) => {
+  const {
+    relatedSemanticNamesByFamily,
+    semanticFamiliesByRoot,
+  } = buildSemanticFamilyObservationMaps(findings);
 
   return findings.map((finding) => {
-    const semanticFamily = finding.details?.semanticFamily;
-    const semanticName = finding.details?.semanticName;
-
-    if (!semanticFamily || !semanticName) {
+    if (!isSemanticFamilyEvidenceFinding(finding)) {
       return finding;
     }
 
+    const { semanticFamily, semanticName, familyRoot } = finding.details;
     const relatedSemanticNames = (relatedSemanticNamesByFamily.get(semanticFamily) ?? []).filter(
       (candidateSemanticName) => candidateSemanticName !== semanticName,
     );
 
-    if (relatedSemanticNames.length === 0) {
-      return finding;
-    }
+    const splitFamilyFlags = (semanticFamiliesByRoot.get(familyRoot) ?? []).length > 1
+      ? [SEMANTIC_FAMILY_SPLIT_FLAGS.ROOT_HAS_MULTIPLE_FAMILIES]
+      : [];
+
+    const detailsWithRelatedNames = relatedSemanticNames.length > 0
+      ? {
+          ...finding.details,
+          relatedSemanticNames,
+        }
+      : finding.details;
 
     return {
       ...finding,
-      details: {
-        ...finding.details,
-        relatedSemanticNames,
-      },
+      details: withSortedUniqueFlags(detailsWithRelatedNames, 'splitFamilyFlags', splitFamilyFlags),
     };
   });
 };

--- a/calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs
+++ b/calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   deriveSemanticFamilyDetails,
   attachRelatedSemanticNames,
+  isSemanticFamilyEvidenceFinding,
 } from '../src/rules/naming-rule-derive-semantic-family.logic.mjs';
 import { summarizeFindings } from '../src/naming-validator.host.mjs';
 
@@ -12,6 +13,7 @@ test('derives bounded semantic-family details for supported list-like semantic-n
     semanticFamily: 'order-payment',
     familyRoot: 'order',
     familySubgroup: 'payment-refund',
+    ambiguityFlags: ['family-boundary-heuristic'],
   });
 });
 
@@ -40,27 +42,68 @@ test('does not derive semantic-family details for unsupported single-token seman
   assert.equal(deriveSemanticFamilyDetails({ semanticName: 'tree' }), null);
 });
 
-test('attaches related semantic names by observed semantic-family clusters only', () => {
+test('semantic-family evidence gate only accepts canonical findings with complete derived signals', () => {
+  assert.equal(
+    isSemanticFamilyEvidenceFinding({
+      classification: 'canonical',
+      details: {
+        semanticName: 'naming-role-index',
+        semanticFamily: 'naming',
+        familyRoot: 'naming',
+      },
+    }),
+    true,
+  );
+
+  assert.equal(
+    isSemanticFamilyEvidenceFinding({
+      classification: 'invalid-ambiguous',
+      details: {
+        semanticName: 'naming-role-index',
+        semanticFamily: 'naming',
+        familyRoot: 'naming',
+      },
+    }),
+    false,
+  );
+});
+
+test('attaches same-family peer names only for canonical semantic-family evidence', () => {
   const findings = attachRelatedSemanticNames([
     {
+      classification: 'canonical',
       path: 'a',
       details: {
         semanticName: 'naming-role-index',
         semanticFamily: 'naming',
+        familyRoot: 'naming',
       },
     },
     {
+      classification: 'canonical',
       path: 'b',
       details: {
         semanticName: 'naming-role-matrix',
         semanticFamily: 'naming',
+        familyRoot: 'naming',
       },
     },
     {
+      classification: 'invalid-ambiguous',
       path: 'c',
+      details: {
+        semanticName: 'naming-role-bad-case',
+        semanticFamily: 'naming',
+        familyRoot: 'naming',
+      },
+    },
+    {
+      classification: 'canonical',
+      path: 'd',
       details: {
         semanticName: 'tree-occurrence-model-and-addressing',
         semanticFamily: 'tree',
+        familyRoot: 'tree',
       },
     },
   ]);
@@ -68,15 +111,53 @@ test('attaches related semantic names by observed semantic-family clusters only'
   assert.deepEqual(findings[0].details.relatedSemanticNames, ['naming-role-matrix']);
   assert.deepEqual(findings[1].details.relatedSemanticNames, ['naming-role-index']);
   assert.equal(findings[2].details.relatedSemanticNames, undefined);
+  assert.equal(findings[3].details.relatedSemanticNames, undefined);
 });
 
-test('summary emits deterministic semantic-family observation counts from derived details', () => {
+test('adds split-family markers when one root maps to multiple observed families', () => {
+  const findings = attachRelatedSemanticNames([
+    {
+      classification: 'canonical',
+      path: 'a',
+      details: {
+        semanticName: 'order-payment-refund-reconcile',
+        semanticFamily: 'order-payment',
+        familyRoot: 'order',
+      },
+    },
+    {
+      classification: 'canonical',
+      path: 'b',
+      details: {
+        semanticName: 'order-shipping-tracker-sync',
+        semanticFamily: 'order-shipping',
+        familyRoot: 'order',
+      },
+    },
+    {
+      classification: 'canonical',
+      path: 'c',
+      details: {
+        semanticName: 'tree-occurrence-model-and-addressing',
+        semanticFamily: 'tree',
+        familyRoot: 'tree',
+      },
+    },
+  ]);
+
+  assert.deepEqual(findings[0].details.splitFamilyFlags, ['family-root-observed-multiple-families']);
+  assert.deepEqual(findings[1].details.splitFamilyFlags, ['family-root-observed-multiple-families']);
+  assert.equal(findings[2].details.splitFamilyFlags, undefined);
+});
+
+test('summary emits deterministic semantic-family observation counts from canonical evidence only', () => {
   const summary = summarizeFindings([
     {
       classification: 'canonical',
       code: 'NAMING_CANONICAL',
       severity: 'info',
       details: {
+        semanticName: 'tree-occurrence-model-and-addressing',
         familyRoot: 'tree',
         familySubgroup: 'occurrence-model-and-addressing',
         semanticFamily: 'tree',
@@ -87,6 +168,7 @@ test('summary emits deterministic semantic-family observation counts from derive
       code: 'NAMING_CANONICAL',
       severity: 'info',
       details: {
+        semanticName: 'naming-role-index',
         familyRoot: 'naming',
         familySubgroup: 'role-index',
         semanticFamily: 'naming',
@@ -97,6 +179,18 @@ test('summary emits deterministic semantic-family observation counts from derive
       code: 'NAMING_CANONICAL',
       severity: 'info',
       details: {
+        semanticName: 'naming-role-matrix',
+        familyRoot: 'naming',
+        familySubgroup: 'role-matrix',
+        semanticFamily: 'naming',
+      },
+    },
+    {
+      classification: 'invalid-ambiguous',
+      code: 'NAMING_BAD_SEMANTIC_CASE',
+      severity: 'warn',
+      details: {
+        semanticName: 'Naming-Role-Matrix',
         familyRoot: 'naming',
         familySubgroup: 'role-matrix',
         semanticFamily: 'naming',

--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -166,15 +166,18 @@ test('classifies canonical file with semantic-family derived details when shape 
   assert.equal(finding.details?.semanticFamily, 'order-payment');
   assert.equal(finding.details?.familyRoot, 'order');
   assert.equal(finding.details?.familySubgroup, 'payment-refund');
+  assert.deepEqual(finding.details?.ambiguityFlags, ['family-boundary-heuristic']);
 });
 
-test('runNamingValidator attaches run-scoped related semantic names without coupling tree runtime', () => {
+test('runNamingValidator attaches run-scoped same-family peers and split markers without coupling tree runtime', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-semantic-family-run-'));
 
   try {
     fs.mkdirSync(path.join(tempRoot, 'src'), { recursive: true });
     fs.writeFileSync(path.join(tempRoot, 'src', 'naming-role-index.logic.mjs'), 'export const index = 1;\n');
     fs.writeFileSync(path.join(tempRoot, 'src', 'naming-role-matrix.logic.mjs'), 'export const matrix = 1;\n');
+    fs.writeFileSync(path.join(tempRoot, 'src', 'order-payment-refund-reconcile.logic.mjs'), 'export const refund = 1;\n');
+    fs.writeFileSync(path.join(tempRoot, 'src', 'order-shipping-tracker-sync.logic.mjs'), 'export const shipping = 1;\n');
     fs.writeFileSync(path.join(tempRoot, 'src', 'tree.logic.mjs'), 'export const tree = 1;\n');
 
     const result = runNamingValidator(tempRoot, { scope: 'app', targets: ['src'] });
@@ -184,17 +187,26 @@ test('runNamingValidator attaches run-scoped related semantic names without coup
     };
     const indexFinding = report.findings.find((finding) => finding.path === 'src/naming-role-index.logic.mjs');
     const matrixFinding = report.findings.find((finding) => finding.path === 'src/naming-role-matrix.logic.mjs');
+    const orderPaymentFinding = report.findings.find((finding) => finding.path === 'src/order-payment-refund-reconcile.logic.mjs');
+    const orderShippingFinding = report.findings.find((finding) => finding.path === 'src/order-shipping-tracker-sync.logic.mjs');
     const treeFinding = report.findings.find((finding) => finding.path === 'src/tree.logic.mjs');
 
     assert.deepEqual(indexFinding?.details?.relatedSemanticNames, ['naming-role-matrix']);
     assert.deepEqual(matrixFinding?.details?.relatedSemanticNames, ['naming-role-index']);
+    assert.equal(orderPaymentFinding?.details?.relatedSemanticNames, undefined);
     assert.equal(treeFinding?.details?.relatedSemanticNames, undefined);
-    assert.deepEqual(report.familyRootCounts, { naming: 2 });
+    assert.deepEqual(orderPaymentFinding?.details?.ambiguityFlags, ['family-boundary-heuristic']);
+    assert.deepEqual(orderPaymentFinding?.details?.splitFamilyFlags, ['family-root-observed-multiple-families']);
+    assert.deepEqual(orderShippingFinding?.details?.ambiguityFlags, ['family-boundary-heuristic']);
+    assert.deepEqual(orderShippingFinding?.details?.splitFamilyFlags, ['family-root-observed-multiple-families']);
+    assert.deepEqual(report.familyRootCounts, { naming: 2, order: 2 });
     assert.deepEqual(report.familySubgroupCounts, {
+      'payment-refund': 1,
       'role-index': 1,
       'role-matrix': 1,
+      'shipping-tracker': 1,
     });
-    assert.deepEqual(report.semanticFamilyCounts, { naming: 2 });
+    assert.deepEqual(report.semanticFamilyCounts, { naming: 2, 'order-payment': 1, 'order-shipping': 1 });
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Make naming-owned semantic-family signals trustworthy for downstream use by tightening which findings contribute to aggregates and by adding bounded ambiguity/split markers. 
- Avoid inflated or policy-like aggregates by making inclusion semantics explicit and deterministic. 
- Provide minimal, naming-owned markers (`ambiguityFlags`, `splitFamilyFlags`) so the report preserves uncertainty/divergence without building fuzzy engines or tree coupling.

### Description
- Implemented an explicit canonical-evidence gate (`isSemanticFamilyEvidenceFinding`) so only `canonical` findings with complete derived fields (`semanticName`, `semanticFamily`, `familyRoot`) contribute to `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`, run-scoped `relatedSemanticNames`, and split-family markers.
- Added deterministic, naming-owned markers: `ambiguityFlags` (currently emits `family-boundary-heuristic`) and `splitFamilyFlags` (currently emits `family-root-observed-multiple-families`), and ensured flags are sorted/unique before attaching.
- Tightened `relatedSemanticNames` semantics: retained the field name but refined it to mean deterministically sorted same-`semanticFamily` peers observed in the current run’s canonical evidence set (no registry or tree claim).
- Updated runtime and helpers in `naming-rule-derive-semantic-family.logic.mjs` and used the evidence gate in `summarizeFindings` inside `naming-validator.logic.mjs` so aggregates are deterministic and not inflated by non-canonical findings.
- Updated docs to reflect the explicit aggregate inclusion rule and marker semantics in `NamingValidatorSpec.md`, `ValidatorReportSchema-V0_1.md`, and the `naming-semantic-family-and-interpretation-spec.md` spec. 
- Tests extended/added to cover ambiguity cases, split-family cases, canonical-only aggregate inclusion, deterministic ordering, and refined `relatedSemanticNames` behavior.

Files changed: `calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs`, `calculogic-validator/naming/src/naming-validator.logic.mjs`, `calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs`, `calculogic-validator/naming/test/naming-validator.test.mjs`, `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md`, `calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md`, `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md`.

### Testing
- Ran focused unit suites: `node --test calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs` (passed), `node --test calculogic-validator/naming/test/naming-validator.test.mjs` (passed), and `node --test calculogic-validator/test/validator-report-schema.conformance.test.mjs` (passed).
- Tests validate: aggregate inclusion is canonical-only, `ambiguityFlags` and `splitFamilyFlags` behavior, deterministic `relatedSemanticNames` ordering, and no tree coupling was introduced. All automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba491d892083318f16b6ed2159a917)