### PR TITLE
Aggregate TREE_OBSERVED_FAMILY_CLUSTER by family / family-in-container

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -575,7 +575,7 @@ Each finding uses the same stable envelope shape used by existing validators:
 
 ### Deferred/planning code candidates (future advisory direction)
 
-- `TREE_OBSERVED_FAMILY_CLUSTER` (`info`) — implemented via naming bridge contributor (bounded thresholded cluster observability)
+- `TREE_OBSERVED_FAMILY_CLUSTER` (`info`) — implemented via naming bridge contributor (bounded thresholded cluster observability, aggregated deterministically at semanticFamily level or semanticFamily-in-container when all family observations are naming-aligned to semantic containers)
 - `TREE_FAMILY_SCATTERED` (`info`) — implemented via naming bridge contributor (bounded family scatter advisory)
 - `TREE_LANE_MIX_HIGH_ENTROPY`
 - `TREE_MISSING_NAMESPACE_ROOT`

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -285,37 +285,76 @@ const collectFamilyScatterFindings = (observations) => {
 };
 
 const collectFamilyClusterFindings = (observations) => {
-  const familyCounts = new Map();
+  const singularObservations = observations
+    .filter((observation) => isSingularFamilyEvidence(observation))
+    .map((observation) => ({
+      observation,
+      placement: classifyScatterPlacement(observation),
+    }));
 
-  for (const observation of observations) {
-    if (!isSingularFamilyEvidence(observation)) {
-      continue;
+  const observationsBySemanticFamily = new Map();
+  for (const entry of singularObservations) {
+    if (!observationsBySemanticFamily.has(entry.observation.semanticFamily)) {
+      observationsBySemanticFamily.set(entry.observation.semanticFamily, []);
     }
 
-    familyCounts.set(observation.semanticFamily, (familyCounts.get(observation.semanticFamily) ?? 0) + 1);
+    observationsBySemanticFamily.get(entry.observation.semanticFamily).push(entry);
   }
 
-  return observations
-    .filter((observation) => isSingularFamilyEvidence(observation))
-    .filter((observation) => (familyCounts.get(observation.semanticFamily) ?? 0) >= FAMILY_CLUSTER_INFO_MIN_FILES)
-    .sort((left, right) => left.path.localeCompare(right.path))
-    .filter((observation, index, sorted) => index === 0 || sorted[index - 1].semanticFamily !== observation.semanticFamily)
-    .map((observation) => ({
-      code: 'TREE_OBSERVED_FAMILY_CLUSTER',
-      severity: 'info',
-      path: observation.path,
-      classification: 'advisory-structure',
-      message:
-        'Naming-owned semantic-family cluster size is high enough to consider a clearer structural grouping surface.',
-      ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
-      details: {
-        semanticFamily: observation.semanticFamily,
-        observedCount: familyCounts.get(observation.semanticFamily),
-        threshold: {
-          minFamilyFilesForClusterObservation: FAMILY_CLUSTER_INFO_MIN_FILES,
-        },
-      },
-    }));
+  return Array.from(observationsBySemanticFamily.entries())
+    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
+    .flatMap(([semanticFamily, familyEntries]) => {
+      const allEntriesHaveSemanticContainer = familyEntries.every(
+        ({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container',
+      );
+
+      const aggregationBuckets = new Map();
+      for (const familyEntry of familyEntries) {
+        const bucketKey = allEntriesHaveSemanticContainer
+          ? `container::${familyEntry.placement.semanticContainerIdentity}`
+          : `family::${semanticFamily}`;
+        if (!aggregationBuckets.has(bucketKey)) {
+          aggregationBuckets.set(bucketKey, []);
+        }
+
+        aggregationBuckets.get(bucketKey).push(familyEntry);
+      }
+
+      return Array.from(aggregationBuckets.entries())
+        .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+        .flatMap(([, bucketEntries]) => {
+          if (bucketEntries.length < FAMILY_CLUSTER_INFO_MIN_FILES) {
+            return [];
+          }
+
+          const sortedPaths = bucketEntries
+            .map(({ observation }) => observation.path)
+            .sort((left, right) => left.localeCompare(right));
+          const semanticContainerIdentity = bucketEntries[0].placement.semanticContainerIdentity ?? null;
+
+          return [
+            {
+              code: 'TREE_OBSERVED_FAMILY_CLUSTER',
+              severity: 'info',
+              path: sortedPaths[0],
+              classification: 'advisory-structure',
+              message:
+                'Naming-owned semantic-family cluster size is high enough to consider a clearer structural grouping surface.',
+              ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
+              details: {
+                semanticFamily,
+                semanticContainerIdentity,
+                aggregationUnit: semanticContainerIdentity ? 'semanticFamily-in-container' : 'semanticFamily',
+                observedCount: bucketEntries.length,
+                observedPaths: sortedPaths,
+                threshold: {
+                  minFamilyFilesForClusterObservation: FAMILY_CLUSTER_INFO_MIN_FILES,
+                },
+              },
+            },
+          ];
+        });
+    });
 };
 
 const collectSharedRootFamilyScatterAcrossLanesFindings = (observations) => {

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -44,7 +44,7 @@ test('tree naming bridge contributor consumes naming-owned semantic-family evide
 
   assert.deepEqual(
     findings.map((finding) => finding.code).sort((left, right) => left.localeCompare(right)),
-    ['TREE_FAMILY_SCATTERED', 'TREE_OBSERVED_FAMILY_CLUSTER'],
+    ['TREE_FAMILY_SCATTERED'],
   );
 });
 
@@ -378,4 +378,246 @@ test('tree naming bridge contributor still emits broad scatter for unrelated cro
   });
 
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), true);
+});
+
+
+test('tree naming bridge contributor emits one cluster finding for dense family in one semantic container', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/cluster/tree-observed-family.logic.mjs',
+        semanticName: 'tree-observed-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-observed-family',
+      },
+      {
+        path: 'calculogic-validator/tree/src/cluster/tree-observed-family.results.mjs',
+        semanticName: 'tree-observed-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-observed-family',
+      },
+      {
+        path: 'calculogic-validator/tree/src/cluster/tree-observed-family.knowledge.mjs',
+        semanticName: 'tree-observed-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-observed-family',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-observed-family.test.mjs',
+        semanticName: 'tree-observed-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-observed-family',
+      },
+    ],
+  });
+
+  const clusterFindings = findings.filter((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER');
+  assert.equal(clusterFindings.length, 1);
+  assert.equal(clusterFindings[0].details.aggregationUnit, 'semanticFamily-in-container');
+  assert.equal(clusterFindings[0].details.semanticContainerIdentity, 'calculogic-validator/tree');
+});
+
+test('tree naming bridge contributor keeps dense family files in one container from inflating cluster count', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/a/tree-density.logic.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/src/b/tree-density.results.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/src/c/tree-density.knowledge.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/src/d/tree-density.wiring.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/src/e/tree-density.host.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+    ],
+  });
+
+  assert.equal(findings.filter((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER').length, 1);
+});
+
+test('tree naming bridge contributor can emit distinct cluster observations across semantic containers', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/tree-multi-container/src/first/component.logic.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/tree/tree-multi-container/src/first/component.results.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/tree/tree-multi-container/src/first/component.knowledge.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/tree/tree-multi-container/test/component.test.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-multi-container/src/first/component.logic.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-multi-container/src/first/component.results.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-multi-container/src/first/component.knowledge.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-multi-container/test/component.test.mjs',
+        semanticName: 'tree-multi-container',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-multi-container',
+      },
+    ],
+  });
+
+  const clusterFindings = findings.filter((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER');
+  assert.equal(clusterFindings.length, 2);
+  assert.deepEqual(
+    clusterFindings.map((finding) => finding.details.semanticContainerIdentity),
+    ['calculogic-validator/naming/tree-multi-container', 'calculogic-validator/tree'],
+  );
+});
+
+test('tree naming bridge contributor keeps ambiguity-only dense families as non-cluster observability', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/a/tree-ambiguous-cluster.logic.mjs',
+        semanticName: 'tree-ambiguous-cluster',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ambiguous-cluster',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'calculogic-validator/tree/src/b/tree-ambiguous-cluster.results.mjs',
+        semanticName: 'tree-ambiguous-cluster',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ambiguous-cluster',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'calculogic-validator/tree/src/c/tree-ambiguous-cluster.knowledge.mjs',
+        semanticName: 'tree-ambiguous-cluster',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ambiguous-cluster',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'calculogic-validator/tree/src/d/tree-ambiguous-cluster.wiring.mjs',
+        semanticName: 'tree-ambiguous-cluster',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ambiguous-cluster',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), false);
+  assert.equal(findings.some((finding) => finding.severity === 'warn'), false);
+});
+
+test('tree naming bridge contributor emits deterministic cluster count and ordering for same input', () => {
+  const payload = {
+    observations: [
+      {
+        path: 'calculogic-validator/tree/tree-ordering-family/test/component.test.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/tree/tree-ordering-family/src/c/component.knowledge.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/tree/tree-ordering-family/src/b/component.results.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/tree/tree-ordering-family/src/a/component.logic.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-ordering-family/test/component.test.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-ordering-family/src/c/component.knowledge.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-ordering-family/src/b/component.results.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+      {
+        path: 'calculogic-validator/naming/tree-ordering-family/src/a/component.logic.mjs',
+        semanticName: 'tree-ordering-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-ordering-family',
+      },
+    ],
+  };
+
+  const first = collectNamingSemanticFamilyBridgeFindings(payload)
+    .filter((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER')
+    .map((finding) => ({ path: finding.path, container: finding.details.semanticContainerIdentity }));
+  const second = collectNamingSemanticFamilyBridgeFindings(payload)
+    .filter((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER')
+    .map((finding) => ({ path: finding.path, container: finding.details.semanticContainerIdentity }));
+
+  assert.deepEqual(first, second);
+  assert.equal(first.length, 2);
+  assert.deepEqual(first.map((entry) => entry.container), ['calculogic-validator/naming/tree-ordering-family', 'calculogic-validator/tree']);
 });


### PR DESCRIPTION
### Motivation
- Reduce noisy repeated `TREE_OBSERVED_FAMILY_CLUSTER` emissions by making cluster observability a bounded family-level (or family-in-container) signal instead of repeating per-file in a single run. 
- Preserve existing ownership boundaries (naming derives `semanticFamily`; tree consumes the naming bridge) and keep the finding advisory-only (`info`).

### Description
- Changed cluster aggregation in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` by replacing the path-order adjacency dedupe with deterministic grouping buckets that aggregate by `semanticFamily` or `semanticFamily`-in-container when all family observations are naming-aligned to semantic containers. 
- New aggregation emits at most one `TREE_OBSERVED_FAMILY_CLUSTER` finding per deterministic bucket (bucketed by container when applicable) and retains representative `path`, `observedPaths`, `observedCount`, `aggregationUnit`, and `semanticContainerIdentity` details; thresholds unchanged (`FAMILY_CLUSTER_INFO_MIN_FILES`).
- Preserved severity (`info`) and classification (`advisory-structure`) so this remains observability telemetry, not debt.
- Added and adjusted focused tests in `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` to cover: one cluster per dense family-in-container, no inflation for many files in same container, distinct container-level clusters when justified, ambiguity-flagged observations not escalating, and deterministic ordering/counts; also updated an expectation for the refined behavior.
- Small spec note update in `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to reflect the shipped aggregation interpretation.
- Files changed: `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, and `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`.

### Testing
- Ran the focused contributor test suite with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, which completed successfully with all tests passing (17 tests, 0 failures). 
- Tests exercise deterministic grouping and the new `semanticFamily`-in-container aggregation behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab0d2995c8331aff36a4995c2c066)