### PR TITLE
docs(validator): align README and naming spec with runner-staged naming→tree bridge behavior

### DIFF
--- a/calculogic-validator/README.md
+++ b/calculogic-validator/README.md
@@ -167,9 +167,16 @@ npm run health:validator
 ```
 
 - `npm run validate:naming`: naming-only validation using repo defaults.
-- `npm run validate:all`: full validator pass (all configured validators).
-- `npm run validate:tree`: tree-structure-advisor validation using repo defaults.
+- `npm run validate:all`: shared-runner validation that stages naming before tree and reports all configured validators.
+- `npm run validate:tree`: tree-structure-advisor validation through the shared runner path (tree only in report output).
 - `npm run health:validator`: validator environment/health diagnostics.
+
+Bridge behavior note (normal runs):
+
+- `validate:naming` remains naming-only.
+- `validate:tree` executes tree through the shared runner path; when tree is selected, the runner stages naming-owned semantic-family evidence first and passes only the bounded naming bridge payload into tree.
+- `validate:all` stages naming before tree in deterministic registry order; tree consumes the same bounded naming bridge payload rather than raw naming internals.
+- Ownership boundary stays explicit: naming interprets and projects semantic-family evidence, runner orchestrates staged execution, and tree consumes that bounded bridge to emit structural `TREE_*` advisories.
 
 ### Reports by scope and target
 
@@ -349,7 +356,7 @@ Canonical report contracts:
 There are two report envelopes:
 
 - slice output (single-slice CLI, for example `validate:naming`)
-- runner output (multi-slice CLI, for example `validate:all`)
+- runner output (runner-style CLIs, including `validate:all` and `validate:tree`)
 
 Validator reports include stable metadata fields for report envelope identity and reproducibility:
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md
@@ -2,7 +2,7 @@
 
 - **Classification:** Normative
 - **Applies to:** Naming-slice semantic-name interpretation extensions.
-- **Status:** Active for bounded naming-owned runtime/report behavior in the current tranche; semantic-family derivation is implemented as report-first observation, while tree consumption remains deferred.
+- **Status:** Active for bounded naming-owned runtime/report behavior in the current tranche; semantic-family derivation is implemented as report-first observation and is now consumable by tree through the runner-staged bounded naming→tree bridge.
 - **Authority posture note:** Bounded normative supporting spec for naming interpretation modeling; does not supersede primary canonical naming authorities.
 
 ## 1) Purpose
@@ -244,15 +244,15 @@ Current maturity boundary remains unchanged:
 
 - warn/error/strict/plan/fix behavior for semantic-family is not implemented in the current runtime tranche yet,
 - semantic-family interpretation remains structurally important and report-first in this phase,
-- results/reporting is the first intended consumer,
-- tree runtime consumption is not activated in this tranche yet and remains deferred until naming-owned implementation maturity justifies it.
+- results/reporting remains a first consumer,
+- tree runtime now consumes naming-owned semantic-family evidence through a bounded runner-staged bridge payload.
 
-Results-first, tree-later handoff clarification:
+Results + tree handoff clarification:
 
 - Results/reporting consumes naming-owned semantic-family outputs first.
-- Tree consumption is later and explicitly deferred in this tranche; that timing deferment does not make semantic-family derivation conceptually optional.
-- Tree may later consume `semanticFamily`/`familyRoot`/`familySubgroup`/`relatedSemanticNames` for semantic-folder expectations or grouping reasoning once naming emits those outputs.
-- Tree may later consume naming-owned aggregate observations such as `familyRootCounts`/`familySubgroupCounts`/`semanticFamilyCounts` only as report context, not as tree-owned policy declaration.
+- Tree consumes a bounded naming bridge payload projected by naming and staged by the shared runner (`namingSemanticFamilyBridge.observations[]`), rather than raw naming runtime internals.
+- Tree consumption remains constrained to naming-owned interpreted outputs (for example `semanticFamily`/`familyRoot`/`familySubgroup` and bounded ambiguity/split markers) and does not re-own derivation.
+- Tree may consume naming-owned aggregate observations such as `familyRootCounts`/`familySubgroupCounts`/`semanticFamilyCounts` as report context, not as tree-owned policy declaration.
 - Tree must not derive semantic-family independently as a competing source.
 
 Classification: Normative


### PR DESCRIPTION
### Motivation

- Audit and align outward-facing validator docs so readers can discover the shipped runner behavior where naming is staged before tree and a bounded naming→tree bridge payload is passed to tree. 
- Make the ownership boundary explicit and scannable so readers understand that naming interprets/projects, the runner orchestrates staging, and tree consumes only the bounded bridge for structural advisories.

### Description

- Updated `calculogic-validator/README.md` to make `validate:naming`, `validate:tree`, and `validate:all` behavior explicit, added a concise "Bridge behavior note" describing the runner-staged naming→tree handoff, and clarified that `validate:tree` is a runner-style CLI surface. 
- Updated `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md` to remove stale "tree consumption deferred" wording and to state that tree now consumes naming-owned semantic-family evidence via the runner-staged `namingSemanticFamilyBridge.observations[]` while preserving naming ownership of derivation. 
- No runtime code or validator semantics were changed; this is a docs-only alignment pass focused on discoverability and ownership clarity.

### Testing

- Verified the shipped runner behavior by inspecting `calculogic-validator/src/core/validator-runner.logic.mjs` to confirm staged naming execution and projection of `namingSemanticFamilyBridge` into tree and this check succeeded. 
- Performed static verification commands (`rg`, `sed`, `nl`, diffs and targeted file inspections) to confirm wording consistency across `README.md` and affected spec files and these checks succeeded. 
- No unit or integration test changes were required for this docs-only change and no runtime tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a284a9748331bbf745f6af78e739)