### PR TITLE
Tighten tree semantic-home inference to folder/subfolder-only placements

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -133,6 +133,11 @@ Ownership and interpretation guardrails for this tranche:
 - tree consumes those naming-owned signals plus path structure to interpret semantic placement
 - this tranche adds bounded placement modeling only
 - this tranche does not broaden finding behavior (no new finding families/codes and no intentional threshold/count/severity broadening)
+- semantic placement values in this tranche are folder/subfolder-derived interpretations
+  - `semanticContainerIdentity` resolves to a folder/subfolder home, not a filename path
+  - `semanticHome` resolves to a folder/subfolder home, not a filename path
+  - `semanticSubhome`, when present, resolves to a folder/subfolder home, not a filename path
+  - filename-level semantic token hits may remain visible in alignment/explanation details, but do not become semantic home/container values
 
 Examples of naming validity judgments that tree advisor must not duplicate:
 

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -96,20 +96,26 @@ const toSignalAlignment = (pathSegments, semanticSignal) => {
 
 export const toNamingBridgePlacementRecord = (observation) => {
   const pathSegments = observation.path.split('/').filter(Boolean);
+  const directorySegments = path.posix.dirname(observation.path).split('/').filter(Boolean);
   const structuralRoot = pathSegments[0] ?? '.';
   const structuralSurface = pathSegments.slice(0, 2).join('/') || structuralRoot;
   const structuralHome = toNormalizedStructuralHome(observation.path);
   const localStructuralHome = toLocalStructuralHome(observation.path, structuralHome);
   const semanticIdentityTokens = toSemanticIdentityTokens(observation);
   const semanticAlignmentHits = toSemanticAlignmentHits(observation, semanticIdentityTokens);
+  const familyRootDirectoryAlignment = toSignalAlignment(directorySegments, observation.familyRoot);
+  const semanticFamilyDirectoryAlignment = toSignalAlignment(directorySegments, observation.semanticFamily);
+  const familySubgroupDirectoryAlignment = toSignalAlignment(directorySegments, observation.familySubgroup);
   const familyRootAlignment = toSignalAlignment(pathSegments, observation.familyRoot);
   const semanticFamilyAlignment = toSignalAlignment(pathSegments, observation.semanticFamily);
   const familySubgroupAlignment = toSignalAlignment(pathSegments, observation.familySubgroup);
-  const semanticContainerIdentity = familyRootAlignment?.pathPrefix ?? null;
-  const semanticHome = semanticFamilyAlignment?.pathPrefix ?? semanticContainerIdentity;
+  const semanticContainerIdentity = familyRootDirectoryAlignment?.pathPrefix ?? null;
+  const semanticHome = semanticFamilyDirectoryAlignment?.pathPrefix ?? semanticContainerIdentity;
   const semanticSubhome =
-    familySubgroupAlignment && semanticHome && familySubgroupAlignment.pathPrefix !== semanticHome
-      ? familySubgroupAlignment.pathPrefix
+    familySubgroupDirectoryAlignment &&
+    semanticHome &&
+    familySubgroupDirectoryAlignment.pathPrefix !== semanticHome
+      ? familySubgroupDirectoryAlignment.pathPrefix
       : null;
 
   return {
@@ -135,6 +141,11 @@ export const toNamingBridgePlacementRecord = (observation) => {
         familyRoot: familyRootAlignment,
         semanticFamily: semanticFamilyAlignment,
         familySubgroup: familySubgroupAlignment,
+      },
+      folderDerivedAlignments: {
+        familyRoot: familyRootDirectoryAlignment,
+        semanticFamily: semanticFamilyDirectoryAlignment,
+        familySubgroup: familySubgroupDirectoryAlignment,
       },
       inferredFromPathStructure: true,
     },

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -86,8 +86,10 @@ test('tree naming bridge placement model derives semantic placement from naming-
   });
 
   assert.equal(placement.semanticContainerIdentity, 'tools/report-capture');
+  assert.equal(placement.semanticHome, 'tools/report-capture');
   assert.equal(placement.semanticAlignmentDetails.alignments.familyRoot.signal, 'report');
   assert.equal(placement.semanticAlignmentDetails.alignments.semanticFamily.signal, 'report-capture');
+  assert.equal(placement.semanticAlignmentDetails.folderDerivedAlignments.familyRoot.pathPrefix, 'tools/report-capture');
   assert.equal(placement.semanticAlignmentDetails.inferredFromPathStructure, true);
 });
 
@@ -114,8 +116,25 @@ test('tree naming bridge placement model keeps structural and semantic placement
   });
 
   assert.equal(placement.structuralHome, 'src/features');
-  assert.equal(placement.semanticContainerIdentity, 'src/features/tree/validator-cli.logic.ts');
+  assert.equal(placement.semanticContainerIdentity, null);
   assert.equal(placement.structuralHome === placement.semanticContainerIdentity, false);
+  assert.equal(placement.semanticAlignmentDetails.alignments.semanticFamily.segment, 'validator-cli.logic.ts');
+  assert.equal(placement.semanticAlignmentDetails.folderDerivedAlignments.semanticFamily, null);
+});
+
+test('tree naming bridge placement model does not elevate filename-only semantic hits into semantic container/home', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'src/features/tree/validator-cli.logic.ts',
+    semanticName: 'validator-cli',
+    familyRoot: 'validator',
+    semanticFamily: 'validator-cli',
+  });
+
+  assert.equal(placement.semanticContainerIdentity, null);
+  assert.equal(placement.semanticHome, null);
+  assert.equal(placement.semanticAlignmentDetails.alignments.familyRoot.segment, 'validator-cli.logic.ts');
+  assert.equal(placement.semanticAlignmentDetails.alignments.semanticFamily.segment, 'validator-cli.logic.ts');
+  assert.equal(placement.semanticAlignmentHits.some((hit) => hit.segment === 'validator-cli.logic.ts'), true);
 });
 
 test('tree naming bridge placement model stays deterministic for identical inputs', () => {


### PR DESCRIPTION
### Motivation
- Make semantic placement (`semanticContainerIdentity`, `semanticHome`, `semanticSubhome`) deterministic and closer to developer mental models by deriving them from folder/subfolder structure only rather than allowing filename-level matches to become homes.
- Follow the NL-first workflow by updating the authoritative tree slice spec before changing runtime logic so behavior intent is documented first.
- Preserve existing ownership and finding behavior by keeping naming-owned signals (`familyRoot`, `semanticFamily`, `familySubgroup`) as inputs and not changing finding families, thresholds, or severities.

### Description
- Updated the tree placement model wording in `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to state that semantic placement values are folder/subfolder-derived and that filename-level token hits remain explanatory-only.
- Refined `toNamingBridgePlacementRecord` in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` to compute semantic container/home/subhome from directory segments (`directorySegments`) and to expose `folderDerivedAlignments` while preserving full-path `alignments` and `semanticAlignmentHits` for diagnostics.
- Kept structural and semantic placement distinct (fields such as `structuralHome`, `localStructuralHome`, `semanticContainerIdentity`, `semanticHome`, `semanticSubhome` remain separate) and preserved naming ownership (tree consumes naming bridge signals only).
- Added/updated focused tests in `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` proving folder-derived semantic container/home/subhome behavior, that filename-only hits remain only in alignment details, structural/semantic distinction, and deterministic outputs.

### Testing
- Ran the contributor test suite with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and all tests passed (`28` tests, `0` failures).
- Verified deterministic placement behavior by asserting identical outputs for repeated `toNamingBridgePlacementRecord` inputs and by exercising cases where filename-only matches should not be elevated into semantic homes, all of which succeeded.
- No changes were made to finding families, counts, thresholds, or severity as part of this slice and no new findings were intentionally introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae92561188331b51ae2e40e712efe)