### PR TITLE
Add validator tree report noise-hardening audit and index it in tree docs

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md
@@ -59,6 +59,7 @@ Interpretation note:
 | `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` | Naming slice runtime/spec authority consumed by tree for naming-signal boundary interpretation | **Canonical slice spec** (cross-slice supporting authority for tree tasks) | Runtime implementation, architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
 | `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md` | Tree NL/config implementation note | **Supporting implementation guidance** | Runtime implementation, Codex task context, historical/reference context for implementation sequencing | **Now colocated** under `ValidatorSpecs/nl-config` with pointer stub retained at the prior repo-root NL path | **Keep** (validator-owned supporting implementation guidance) |
 | `calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-structural-reality.audit.md` | Tree structural-reality audit baseline for advisor-signal hardening | **Audit** | Architecture/modeling, advisory-noise hardening calibration, Codex task setup context | **Now colocated** under `ValidatorSpecs/tree-owned` for tree-owned discoverability | **Keep** |
+| `calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-report-noise-hardening.audit.md` | Tree report-vs-baseline comparison audit for advisory precision hardening targets | **Audit** | Architecture/modeling, advisory precision calibration, implementation-slice planning context | **Now colocated** under `ValidatorSpecs/tree-owned` for tree-owned discoverability | **Keep** |
 | `calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md` | Naming grammar/taxonomy authority consumed by tree for filename/role vocabulary boundaries | **Canonical contract** (cross-slice naming authority) | Architecture/modeling, Codex task context, supporting context only for tree | **Stay put** at current path | **Reference only** for tree tasks |
 | `calculogic-validator/doc/ConventionRoutines/DeterministicStructuralAddressingSpec-Draft.md` | Bounded draft reference for report-only tree-address grammar alignment | **Draft** (bounded modeling guidance) | Architecture/modeling, supporting context only, historical/deferred decision reference | **Stay put** at current path | **Reference only** |
 
@@ -82,6 +83,7 @@ Interpretation note:
    - `tree-structural-vocabulary-and-root-classification.spec.md`
    - `tree-top-root-registry-transition-inventory.md`
    - `validator-tree-structural-reality.audit.md`
+   - `validator-tree-report-noise-hardening.audit.md`
    - **Outcome:** tree-specific supporting material is easier to scan without moving the canonical tree slice spec or the path-sensitive NL/config note.
 
 ### Split-later / merge-later posture

--- a/calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-report-noise-hardening.audit.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-report-noise-hardening.audit.md
@@ -1,0 +1,217 @@
+# Validator Tree Report Noise Hardening Audit
+
+## Purpose
+
+This audit compares a **fresh validator-scope tree report** against the established structural-reality baseline so the next hardening slice can separate durable structure signal from naming-bridge noise.
+
+This pass is intentionally bounded to documentation and planning:
+
+- no runtime logic changes,
+- no tree heuristic changes,
+- no suppression implementation,
+- no ownership-model changes.
+
+Classification: Audit
+
+## Runtime evidence command (exact)
+
+```bash
+npm run report:tree:validator
+```
+
+Report artifact produced in this pass:
+
+- `.reports/validate-tree-validator-2026-04-11_16-46-46.txt`
+
+Classification: Audit
+
+## Fresh runtime report summary
+
+Validator entry summary (`tree-structure-advisor`, scope `validator`):
+
+- `totalFilesScanned`: `199`
+- total findings: `19`
+- code counts:
+  - `TREE_OBSERVED_FAMILY_CLUSTER`: `10`
+  - `TREE_FAMILY_SCATTERED`: `5`
+  - `TREE_SHIM_SURFACE_PRESENT`: `4`
+
+Primary recurring families/patterns in this run:
+
+- family clusters/scatter around `validator`, `tree`, `naming`, `report`, `registry`
+- repeated cross-home spread where docs + implementation lanes are both present
+- repeated bridge/shim token observability (`bridge`, `shim`) without thin re-export evidence
+
+At-a-glance strength vs noise:
+
+- strongest structural signal: `TREE_FAMILY_SCATTERED` when emitted for mixed script/tooling wrappers where structural flattening opportunities are already known.
+- strongest observability signal (non-actionable now): `TREE_OBSERVED_FAMILY_CLUSTER` for large families (`validator`, `tree`) as context only.
+- noisiest signal: repeated `TREE_OBSERVED_FAMILY_CLUSTER` and some `TREE_FAMILY_SCATTERED` emissions on healthy docs/implementation pairing.
+- secondary noise: `TREE_SHIM_SURFACE_PRESENT` token-only findings for `bridge`/`shim` naming in runtimeish files with no thin re-export evidence.
+
+Classification: Audit
+
+## Baseline comparison against structural-reality audit
+
+Baseline authority used for comparison:
+
+- `validator-tree-structural-reality.audit.md`
+
+The baseline already marked the following as healthy and worth preserving:
+
+- docs/implementation pairing by authority lane,
+- config/registry spread across suite-core and slices,
+- layered CLI surfaces,
+- `tools/report-capture/` + root script-wrapper pairing.
+
+The fresh report currently re-emits advisories over several of those healthy patterns, which means the naming-bridge tree advisories are directionally useful but still too coarse in precision.
+
+Classification: Audit
+
+## True positives worth preserving
+
+### 1) Mixed script/tooling family spread remains a real structural opportunity
+
+`report` family scatter across:
+
+- `calculogic-validator/scripts/report-capture-*.host.mjs`
+- `calculogic-validator/tools/report-capture/src/report-capture.*.mjs`
+
+This aligns with baseline Opportunity B (`scripts/` mixed families). Keep this as actionable signal for future bounded grouping improvements.
+
+### 2) Large family clusters are useful as *context*, not automatic debt
+
+High cluster counts (`validator=17`, `tree=11`, `naming=13`, `report=6`) are useful telemetry that families are real and recurring. Preserve this observability because it helps size future hardening opportunities.
+
+### 3) `registry` family scatter may indicate cross-lane model friction
+
+`registry` spread across docs and naming runtime surfaces can be a valid advisory seed when coupled with explicit ownership boundaries (spec vs runtime registry logic). Preserve as a cautious, review-required signal.
+
+Classification: Audit
+
+## Technically true but low-value / noisy findings
+
+### 1) Docs + implementation authority pairing flagged as scatter
+
+Scatter findings for `naming`, `tree`, and `validator` frequently cross:
+
+- `calculogic-validator/doc/**`
+- corresponding owned implementation roots (`naming/src`, `tree/src`, suite-core `src/core`)
+
+This is structurally expected per baseline and should not default to “needs regrouping.”
+
+### 2) Repeated cluster findings on many files in the same family
+
+`TREE_OBSERVED_FAMILY_CLUSTER` currently emits repeatedly on multiple files for the same family in a single run. That inflates noise relative to planning value.
+
+### 3) Token-only shim-surface observability is high-noise for bridge/shim names
+
+`TREE_SHIM_SURFACE_PRESENT` for runtimeish `bridge`/`shim` token matches (no thin re-export evidence) is useful as telemetry but low-value as repeated per-file advisory debt signal.
+
+Classification: Audit
+
+## Structurally expected patterns likely to suppress/refine later
+
+Patterns that should not drive immediate reorg decisions:
+
+- canonical spec docs + owned runtime implementations sharing a semantic family token (`tree`, `naming`, `validator`),
+- suite-core CLI helper lane + wrapper scripts + slice-local CLI files,
+- report-capture implementation in `tools/report-capture/` plus operator wrappers in root `scripts/`.
+
+These are expected layered ownership surfaces in current repo reality and should be guarded from coarse scatter treatment.
+
+Classification: Audit
+
+## Ambiguous cases (careful handling required)
+
+### 1) `registry` family
+
+Could be:
+
+- legitimate cross-surface model documentation + implementation pairing (healthy), or
+- early sign of over-dispersed registry logic/documentation naming.
+
+Needs case-specific review before any suppression or escalation.
+
+### 2) `validator` family breadth
+
+Very large family footprint can mean:
+
+- healthy suite-core platform identity, or
+- over-broad semantic grouping that hides finer structural families.
+
+Do not harden with broad suppression or broad escalation until family granularity rules are explicitly bounded.
+
+Classification: Audit
+
+## Hardening targets (bounded next implementation slice)
+
+This section defines a bounded plan for later implementation while preserving current ownership model:
+
+- naming interprets,
+- runner stages,
+- tree consumes structural + naming bridge evidence.
+
+### A) `TREE_FAMILY_SCATTERED` precision hardening
+
+Behaviors that appear too coarse now:
+
+- treating docs/runtime cross-home pairing as default scatter concern,
+- emitting scatter where observed homes reflect known healthy authority layering.
+
+Bounded hardening targets:
+
+1. Add explicit **structural guardrails** for healthy cross-home pairings (docs authority lane + owned runtime lane) so these pairings reduce advisory strength or do not emit by default.
+2. Keep scatter emissions for known high-ROI surfaces (especially mixed script/tooling families) where baseline already identifies structural opportunities.
+3. Preserve deterministic thresholds and explicit details payloads; refine eligibility, not randomize scoring.
+4. Keep naming interpretation in naming slice; tree only consumes bridge evidence and applies structural gating.
+
+What should continue to emit:
+
+- scatter findings where mixed structural homes map to actionable regrouping opportunities already supported by baseline.
+
+What should likely be suppressed/refined:
+
+- scatter findings driven primarily by healthy docs/runtime authority pairings.
+
+### B) `TREE_OBSERVED_FAMILY_CLUSTER` signal shaping
+
+Behaviors that appear too coarse now:
+
+- repeated per-file cluster emissions for the same family in one run.
+
+Bounded hardening targets:
+
+1. Shift toward one deterministic representative emission per family cluster per run (or equivalent bounded aggregation surface).
+2. Preserve cluster observability as planning context, not direct structural debt.
+3. Keep severity/info posture unless coupled with additional structural risk signals.
+
+What should continue to emit:
+
+- family cluster observability for large recurring families.
+
+What should likely be suppressed/refined:
+
+- duplicate cluster advisories that do not add new structural context.
+
+### C) Out-of-scope for this hardening slice
+
+Do **not** do the following in the next precision pass:
+
+- move semantic-family derivation into tree,
+- adopt raw family-name denylist as primary strategy,
+- broad heuristic rewrite across unrelated tree signals,
+- add generic suppression infrastructure unless a narrowly scoped, deterministic contract is justified,
+- change suite ownership boundaries (naming/runner/tree split).
+
+Classification: Audit
+
+## Implementation-ready next-slice checklist
+
+1. Define deterministic healthy-pairing guardrails for `TREE_FAMILY_SCATTERED` (docs authority lane + owned runtime lane).
+2. Define deterministic emission cardinality rules for `TREE_OBSERVED_FAMILY_CLUSTER` (family-level aggregation/reduction).
+3. Retain high-ROI emissions for mixed script/tooling families.
+4. Keep shim token-only observability as non-debt telemetry unless higher-confidence evidence is present.
+5. Keep all changes within tree advisory consumption/gating; no naming ownership transfer.
+
+Classification: Audit


### PR DESCRIPTION
### Motivation

- Ground the next tree-advisor hardening pass in fresh runtime evidence by comparing a live validator-scope tree report against the existing structural-reality audit. 
- Produce a bounded, implementation-ready hardening plan that improves advisory precision for `TREE_FAMILY_SCATTERED` and `TREE_OBSERVED_FAMILY_CLUSTER` while preserving current ownership and runner/naming boundaries. 

### Description

- Add `calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-report-noise-hardening.audit.md`, a report-vs-baseline audit containing purpose, exact report command, runtime summary, true-positives, noisy findings, ambiguous cases, and a bounded hardening plan. 
- Use a freshly generated validator-scope tree report as runtime evidence (`npm run report:tree:validator`) and reference the produced artifact `.reports/validate-tree-validator-2026-04-11_16-46-46.txt` in the audit. 
- Update the tree documentation inventory `calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md` to index the new audit for discoverability. 
- No runtime code, heuristics, or suppression infrastructure were changed in this pass; this is documentation-only. 

### Testing

- Executed the exact runtime evidence command `npm run report:tree:validator` and confirmed successful run and report emission; the run produced `totalFilesScanned: 199` and findings counts (`TREE_OBSERVED_FAMILY_CLUSTER=10`, `TREE_FAMILY_SCATTERED=5`, `TREE_SHIM_SURFACE_PRESENT=4`) and the artifact `.reports/validate-tree-validator-2026-04-11_16-46-46.txt`. 
- No unit or runtime code changes were made, so no additional tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7ad31c4883318fb174a1d92345db)