### PR TITLE
Add TREE_FAMILY_SUBGROUP_OPPORTUNITY advisory (container-local subgroup detection)

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -143,6 +143,24 @@ Tree consumes this normalized bridge payload only. Tree runtime must not parse f
 - bounded allowed cross-container pairings are exempt from broad scatter by default (for example canonical docs authority lane with aligned owned runtime container pairing),
 - broad scatter remains for family spread across unrelated structural homes/containers when no allowed pairing covers the spread.
 
+### Family subgroup opportunity inside one semantic container (Status: Current runtime behavior, bounded)
+
+`TREE_FAMILY_SUBGROUP_OPPORTUNITY` is a bounded, info-level, advisory-only signal for lower-level family grouping opportunity *inside one naming-aligned semantic container*.
+
+Current runtime trigger posture:
+
+- observations must be singular naming evidence (`ambiguityFlags[]` absent),
+- observations for the family must all classify to one valid naming-aligned semantic container identity,
+- density must meet explicit thresholds (`minFilesInContainer`, `minDistinctContainerLocalHomes`),
+- lower-level grouping signal must be present (currently from naming-owned `familySubgroup` or `semanticFamily` alignment with `familyRoot`),
+- this signal is container-local guidance and does not replace broad cross-container scatter behavior.
+
+Boundary note:
+
+- broad cross-container spread remains represented by `TREE_FAMILY_SCATTERED`,
+- container-local high-count observability remains represented by `TREE_OBSERVED_FAMILY_CLUSTER`,
+- subgroup opportunity is the bounded “between” signal for dense/cohesive lower-level grouping in one semantic container.
+
 Ownership boundary remains unchanged:
 
 - naming owns semantic-family derivation and validity semantics,

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -3,6 +3,9 @@ import path from 'node:path';
 const FAMILY_SCATTER_MIN_STRUCTURAL_HOMES = 2;
 const FAMILY_SCATTER_MIN_FILES = 3;
 const FAMILY_CLUSTER_INFO_MIN_FILES = 4;
+const FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER = 4;
+const FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES = 2;
+const FAMILY_SUBGROUP_OPPORTUNITY_REQUIRES_LOWER_LEVEL_GROUPING_SIGNAL = true;
 const TREE_STRUCTURAL_ROOT_SURFACES = ['src', 'test', 'doc', 'docs', 'scripts', 'tools', 'bin', 'public', 'calculogic-validator'];
 const TREE_STRUCTURAL_ROOT_SURFACE_SET = new Set(TREE_STRUCTURAL_ROOT_SURFACES);
 const ALLOWED_STRUCTURAL_ROOT_PAIRINGS = [
@@ -185,6 +188,31 @@ export const prepareNamingSemanticFamilyBridge = (bridgePayload) => {
 
 const isSingularFamilyEvidence = (observation) => (observation.ambiguityFlags ?? []).length === 0;
 
+const toContainerLocalHome = (placement) => {
+  if (placement.semanticContainerRole !== 'naming-aligned-semantic-container' || !placement.semanticContainerIdentity) {
+    return placement.structuralHome;
+  }
+
+  const containerPrefix = `${placement.semanticContainerIdentity}/`;
+  if (!placement.path.startsWith(containerPrefix)) {
+    return placement.structuralHome;
+  }
+
+  const containerRelativePath = placement.path.slice(containerPrefix.length);
+  const containerRelativeSegments = path.posix.dirname(containerRelativePath).split('/').filter(Boolean);
+  const [firstLocalHome] = containerRelativeSegments;
+
+  return firstLocalHome ?? '.';
+};
+
+const hasLowerLevelGroupingSignal = (observation) => {
+  if (typeof observation.familySubgroup === 'string' && observation.familySubgroup.length > 0) {
+    return true;
+  }
+
+  return observation.semanticFamily.startsWith(`${observation.familyRoot}-`);
+};
+
 const toSharedRootLaneObservation = (observation) => {
   for (const sharedRoot of SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS) {
     const sharedRootPrefix = `${sharedRoot}/`;
@@ -357,6 +385,86 @@ const collectFamilyClusterFindings = (observations) => {
     });
 };
 
+const collectFamilySubgroupOpportunityFindings = (observations) => {
+  const singularObservations = observations
+    .filter((observation) => isSingularFamilyEvidence(observation))
+    .map((observation) => ({
+      observation,
+      placement: classifyScatterPlacement(observation),
+    }));
+
+  const observationsBySemanticFamily = new Map();
+  for (const entry of singularObservations) {
+    if (!observationsBySemanticFamily.has(entry.observation.semanticFamily)) {
+      observationsBySemanticFamily.set(entry.observation.semanticFamily, []);
+    }
+
+    observationsBySemanticFamily.get(entry.observation.semanticFamily).push(entry);
+  }
+
+  return Array.from(observationsBySemanticFamily.entries())
+    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
+    .flatMap(([semanticFamily, familyEntries]) => {
+      const semanticContainerIdentities = toSortedUnique(
+        familyEntries
+          .filter(({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
+          .map(({ placement }) => placement.semanticContainerIdentity),
+      );
+      const allEntriesInsideOneSemanticContainer =
+        semanticContainerIdentities.length === 1 &&
+        familyEntries.every(({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
+
+      if (!allEntriesInsideOneSemanticContainer) {
+        return [];
+      }
+
+      const sortedPaths = familyEntries
+        .map(({ observation }) => observation.path)
+        .sort((left, right) => left.localeCompare(right));
+      const observedContainerLocalHomes = toSortedUnique(
+        familyEntries.map(({ placement }) => toContainerLocalHome(placement)),
+      );
+      const lowerLevelGroupingSignalPresent = familyEntries.some(({ observation }) => hasLowerLevelGroupingSignal(observation));
+      const groupingSignalRequiredAndMissing =
+        FAMILY_SUBGROUP_OPPORTUNITY_REQUIRES_LOWER_LEVEL_GROUPING_SIGNAL && !lowerLevelGroupingSignalPresent;
+
+      if (
+        sortedPaths.length < FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER ||
+        observedContainerLocalHomes.length < FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES ||
+        groupingSignalRequiredAndMissing
+      ) {
+        return [];
+      }
+
+      const semanticContainerIdentity = semanticContainerIdentities[0];
+      return [
+        {
+          code: 'TREE_FAMILY_SUBGROUP_OPPORTUNITY',
+          severity: 'info',
+          path: sortedPaths[0],
+          classification: 'advisory-structure',
+          message:
+            'Naming-owned semantic-family evidence is dense inside one naming-aligned semantic container and may benefit from a lower-level subgroup folder.',
+          ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
+          details: {
+            semanticFamily,
+            semanticContainerIdentity,
+            observedCount: sortedPaths.length,
+            observedPaths: sortedPaths,
+            observedContainerLocalHomes,
+            lowerLevelGroupingSignalPresent,
+            thresholds: {
+              minFilesInContainer: FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER,
+              minDistinctContainerLocalHomes: FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES,
+              requireLowerLevelGroupingSignal: FAMILY_SUBGROUP_OPPORTUNITY_REQUIRES_LOWER_LEVEL_GROUPING_SIGNAL,
+            },
+            scopeBoundary: 'container-local subgroup opportunity; broad cross-container spread remains TREE_FAMILY_SCATTERED',
+          },
+        },
+      ];
+    });
+};
+
 const collectSharedRootFamilyScatterAcrossLanesFindings = (observations) => {
   const observationsBySharedRootAndFamily = new Map();
 
@@ -431,6 +539,7 @@ export const collectNamingSemanticFamilyBridgeFindings = (bridgePayload) => {
 
   return [
     ...collectFamilyScatterFindings(observations),
+    ...collectFamilySubgroupOpportunityFindings(observations),
     ...collectFamilyClusterFindings(observations),
     ...collectSharedRootFamilyScatterAcrossLanesFindings(observations),
   ];

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -324,6 +324,7 @@ test('tree naming bridge contributor evaluates lower-level density in one semant
 
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
   assert.equal(findings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), true);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), true);
 });
 
 test('tree naming bridge contributor suppresses broad scatter for bounded allowed cross-container pairing', () => {
@@ -516,6 +517,193 @@ test('tree naming bridge contributor can emit distinct cluster observations acro
     clusterFindings.map((finding) => finding.details.semanticContainerIdentity),
     ['calculogic-validator/naming/tree-multi-container', 'calculogic-validator/tree'],
   );
+});
+
+test('tree naming bridge contributor emits subgroup opportunity for dense lower-level family inside one semantic container', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/tree-occurrence/tree-occurrence-observed.logic.mjs',
+        semanticName: 'tree-occurrence-observed',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-shim/tree-occurrence-observed.wiring.mjs',
+        semanticName: 'tree-occurrence-observed',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-occurrence/tree-occurrence-observed.test.mjs',
+        semanticName: 'tree-occurrence-observed',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/validator-cli/tree-occurrence-observed.host.mjs',
+        semanticName: 'tree-occurrence-observed',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+    ],
+  });
+
+  const subgroupFindings = findings.filter((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY');
+  assert.equal(subgroupFindings.length, 1);
+  assert.equal(subgroupFindings[0].details.semanticContainerIdentity, 'calculogic-validator/tree');
+  assert.deepEqual(subgroupFindings[0].details.observedContainerLocalHomes, ['src', 'test', 'validator-cli']);
+});
+
+test('tree naming bridge contributor does not emit subgroup opportunity for ordinary family presence below subgroup threshold', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/tree-occurrence/tree-occurrence-lower.logic.mjs',
+        semanticName: 'tree-occurrence-lower',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-occurrence/tree-occurrence-lower.test.mjs',
+        semanticName: 'tree-occurrence-lower',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/validator-cli/tree-occurrence-lower.host.mjs',
+        semanticName: 'tree-occurrence-lower',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), false);
+});
+
+test('tree naming bridge contributor keeps broad cross-container spread as TREE_FAMILY_SCATTERED instead of subgroup opportunity', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/tree-shim/tree-shim-family.logic.mjs',
+        semanticName: 'tree-shim-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-shim',
+        familySubgroup: 'shim',
+      },
+      {
+        path: 'calculogic-validator/naming/src/naming-lane/tree-shim-family.wiring.mjs',
+        semanticName: 'tree-shim-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-shim',
+        familySubgroup: 'shim',
+      },
+      {
+        path: 'tools/tree/tree-shim-family.host.mjs',
+        semanticName: 'tree-shim-family',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-shim',
+        familySubgroup: 'shim',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), true);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), false);
+});
+
+test('tree naming bridge contributor does not emit subgroup opportunity from ambiguity-flagged observations', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/tree-occurrence/tree-occurrence-ambiguous.logic.mjs',
+        semanticName: 'tree-occurrence-ambiguous',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-shim/tree-occurrence-ambiguous.wiring.mjs',
+        semanticName: 'tree-occurrence-ambiguous',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-occurrence/tree-occurrence-ambiguous.test.mjs',
+        semanticName: 'tree-occurrence-ambiguous',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+      {
+        path: 'calculogic-validator/tree/validator-cli/tree-occurrence-ambiguous.host.mjs',
+        semanticName: 'tree-occurrence-ambiguous',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+        familySubgroup: 'occurrence',
+        ambiguityFlags: ['family-boundary-heuristic'],
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), false);
+});
+
+test('tree naming bridge contributor emits deterministic subgroup opportunity finding count and ordering for identical inputs', () => {
+  const payload = {
+    observations: [
+      {
+        path: 'calculogic-validator/tree/validator-cli/tree-subgroup-deterministic.host.mjs',
+        semanticName: 'tree-subgroup-deterministic',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-subgroup',
+        familySubgroup: 'subgroup',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-subgroup/tree-subgroup-deterministic.test.mjs',
+        semanticName: 'tree-subgroup-deterministic',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-subgroup',
+        familySubgroup: 'subgroup',
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-shim/tree-subgroup-deterministic.wiring.mjs',
+        semanticName: 'tree-subgroup-deterministic',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-subgroup',
+        familySubgroup: 'subgroup',
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-occurrence/tree-subgroup-deterministic.logic.mjs',
+        semanticName: 'tree-subgroup-deterministic',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-subgroup',
+        familySubgroup: 'subgroup',
+      },
+    ],
+  };
+
+  const first = collectNamingSemanticFamilyBridgeFindings(payload)
+    .filter((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY')
+    .map((finding) => finding.path);
+  const second = collectNamingSemanticFamilyBridgeFindings(payload)
+    .filter((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY')
+    .map((finding) => finding.path);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.length, 1);
 });
 
 test('tree naming bridge contributor keeps ambiguity-only dense families as non-cluster observability', () => {


### PR DESCRIPTION
### Motivation
- Surface a bounded, report-only advisory when a naming-owned lower-level family is dense and cohesive inside a single naming-aligned semantic container and may benefit from its own subgroup folder without escalating to broad cross-container scatter.

### Description
- Add new advisory code `TREE_FAMILY_SUBGROUP_OPPORTUNITY` and implement deterministic, container-local detection in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` using tree-side placement classification and naming-owned bridge evidence.
- Trigger conditions are explicit and deterministic: observations must be singular naming evidence (no `ambiguityFlags`), all observations must classify to one naming-aligned semantic container, density thresholds must be met (`minFilesInContainer = 4`, `minDistinctContainerLocalHomes = 2`), and a lower-level grouping signal must be present (`familySubgroup` or `semanticFamily` starting with `familyRoot-`).
- The advisory is `info` and report-only; it does not mutate files and preserves ownership boundaries (naming supplies `semanticFamily`/`familySubgroup`; tree consumes that evidence and performs structural interpretation).
- Updated validator spec with a minimal runtime section clarifying what remains cluster-only (`TREE_OBSERVED_FAMILY_CLUSTER`), what is subgroup-opportunity (`TREE_FAMILY_SUBGROUP_OPPORTUNITY`), and what remains broad scatter (`TREE_FAMILY_SCATTERED`).
- Files changed: `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, and `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`.

### Testing
- Ran `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` (22 tests) and observed all tests pass (22/22).
- Ran the full tree test set `node --test calculogic-validator/tree/test/*.test.mjs` (81 tests) and observed all tests pass (81/81), including deterministic-order and ambiguity-suppression cases for the new advisory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabb6c44a08331b5c3e64ef5125a39)