### PR TITLE
Stage naming semantic-family bridge before tree in shared runner

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -383,6 +383,14 @@ Prepared bridge projection (small explicit surface):
 
 This bridge is an intentionally narrow projection for advisory consumption. It is not a generic "pass the full naming report to tree" contract.
 
+Current runner production path (shipped behavior):
+
+- the shared suite runner stages naming before tree whenever tree is selected in the run
+- naming-owned projection is prepared from naming findings through a dedicated naming-owned bridge projection helper
+- tree receives only `namingSemanticFamilyBridge.observations[]` through tree wiring; tree never receives raw naming runtime internals from runner staging
+- `validate:naming` remains naming-only output
+- `validate:tree` and `validate:all` now automatically include naming-produced bridge evidence for tree advisories through the shared runner path
+
 ### Special-case subtype metadata
 
 V0.1.2 keeps top-level classification `allowed-special-case` and includes deterministic subtype metadata in `details.specialCaseType`:

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -96,16 +96,18 @@ Tree advisor consumes naming-shaped metadata only across an explicit slice bound
 - tree runtime now supports a bounded naming→tree prepared-input bridge for contributor-backed semantic-family advisory consumption
 - consumed bridge payload is naming-owned evidence projection only (not raw naming runtime internals)
 - shipped semantic-family tree advisories remain report-first and deterministic
-- tree findings continue to be driven by deterministic path/basename/scope/target/shim/occurrence signals plus optional naming bridge evidence when provided
+- tree findings continue to be driven by deterministic path/basename/scope/target/shim/occurrence signals plus naming bridge evidence staged by the shared runner when tree executes through normal runner paths
 - tree heuristics that need semantic-family or role information must consume naming-derived signals rather than re-implement naming interpretation locally
 
 Bounded consumable naming bridge surfaces include:
 
+- `path`
 - `semanticName`
-- semantic family/group outputs derived by naming from `semanticName`
-- naming-owned aggregate observations such as `familyRootCounts`, `familySubgroupCounts`, and `semanticFamilyCounts` when/if naming later emits them
-- `role`
-- role category/status metadata
+- `familyRoot`
+- `semanticFamily`
+- optional `familySubgroup`
+- optional `ambiguityFlags[]`
+- optional `splitFamilyFlags[]`
 
 Tree advisor does **not** re-own naming validity judgments. Naming validity remains owned by naming conventions/specs and the naming validator slice.
 
@@ -116,7 +118,7 @@ Examples of naming validity judgments that tree advisor must not duplicate:
 - deprecated role
 - hyphen-role ambiguity
 
-When usable naming-shaped metadata is unavailable, incomplete, or not yet wired into tree runtime, tree advisor should reduce confidence and/or recommend running naming validation rather than inventing naming-invalid findings inside tree output. Naming-owned aggregate observations are downstream evidence only and do not let tree declare registry truth on its own.
+When usable naming-shaped metadata is unavailable, incomplete, or not yet wired into tree runtime in a bounded context, tree advisor should reduce confidence and/or recommend running naming validation rather than inventing naming-invalid findings inside tree output.
 
 Bridge shape (prepared-input contract):
 
@@ -590,7 +592,7 @@ Attached shim contributor currently ships during normal tree runs:
 - `TREE_SHIM_SURFACE_PRESENT`
 - `TREE_SHIM_OUTSIDE_COMPAT`
 
-Attached naming bridge contributor (when bridge payload is provided) currently ships:
+Attached naming bridge contributor (with runner-staged bridge payload during normal runner execution) currently ships:
 
 - `TREE_OBSERVED_FAMILY_CLUSTER`
 - `TREE_FAMILY_SCATTERED`

--- a/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
+++ b/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
@@ -1,0 +1,63 @@
+const toSortedUniqueStringFlags = (flags) =>
+  Array.from(
+    new Set(flags.filter((flag) => typeof flag === 'string' && flag.length > 0)),
+  ).sort((left, right) => left.localeCompare(right));
+
+const toBridgeObservationFromFinding = (finding) => {
+  if (!finding || typeof finding !== 'object' || Array.isArray(finding)) {
+    return null;
+  }
+
+  if (finding.classification !== 'canonical') {
+    return null;
+  }
+
+  if (typeof finding.path !== 'string' || finding.path.length === 0) {
+    return null;
+  }
+
+  const details = finding.details;
+  if (!details || typeof details !== 'object' || Array.isArray(details)) {
+    return null;
+  }
+
+  if (
+    typeof details.semanticName !== 'string' ||
+    details.semanticName.length === 0 ||
+    typeof details.familyRoot !== 'string' ||
+    details.familyRoot.length === 0 ||
+    typeof details.semanticFamily !== 'string' ||
+    details.semanticFamily.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    path: finding.path,
+    semanticName: details.semanticName,
+    familyRoot: details.familyRoot,
+    semanticFamily: details.semanticFamily,
+    ...(typeof details.familySubgroup === 'string' && details.familySubgroup.length > 0
+      ? { familySubgroup: details.familySubgroup }
+      : {}),
+    ...(Array.isArray(details.ambiguityFlags)
+      ? { ambiguityFlags: toSortedUniqueStringFlags(details.ambiguityFlags) }
+      : {}),
+    ...(Array.isArray(details.splitFamilyFlags)
+      ? { splitFamilyFlags: toSortedUniqueStringFlags(details.splitFamilyFlags) }
+      : {}),
+  };
+};
+
+export const projectNamingSemanticFamilyBridge = (namingRuntimeOrReportOutput = {}) => {
+  const findings = Array.isArray(namingRuntimeOrReportOutput.findings)
+    ? namingRuntimeOrReportOutput.findings
+    : [];
+
+  return {
+    observations: findings
+      .map(toBridgeObservationFromFinding)
+      .filter(Boolean)
+      .sort((left, right) => left.path.localeCompare(right.path)),
+  };
+};

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -20,6 +20,7 @@ import {
   getScopeProfile,
   summarizeFindings as summarizeFindingsRuntime,
 } from './naming-validator.logic.mjs';
+import { projectNamingSemanticFamilyBridge } from './naming-semantic-family-bridge-projection.logic.mjs';
 import {
   normalizePath,
   resolveScopedTargets,
@@ -115,4 +116,5 @@ export {
   normalizePath,
   listNamingValidatorScopes,
   getScopeProfile,
+  projectNamingSemanticFamilyBridge,
 };

--- a/calculogic-validator/naming/test/naming-semantic-family-bridge-projection.test.mjs
+++ b/calculogic-validator/naming/test/naming-semantic-family-bridge-projection.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { projectNamingSemanticFamilyBridge } from '../src/naming-validator.host.mjs';
+
+test('naming bridge projection emits bounded semantic-family observation fields only', () => {
+  const projected = projectNamingSemanticFamilyBridge({
+    findings: [
+      {
+        path: 'src/a/build-surface.logic.ts',
+        classification: 'canonical',
+        details: {
+          semanticName: 'build-surface',
+          familyRoot: 'build',
+          semanticFamily: 'build-surface',
+          familySubgroup: 'surface',
+          ambiguityFlags: ['family-boundary-heuristic', 'family-boundary-heuristic'],
+          splitFamilyFlags: ['family-root-observed-multiple-families'],
+          unrelatedRuntimeField: 'must-not-leak',
+        },
+        unrelatedFindingField: 'must-not-leak',
+      },
+      {
+        path: 'src/b/non-canonical.logic.ts',
+        classification: 'invalid-legacy',
+        details: {
+          semanticName: 'non-canonical',
+          familyRoot: 'non',
+          semanticFamily: 'non-canonical',
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(projected, {
+    observations: [
+      {
+        path: 'src/a/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+        familySubgroup: 'surface',
+        ambiguityFlags: ['family-boundary-heuristic'],
+        splitFamilyFlags: ['family-root-observed-multiple-families'],
+      },
+    ],
+  });
+});
+
+test('naming bridge projection tolerates missing findings arrays with empty observations', () => {
+  assert.deepEqual(projectNamingSemanticFamilyBridge({}), { observations: [] });
+});

--- a/calculogic-validator/src/core/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/core/validator-registry.knowledge.mjs
@@ -36,10 +36,12 @@ const runTreeStructureAdvisorHook = (repositoryRoot, options = {}) => {
   const scope = options.scope;
   const config = options.config;
   const targets = options.targets;
+  const namingSemanticFamilyBridge = options.namingSemanticFamilyBridge;
   const treeStructureAdvisorResult = runTreeStructureAdvisor(repositoryRoot, {
     scope,
     config,
     targets,
+    namingSemanticFamilyBridge,
   });
   const summary = summarizeTreeStructureAdvisorFindings(treeStructureAdvisorResult.findings);
   const meta = {};

--- a/calculogic-validator/src/core/validator-runner.logic.mjs
+++ b/calculogic-validator/src/core/validator-runner.logic.mjs
@@ -1,6 +1,7 @@
 import { CALCULOGIC_VALIDATOR_REPORT_VERSION } from './validator-report.contracts.mjs';
 import { VALIDATOR_REGISTRY, getValidatorById } from './validator-registry.knowledge.mjs';
 import { getSourceSnapshot } from './source-snapshot.logic.mjs';
+import { projectNamingSemanticFamilyBridge } from '../../naming/src/naming-validator.host.mjs';
 
 const toValidatorReportEntry = (registryEntry, validatorResult) => {
   const summary = validatorResult.summary ?? null;
@@ -44,8 +45,32 @@ export const runValidatorRunner = (repositoryRoot, options = {}) => {
   const config = options.config;
   const targets = options.targets;
 
+  const shouldRunTreeStructureAdvisor = validatorsToRun.some(
+    (registryEntry) => registryEntry.id === 'tree-structure-advisor',
+  );
+  const shouldIncludeNamingReport = validatorsToRun.some((registryEntry) => registryEntry.id === 'naming');
+  const namingRegistryEntry = getValidatorById('naming');
+
+  let stagedNamingResult = null;
+  let stagedNamingSemanticFamilyBridge = undefined;
+  if (shouldRunTreeStructureAdvisor && namingRegistryEntry) {
+    stagedNamingResult = namingRegistryEntry.run(repositoryRoot, { scope, config, targets });
+    stagedNamingSemanticFamilyBridge = projectNamingSemanticFamilyBridge(stagedNamingResult);
+  }
+
   const validators = validatorsToRun.map((registryEntry) => {
-    const result = registryEntry.run(repositoryRoot, { scope, config, targets });
+    if (registryEntry.id === 'naming' && shouldIncludeNamingReport && stagedNamingResult) {
+      return toValidatorReportEntry(registryEntry, stagedNamingResult);
+    }
+
+    const result = registryEntry.run(repositoryRoot, {
+      scope,
+      config,
+      targets,
+      ...(registryEntry.id === 'tree-structure-advisor' && stagedNamingSemanticFamilyBridge
+        ? { namingSemanticFamilyBridge: stagedNamingSemanticFamilyBridge }
+        : {}),
+    });
     return toValidatorReportEntry(registryEntry, result);
   });
 

--- a/calculogic-validator/test/validator-runner.test.mjs
+++ b/calculogic-validator/test/validator-runner.test.mjs
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
 import { runValidatorRunner } from '../src/core/validator-runner.logic.mjs';
 
@@ -75,4 +78,89 @@ test('runner omits naming filter meta when no targets are provided', () => {
   assert.equal(report.validators[0].id, 'naming');
   assert.equal(report.validators[0].validatorId, 'naming');
   assert.equal(report.validators[0].meta?.filters, undefined);
+});
+
+test('runner stages naming-owned bridge evidence before tree in tree-only runs', async () => {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-runner-tree-bridge-'));
+
+  try {
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'a'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'b'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'c'), { recursive: true });
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'a', 'build-surface.logic.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'b', 'build-surface.results.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'c', 'build-surface.knowledge.ts'), 'export {};\n', 'utf8');
+
+    const report = runValidatorRunner(fixtureRoot, {
+      validators: ['tree-structure-advisor'],
+      scope: 'repo',
+    });
+
+    assert.deepEqual(report.validators.map((validator) => validator.id), ['tree-structure-advisor']);
+    assert.equal(
+      report.validators[0].findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'),
+      true,
+    );
+    assert.equal(
+      report.validators[0].findings.some((finding) => finding.code.startsWith('NAMING_')),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('runner tree output remains deterministic for identical staged naming bridge inputs', async () => {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-runner-tree-deterministic-'));
+
+  try {
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'a'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'b'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'c'), { recursive: true });
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'a', 'build-surface.logic.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'b', 'build-surface.results.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'c', 'build-surface.knowledge.ts'), 'export {};\n', 'utf8');
+
+    const first = runValidatorRunner(fixtureRoot, {
+      validators: ['tree-structure-advisor'],
+      scope: 'repo',
+    });
+    const second = runValidatorRunner(fixtureRoot, {
+      validators: ['tree-structure-advisor'],
+      scope: 'repo',
+    });
+
+    assert.deepEqual(first.validators[0].findings, second.validators[0].findings);
+  } finally {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('runner excludes ambiguity-flagged naming observations from stronger tree bridge advisories', async () => {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-runner-tree-ambiguity-'));
+
+  try {
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'a'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'b'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'c'), { recursive: true });
+    await fs.mkdir(path.join(fixtureRoot, 'src', 'd'), { recursive: true });
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'a', 'alpha-beta-gamma-delta.logic.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'b', 'alpha-beta-gamma-delta.results.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'c', 'alpha-beta-gamma-delta.knowledge.ts'), 'export {};\n', 'utf8');
+    await fs.writeFile(path.join(fixtureRoot, 'src', 'd', 'alpha-beta-gamma-delta.build.tsx'), 'export {};\n', 'utf8');
+
+    const report = runValidatorRunner(fixtureRoot, {
+      validators: ['tree-structure-advisor'],
+      scope: 'repo',
+    });
+
+    const treeFindings = report.validators[0].findings;
+    assert.equal(treeFindings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+    assert.equal(
+      treeFindings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'),
+      false,
+    );
+  } finally {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
### Motivation

- Provide a bounded end-to-end naming→tree bridge so ordinary runner executions can stage naming-owned semantic-family evidence for tree without exposing naming internals. 
- Keep naming as the owner of interpretation and projection while keeping tree as the owner of structural advisories. 
- Implement the smallest explicit staging path in the shared runner rather than a generic cross-validator dependency graph.

### Description

- Add a naming-owned projection helper `projectNamingSemanticFamilyBridge` that converts naming findings into a narrow `namingSemanticFamilyBridge.observations[]` payload containing only `path`, `semanticName`, `familyRoot`, `semanticFamily`, and optional `familySubgroup`, `ambiguityFlags`, and `splitFamilyFlags`.
- Export the projection through naming wiring so the runner can call it without tree importing naming internals. 
- Update the shared runner `runValidatorRunner` so that when `tree-structure-advisor` is selected it runs `naming` first, stages the naming report, projects the bounded bridge payload, reuses the staged naming report for the naming entry (if naming is also selected), and passes only the projected `namingSemanticFamilyBridge` into the tree runner invocation.
- Wire the `namingSemanticFamilyBridge` option through the validator registry hook into the tree wiring so tree contributors consume only the normalized bridge payload.
- Add focused tests that assert projection shape and runner end-to-end behavior and update naming/tree spec docs to reflect the shipped staged runner path.

Files changed (key):

- Affected naming code: `calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs` (new), `calculogic-validator/naming/src/naming-validator.wiring.mjs` (export added), `calculogic-validator/naming/test/naming-semantic-family-bridge-projection.test.mjs` (new test).
- Runner/registry: `calculogic-validator/src/core/validator-runner.logic.mjs` (stage-and-pass logic), `calculogic-validator/src/core/validator-registry.knowledge.mjs` (tree hook accepts bridge).
- Tests: `calculogic-validator/test/validator-runner.test.mjs` (added end-to-end runner tests).
- Docs/specs: `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` and `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` (clarified runner-staged bridge behavior).

### Testing

- Ran the naming bridge unit tests and the runner/tree end-to-end tests with `node --test calculogic-validator/naming/test/naming-semantic-family-bridge-projection.test.mjs calculogic-validator/test/validator-runner.test.mjs calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, and all tests passed (15 tests in that run passed).
- Ran integration target tests with `node --test calculogic-validator/test/validate-all.targets.integration.test.mjs`, and all tests passed (4 tests passed).
- Tests confirm: the runner stages naming before tree in tree-only runs, tree receives only the bounded projection (no raw naming internals), tree findings remain `TREE_*` and deterministic for identical inputs, naming-only runs remain unaffected, and ambiguity-flagged observations are excluded from stronger tree advisories.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59b1c2b9c8331995137056d0600db)