### PR TITLE
docs(tree): clarify structural-root vs semantic-container modeling

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-structural-reality.audit.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-structural-reality.audit.md
@@ -115,4 +115,10 @@ A better tree-advisor signal should:
 - **Avoid noise** on healthy cross-surface pairings that represent explicit ownership boundaries rather than accidental scatter.
 - **Treat ambiguous IA choices cautiously** unless extractability, ownership clarity, or deterministic navigation measurably improves.
 
+Short modeling-preservation note for later hardening:
+
+- account for top-level semantic-family containers (for example `tree/`, `naming/` in repo shapes where they exist),
+- evaluate lower-level family grouping opportunities within each container before escalating to repo-wide scatter,
+- and distinguish healthy container-local family density from true cross-container semantic scatter.
+
 Classification: Audit

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -172,6 +172,28 @@ Future tree root registries may require metadata richer than a flat string list,
 
 This is a modeling direction note only, not an implementation claim for this version.
 
+### 5) Structural-root vs semantic-container modeling clarification (bounded; non-runtime)
+
+Classification: Informative
+
+This bounded modeling note preserves ownership and interpretation direction for future tree hardening without claiming shipped behavior changes.
+
+- **Structural folders/nodes** are tree-owned structural surfaces and are the most direct candidates for eventual registry-backed tree-node modeling.
+- **Semantic folders** should generally be interpreted through alignment with naming-owned semantic-family signals (for example `semanticFamily`, `familyRoot`, optional `familySubgroup`) rather than as an independent flat truth source owned by tree.
+- **Top-level semantic folders** (repo-shape dependent examples can include `tree/` and `naming/`) may function as semantic-family containers, not only as generic folder roots.
+- Inside one such top-level semantic container, lower-level family distribution should be evaluated first as:
+  1. expected family presence / healthy family density,
+  2. lower-level family subfolder opportunity,
+  3. and only secondarily as broader scatter.
+- **Cross-container family presence** should count as meaningful scatter only when no allowed structural or cross-concern rule explains that placement.
+- Tree organization and tree addressing stay distinct from file-level structural addressing concerns; tree addressing remains tree-owned report/organization metadata and does not re-own naming derivation.
+
+Ownership boundary restatement:
+
+- naming slice owns semantic-family derivation (`semanticFamily`, `familyRoot`, `familySubgroup`)
+- tree slice owns folder/node interpretation and may consume naming-owned derivation as bounded evidence
+- tree must not re-derive or re-own naming validity semantics
+
 ---
 
 ## Tree Addressing (Report-Only, Status: Future advisory direction)


### PR DESCRIPTION
### Motivation

- Preserve a clear, bounded modeling distinction between structural folder roots and semantic-family containers so future tree hardening evaluates grouping opportunities correctly. 
- Make the tree spec and the structural-reality audit explicitly record that semantic-family signals are naming-owned and that tree-owned folder/node interpretation may consume those signals without re-owning naming derivation. 
- Keep the change strictly documentation-only to avoid implying any runtime or heuristic changes.

### Description

- Updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` with a bounded, non-runtime modeling clarification that: structural folders/nodes are tree-owned and are primary candidates for registry-backed modeling; semantic folders should be recognized via naming-owned signals such as `semanticFamily`, `familyRoot`, and optional `familySubgroup`; top-level semantic folders (repo-shape examples like `tree/` and `naming/`) may act as semantic-family containers; lower-level family spread inside those containers should be judged first for expected presence, subfolder opportunity, then for broader scatter; and cross-container presence counts as scatter only when no allowed rule explains it. 
- Added a short preservation note to `calculogic-validator/doc/ValidatorSpecs/tree-owned/validator-tree-structural-reality.audit.md` requesting that future hardening account for top-level semantic-family containers, assess lower-level grouping inside those containers first, and distinguish healthy container-local family density from true cross-container scatter. 
- Restated ownership boundaries so that `naming` owns semantic-family derivation and `tree` owns folder/node interpretation while consuming naming-derived evidence only, and explicitly avoided introducing any registry design, heuristic, or runtime claims. 
- Confirmed the scope is docs-only and did not change runtime behavior, tree heuristics, or implement any registry surface.

### Testing

- No automated tests were run because this is a documentation-only change and does not affect runtime code or validators.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8c7df4cc83318117f90837a4aaa3)