### PR TITLE
docs(validator): document validator-internal presets and raw --scope=validator --target examples

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -216,6 +216,21 @@ npm run report:summarize
 - `report:verify`: checks report-capture wiring/outputs.
 - `report:summarize`: summarizes captured reports.
 
+### Validator-internal naming/report presets (bounded convenience wrappers)
+
+These presets are convenience wrappers for validator-internal workflows. They **do not** add new built-in scopes; each command remains `--scope=validator` with explicit `--target` narrowing.
+
+```bash
+npm run validate:naming:validator:entry
+npm run validate:naming:validator:naming
+npm run validate:naming:validator:tree
+npm run validate:naming:validator:doc
+npm run report:naming:validator:entry
+npm run report:naming:validator:naming
+npm run report:naming:validator:tree
+npm run report:naming:validator:doc
+```
+
 ## 5) Validator entrypoints and direct invocation
 
 This section includes package-defined validator entrypoints plus direct script invocation where useful, all executable from repo root.
@@ -258,6 +273,19 @@ npm run validate:tree -- --scope=repo --target calculogic-validator
 ```
 
 Use scope-specific `report:*` commands when you want one-command capture per target/scope combination.
+
+Raw target-filter pattern (adaptable to your own validator-focused areas/files):
+
+```bash
+npm run validate:naming -- --scope=validator --target calculogic-validator/doc
+npm run validate:naming -- --scope=validator --target calculogic-validator/naming
+npm run validate:naming -- --scope=validator --target calculogic-validator/tree
+npm run validate:naming -- --scope=validator --target calculogic-validator/bin --target calculogic-validator/scripts
+npm run validate:naming -- --scope=validator --target calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-validator-doc -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.host.mjs --scope=validator --target calculogic-validator/doc
+```
+
+Scope boundary note: validator-internal presets do not create new built-in scope profiles. `validator` remains the actual scope, and `--target` is the narrowing layer inside that scope.
 
 ## 7) Strict config and schema
 


### PR DESCRIPTION
### Motivation
- Make the new validator-internal naming/report presets discoverable and show the raw `--scope=validator --target ...` pattern so users can adapt validator-targeted runs without implying new built-in scopes.

### Description
- Updated `calculogic-validator/README.md` to add a small "Validator-internal naming/report presets" subsection that lists the preset commands (`npm run validate:naming:validator:entry`, `npm run validate:naming:validator:naming`, `npm run validate:naming:validator:tree`, `npm run validate:naming:validator:doc`, `npm run report:naming:validator:entry`, `npm run report:naming:validator:naming`, `npm run report:naming:validator:tree`, `npm run report:naming:validator:doc`) and to add a bounded raw target-filter examples block showing the `npm run validate:naming -- --scope=validator --target ...` pattern (including multi-target and file-target examples) and one `calculogic-report-capture` example; also added an explicit scope-boundary note clarifying these are convenience wrappers over `--scope=validator` + `--target` and do not introduce new scope profiles.

### Testing
- No automated tests were required for this README-only change; validated the edit by inspecting the diff (`git diff -- calculogic-validator/README.md`) and viewing the updated README content, and committed the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5abe833048331b8d09bb745095cd9)