### PR TITLE
Add bounded local placement-coherence classification to tree naming bridge

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -127,11 +127,21 @@ At minimum, the placement model distinguishes:
 - `semanticHome`
 - `semanticSubhome`
 
+On top of those placement fields, tree also records a bounded local placement-coherence classification so the local relationship between structural and semantic placement is explicit and inspectable.
+
+Bounded local placement-coherence values in this tranche:
+
+- `aligned-local-home`
+- `structural-home-only`
+- `semantic-home-only`
+- `divergent-local-placement`
+- `no-semantic-home`
+
 Ownership and interpretation guardrails for this tranche:
 
 - naming still owns `familyRoot`, `semanticFamily`, and optional `familySubgroup`
 - tree consumes those naming-owned signals plus path structure to interpret semantic placement
-- this tranche adds bounded placement modeling only
+- this tranche adds bounded placement modeling plus local structural-vs-semantic coherence classification only
 - this tranche does not broaden finding behavior (no new finding families/codes and no intentional threshold/count/severity broadening)
 - semantic placement values in this tranche are folder/subfolder-derived interpretations
   - `semanticContainerIdentity` resolves to a folder/subfolder home, not a filename path

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -94,6 +94,102 @@ const toSignalAlignment = (pathSegments, semanticSignal) => {
   };
 };
 
+const toFirstSegmentAfterPrefix = (fullPath, prefixPath) => {
+  if (typeof fullPath !== 'string' || fullPath.length === 0) {
+    return null;
+  }
+
+  if (typeof prefixPath !== 'string' || prefixPath.length === 0) {
+    return null;
+  }
+
+  if (fullPath === prefixPath) {
+    return '.';
+  }
+
+  const prefix = `${prefixPath}/`;
+  if (!fullPath.startsWith(prefix)) {
+    return null;
+  }
+
+  const [firstSegment] = fullPath.slice(prefix.length).split('/').filter(Boolean);
+  return firstSegment ?? '.';
+};
+
+const classifyLocalPlacementCoherence = ({
+  structuralHome,
+  localStructuralHome,
+  semanticContainerIdentity,
+  semanticHome,
+  semanticSubhome,
+  semanticAlignmentHits,
+}) => {
+  if (!semanticHome) {
+    return {
+      classification: semanticAlignmentHits.length > 0 ? 'structural-home-only' : 'no-semantic-home',
+      details: {
+        reason: semanticAlignmentHits.length > 0 ? 'semantic-hits-without-folder-derived-semantic-home' : 'no-folder-derived-semantic-home',
+        semanticAlignmentHitCount: semanticAlignmentHits.length,
+      },
+    };
+  }
+
+  if (!structuralHome) {
+    return {
+      classification: 'semantic-home-only',
+      details: {
+        reason: 'semantic-home-present-while-structural-home-missing',
+      },
+    };
+  }
+
+  const semanticLocalHome =
+    toFirstSegmentAfterPrefix(semanticSubhome, semanticHome) ??
+    toFirstSegmentAfterPrefix(semanticHome, semanticContainerIdentity) ??
+    '.';
+  const semanticSubhomeDepthFromSemanticHome =
+    typeof semanticSubhome === 'string' && semanticSubhome.startsWith(`${semanticHome}/`)
+      ? semanticSubhome
+          .slice(`${semanticHome}/`.length)
+          .split('/')
+          .filter(Boolean).length
+      : 0;
+  const homesAligned = structuralHome === semanticHome;
+  const localHomesAligned = semanticLocalHome === '.' || semanticLocalHome === localStructuralHome;
+
+  if (homesAligned && semanticSubhomeDepthFromSemanticHome > 1) {
+    return {
+      classification: 'divergent-local-placement',
+      details: {
+        reason: 'semantic-subhome-signals-lower-local-placement',
+        semanticLocalHome,
+        semanticSubhomeDepthFromSemanticHome,
+      },
+    };
+  }
+
+  if (homesAligned && localHomesAligned) {
+    return {
+      classification: 'aligned-local-home',
+      details: {
+        reason: 'structural-home-and-semantic-home-align-locally',
+        semanticLocalHome,
+      },
+    };
+  }
+
+  return {
+    classification: 'divergent-local-placement',
+    details: {
+      reason: homesAligned ? 'semantic-local-home-diverges-from-structural-local-home' : 'semantic-home-diverges-from-structural-home',
+      semanticLocalHome,
+      localStructuralHome,
+      structuralHome,
+      semanticHome,
+    },
+  };
+};
+
 export const toNamingBridgePlacementRecord = (observation) => {
   const pathSegments = observation.path.split('/').filter(Boolean);
   const directorySegments = path.posix.dirname(observation.path).split('/').filter(Boolean);
@@ -117,6 +213,14 @@ export const toNamingBridgePlacementRecord = (observation) => {
     familySubgroupDirectoryAlignment.pathPrefix !== semanticHome
       ? familySubgroupDirectoryAlignment.pathPrefix
       : null;
+  const localPlacementCoherence = classifyLocalPlacementCoherence({
+    structuralHome,
+    localStructuralHome,
+    semanticContainerIdentity,
+    semanticHome,
+    semanticSubhome,
+    semanticAlignmentHits,
+  });
 
   return {
     path: observation.path,
@@ -129,6 +233,8 @@ export const toNamingBridgePlacementRecord = (observation) => {
     semanticContainerIdentity,
     semanticHome,
     semanticSubhome,
+    localPlacementCoherence: localPlacementCoherence.classification,
+    localPlacementCoherenceDetails: localPlacementCoherence.details,
     semanticIdentityTokens,
     semanticAlignmentHits,
     semanticAlignmentDetails: {

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -75,6 +75,7 @@ test('tree naming bridge placement model resolves structural home and semantic c
   assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/tree');
   assert.equal(placement.semanticHome, 'calculogic-validator/tree');
   assert.equal(placement.localStructuralHome, 'src');
+  assert.equal(placement.localPlacementCoherence, 'aligned-local-home');
 });
 
 test('tree naming bridge placement model derives semantic placement from naming-owned signals and path alignment', () => {
@@ -93,6 +94,20 @@ test('tree naming bridge placement model derives semantic placement from naming-
   assert.equal(placement.semanticAlignmentDetails.inferredFromPathStructure, true);
 });
 
+test('tree naming bridge placement model classifies divergent local placement when semantic home differs from structural home', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'src/features/report-capture/runtime/report-capture.logic.ts',
+    semanticName: 'report-capture',
+    familyRoot: 'report',
+    semanticFamily: 'report-capture',
+  });
+
+  assert.equal(placement.structuralHome, 'src/features');
+  assert.equal(placement.semanticHome, 'src/features/report-capture');
+  assert.equal(placement.localPlacementCoherence, 'divergent-local-placement');
+  assert.equal(placement.localPlacementCoherenceDetails.reason, 'semantic-home-diverges-from-structural-home');
+});
+
 test('tree naming bridge placement model can represent semantic subhome from family subgroup signals', () => {
   const placement = toNamingBridgePlacementRecord({
     path: 'calculogic-validator/naming/src/lane/naming-lane.logic.mjs',
@@ -104,6 +119,11 @@ test('tree naming bridge placement model can represent semantic subhome from fam
 
   assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/naming');
   assert.equal(placement.semanticSubhome, 'calculogic-validator/naming/src/lane');
+  assert.equal(placement.localPlacementCoherence, 'divergent-local-placement');
+  assert.equal(
+    placement.localPlacementCoherenceDetails.reason,
+    'semantic-subhome-signals-lower-local-placement',
+  );
 });
 
 test('tree naming bridge placement model keeps structural and semantic placement distinct when they differ', () => {
@@ -118,6 +138,7 @@ test('tree naming bridge placement model keeps structural and semantic placement
   assert.equal(placement.structuralHome, 'src/features');
   assert.equal(placement.semanticContainerIdentity, null);
   assert.equal(placement.structuralHome === placement.semanticContainerIdentity, false);
+  assert.equal(placement.localPlacementCoherence, 'structural-home-only');
   assert.equal(placement.semanticAlignmentDetails.alignments.semanticFamily.segment, 'validator-cli.logic.ts');
   assert.equal(placement.semanticAlignmentDetails.folderDerivedAlignments.semanticFamily, null);
 });
@@ -132,9 +153,28 @@ test('tree naming bridge placement model does not elevate filename-only semantic
 
   assert.equal(placement.semanticContainerIdentity, null);
   assert.equal(placement.semanticHome, null);
+  assert.equal(placement.localPlacementCoherence, 'structural-home-only');
+  assert.equal(
+    placement.localPlacementCoherenceDetails.reason,
+    'semantic-hits-without-folder-derived-semantic-home',
+  );
   assert.equal(placement.semanticAlignmentDetails.alignments.familyRoot.segment, 'validator-cli.logic.ts');
   assert.equal(placement.semanticAlignmentDetails.alignments.semanticFamily.segment, 'validator-cli.logic.ts');
   assert.equal(placement.semanticAlignmentHits.some((hit) => hit.segment === 'validator-cli.logic.ts'), true);
+});
+
+test('tree naming bridge placement model classifies no semantic home when no semantic token alignment is present', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'src/features/tree/unrelated.logic.ts',
+    semanticName: 'validator-cli',
+    familyRoot: 'validator',
+    semanticFamily: 'validator-cli',
+  });
+
+  assert.equal(placement.semanticContainerIdentity, null);
+  assert.equal(placement.semanticHome, null);
+  assert.equal(placement.semanticAlignmentHits.length, 0);
+  assert.equal(placement.localPlacementCoherence, 'no-semantic-home');
 });
 
 test('tree naming bridge placement model stays deterministic for identical inputs', () => {


### PR DESCRIPTION
### Motivation

- Add the next minimal tree reasoning layer to make explicit how structural placement and naming-derived semantic placement relate locally without changing existing finding semantics. 
- Follow NL-first conventions by updating the tree spec before code so the change is documented as a bounded modeling note. 
- Keep the slice narrow, deterministic, and inspectable so later local-coherence and spread reasoning can build on a clear placement surface.

### Description

- Updated the tree validator spec `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to document an explicit local placement-coherence layer and enumerate the bounded values: `aligned-local-home`, `structural-home-only`, `semantic-home-only`, `divergent-local-placement`, and `no-semantic-home`.
- Implemented a small deterministic classifier (`classifyLocalPlacementCoherence`) and helper (`toFirstSegmentAfterPrefix`) in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` and attached the additive fields `localPlacementCoherence` and `localPlacementCoherenceDetails` to the naming-bridge placement record.
- Kept structural vs semantic placement distinct and derived coherence only from existing placement fields (`structuralHome`, `localStructuralHome`, `semanticContainerIdentity`, `semanticHome`, `semanticSubhome`, and semantic alignment hits) so no thresholds, finding families, or severities were intentionally changed.
- Changed files: `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`, `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, and `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`.

### Testing

- Ran the contributor unit tests with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and all tests passed. 
- Tests added/updated cover aligned local classification, structural-only/no-semantic-home, divergent placement, semantic `subhome` influence, filename-only diagnostic behavior, and deterministic outputs for identical inputs. 
- No intentional finding-output changes were introduced; the coherence fields are additive and inspectable and were validated to not alter existing `TREE_*` finding behaviour in this tranche.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daefe51e508331b37c2e3b29077983)