### PR TITLE
docs(naming-spec): align non-goal with shipped naming→tree bridge

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md
@@ -369,7 +369,7 @@ Classification: Normative
 - No runtime behavior changes.
 - No custom-registry implementation changes.
 - No warn/error/strict/fix/plan policy changes.
-- No tree runtime integration changes.
+- No additional tree runtime integration changes beyond the bounded runner-staged naming→tree bridge already shipped.
 - No registry payload mutation requirements.
 
 Classification: Normative


### PR DESCRIPTION
### Motivation
- Remove a stale non-goal that contradicted earlier sections which state that tree already consumes bounded naming-owned semantic-family evidence via the runner-staged naming→tree bridge.

### Description
- In `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md` replaced the line `No tree runtime integration changes.` with `No additional tree runtime integration changes beyond the bounded runner-staged naming→tree bridge already shipped.` which preserves the ownership model (naming owns derivation; the runner stages the bridge; tree remains a downstream consumer).

### Testing
- Verified the edit with `rg -n "No tree runtime integration changes|No additional tree runtime integration changes" calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md`, inspected the `git diff -- <file>` output, and committed the single-file docs change; all checks succeeded and no runtime code was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a65a87d08331b0444885d20b929f)