### PR TITLE
Gate TREE_FAMILY_SCATTERED with structural-root + semantic-container rules

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -133,6 +133,21 @@ Bridge shape (prepared-input contract):
 
 Tree consumes this normalized bridge payload only. Tree runtime must not parse filenames to recreate these fields.
 
+### Family-scatter structural gating (Status: Current runtime behavior, bounded)
+
+`TREE_FAMILY_SCATTERED` now applies a bounded tree-owned structural interpretation layer before emitting broader scatter:
+
+- tree classifies each family observation by structural root/surface and naming-aligned semantic-container placement,
+- semantic-container recognition is based on path alignment with naming-owned bridge evidence (`familyRoot`, `semanticFamily`, optional `familySubgroup`), not a hardcoded semantic-folder allowlist,
+- family presence confined to one valid naming-aligned semantic container is treated as expected/container-local density first (not immediate broad scatter),
+- bounded allowed cross-container pairings are exempt from broad scatter by default (for example canonical docs authority lane with aligned owned runtime container pairing),
+- broad scatter remains for family spread across unrelated structural homes/containers when no allowed pairing covers the spread.
+
+Ownership boundary remains unchanged:
+
+- naming owns semantic-family derivation and validity semantics,
+- tree owns structural interpretation/gating decisions that consume naming bridge evidence.
+
 Boundary note (canonical_target for this slice): tree validator ownership is under `calculogic-validator/tree/src/**`. Legacy flat suite-core paths such as `calculogic-validator/src/tree-structure-advisor.*.mjs` are compatibility wrappers only, not canonical ownership.
 
 ## Top-Root Registry Classes and Ownership Boundary (Status: Bounded modeling note)

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -3,6 +3,17 @@ import path from 'node:path';
 const FAMILY_SCATTER_MIN_STRUCTURAL_HOMES = 2;
 const FAMILY_SCATTER_MIN_FILES = 3;
 const FAMILY_CLUSTER_INFO_MIN_FILES = 4;
+const TREE_STRUCTURAL_ROOT_SURFACES = ['src', 'test', 'doc', 'docs', 'scripts', 'tools', 'bin', 'public', 'calculogic-validator'];
+const TREE_STRUCTURAL_ROOT_SURFACE_SET = new Set(TREE_STRUCTURAL_ROOT_SURFACES);
+const ALLOWED_STRUCTURAL_ROOT_PAIRINGS = [
+  ['src', 'test'],
+  ['doc', 'docs'],
+];
+const ALLOWED_STRUCTURAL_ROOT_PAIRING_SET = new Set(
+  ALLOWED_STRUCTURAL_ROOT_PAIRINGS.map((pair) => pair.slice().sort((left, right) => left.localeCompare(right)).join('::')),
+);
+const CANONICAL_DOC_AUTHORITY_ROOT_PREFIX = 'calculogic-validator/doc/';
+const CANONICAL_VALIDATOR_ROOT_PREFIX = 'calculogic-validator/';
 const SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS = ['src/shared'];
 const SHARED_ROOT_LANE_FIRST_PARTITIONS = ['build', 'build-style', 'logic', 'knowledge', 'results', 'results-style', 'tests', 'docs'];
 const SHARED_ROOT_LANE_FIRST_PARTITION_SET = new Set(SHARED_ROOT_LANE_FIRST_PARTITIONS);
@@ -26,6 +37,102 @@ const toNormalizedStructuralHome = (normalizedPath) => {
   }
 
   return segments.slice(0, 2).join('/');
+};
+
+const toSemanticIdentityTokens = (observation) =>
+  toSortedUnique(
+    [observation.familyRoot, observation.semanticFamily, observation.familySubgroup]
+      .filter((value) => typeof value === 'string' && value.length > 0)
+      .flatMap((value) => value.split('-').filter(Boolean).concat(value)),
+  );
+
+const toSemanticAlignmentHits = ({ path: normalizedPath }, semanticIdentityTokens) => {
+  const pathSegments = normalizedPath.split('/').filter(Boolean);
+  const semanticIdentityTokenSet = new Set(semanticIdentityTokens);
+
+  return pathSegments.flatMap((segment, index) => {
+    if (
+      semanticIdentityTokenSet.has(segment) ||
+      semanticIdentityTokens.some((token) => segment.startsWith(`${token}-`))
+    ) {
+      return [{ segment, index }];
+    }
+
+    return [];
+  });
+};
+
+const classifyScatterPlacement = (observation) => {
+  const pathSegments = observation.path.split('/').filter(Boolean);
+  const structuralRoot = pathSegments[0] ?? '.';
+  const structuralSurface = pathSegments.slice(0, 2).join('/') || structuralRoot;
+  const semanticIdentityTokens = toSemanticIdentityTokens(observation);
+  const semanticAlignmentHits = toSemanticAlignmentHits(observation, semanticIdentityTokens);
+  const firstSemanticAlignmentHit = semanticAlignmentHits[0] ?? null;
+  const semanticContainerIdentity = firstSemanticAlignmentHit
+    ? pathSegments.slice(0, firstSemanticAlignmentHit.index + 1).join('/')
+    : null;
+
+  return {
+    path: observation.path,
+    structuralRoot,
+    structuralHome: toNormalizedStructuralHome(observation.path),
+    structuralSurface,
+    structuralRootKind: TREE_STRUCTURAL_ROOT_SURFACE_SET.has(structuralRoot) ? 'structural-surface' : 'non-structural-surface',
+    semanticContainerRole: semanticContainerIdentity ? 'naming-aligned-semantic-container' : 'none',
+    semanticContainerIdentity,
+    semanticIdentityTokens,
+    semanticAlignmentHits,
+  };
+};
+
+const isAllowedStructuralRootPairing = (leftPlacement, rightPlacement) => {
+  const key = [leftPlacement.structuralRoot, rightPlacement.structuralRoot]
+    .sort((left, right) => left.localeCompare(right))
+    .join('::');
+  return ALLOWED_STRUCTURAL_ROOT_PAIRING_SET.has(key);
+};
+
+const isAllowedCanonicalDocAuthorityRuntimePairing = (leftPlacement, rightPlacement) => {
+  const placementPair = [leftPlacement, rightPlacement];
+  const docPlacement = placementPair.find((placement) => placement.path.startsWith(CANONICAL_DOC_AUTHORITY_ROOT_PREFIX));
+  const runtimePlacement = placementPair.find(
+    (placement) =>
+      placement.path.startsWith(CANONICAL_VALIDATOR_ROOT_PREFIX) &&
+      !placement.path.startsWith(CANONICAL_DOC_AUTHORITY_ROOT_PREFIX),
+  );
+  if (!docPlacement || !runtimePlacement) {
+    return false;
+  }
+
+  if (runtimePlacement.semanticContainerRole !== 'naming-aligned-semantic-container') {
+    return false;
+  }
+
+  const runtimeContainerSegment = runtimePlacement.semanticContainerIdentity?.split('/')[1];
+  if (!runtimeContainerSegment) {
+    return false;
+  }
+
+  return docPlacement.semanticAlignmentHits.some(
+    (hit) => hit.segment === runtimeContainerSegment || hit.segment.startsWith(`${runtimeContainerSegment}-`),
+  );
+};
+
+const isAllowedCrossContainerPlacementPair = (leftPlacement, rightPlacement) => {
+  if (
+    leftPlacement.semanticContainerRole === 'naming-aligned-semantic-container' &&
+    rightPlacement.semanticContainerRole === 'naming-aligned-semantic-container' &&
+    leftPlacement.semanticContainerIdentity === rightPlacement.semanticContainerIdentity
+  ) {
+    return true;
+  }
+
+  if (isAllowedStructuralRootPairing(leftPlacement, rightPlacement)) {
+    return true;
+  }
+
+  return isAllowedCanonicalDocAuthorityRuntimePairing(leftPlacement, rightPlacement);
 };
 
 const toNormalizedBridgeObservation = (observation) => {
@@ -121,13 +228,28 @@ const collectFamilyScatterFindings = (observations) => {
     .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
     .flatMap(([semanticFamily, familyObservations]) => {
       const sortedPaths = familyObservations.map(({ path: normalizedPath }) => normalizedPath).sort((a, b) => a.localeCompare(b));
-      const structuralHomes = toSortedUnique(
-        familyObservations.map(({ path: normalizedPath }) => toNormalizedStructuralHome(normalizedPath)),
+      const placements = familyObservations.map(classifyScatterPlacement);
+      const structuralHomes = toSortedUnique(placements.map((placement) => placement.structuralHome));
+      const semanticContainerIdentities = toSortedUnique(
+        placements
+          .filter((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
+          .map((placement) => placement.semanticContainerIdentity),
+      );
+      const allPlacementsInOneSemanticContainer =
+        semanticContainerIdentities.length === 1 &&
+        placements.every((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
+
+      const allCrossContainerPlacementsCoveredByAllowedRules = placements.every((leftPlacement, leftIndex) =>
+        placements
+          .slice(leftIndex + 1)
+          .every((rightPlacement) => isAllowedCrossContainerPlacementPair(leftPlacement, rightPlacement)),
       );
 
       if (
         sortedPaths.length < FAMILY_SCATTER_MIN_FILES ||
-        structuralHomes.length < FAMILY_SCATTER_MIN_STRUCTURAL_HOMES
+        structuralHomes.length < FAMILY_SCATTER_MIN_STRUCTURAL_HOMES ||
+        allPlacementsInOneSemanticContainer ||
+        allCrossContainerPlacementsCoveredByAllowedRules
       ) {
         return [];
       }
@@ -145,6 +267,13 @@ const collectFamilyScatterFindings = (observations) => {
             semanticFamily,
             observedPaths: sortedPaths,
             observedStructuralHomes: structuralHomes,
+            observedStructuralRoots: toSortedUnique(placements.map((placement) => placement.structuralRoot)),
+            observedContainerIdentities: semanticContainerIdentities,
+            observedStructuralRootKinds: toSortedUnique(placements.map((placement) => placement.structuralRootKind)),
+            allowedCrossContainerPatterns: {
+              structuralRootPairings: ALLOWED_STRUCTURAL_ROOT_PAIRINGS,
+              canonicalDocAuthorityRuntimePairing: 'calculogic-validator/doc/** <-> calculogic-validator/<semantic-container>/**',
+            },
             thresholds: {
               minFamilyFiles: FAMILY_SCATTER_MIN_FILES,
               minStructuralHomes: FAMILY_SCATTER_MIN_STRUCTURAL_HOMES,

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -260,3 +260,122 @@ test('tree naming bridge contributor keeps shared-root advisory deterministic fo
   assert.deepEqual(firstSharedRootFindings, secondSharedRootFindings);
   assert.equal(firstSharedRootFindings.length, 1);
 });
+
+test('tree naming bridge contributor treats one naming-aligned semantic container as expected presence, not broad scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/contributors/tree-family.logic.mjs',
+        semanticName: 'tree-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-family',
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-family.results.mjs',
+        semanticName: 'tree-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-family',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-family.test.mjs',
+        semanticName: 'tree-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-family',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
+test('tree naming bridge contributor evaluates lower-level density in one semantic container before broad scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/naming/src/lanes/naming-lane.logic.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+      {
+        path: 'calculogic-validator/naming/src/families/naming-lane.results.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+      {
+        path: 'calculogic-validator/naming/test/naming-lane.test.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+      {
+        path: 'calculogic-validator/naming/src/naming-lane.knowledge.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), true);
+});
+
+test('tree naming bridge contributor suppresses broad scatter for bounded allowed cross-container pairing', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-model.spec.md',
+        semanticName: 'tree-model',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-model',
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-model.logic.mjs',
+        semanticName: 'tree-model',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-model',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-model.test.mjs',
+        semanticName: 'tree-model',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-model',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
+test('tree naming bridge contributor still emits broad scatter for unrelated cross-container spread', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/features/validator/validator-summary.logic.ts',
+        semanticName: 'validator-summary',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-summary',
+      },
+      {
+        path: 'tools/validator/validator-summary.wiring.mjs',
+        semanticName: 'validator-summary',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-summary',
+      },
+      {
+        path: 'doc/validator/validator-summary.spec.md',
+        semanticName: 'validator-summary',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-summary',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), true);
+});


### PR DESCRIPTION
### Motivation

- Reduce noisy `TREE_FAMILY_SCATTERED` advisories by adding a bounded tree-owned structural interpretation layer that distinguishes structural roots/surfaces, naming-aligned semantic containers, and allowed cross-container placements before emitting scatter.
- Preserve ownership: naming still provides semantic-family derivation; tree consumes that bridge evidence and decides structural gating deterministically.

### Description

- Added a small deterministic scatter-placement classifier that computes `structuralRoot`, `structuralHome`, `structuralSurface`, `semanticContainerIdentity`, `semanticIdentityTokens`, and semantic-alignment hits from naming bridge observations; helper functions include `classifyScatterPlacement`, `toSemanticIdentityTokens`, and `toSemanticAlignmentHits` implemented in `tree-naming-semantic-family-bridge-contributor.logic.mjs`.
- Introduced explicit structural-root surfaces (`TREE_STRUCTURAL_ROOT_SURFACES`) and a narrow set of allowed cross-root pairings (`ALLOWED_STRUCTURAL_ROOT_PAIRINGS`) plus a bounded canonical docs-authority ↔ runtime pairing rule; exposed `isAllowedCrossContainerPlacementPair` to recognize covered cross-container placements.
- Gated `TREE_FAMILY_SCATTERED` in `collectFamilyScatterFindings` so that scatter is suppressed when (a) all observations fall into one naming-aligned semantic container, or (b) every cross-placement pair is covered by an allowed rule; unchanged behavior emits `TREE_FAMILY_SCATTERED` when family spread crosses unrelated structural homes/containers and thresholds are met.
- Kept ambiguity-safety and cluster info behavior: ambiguity-flagged observations continue to be excluded from stronger scatter advisories and `TREE_OBSERVED_FAMILY_CLUSTER` logic still operates for dense container-local clusters.
- Files changed: `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, and `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` with a concise spec note documenting the bounded gating.

### Testing

- Ran focused contributor tests with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and observed all subtests passing.
- Ran full tree test set with `node --test calculogic-validator/tree/test/*.mjs` (suite run) and observed all tests passing (71 tests, 0 failures).
- Verified determinism and behavior cases covered by new tests: one-container expected presence (no `TREE_FAMILY_SCATTERED`), lower-level density inside a valid semantic container (cluster info emitted, no broad scatter), allowed doc-authority/runtime pairing (no broad scatter), and unrelated cross-container spread (still emits `TREE_FAMILY_SCATTERED`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa6565c148331a6144a1ac844abf4)