### PR TITLE
Tighten naming semantic-family evidence semantics

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -332,15 +332,16 @@ Current naming runtime now emits bounded naming-owned semantic-family report sur
 
 Aggregate inclusion rule (explicit current runtime behavior):
 
-- only findings classified as `canonical` and carrying a complete naming-derived semantic-family observation (`semanticName`, `semanticFamily`, `familyRoot`) contribute to `familyRootCounts`, `familySubgroupCounts`, `semanticFamilyCounts`, `relatedSemanticNames`, and split-family observation markers
+- `familyRootCounts` uses canonical root evidence only: findings must be classified as `canonical` and carry naming-derived `semanticName` plus `familyRoot`
+- `familySubgroupCounts`, `semanticFamilyCounts`, `relatedSemanticNames`, and split-family observation markers require singular family evidence: findings must be `canonical`, carry `semanticName` + `semanticFamily` + `familyRoot`, and must not carry the non-singular boundary marker `ambiguityFlags: ["family-boundary-heuristic"]`
 - invalid, deprecated, missing-role, special-case, or other non-canonical findings never contribute semantic-family aggregates even if a caller manually injects similar-looking fields into `details`
-- this keeps aggregate counts aligned to trustworthy naming evidence instead of “any finding with family-looking fields”
+- this keeps family-root observation available while preventing heuristic/non-singular family assignments from inflating family/subgroup peer evidence
 
 Marker semantics (bounded, observational, non-policy):
 
 - `ambiguityFlags` mark bounded cases where current deterministic interpretation required a heuristic family boundary choice; current runtime emits `family-boundary-heuristic` for connector-free semantic names with four or more tokens
 - `splitFamilyFlags` mark bounded run-scoped divergence where one observed `familyRoot` maps to multiple observed `semanticFamily` values; current runtime emits `family-root-observed-multiple-families`
-- `relatedSemanticNames` is retained and now means same-`semanticFamily` peer semantic names observed in the current run's canonical evidence set, sorted deterministically; it is not a registry declaration or a generic semantic-relatedness engine
+- `relatedSemanticNames` is retained and now means same-`semanticFamily` peer semantic names observed in the current run's singular canonical evidence set, sorted deterministically; it is not a registry declaration or a generic semantic-relatedness engine
 
 Boundary clarifications:
 

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorReportSchema-V0_1.md
@@ -58,9 +58,9 @@ Current naming CLI output includes:
 Slice-specific note (current naming emitted behavior):
 
 - Naming now emits bounded semantic-family-derived per-file details inside `finding.details` when the semantic-name shape supports deterministic derivation. Current derived fields include `semanticTokens`, `semanticFamily`, `familyRoot`, `familySubgroup`, optional `ambiguityFlags`, optional `splitFamilyFlags`, and run-scoped `relatedSemanticNames` when observed.
-- `relatedSemanticNames` means same-`semanticFamily` peer semantic names observed in the current run's canonical semantic-family evidence set; it is intentionally narrower than generic semantic relatedness.
+- `relatedSemanticNames` means same-`semanticFamily` peer semantic names observed in the current run's singular canonical semantic-family evidence set; it is intentionally narrower than generic semantic relatedness.
 - Naming now also emits `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` at the slice-report top level.
-- Aggregate inclusion is explicit: only `canonical` findings with complete naming-derived semantic-family evidence (`semanticName`, `semanticFamily`, `familyRoot`) contribute to these report-level family count objects.
+- Aggregate inclusion is explicit and tiered: `familyRootCounts` only uses `canonical` findings with naming-derived `semanticName` + `familyRoot`, while `familySubgroupCounts` and `semanticFamilyCounts` only use singular family evidence (`canonical` + `semanticName` + `semanticFamily` + `familyRoot` and no `family-boundary-heuristic` ambiguity marker).
 - These aggregate fields and per-file markers are report observations rather than automatic registry/policy declarations.
 
 ## 4) Canonical current contract: Runner Report Envelope

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation-spec.md
@@ -183,7 +183,7 @@ Observation/policy boundary for this tranche:
 
 - per-file derived outputs are naming-owned interpreted results,
 - aggregate count surfaces are naming-owned observed run statistics,
-- current aggregate inclusion is explicit: only findings classified as `canonical` with complete naming-derived semantic-family evidence (`semanticName`, `semanticFamily`, `familyRoot`) contribute to aggregate family counts or run-scoped peer/split observation maps,
+- current aggregate inclusion is explicit and tiered: `familyRootCounts` use canonical root evidence (`semanticName` + `familyRoot`), while `familySubgroupCounts`, `semanticFamilyCounts`, and run-scoped peer/split observation maps require singular canonical family evidence (`semanticName` + `semanticFamily` + `familyRoot` and no `family-boundary-heuristic` marker),
 - `familyRootCounts.tree = 12` means the naming run observed 12 canonical-evidence files whose derived `familyRoot` was `tree`,
 - that observation does **not** mean `tree` is now a declared registry root or registry-approved family,
 - later customization/registry work may review these observations as candidate evidence, but policy declaration remains a separate later ownership lane.
@@ -233,8 +233,8 @@ Cross-slice boundary clarification:
 - Cross-slice contracts define what results/tree may consume.
 - Cross-slice contracts do **not** re-own derivation logic.
 - `familyRoot`, `familySubgroup`, and `relatedSemanticNames` are not cross-slice owned; they are naming-owned outputs with later cross-slice utility.
-- `relatedSemanticNames` remains the current field name for bounded churn reasons and now means same-`semanticFamily` peer semantic names observed within the current run's canonical evidence set; it is intentionally not a generic semantic-relatedness claim.
-- Current runtime `ambiguityFlags` and `splitFamilyFlags` are bounded observational markers: `family-boundary-heuristic` records a deterministic but not-confidently-singular boundary choice for connector-free 4+ token semantic names, and `family-root-observed-multiple-families` records that one observed `familyRoot` mapped to multiple observed `semanticFamily` values in the run.
+- `relatedSemanticNames` remains the current field name for bounded churn reasons and now means same-`semanticFamily` peer semantic names observed within the current run's singular canonical family-evidence set; it is intentionally not a generic semantic-relatedness claim.
+- Current runtime `ambiguityFlags` and `splitFamilyFlags` are bounded observational markers: `family-boundary-heuristic` records a deterministic but not-confidently-singular boundary choice for connector-free 4+ token semantic names, and `family-root-observed-multiple-families` records that one observed `familyRoot` mapped to multiple singular observed `semanticFamily` values in the run.
 
 Classification: Normative
 

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -20,7 +20,8 @@ import { deriveDisambiguationHints } from './rules/naming-rule-derive-disambigua
 import {
   deriveSemanticFamilyDetails,
   attachRelatedSemanticNames,
-  isSemanticFamilyEvidenceFinding,
+  isSemanticFamilyRootEvidenceFinding,
+  isSingularSemanticFamilyEvidenceFinding,
 } from './rules/naming-rule-derive-semantic-family.logic.mjs';
 import {
   getRoleMetadata,
@@ -514,9 +515,11 @@ export const summarizeFindings = (findings, summaryBucketsRuntime) => {
       incrementSecondaryFamilyCounter('warningRoleCategoryCounts', finding.details.roleCategory);
     }
 
-    if (isSemanticFamilyEvidenceFinding(finding)) {
+    if (isSemanticFamilyRootEvidenceFinding(finding)) {
       incrementSecondaryFamilyCounter('familyRootCounts', finding.details.familyRoot);
+    }
 
+    if (isSingularSemanticFamilyEvidenceFinding(finding)) {
       if (finding.details.familySubgroup) {
         incrementSecondaryFamilyCounter('familySubgroupCounts', finding.details.familySubgroup);
       }

--- a/calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs
+++ b/calculogic-validator/naming/src/rules/naming-rule-derive-semantic-family.logic.mjs
@@ -60,6 +60,19 @@ const withSortedUniqueFlags = (details, fieldName, flags) => {
   };
 };
 
+const hasCompleteSemanticFamilyRootObservation = (finding) =>
+  SEMANTIC_FAMILY_EVIDENCE_CLASSIFICATIONS.has(finding.classification) &&
+  typeof finding.details?.semanticName === 'string' &&
+  typeof finding.details?.familyRoot === 'string';
+
+const hasCompleteSemanticFamilyObservation = (finding) =>
+  hasCompleteSemanticFamilyRootObservation(finding) &&
+  typeof finding.details?.semanticFamily === 'string';
+
+const hasNonSingularFamilyBoundary = (finding) =>
+  Array.isArray(finding.details?.ambiguityFlags) &&
+  finding.details.ambiguityFlags.includes(SEMANTIC_FAMILY_AMBIGUITY_FLAGS.FAMILY_BOUNDARY_HEURISTIC);
+
 export const deriveSemanticFamilyDetails = ({ semanticName }) => {
   const semanticTokens = splitSemanticTokens(semanticName);
 
@@ -80,18 +93,20 @@ export const deriveSemanticFamilyDetails = ({ semanticName }) => {
   }, 'ambiguityFlags', deriveAmbiguityFlags({ semanticTokens }));
 };
 
-export const isSemanticFamilyEvidenceFinding = (finding) =>
-  SEMANTIC_FAMILY_EVIDENCE_CLASSIFICATIONS.has(finding.classification) &&
-  typeof finding.details?.semanticName === 'string' &&
-  typeof finding.details?.semanticFamily === 'string' &&
-  typeof finding.details?.familyRoot === 'string';
+export const isSemanticFamilyEvidenceFinding = (finding) => hasCompleteSemanticFamilyObservation(finding);
+
+export const isSemanticFamilyRootEvidenceFinding = (finding) => hasCompleteSemanticFamilyRootObservation(finding);
+
+export const isSingularSemanticFamilyEvidenceFinding = (finding) =>
+  hasCompleteSemanticFamilyObservation(finding) &&
+  !hasNonSingularFamilyBoundary(finding);
 
 const buildSemanticFamilyObservationMaps = (findings) => {
   const semanticNamesByFamily = new Map();
   const semanticFamiliesByRoot = new Map();
 
   for (const finding of findings) {
-    if (!isSemanticFamilyEvidenceFinding(finding)) {
+    if (!isSingularSemanticFamilyEvidenceFinding(finding)) {
       continue;
     }
 
@@ -134,6 +149,10 @@ export const attachRelatedSemanticNames = (findings) => {
 
   return findings.map((finding) => {
     if (!isSemanticFamilyEvidenceFinding(finding)) {
+      return finding;
+    }
+
+    if (!isSingularSemanticFamilyEvidenceFinding(finding)) {
       return finding;
     }
 

--- a/calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs
+++ b/calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs
@@ -4,6 +4,8 @@ import {
   deriveSemanticFamilyDetails,
   attachRelatedSemanticNames,
   isSemanticFamilyEvidenceFinding,
+  isSemanticFamilyRootEvidenceFinding,
+  isSingularSemanticFamilyEvidenceFinding,
 } from '../src/rules/naming-rule-derive-semantic-family.logic.mjs';
 import { summarizeFindings } from '../src/naming-validator.host.mjs';
 
@@ -42,21 +44,23 @@ test('does not derive semantic-family details for unsupported single-token seman
   assert.equal(deriveSemanticFamilyDetails({ semanticName: 'tree' }), null);
 });
 
-test('semantic-family evidence gate only accepts canonical findings with complete derived signals', () => {
-  assert.equal(
-    isSemanticFamilyEvidenceFinding({
-      classification: 'canonical',
-      details: {
-        semanticName: 'naming-role-index',
-        semanticFamily: 'naming',
-        familyRoot: 'naming',
-      },
-    }),
-    true,
-  );
+test('semantic-family evidence gates distinguish root evidence from singular family evidence', () => {
+  const canonicalAmbiguousFinding = {
+    classification: 'canonical',
+    details: {
+      semanticName: 'order-payment-refund-reconcile',
+      semanticFamily: 'order-payment',
+      familyRoot: 'order',
+      ambiguityFlags: ['family-boundary-heuristic'],
+    },
+  };
+
+  assert.equal(isSemanticFamilyEvidenceFinding(canonicalAmbiguousFinding), true);
+  assert.equal(isSemanticFamilyRootEvidenceFinding(canonicalAmbiguousFinding), true);
+  assert.equal(isSingularSemanticFamilyEvidenceFinding(canonicalAmbiguousFinding), false);
 
   assert.equal(
-    isSemanticFamilyEvidenceFinding({
+    isSemanticFamilyRootEvidenceFinding({
       classification: 'invalid-ambiguous',
       details: {
         semanticName: 'naming-role-index',
@@ -68,13 +72,13 @@ test('semantic-family evidence gate only accepts canonical findings with complet
   );
 });
 
-test('attaches same-family peer names only for canonical semantic-family evidence', () => {
+test('attaches same-family peer names only for singular canonical semantic-family evidence', () => {
   const findings = attachRelatedSemanticNames([
     {
       classification: 'canonical',
       path: 'a',
       details: {
-        semanticName: 'naming-role-index',
+        semanticName: 'naming-role-matrix',
         semanticFamily: 'naming',
         familyRoot: 'naming',
       },
@@ -83,18 +87,76 @@ test('attaches same-family peer names only for canonical semantic-family evidenc
       classification: 'canonical',
       path: 'b',
       details: {
-        semanticName: 'naming-role-matrix',
+        semanticName: 'naming-role-index',
         semanticFamily: 'naming',
         familyRoot: 'naming',
       },
     },
     {
-      classification: 'invalid-ambiguous',
+      classification: 'canonical',
       path: 'c',
+      details: {
+        semanticName: 'order-payment-refund-reconcile',
+        semanticFamily: 'order-payment',
+        familyRoot: 'order',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+    },
+    {
+      classification: 'invalid-ambiguous',
+      path: 'd',
       details: {
         semanticName: 'naming-role-bad-case',
         semanticFamily: 'naming',
         familyRoot: 'naming',
+      },
+    },
+    {
+      classification: 'canonical',
+      path: 'e',
+      details: {
+        semanticName: 'tree-occurrence-model-and-addressing',
+        semanticFamily: 'tree',
+        familyRoot: 'tree',
+      },
+    },
+  ]);
+
+  assert.deepEqual(findings[0].details.relatedSemanticNames, ['naming-role-index']);
+  assert.deepEqual(findings[1].details.relatedSemanticNames, ['naming-role-matrix']);
+  assert.equal(findings[2].details.relatedSemanticNames, undefined);
+  assert.equal(findings[3].details.relatedSemanticNames, undefined);
+  assert.equal(findings[4].details.relatedSemanticNames, undefined);
+});
+
+test('adds split-family markers only when singular observed families share one root', () => {
+  const findings = attachRelatedSemanticNames([
+    {
+      classification: 'canonical',
+      path: 'a',
+      details: {
+        semanticName: 'order-payment-index',
+        semanticFamily: 'order',
+        familyRoot: 'order',
+      },
+    },
+    {
+      classification: 'canonical',
+      path: 'b',
+      details: {
+        semanticName: 'order-payment-refund-reconcile',
+        semanticFamily: 'order-payment',
+        familyRoot: 'order',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+    },
+    {
+      classification: 'canonical',
+      path: 'c',
+      details: {
+        semanticName: 'order-shipping-index',
+        semanticFamily: 'order-shipping',
+        familyRoot: 'order',
       },
     },
     {
@@ -108,49 +170,13 @@ test('attaches same-family peer names only for canonical semantic-family evidenc
     },
   ]);
 
-  assert.deepEqual(findings[0].details.relatedSemanticNames, ['naming-role-matrix']);
-  assert.deepEqual(findings[1].details.relatedSemanticNames, ['naming-role-index']);
-  assert.equal(findings[2].details.relatedSemanticNames, undefined);
-  assert.equal(findings[3].details.relatedSemanticNames, undefined);
-});
-
-test('adds split-family markers when one root maps to multiple observed families', () => {
-  const findings = attachRelatedSemanticNames([
-    {
-      classification: 'canonical',
-      path: 'a',
-      details: {
-        semanticName: 'order-payment-refund-reconcile',
-        semanticFamily: 'order-payment',
-        familyRoot: 'order',
-      },
-    },
-    {
-      classification: 'canonical',
-      path: 'b',
-      details: {
-        semanticName: 'order-shipping-tracker-sync',
-        semanticFamily: 'order-shipping',
-        familyRoot: 'order',
-      },
-    },
-    {
-      classification: 'canonical',
-      path: 'c',
-      details: {
-        semanticName: 'tree-occurrence-model-and-addressing',
-        semanticFamily: 'tree',
-        familyRoot: 'tree',
-      },
-    },
-  ]);
-
   assert.deepEqual(findings[0].details.splitFamilyFlags, ['family-root-observed-multiple-families']);
-  assert.deepEqual(findings[1].details.splitFamilyFlags, ['family-root-observed-multiple-families']);
-  assert.equal(findings[2].details.splitFamilyFlags, undefined);
+  assert.equal(findings[1].details.splitFamilyFlags, undefined);
+  assert.deepEqual(findings[2].details.splitFamilyFlags, ['family-root-observed-multiple-families']);
+  assert.equal(findings[3].details.splitFamilyFlags, undefined);
 });
 
-test('summary emits deterministic semantic-family observation counts from canonical evidence only', () => {
+test('summary counts family roots from canonical root evidence but reserves family/subgroup counts for singular evidence', () => {
   const summary = summarizeFindings([
     {
       classification: 'canonical',
@@ -186,6 +212,18 @@ test('summary emits deterministic semantic-family observation counts from canoni
       },
     },
     {
+      classification: 'canonical',
+      code: 'NAMING_CANONICAL',
+      severity: 'info',
+      details: {
+        semanticName: 'order-payment-refund-reconcile',
+        familyRoot: 'order',
+        familySubgroup: 'payment-refund',
+        semanticFamily: 'order-payment',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+    },
+    {
       classification: 'invalid-ambiguous',
       code: 'NAMING_BAD_SEMANTIC_CASE',
       severity: 'warn',
@@ -200,6 +238,7 @@ test('summary emits deterministic semantic-family observation counts from canoni
 
   assert.deepEqual(summary.familyRootCounts, {
     naming: 2,
+    order: 1,
     tree: 1,
   });
   assert.deepEqual(summary.familySubgroupCounts, {

--- a/calculogic-validator/naming/test/naming-validator.test.mjs
+++ b/calculogic-validator/naming/test/naming-validator.test.mjs
@@ -196,17 +196,15 @@ test('runNamingValidator attaches run-scoped same-family peers and split markers
     assert.equal(orderPaymentFinding?.details?.relatedSemanticNames, undefined);
     assert.equal(treeFinding?.details?.relatedSemanticNames, undefined);
     assert.deepEqual(orderPaymentFinding?.details?.ambiguityFlags, ['family-boundary-heuristic']);
-    assert.deepEqual(orderPaymentFinding?.details?.splitFamilyFlags, ['family-root-observed-multiple-families']);
+    assert.equal(orderPaymentFinding?.details?.splitFamilyFlags, undefined);
     assert.deepEqual(orderShippingFinding?.details?.ambiguityFlags, ['family-boundary-heuristic']);
-    assert.deepEqual(orderShippingFinding?.details?.splitFamilyFlags, ['family-root-observed-multiple-families']);
+    assert.equal(orderShippingFinding?.details?.splitFamilyFlags, undefined);
     assert.deepEqual(report.familyRootCounts, { naming: 2, order: 2 });
     assert.deepEqual(report.familySubgroupCounts, {
-      'payment-refund': 1,
       'role-index': 1,
       'role-matrix': 1,
-      'shipping-tracker': 1,
     });
-    assert.deepEqual(report.semanticFamilyCounts, { naming: 2, 'order-payment': 1, 'order-shipping': 1 });
+    assert.deepEqual(report.semanticFamilyCounts, { naming: 2 });
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Prevent aggregate family counts from being inflated by heuristic or non-canonical findings by making inclusion rules explicit and deterministic.
- Surface bounded ambiguity and split markers in naming-owned outputs so downstream consumers (later tree/registry work) get cleaner signals.
- Keep `relatedSemanticNames` stable to avoid churn while clarifying its truthful runtime meaning as same-family peer discovery from singular canonical evidence only.

### Description
- Introduced explicit evidence gates in `naming-rule-derive-semantic-family.logic.mjs`: added `isSemanticFamilyRootEvidenceFinding`, `isSingularSemanticFamilyEvidenceFinding`, and tightened `isSemanticFamilyEvidenceFinding` to reflect root vs singular semantics, and kept ambiguity/split flags (`family-boundary-heuristic`, `family-root-observed-multiple-families`).
- Updated `attachRelatedSemanticNames` to only attach run-scoped peer lists and split markers when the finding has singular canonical family evidence.
- Updated summary logic in `naming-validator.logic.mjs` so `familyRootCounts` uses canonical root evidence, while `familySubgroupCounts` and `semanticFamilyCounts` only increment from singular canonical family evidence (no `family-boundary-heuristic`).
- Kept the `relatedSemanticNames` field name but refined docs/tests to state it means same-`semanticFamily` peers observed within the run's singular canonical evidence set.
- Updated docs: `NamingValidatorSpec.md`, `ValidatorReportSchema-V0_1.md`, and `naming-semantic-family-and-interpretation-spec.md` to describe the tiered aggregate inclusion rule, ambiguity/split marker meanings, and the observation-vs-policy boundary.
- Adjusted and extended tests in `naming-semantic-family-derivation.test.mjs` and `naming-validator.test.mjs` to cover root vs singular evidence, ambiguity exclusion from singular-family aggregates, split-marker behavior, deterministic peer ordering, and no tree coupling.

### Testing
- Ran the focused test suite with: `node --test calculogic-validator/naming/test/naming-semantic-family-derivation.test.mjs calculogic-validator/naming/test/naming-validator.test.mjs calculogic-validator/test/validator-report-schema.conformance.test.mjs` and all tests passed.
- Verified deterministic ordering and summary outputs in `summarizeFindings` for the new inclusion rules; the updated tests assert the new counts and markers and succeeded.
- No tree runtime or registry behavior was changed or tested as part of this PR (deliberately deferred).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baefd12f8c8331a8e5a38a0b1f6402)