### PR TITLE
Add bounded tree naming-bridge placement model (structural + semantic homes)

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -111,6 +111,29 @@ Bounded consumable naming bridge surfaces include:
 
 Tree advisor does **not** re-own naming validity judgments. Naming validity remains owned by naming conventions/specs and the naming validator slice.
 
+### Naming-bridge placement model (Status: Bounded modeling note)
+
+Classification: Informative
+
+Tree now carries a bounded, explicit placement model when consuming naming-bridge observations so structural and semantic placement can be interpreted side-by-side without collapsing them into one field.
+
+At minimum, the placement model distinguishes:
+
+- `structuralRoot`
+- `structuralSurface`
+- `structuralHome`
+- `localStructuralHome`
+- `semanticContainerIdentity`
+- `semanticHome`
+- `semanticSubhome`
+
+Ownership and interpretation guardrails for this tranche:
+
+- naming still owns `familyRoot`, `semanticFamily`, and optional `familySubgroup`
+- tree consumes those naming-owned signals plus path structure to interpret semantic placement
+- this tranche adds bounded placement modeling only
+- this tranche does not broaden finding behavior (no new finding families/codes and no intentional threshold/count/severity broadening)
+
 Examples of naming validity judgments that tree advisor must not duplicate:
 
 - bad semantic case

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -42,6 +42,13 @@ const toNormalizedStructuralHome = (normalizedPath) => {
   return segments.slice(0, 2).join('/');
 };
 
+const toLocalStructuralHome = (normalizedPath, structuralHome) => {
+  const parentSegments = path.posix.dirname(normalizedPath).split('/').filter(Boolean);
+  const structuralHomeSegments = structuralHome.split('/').filter(Boolean);
+  const [firstLocalSegment] = parentSegments.slice(structuralHomeSegments.length);
+  return firstLocalSegment ?? '.';
+};
+
 const toSemanticIdentityTokens = (observation) =>
   toSortedUnique(
     [observation.familyRoot, observation.semanticFamily, observation.familySubgroup]
@@ -65,29 +72,76 @@ const toSemanticAlignmentHits = ({ path: normalizedPath }, semanticIdentityToken
   });
 };
 
-const classifyScatterPlacement = (observation) => {
+const toSignalAlignment = (pathSegments, semanticSignal) => {
+  if (typeof semanticSignal !== 'string' || semanticSignal.length === 0) {
+    return null;
+  }
+
+  const signalTokens = toSortedUnique(semanticSignal.split('-').filter(Boolean).concat(semanticSignal));
+  const hit = pathSegments.findIndex(
+    (segment) => signalTokens.includes(segment) || signalTokens.some((token) => segment.startsWith(`${token}-`)),
+  );
+  if (hit < 0) {
+    return null;
+  }
+
+  return {
+    signal: semanticSignal,
+    tokenSet: signalTokens,
+    segment: pathSegments[hit],
+    segmentIndex: hit,
+    pathPrefix: pathSegments.slice(0, hit + 1).join('/'),
+  };
+};
+
+export const toNamingBridgePlacementRecord = (observation) => {
   const pathSegments = observation.path.split('/').filter(Boolean);
   const structuralRoot = pathSegments[0] ?? '.';
   const structuralSurface = pathSegments.slice(0, 2).join('/') || structuralRoot;
+  const structuralHome = toNormalizedStructuralHome(observation.path);
+  const localStructuralHome = toLocalStructuralHome(observation.path, structuralHome);
   const semanticIdentityTokens = toSemanticIdentityTokens(observation);
   const semanticAlignmentHits = toSemanticAlignmentHits(observation, semanticIdentityTokens);
-  const firstSemanticAlignmentHit = semanticAlignmentHits[0] ?? null;
-  const semanticContainerIdentity = firstSemanticAlignmentHit
-    ? pathSegments.slice(0, firstSemanticAlignmentHit.index + 1).join('/')
-    : null;
+  const familyRootAlignment = toSignalAlignment(pathSegments, observation.familyRoot);
+  const semanticFamilyAlignment = toSignalAlignment(pathSegments, observation.semanticFamily);
+  const familySubgroupAlignment = toSignalAlignment(pathSegments, observation.familySubgroup);
+  const semanticContainerIdentity = familyRootAlignment?.pathPrefix ?? null;
+  const semanticHome = semanticFamilyAlignment?.pathPrefix ?? semanticContainerIdentity;
+  const semanticSubhome =
+    familySubgroupAlignment && semanticHome && familySubgroupAlignment.pathPrefix !== semanticHome
+      ? familySubgroupAlignment.pathPrefix
+      : null;
 
   return {
     path: observation.path,
     structuralRoot,
-    structuralHome: toNormalizedStructuralHome(observation.path),
     structuralSurface,
+    structuralHome,
+    localStructuralHome,
     structuralRootKind: TREE_STRUCTURAL_ROOT_SURFACE_SET.has(structuralRoot) ? 'structural-surface' : 'non-structural-surface',
     semanticContainerRole: semanticContainerIdentity ? 'naming-aligned-semantic-container' : 'none',
     semanticContainerIdentity,
+    semanticHome,
+    semanticSubhome,
     semanticIdentityTokens,
     semanticAlignmentHits,
+    semanticAlignmentDetails: {
+      consumedSignals: {
+        familyRoot: observation.familyRoot,
+        semanticFamily: observation.semanticFamily,
+        familySubgroup: observation.familySubgroup ?? null,
+      },
+      alignments: {
+        familyRoot: familyRootAlignment,
+        semanticFamily: semanticFamilyAlignment,
+        familySubgroup: familySubgroupAlignment,
+      },
+      inferredFromPathStructure: true,
+    },
   };
 };
+
+const classifyScatterPlacement = (observation) => toNamingBridgePlacementRecord(observation);
 
 const isAllowedStructuralRootPairing = (leftPlacement, rightPlacement) => {
   const key = [leftPlacement.structuralRoot, rightPlacement.structuralRoot]

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   collectNamingSemanticFamilyBridgeFindings,
+  toNamingBridgePlacementRecord,
 } from '../src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs';
 import { runTreeStructureAdvisor } from '../src/tree-structure-advisor.logic.mjs';
 
@@ -60,6 +61,75 @@ test('tree naming bridge contributor does not derive semantic-family when naming
   });
 
   assert.deepEqual(findings, []);
+});
+
+test('tree naming bridge placement model resolves structural home and semantic container separately', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'calculogic-validator/tree/src/contributors/tree-occurrence.logic.mjs',
+    semanticName: 'tree-occurrence',
+    familyRoot: 'tree',
+    semanticFamily: 'tree-occurrence',
+  });
+
+  assert.equal(placement.structuralHome, 'calculogic-validator/tree');
+  assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/tree');
+  assert.equal(placement.semanticHome, 'calculogic-validator/tree');
+  assert.equal(placement.localStructuralHome, 'src');
+});
+
+test('tree naming bridge placement model derives semantic placement from naming-owned signals and path alignment', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'tools/report-capture/runtime/report-capture.logic.mjs',
+    semanticName: 'report-capture',
+    familyRoot: 'report',
+    semanticFamily: 'report-capture',
+  });
+
+  assert.equal(placement.semanticContainerIdentity, 'tools/report-capture');
+  assert.equal(placement.semanticAlignmentDetails.alignments.familyRoot.signal, 'report');
+  assert.equal(placement.semanticAlignmentDetails.alignments.semanticFamily.signal, 'report-capture');
+  assert.equal(placement.semanticAlignmentDetails.inferredFromPathStructure, true);
+});
+
+test('tree naming bridge placement model can represent semantic subhome from family subgroup signals', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'calculogic-validator/naming/src/lane/naming-lane.logic.mjs',
+    semanticName: 'naming-lane',
+    familyRoot: 'naming',
+    semanticFamily: 'naming-lane',
+    familySubgroup: 'lane',
+  });
+
+  assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/naming');
+  assert.equal(placement.semanticSubhome, 'calculogic-validator/naming/src/lane');
+});
+
+test('tree naming bridge placement model keeps structural and semantic placement distinct when they differ', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'src/features/tree/validator-cli.logic.ts',
+    semanticName: 'validator-cli',
+    familyRoot: 'validator',
+    semanticFamily: 'validator-cli',
+    familySubgroup: 'cli',
+  });
+
+  assert.equal(placement.structuralHome, 'src/features');
+  assert.equal(placement.semanticContainerIdentity, 'src/features/tree/validator-cli.logic.ts');
+  assert.equal(placement.structuralHome === placement.semanticContainerIdentity, false);
+});
+
+test('tree naming bridge placement model stays deterministic for identical inputs', () => {
+  const observation = {
+    path: 'calculogic-validator/naming/src/lanes/naming-lane.logic.mjs',
+    semanticName: 'naming-lane',
+    familyRoot: 'naming',
+    semanticFamily: 'naming-lane',
+    familySubgroup: 'lane',
+  };
+
+  const first = toNamingBridgePlacementRecord(observation);
+  const second = toNamingBridgePlacementRecord(observation);
+  assert.deepEqual(first, second);
 });
 
 test('tree naming bridge contributor does not emit naming validity judgments', () => {


### PR DESCRIPTION
### Motivation
- Introduce a bounded, inspectable placement model so tree can record structural and semantic placement side-by-side before any scatter/cluster/subgroup behavior changes. 
- Follow NL-first convention by updating the canonical tree spec prior to runtime code changes to document the new placement-model layer. 
- Treat naming as the owner of `familyRoot`/`semanticFamily`/`familySubgroup` while making tree consume those signals deterministically to interpret semantic placement. 

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to add a bounded “Naming-bridge placement model” note and list the placement fields added. 
- Added a tree-owned helper `toNamingBridgePlacementRecord` in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` that returns a deterministic placement record per naming-bridge observation and preserves the structural vs semantic distinction. 
- Placement record fields now include `structuralRoot`, `structuralSurface`, `structuralHome`, `localStructuralHome`, `semanticContainerIdentity`, `semanticHome`, `semanticSubhome`, and `semanticAlignmentDetails` that explain which naming signals were consumed and how path alignment was inferred. 
- Kept existing finding logic unchanged by routing placement classification through the new helper (existing finding codes, thresholds, and severities were not intentionally modified), and added focused tests in `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`. 

### Testing
- Ran the focused contributor test with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and fixed an initial expectation mismatch; the final run passed all tests. 
- Test coverage exercised: placement record resolution, semantic placement derived from naming signals + path alignment, semantic subhome support, structural vs semantic divergence, and determinism for identical inputs. 
- No finding emissions/counts/severity/thresholds were intentionally changed by this tranche; automated tests that assert finding codes continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae62f6b788331b4503be5c46d6cb0)