### PR TITLE
Gate TREE_FAMILY_SCATTERED behind local-first family interpretation

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -177,9 +177,28 @@ Tree consumes this normalized bridge payload only. Tree runtime must not parse f
 
 - tree classifies each family observation by structural root/surface and naming-aligned semantic-container placement,
 - semantic-container recognition is based on path alignment with naming-owned bridge evidence (`familyRoot`, `semanticFamily`, optional `familySubgroup`), not a hardcoded semantic-folder allowlist,
-- family presence confined to one valid naming-aligned semantic container is treated as expected/container-local density first (not immediate broad scatter),
+- tree evaluates family interpretation in explicit local-first order:
+  1. structural placement,
+  2. semantic placement,
+  3. local placement coherence,
+  4. local-first family interpretation lane selection,
+  5. broad scatter eligibility only when local interpretation does not sufficiently explain observed placement,
+- family presence confined to one valid naming-aligned semantic container is treated as expected/container-local density/subgroup opportunity first (not immediate broad scatter),
 - bounded allowed cross-container pairings are exempt from broad scatter by default (for example canonical docs authority lane with aligned owned runtime container pairing),
 - broad scatter remains for family spread across unrelated structural homes/containers when no allowed pairing covers the spread.
+
+Current bounded local-first family interpretation outcomes used for this gate:
+
+- `expected-local-presence`
+- `local-density-first`
+- `local-subgroup-first`
+- `local-divergence-needs-broader-review`
+- `no-local-semantic-explanation`
+
+Behavior boundary for this slice:
+
+- no new findings/codes are introduced,
+- this slice only refines when existing broad-scatter eligibility (`TREE_FAMILY_SCATTERED`) is allowed after local-first interpretation.
 
 ### Family subgroup opportunity inside one semantic container (Status: Current runtime behavior, bounded)
 

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -22,6 +22,13 @@ const SHARED_ROOT_LANE_FIRST_PARTITIONS = ['build', 'build-style', 'logic', 'kno
 const SHARED_ROOT_LANE_FIRST_PARTITION_SET = new Set(SHARED_ROOT_LANE_FIRST_PARTITIONS);
 const SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS = 2;
 const SHARED_ROOT_MIN_FAMILY_FILES = 3;
+const LOCAL_FIRST_FAMILY_INTERPRETATION = Object.freeze({
+  EXPECTED_LOCAL_PRESENCE: 'expected-local-presence',
+  LOCAL_DENSITY_FIRST: 'local-density-first',
+  LOCAL_SUBGROUP_FIRST: 'local-subgroup-first',
+  LOCAL_DIVERGENCE_NEEDS_BROADER_REVIEW: 'local-divergence-needs-broader-review',
+  NO_LOCAL_SEMANTIC_EXPLANATION: 'no-local-semantic-explanation',
+});
 
 const toSortedUnique = (values) => Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
 
@@ -384,6 +391,109 @@ const hasLowerLevelGroupingSignal = (observation) => {
   return observation.semanticFamily.startsWith(`${observation.familyRoot}-`);
 };
 
+const interpretFamilyLocalFirst = (familyEntries) => {
+  const sortedPaths = familyEntries
+    .map(({ observation }) => observation.path)
+    .sort((left, right) => left.localeCompare(right));
+  const localPlacementCoherenceClasses = toSortedUnique(
+    familyEntries.map(({ placement }) => placement.localPlacementCoherence),
+  );
+  const semanticContainerIdentities = toSortedUnique(
+    familyEntries
+      .filter(({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
+      .map(({ placement }) => placement.semanticContainerIdentity),
+  );
+  const allEntriesInsideOneSemanticContainer =
+    semanticContainerIdentities.length === 1 &&
+    familyEntries.every(({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
+  const observedContainerLocalHomes = allEntriesInsideOneSemanticContainer
+    ? toSortedUnique(familyEntries.map(({ placement }) => toContainerLocalHome(placement)))
+    : [];
+  const lowerLevelGroupingSignalPresent = familyEntries.some(({ observation }) => hasLowerLevelGroupingSignal(observation));
+  const localDivergencePresent = familyEntries.some(
+    ({ placement }) =>
+      placement.localPlacementCoherence === 'divergent-local-placement' ||
+      placement.localPlacementCoherence === 'semantic-home-only',
+  );
+  const localSemanticExplanationAbsent = familyEntries.every(
+    ({ placement }) =>
+      placement.localPlacementCoherence === 'structural-home-only' ||
+      placement.localPlacementCoherence === 'no-semantic-home',
+  );
+
+  if (allEntriesInsideOneSemanticContainer) {
+    const hasContainerLocalDensity =
+      sortedPaths.length >= FAMILY_CLUSTER_INFO_MIN_FILES ||
+      observedContainerLocalHomes.length >= FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES;
+    const hasContainerLocalSubgroupOpportunity =
+      sortedPaths.length >= FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER &&
+      observedContainerLocalHomes.length >= FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES &&
+      lowerLevelGroupingSignalPresent;
+
+    if (hasContainerLocalSubgroupOpportunity) {
+      return {
+        classification: LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST,
+        details: {
+          semanticContainerIdentity: semanticContainerIdentities[0],
+          observedContainerLocalHomes,
+          lowerLevelGroupingSignalPresent,
+          localPlacementCoherence: localPlacementCoherenceClasses,
+        },
+      };
+    }
+
+    if (hasContainerLocalDensity) {
+      return {
+        classification: LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST,
+        details: {
+          semanticContainerIdentity: semanticContainerIdentities[0],
+          observedContainerLocalHomes,
+          lowerLevelGroupingSignalPresent,
+          localPlacementCoherence: localPlacementCoherenceClasses,
+        },
+      };
+    }
+
+    return {
+      classification: LOCAL_FIRST_FAMILY_INTERPRETATION.EXPECTED_LOCAL_PRESENCE,
+      details: {
+        semanticContainerIdentity: semanticContainerIdentities[0],
+        observedContainerLocalHomes,
+        localPlacementCoherence: localPlacementCoherenceClasses,
+      },
+    };
+  }
+
+  if (localDivergencePresent) {
+    return {
+      classification: LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DIVERGENCE_NEEDS_BROADER_REVIEW,
+      details: {
+        semanticContainerIdentities,
+        localPlacementCoherence: localPlacementCoherenceClasses,
+      },
+    };
+  }
+
+  if (localSemanticExplanationAbsent) {
+    return {
+      classification: LOCAL_FIRST_FAMILY_INTERPRETATION.NO_LOCAL_SEMANTIC_EXPLANATION,
+      details: {
+        semanticContainerIdentities,
+        localPlacementCoherence: localPlacementCoherenceClasses,
+      },
+    };
+  }
+
+  return {
+    classification: LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DIVERGENCE_NEEDS_BROADER_REVIEW,
+    details: {
+      semanticContainerIdentities,
+      localPlacementCoherence: localPlacementCoherenceClasses,
+      reason: 'mixed-local-placement-coherence-outside-one-semantic-container',
+    },
+  };
+};
+
 const toSharedRootLaneObservation = (observation) => {
   for (const sharedRoot of SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS) {
     const sharedRootPrefix = `${sharedRoot}/`;
@@ -427,13 +537,18 @@ const collectFamilyScatterFindings = (observations) => {
     .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
     .flatMap(([semanticFamily, familyObservations]) => {
       const sortedPaths = familyObservations.map(({ path: normalizedPath }) => normalizedPath).sort((a, b) => a.localeCompare(b));
-      const placements = familyObservations.map(classifyScatterPlacement);
+      const familyEntries = familyObservations.map((observation) => ({
+        observation,
+        placement: classifyScatterPlacement(observation),
+      }));
+      const placements = familyEntries.map(({ placement }) => placement);
       const structuralHomes = toSortedUnique(placements.map((placement) => placement.structuralHome));
       const semanticContainerIdentities = toSortedUnique(
         placements
           .filter((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
           .map((placement) => placement.semanticContainerIdentity),
       );
+      const localFirstInterpretation = interpretFamilyLocalFirst(familyEntries);
       const allPlacementsInOneSemanticContainer =
         semanticContainerIdentities.length === 1 &&
         placements.every((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
@@ -447,6 +562,9 @@ const collectFamilyScatterFindings = (observations) => {
       if (
         sortedPaths.length < FAMILY_SCATTER_MIN_FILES ||
         structuralHomes.length < FAMILY_SCATTER_MIN_STRUCTURAL_HOMES ||
+        localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.EXPECTED_LOCAL_PRESENCE ||
+        localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST ||
+        localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST ||
         allPlacementsInOneSemanticContainer ||
         allCrossContainerPlacementsCoveredByAllowedRules
       ) {
@@ -469,6 +587,7 @@ const collectFamilyScatterFindings = (observations) => {
             observedStructuralRoots: toSortedUnique(placements.map((placement) => placement.structuralRoot)),
             observedContainerIdentities: semanticContainerIdentities,
             observedStructuralRootKinds: toSortedUnique(placements.map((placement) => placement.structuralRootKind)),
+            localFirstInterpretation,
             allowedCrossContainerPatterns: {
               structuralRootPairings: ALLOWED_STRUCTURAL_ROOT_PAIRINGS,
               canonicalDocAuthorityRuntimePairing: 'calculogic-validator/doc/** <-> calculogic-validator/<semantic-container>/**',

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -510,6 +510,170 @@ test('tree naming bridge contributor still emits broad scatter for unrelated cro
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), true);
 });
 
+test('tree naming bridge contributor keeps locally aligned family observations in local-first lanes before broad scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/placements/tree-placement.logic.mjs',
+        semanticName: 'tree-placement',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-placement',
+      },
+      {
+        path: 'calculogic-validator/tree/src/placements/tree-placement.results.mjs',
+        semanticName: 'tree-placement',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-placement',
+      },
+      {
+        path: 'calculogic-validator/tree/src/placements/tree-placement.knowledge.mjs',
+        semanticName: 'tree-placement',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-placement',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
+test('tree naming bridge contributor keeps local-density-first families out of broad scatter and retains deterministic finding behavior', () => {
+  const payload = {
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/local-density/tree-density.logic.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/src/local-density/tree-density.results.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/test/local-density/tree-density.test.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+      {
+        path: 'calculogic-validator/tree/src/local-density/tree-density.knowledge.mjs',
+        semanticName: 'tree-density',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-density',
+      },
+    ],
+  };
+
+  const first = collectNamingSemanticFamilyBridgeFindings(payload);
+  const second = collectNamingSemanticFamilyBridgeFindings(payload);
+  assert.deepEqual(first, second);
+  assert.equal(first.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+  assert.equal(first.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), true);
+});
+
+test('tree naming bridge contributor keeps local-subgroup-first families out of broad scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/naming/src/lane/naming-lane.logic.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+      {
+        path: 'calculogic-validator/naming/src/family/naming-lane.results.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+      {
+        path: 'calculogic-validator/naming/test/lane/naming-lane.test.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+      {
+        path: 'calculogic-validator/naming/src/naming-lane.knowledge.mjs',
+        semanticName: 'naming-lane',
+        familyRoot: 'naming',
+        semanticFamily: 'naming-lane',
+        familySubgroup: 'lane',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), true);
+});
+
+test('tree naming bridge contributor keeps divergent local placement eligible for broad scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/features/report-capture/runtime/report-capture.logic.ts',
+        semanticName: 'report-capture',
+        familyRoot: 'report',
+        semanticFamily: 'report-capture',
+      },
+      {
+        path: 'tools/report-capture/runtime/report-capture.results.mjs',
+        semanticName: 'report-capture',
+        familyRoot: 'report',
+        semanticFamily: 'report-capture',
+      },
+      {
+        path: 'doc/report-capture/report-capture.spec.md',
+        semanticName: 'report-capture',
+        familyRoot: 'report',
+        semanticFamily: 'report-capture',
+      },
+    ],
+  });
+  const scatterFinding = findings.find((finding) => finding.code === 'TREE_FAMILY_SCATTERED');
+  assert.equal(Boolean(scatterFinding), true);
+  assert.equal(
+    scatterFinding.details.localFirstInterpretation.classification,
+    'local-divergence-needs-broader-review',
+  );
+});
+
+test('tree naming bridge contributor keeps no-local-semantic-explanation families eligible for broad scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/alpha/unrelated.logic.ts',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+      {
+        path: 'tools/beta/unrelated.results.mjs',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+      {
+        path: 'doc/gamma/unrelated.spec.md',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+    ],
+  });
+  const scatterFinding = findings.find((finding) => finding.code === 'TREE_FAMILY_SCATTERED');
+  assert.equal(Boolean(scatterFinding), true);
+  assert.equal(
+    scatterFinding.details.localFirstInterpretation.classification,
+    'no-local-semantic-explanation',
+  );
+});
+
 
 test('tree naming bridge contributor emits one cluster finding for dense family in one semantic container', () => {
   const findings = collectNamingSemanticFamilyBridgeFindings({


### PR DESCRIPTION
### Motivation
- Make family interpretation local-first using the new placement model (structural placement → semantic placement → local placement coherence → local-first family interpretation) so broad scatter is only considered after local explanations are evaluated. 
- Keep the change bounded and deterministic without introducing new finding codes or broad rewrites. 

### Description
- Updated the tree spec (NL-first) in `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to document the explicit local-first reasoning order and the permitted local-first interpretation outcomes. 
- Added a bounded, deterministic helper `interpretFamilyLocalFirst` and an enum-like `LOCAL_FIRST_FAMILY_INTERPRETATION` in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` that classifies families into `expected-local-presence`, `local-density-first`, `local-subgroup-first`, `local-divergence-needs-broader-review`, and `no-local-semantic-explanation`. 
- Gate `TREE_FAMILY_SCATTERED` eligibility with the local-first interpretation so families classified as `expected-local-presence`, `local-density-first`, or `local-subgroup-first` do not escalate to broad scatter first, while `local-divergence-needs-broader-review` and `no-local-semantic-explanation` remain eligible; the finding now carries `details.localFirstInterpretation` for inspectability. 
- Changed only minimal internal logic used by the naming-bridge contributor and preserved ownership/naming boundaries and existing finding families. 

### Testing
- Ran the focused tree naming-bridge tests with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and all tests passed (35 tests, 0 failures). 
- Included deterministic checks in tests that compare repeated invocations and cluster/subgroup expectations, and those assertions succeeded. 
- Files modified: `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`, `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, and `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf4eb59b4833193db3f6499f0a86e)