### PR TITLE
Add bounded naming→tree semantic-family bridge contributor slice

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -358,8 +358,30 @@ Boundary clarifications:
 - these are naming-owned observed report surfaces, not shared registry declarations
 - aggregate counts represent what a naming run observed after canonical-evidence inclusion; they are not policy truth by themselves
 - current runtime only emits these derived details when the semantic-name shape supports bounded deterministic interpretation; it does not force every filename to have family outputs
-- tree may later consume naming-owned emitted surfaces rather than deriving semantic-family independently
+- tree may consume these naming-owned emitted surfaces through a bounded prepared-input bridge and must not re-derive semantic-family semantics from filenames locally
 - later custom-registry work may review recurring observations as candidate evidence for additions, overlays, or pinning, but registry truth must still be declared through a separate policy/customization lane
+
+### Naming→Tree semantic-family bridge contract (bounded cross-slice consumption)
+
+Naming remains the sole owner of semantic-family derivation and validity interpretation. Tree may consume naming-emitted semantic-family evidence only through a bounded prepared-input projection, not by reading arbitrary naming runtime internals.
+
+Canonical ownership split:
+
+- naming owns semantic interpretation (`semanticName`, `familyRoot`, `semanticFamily`, optional `familySubgroup`, optional ambiguity/split markers) and naming-validity judgments
+- tree owns structural advisories and recommendations derived from prepared structural + naming-owned evidence
+- tree must not re-parse semantic names, infer family roots, or reproduce naming validity checks (`missing role`, `bad semantic case`, `deprecated role`, `role-hyphen ambiguity`)
+
+Prepared bridge projection (small explicit surface):
+
+- `path` (normalized repo-relative path)
+- `semanticName`
+- `familyRoot`
+- `semanticFamily`
+- optional `familySubgroup`
+- optional `ambiguityFlags`
+- optional `splitFamilyFlags`
+
+This bridge is an intentionally narrow projection for advisory consumption. It is not a generic "pass the full naming report to tree" contract.
 
 ### Special-case subtype metadata
 

--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -60,7 +60,7 @@ V0.1.x uses deterministic path-based and occurrence-backed signals only:
 - filename basename patterns that strongly indicate validator ownership
 - occurrence-derived structural records when `occurrenceSnapshot.occurrenceRecords` is available
 
-Current boundary note: shipped tree heuristics do **not** yet ingest naming-derived semantic-family/role outputs. That consumption path remains deferred and, when added later, must consume naming-owned signals rather than derive naming semantics independently.
+Current boundary note: shipped tree heuristics may ingest naming-derived semantic-family evidence only through a bounded prepared-input bridge projection. Tree must consume naming-owned signals and must not derive semantic-family semantics independently.
 
 ### 2.3 Initial advisory heuristics (narrow slice)
 
@@ -92,6 +92,7 @@ V0.1.7 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - suite-core helper owns scope profile read, includeRoots walk, includeRootFiles inclusion, normalized path collection, target filtering, and deterministic sort/dedupe
 - tree wiring consumes the shared scoped snapshot input and still prepares tree-local top-level directory inventory
 - tree runtime remains slice-owned for tree-core findings using prepared tree-core inputs only (`selectedPaths`, `topLevelDirectoryNames`, `targets`) and consumes occurrence-derived file-path reasoning input when `occurrenceSnapshot.occurrenceRecords` is available (bounded fallback to `selectedPaths` when occurrence snapshot is absent/malformed)
+- tree contributor attachment now supports bounded naming-owned semantic-family bridge payloads (`namingSemanticFamilyBridge.observations[]`) for structural advisories while preserving naming ownership of semantic derivation and validity interpretation
 - occurrence-driven file reasoning now carries bounded structural class metadata on occurrence records (`structuralClass`, `structuralKind`, repo-top known-root flags, scoped-root flag, subtree-partition candidate flag) for near-term tree-local interpretation
 - tree-run default contributor selection is owned by a dedicated assembly/wiring module so tree wiring only prepares tree-core inputs
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
@@ -154,7 +155,6 @@ Each finding follows existing report conventions:
 
 Deferred to later slices:
 
-- naming-derived semantic-family/lane heuristics and clustering
 - docs/runtime/test co-location drift heuristics
 - mixed concern folder smell heuristics
 - structural recommendation planning and move proposals

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -93,11 +93,13 @@ Tree advisor consumes naming-shaped metadata only across an explicit slice bound
 
 **Current shipped runtime posture:**
 
-- current tree findings do **not** yet ingest parsed naming-validator outputs or semantic-family clustering data
-- current shipped tree findings are driven by deterministic path, basename, scope, target, shim-evidence, and occurrence-derived structural signals
-- the naming boundary still matters now because any later tree heuristic that needs semantic-family or role information must consume naming-derived signals rather than re-implement naming interpretation locally
+- tree runtime now supports a bounded naming→tree prepared-input bridge for contributor-backed semantic-family advisory consumption
+- consumed bridge payload is naming-owned evidence projection only (not raw naming runtime internals)
+- shipped semantic-family tree advisories remain report-first and deterministic
+- tree findings continue to be driven by deterministic path/basename/scope/target/shim/occurrence signals plus optional naming bridge evidence when provided
+- tree heuristics that need semantic-family or role information must consume naming-derived signals rather than re-implement naming interpretation locally
 
-When naming-derived signal input is explicitly wired in later, intended consumable surfaces include:
+Bounded consumable naming bridge surfaces include:
 
 - `semanticName`
 - semantic family/group outputs derived by naming from `semanticName`
@@ -115,6 +117,19 @@ Examples of naming validity judgments that tree advisor must not duplicate:
 - hyphen-role ambiguity
 
 When usable naming-shaped metadata is unavailable, incomplete, or not yet wired into tree runtime, tree advisor should reduce confidence and/or recommend running naming validation rather than inventing naming-invalid findings inside tree output. Naming-owned aggregate observations are downstream evidence only and do not let tree declare registry truth on its own.
+
+Bridge shape (prepared-input contract):
+
+- `namingSemanticFamilyBridge.observations[]`
+  - `path`
+  - `semanticName`
+  - `familyRoot`
+  - `semanticFamily`
+  - optional `familySubgroup`
+  - optional `ambiguityFlags[]`
+  - optional `splitFamilyFlags[]`
+
+Tree consumes this normalized bridge payload only. Tree runtime must not parse filenames to recreate these fields.
 
 Boundary note (canonical_target for this slice): tree validator ownership is under `calculogic-validator/tree/src/**`. Legacy flat suite-core paths such as `calculogic-validator/src/tree-structure-advisor.*.mjs` are compatibility wrappers only, not canonical ownership.
 
@@ -521,8 +536,8 @@ Each finding uses the same stable envelope shape used by existing validators:
 
 ### Deferred/planning code candidates (future advisory direction)
 
-- `TREE_OBSERVED_FAMILY_CLUSTER`
-- `TREE_FAMILY_SCATTERED`
+- `TREE_OBSERVED_FAMILY_CLUSTER` (`info`) — implemented via naming bridge contributor (bounded thresholded cluster observability)
+- `TREE_FAMILY_SCATTERED` (`info`) — implemented via naming bridge contributor (bounded family scatter advisory)
 - `TREE_LANE_MIX_HIGH_ENTROPY`
 - `TREE_MISSING_NAMESPACE_ROOT`
 - `TREE_SUBSYSTEM_SCAFFOLD_ASYMMETRY`
@@ -553,7 +568,7 @@ Deferred candidates above are a documentation menu only. They are not current ru
   - `findingContributors` (array of contributor callbacks)
 - Tree core does **not** require `getFileContent(relativePath)`.
 - Current tree runtime does **not** consume tree-specific config surfaces. The dedicated CLI may accept `--config=<path>` through shared suite runner plumbing, but current tree behavior only validates/normalizes the shared config shape and exposes `configDigest` at the runner envelope when config is supplied.
-- Current tree runtime does **not** emit tree addresses, move proposals, semantic-family clustering payloads, or naming-derived parsed metadata in findings/report payloads.
+- Current tree runtime does **not** emit tree addresses or move proposals. Naming bridge payload is consumed as contributor input and is not re-emitted as a raw payload surface.
 
 ### Composition ownership
 
@@ -574,6 +589,11 @@ Attached shim contributor currently ships during normal tree runs:
 
 - `TREE_SHIM_SURFACE_PRESENT`
 - `TREE_SHIM_OUTSIDE_COMPAT`
+
+Attached naming bridge contributor (when bridge payload is provided) currently ships:
+
+- `TREE_OBSERVED_FAMILY_CLUSTER`
+- `TREE_FAMILY_SCATTERED`
 
 ### Current report payload from tree runtime
 

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -1,0 +1,175 @@
+import path from 'node:path';
+
+const FAMILY_SCATTER_MIN_STRUCTURAL_HOMES = 2;
+const FAMILY_SCATTER_MIN_FILES = 3;
+const FAMILY_CLUSTER_INFO_MIN_FILES = 4;
+
+const toSortedUnique = (values) => Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+
+const toSortedUniqueStringFlags = (flags) =>
+  toSortedUnique(flags.filter((flag) => typeof flag === 'string' && flag.length > 0));
+
+const toNormalizedStructuralHome = (normalizedPath) => {
+  const parentDirectory = path.posix.dirname(normalizedPath);
+  if (parentDirectory === '.') {
+    return '.';
+  }
+
+  const segments = parentDirectory.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return parentDirectory;
+  }
+
+  return segments.slice(0, 2).join('/');
+};
+
+const toNormalizedBridgeObservation = (observation) => {
+  if (!observation || typeof observation !== 'object' || Array.isArray(observation)) {
+    return null;
+  }
+
+  const requiredFields = ['path', 'semanticName', 'familyRoot', 'semanticFamily'];
+  for (const requiredField of requiredFields) {
+    if (typeof observation[requiredField] !== 'string' || observation[requiredField].length === 0) {
+      return null;
+    }
+  }
+
+  return {
+    path: observation.path,
+    semanticName: observation.semanticName,
+    familyRoot: observation.familyRoot,
+    semanticFamily: observation.semanticFamily,
+    ...(typeof observation.familySubgroup === 'string' && observation.familySubgroup.length > 0
+      ? { familySubgroup: observation.familySubgroup }
+      : {}),
+    ...(Array.isArray(observation.ambiguityFlags)
+      ? { ambiguityFlags: toSortedUniqueStringFlags(observation.ambiguityFlags) }
+      : {}),
+    ...(Array.isArray(observation.splitFamilyFlags)
+      ? { splitFamilyFlags: toSortedUniqueStringFlags(observation.splitFamilyFlags) }
+      : {}),
+  };
+};
+
+export const prepareNamingSemanticFamilyBridge = (bridgePayload) => {
+  if (!bridgePayload || typeof bridgePayload !== 'object' || Array.isArray(bridgePayload)) {
+    return { observations: [] };
+  }
+
+  if (!Array.isArray(bridgePayload.observations)) {
+    throw new Error('Tree naming semantic-family bridge requires observations[] when payload is provided.');
+  }
+
+  const normalizedObservations = bridgePayload.observations
+    .map(toNormalizedBridgeObservation)
+    .filter(Boolean)
+    .sort((left, right) => left.path.localeCompare(right.path));
+
+  return {
+    observations: normalizedObservations,
+  };
+};
+
+const isSingularFamilyEvidence = (observation) => (observation.ambiguityFlags ?? []).length === 0;
+
+const collectFamilyScatterFindings = (observations) => {
+  const observationsBySemanticFamily = new Map();
+
+  for (const observation of observations) {
+    if (!isSingularFamilyEvidence(observation)) {
+      continue;
+    }
+
+    if (!observationsBySemanticFamily.has(observation.semanticFamily)) {
+      observationsBySemanticFamily.set(observation.semanticFamily, []);
+    }
+
+    observationsBySemanticFamily.get(observation.semanticFamily).push(observation);
+  }
+
+  return Array.from(observationsBySemanticFamily.entries())
+    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
+    .flatMap(([semanticFamily, familyObservations]) => {
+      const sortedPaths = familyObservations.map(({ path: normalizedPath }) => normalizedPath).sort((a, b) => a.localeCompare(b));
+      const structuralHomes = toSortedUnique(
+        familyObservations.map(({ path: normalizedPath }) => toNormalizedStructuralHome(normalizedPath)),
+      );
+
+      if (
+        sortedPaths.length < FAMILY_SCATTER_MIN_FILES ||
+        structuralHomes.length < FAMILY_SCATTER_MIN_STRUCTURAL_HOMES
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          code: 'TREE_FAMILY_SCATTERED',
+          severity: 'info',
+          path: sortedPaths[0],
+          classification: 'advisory-structure',
+          message:
+            'Naming-owned semantic-family evidence is spread across multiple structural homes and may benefit from clearer semantic-first grouping.',
+          ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
+          details: {
+            semanticFamily,
+            observedPaths: sortedPaths,
+            observedStructuralHomes: structuralHomes,
+            thresholds: {
+              minFamilyFiles: FAMILY_SCATTER_MIN_FILES,
+              minStructuralHomes: FAMILY_SCATTER_MIN_STRUCTURAL_HOMES,
+            },
+          },
+        },
+      ];
+    });
+};
+
+const collectFamilyClusterFindings = (observations) => {
+  const familyCounts = new Map();
+
+  for (const observation of observations) {
+    if (!isSingularFamilyEvidence(observation)) {
+      continue;
+    }
+
+    familyCounts.set(observation.semanticFamily, (familyCounts.get(observation.semanticFamily) ?? 0) + 1);
+  }
+
+  return observations
+    .filter((observation) => isSingularFamilyEvidence(observation))
+    .filter((observation) => (familyCounts.get(observation.semanticFamily) ?? 0) >= FAMILY_CLUSTER_INFO_MIN_FILES)
+    .sort((left, right) => left.path.localeCompare(right.path))
+    .filter((observation, index, sorted) => index === 0 || sorted[index - 1].semanticFamily !== observation.semanticFamily)
+    .map((observation) => ({
+      code: 'TREE_OBSERVED_FAMILY_CLUSTER',
+      severity: 'info',
+      path: observation.path,
+      classification: 'advisory-structure',
+      message:
+        'Naming-owned semantic-family cluster size is high enough to consider a clearer structural grouping surface.',
+      ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
+      details: {
+        semanticFamily: observation.semanticFamily,
+        observedCount: familyCounts.get(observation.semanticFamily),
+        threshold: {
+          minFamilyFilesForClusterObservation: FAMILY_CLUSTER_INFO_MIN_FILES,
+        },
+      },
+    }));
+};
+
+export const collectNamingSemanticFamilyBridgeFindings = (bridgePayload) => {
+  const namingSemanticFamilyBridge = prepareNamingSemanticFamilyBridge(bridgePayload);
+  const observations = namingSemanticFamilyBridge.observations;
+
+  if (observations.length === 0) {
+    return [];
+  }
+
+  return [
+    ...collectFamilyScatterFindings(observations),
+    ...collectFamilyClusterFindings(observations),
+  ];
+};

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.wiring.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.wiring.mjs
@@ -1,0 +1,11 @@
+import {
+  collectNamingSemanticFamilyBridgeFindings,
+} from './tree-naming-semantic-family-bridge-contributor.logic.mjs';
+
+export const attachTreeNamingSemanticFamilyBridgeContributor = ({ namingSemanticFamilyBridge }) => {
+  if (namingSemanticFamilyBridge === undefined) {
+    return null;
+  }
+
+  return () => collectNamingSemanticFamilyBridgeFindings(namingSemanticFamilyBridge);
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor-contributors-assembly.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor-contributors-assembly.wiring.mjs
@@ -1,11 +1,20 @@
 import {
   attachTreeShimDiagnosticsContributor,
 } from './contributors/tree-shim-diagnostics-contributor.wiring.mjs';
+import {
+  attachTreeNamingSemanticFamilyBridgeContributor,
+} from './contributors/tree-naming-semantic-family-bridge-contributor.wiring.mjs';
 
-export const collectDefaultTreeStructureAdvisorContributors = ({ repositoryRoot, selectedPaths }) => [
+export const collectDefaultTreeStructureAdvisorContributors = ({
+  repositoryRoot,
+  selectedPaths,
+  namingSemanticFamilyBridge,
+}) => [
   attachTreeShimDiagnosticsContributor({
     repositoryRoot,
     selectedPaths,
   }),
-];
-
+  attachTreeNamingSemanticFamilyBridgeContributor({
+    namingSemanticFamilyBridge,
+  }),
+].filter(Boolean);

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -32,7 +32,10 @@ const collectTopLevelDirectoryNames = (repositoryRoot) =>
     .filter((directoryName) => !directoryName.startsWith('.'))
     .sort((left, right) => left.localeCompare(right));
 
-export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targets } = {}) => {
+export const prepareTreeStructureAdvisorInputs = (
+  repositoryRoot,
+  { scope, targets, namingSemanticFamilyBridge } = {},
+) => {
   const scopedSnapshotInputs = collectSuiteScopedSnapshotInputs(repositoryRoot, {
     scope,
     targets,
@@ -54,12 +57,17 @@ export const prepareTreeStructureAdvisorInputs = (repositoryRoot, { scope, targe
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,
       selectedPaths,
+      namingSemanticFamilyBridge,
     }),
   };
 };
 
-export const runTreeStructureAdvisor = (repositoryRoot, { scope, targets } = {}) => {
-  const preparedInputs = prepareTreeStructureAdvisorInputs(repositoryRoot, { scope, targets });
+export const runTreeStructureAdvisor = (repositoryRoot, { scope, targets, namingSemanticFamilyBridge } = {}) => {
+  const preparedInputs = prepareTreeStructureAdvisorInputs(repositoryRoot, {
+    scope,
+    targets,
+    namingSemanticFamilyBridge,
+  });
   return runTreeStructureAdvisorRuntime(preparedInputs);
 };
 

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  collectNamingSemanticFamilyBridgeFindings,
+} from '../src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs';
+import { runTreeStructureAdvisor } from '../src/tree-structure-advisor.logic.mjs';
+
+const createPreparedTreeCoreInputs = (findingContributors = []) => ({
+  selectedPaths: [],
+  topLevelDirectoryNames: [],
+  targets: [],
+  findingContributors,
+});
+
+test('tree naming bridge contributor consumes naming-owned semantic-family evidence', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/shared/build/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/features/build/build-surface.results.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/features/build/build-surface.knowledge.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/features/build/build-surface.build.tsx',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    findings.map((finding) => finding.code).sort((left, right) => left.localeCompare(right)),
+    ['TREE_FAMILY_SCATTERED', 'TREE_OBSERVED_FAMILY_CLUSTER'],
+  );
+});
+
+test('tree naming bridge contributor does not derive semantic-family when naming-owned fields are absent', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/features/odd/file.logic.ts',
+        semanticName: 'would-need-local-derivation',
+        familyRoot: 'would',
+      },
+    ],
+  });
+
+  assert.deepEqual(findings, []);
+});
+
+test('tree naming bridge contributor does not emit naming validity judgments', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/a/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/b/build-surface.results.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/c/build-surface.knowledge.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code.startsWith('NAMING_')), false);
+});
+
+test('tree runtime keeps naming bridge contributor output deterministic for identical prepared inputs', () => {
+  const namingBridgePayload = {
+    observations: [
+      {
+        path: 'src/a/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/c/build-surface.knowledge.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/b/build-surface.results.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+    ],
+  };
+
+  const namingBridgeContributor = () => collectNamingSemanticFamilyBridgeFindings(namingBridgePayload);
+  const preparedInputs = createPreparedTreeCoreInputs([namingBridgeContributor]);
+
+  const first = runTreeStructureAdvisor(preparedInputs);
+  const second = runTreeStructureAdvisor(preparedInputs);
+
+  assert.deepEqual(first.findings, second.findings);
+  assert.equal(first.findings.length, 1);
+  assert.equal(first.findings[0].code, 'TREE_FAMILY_SCATTERED');
+});
+
+test('tree naming bridge contributor excludes ambiguity-flagged observations from stronger family advisories', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/a/alpha-beta-gamma-delta.logic.ts',
+        semanticName: 'alpha-beta-gamma-delta',
+        familyRoot: 'alpha',
+        semanticFamily: 'alpha-beta',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'src/b/alpha-beta-gamma-delta.results.ts',
+        semanticName: 'alpha-beta-gamma-delta',
+        familyRoot: 'alpha',
+        semanticFamily: 'alpha-beta',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'src/c/alpha-beta-gamma-delta.knowledge.ts',
+        semanticName: 'alpha-beta-gamma-delta',
+        familyRoot: 'alpha',
+        semanticFamily: 'alpha-beta',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'src/d/alpha-beta-gamma-delta.build.tsx',
+        semanticName: 'alpha-beta-gamma-delta',
+        familyRoot: 'alpha',
+        semanticFamily: 'alpha-beta',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+    ],
+  });
+
+  assert.deepEqual(findings, []);
+});


### PR DESCRIPTION
### Motivation

- Make the naming→tree ownership boundary explicit so `tree` can consume naming-owned semantic-family evidence without re-deriving naming semantics locally.
- Provide a small, deterministic prepared-input bridge shape that keeps naming validity and interpretation owned by `naming` while enabling tree-side advisory heuristics.
- Ship a minimal, contributor-backed tree advisory that demonstrates useful structural recommendations (family cluster / scatter) without broad runtime or registry changes.

### Description

- Add a bounded prepared-input bridge and bridge contract documented in `NamingValidatorSpec.md` and `tree-structure-advisor-validator.spec.md`, declaring the narrow projection fields such as `path`, `semanticName`, `familyRoot`, `semanticFamily`, optional `familySubgroup`, `ambiguityFlags`, and `splitFamilyFlags` and reaffirming that tree must not re-derive naming validity.
- Implement a new naming→tree contributor with deterministic thresholds and findings: `TREE_FAMILY_SCATTERED` and `TREE_OBSERVED_FAMILY_CLUSTER`, in `tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` and its wiring `...-bridge-contributor.wiring.mjs` and integrate it into the default contributor assembly via `tree-structure-advisor-contributors-assembly.wiring.mjs` while passing the optional `namingSemanticFamilyBridge` through `tree-structure-advisor.wiring.mjs`.
- Keep tree core bounded and unchanged in semantics beyond wiring; the contributor normalizes observations, excludes ambiguity-flagged entries from stronger advisories, and uses explicit constants `FAMILY_SCATTER_MIN_STRUCTURAL_HOMES`, `FAMILY_SCATTER_MIN_FILES`, and `FAMILY_CLUSTER_INFO_MIN_FILES` for deterministic decisions.
- Add focused tests in `tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` that prove bridge consumption, no local re-derivation of naming semantics, no emission of naming validity findings, deterministic results for identical prepared inputs, and exclusion of ambiguity-flagged observations; also update NL/config note `cfg-treeStructureAdvisor.md` to reflect the bounded bridge behavior.

### Testing

- Ran the new focused bridge test plus the existing tree test suite with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs calculogic-validator/tree/test/tree-structure-advisor.test.mjs` and all tests passed (41 tests, 0 failures).
- New tests assert that `collectNamingSemanticFamilyBridgeFindings(...)` returns the expected `TREE_FAMILY_SCATTERED` and `TREE_OBSERVED_FAMILY_CLUSTER` codes for canonical observations and that ambiguity-flagged observations are excluded, and these assertions succeeded.
- Determinism checks assert identical findings ordering and counts for identical prepared inputs and succeeded during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d589909af883318855ecfa0cb0e82b)