### PR TITLE
docs(validator): clarify validator-internal preset target mapping in README

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -231,6 +231,12 @@ npm run report:naming:validator:tree
 npm run report:naming:validator:doc
 ```
 
+Preset target mapping:
+- `entry` → `calculogic-validator/bin` + `calculogic-validator/scripts`
+- `naming` → `calculogic-validator/naming`
+- `tree` → `calculogic-validator/tree`
+- `doc` → `calculogic-validator/doc`
+
 ## 5) Validator entrypoints and direct invocation
 
 This section includes package-defined validator entrypoints plus direct script invocation where useful, all executable from repo root.


### PR DESCRIPTION
### Motivation
- Make the validator-internal preset labels immediately self-explanatory by showing the preset label → target mapping next to the preset command list.

### Description
- Inserted a compact mapping note under the "Validator-internal naming/report presets" command block in `calculogic-validator/README.md` that clarifies: `entry` → `calculogic-validator/bin` + `calculogic-validator/scripts`, `naming` → `calculogic-validator/naming`, `tree` → `calculogic-validator/tree`, and `doc` → `calculogic-validator/doc`; this is README-only and does not modify scripts, runtime behavior, or scope taxonomy.

### Testing
- No automated tests were run because this is a documentation-only change and does not affect runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caeb4b41b48331aa524cdfac94dff1)