### PR TITLE
Route cluster/subgroup/scatter through shared local-first family interpretation

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -200,6 +200,35 @@ Behavior boundary for this slice:
 - no new findings/codes are introduced,
 - this slice only refines when existing broad-scatter eligibility (`TREE_FAMILY_SCATTERED`) is allowed after local-first interpretation.
 
+### Shared local-first family interpretation spine for family outcomes (Status: Current runtime behavior, bounded)
+
+Classification: Normative
+
+Current family-level tree outcomes now share one bounded local-first interpretation authority (`interpretFamilyLocalFirst`) before emitting family findings.
+
+The shared local-first interpretation spine routes existing family findings as follows:
+
+- `expected-local-presence`
+  - suppresses broad scatter (`TREE_FAMILY_SCATTERED`)
+  - does not force local debt-style cluster/subgroup signaling
+- `local-density-first`
+  - enables cluster-first local signaling (`TREE_OBSERVED_FAMILY_CLUSTER`) using existing bounded thresholds/details
+  - suppresses broad scatter-first routing
+- `local-subgroup-first`
+  - enables subgroup-opportunity-first local signaling (`TREE_FAMILY_SUBGROUP_OPPORTUNITY`) using existing bounded thresholds/details
+  - suppresses broad scatter-first routing
+- `local-divergence-needs-broader-review`
+  - keeps broad scatter (`TREE_FAMILY_SCATTERED`) eligible under existing bounded scatter thresholds/rules
+- `no-local-semantic-explanation`
+  - keeps broad scatter (`TREE_FAMILY_SCATTERED`) eligible under existing bounded scatter thresholds/rules
+
+Boundary notes for this consolidation slice:
+
+- no new finding codes are introduced,
+- no new family/advisory families are introduced,
+- routing is consolidated so existing family findings derive from one bounded local-first interpretation model,
+- naming ownership remains unchanged (`familyRoot`, `semanticFamily`, optional `familySubgroup` stay naming-owned).
+
 ### Family subgroup opportunity inside one semantic container (Status: Current runtime behavior, bounded)
 
 `TREE_FAMILY_SUBGROUP_OPPORTUNITY` is a bounded, info-level, advisory-only signal for lower-level family grouping opportunity *inside one naming-aligned semantic container*.

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -494,6 +494,58 @@ const interpretFamilyLocalFirst = (familyEntries) => {
   };
 };
 
+const toSingularFamilyEntriesBySemanticFamily = (observations) => {
+  const singularObservations = observations
+    .filter((observation) => isSingularFamilyEvidence(observation))
+    .map((observation) => ({
+      observation,
+      placement: classifyScatterPlacement(observation),
+    }));
+
+  const observationsBySemanticFamily = new Map();
+  for (const entry of singularObservations) {
+    if (!observationsBySemanticFamily.has(entry.observation.semanticFamily)) {
+      observationsBySemanticFamily.set(entry.observation.semanticFamily, []);
+    }
+
+    observationsBySemanticFamily.get(entry.observation.semanticFamily).push(entry);
+  }
+
+  return observationsBySemanticFamily;
+};
+
+const toFamilyLocalFirstAnalysis = (semanticFamily, familyEntries) => {
+  const sortedPaths = familyEntries.map(({ observation }) => observation.path).sort((left, right) => left.localeCompare(right));
+  const placements = familyEntries.map(({ placement }) => placement);
+  const structuralHomes = toSortedUnique(placements.map((placement) => placement.structuralHome));
+  const semanticContainerIdentities = toSortedUnique(
+    placements
+      .filter((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
+      .map((placement) => placement.semanticContainerIdentity),
+  );
+  const allEntriesInsideOneSemanticContainer =
+    semanticContainerIdentities.length === 1 &&
+    placements.every((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
+  const observedContainerLocalHomes = allEntriesInsideOneSemanticContainer
+    ? toSortedUnique(familyEntries.map(({ placement }) => toContainerLocalHome(placement)))
+    : [];
+  const lowerLevelGroupingSignalPresent = familyEntries.some(({ observation }) => hasLowerLevelGroupingSignal(observation));
+  const localFirstInterpretation = interpretFamilyLocalFirst(familyEntries);
+
+  return {
+    semanticFamily,
+    familyEntries,
+    sortedPaths,
+    placements,
+    structuralHomes,
+    semanticContainerIdentities,
+    allEntriesInsideOneSemanticContainer,
+    observedContainerLocalHomes,
+    lowerLevelGroupingSignalPresent,
+    localFirstInterpretation,
+  };
+};
+
 const toSharedRootLaneObservation = (observation) => {
   for (const sharedRoot of SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS) {
     const sharedRootPrefix = `${sharedRoot}/`;
@@ -519,53 +571,26 @@ const toSharedRootLaneObservation = (observation) => {
 };
 
 const collectFamilyScatterFindings = (observations) => {
-  const observationsBySemanticFamily = new Map();
-
-  for (const observation of observations) {
-    if (!isSingularFamilyEvidence(observation)) {
-      continue;
-    }
-
-    if (!observationsBySemanticFamily.has(observation.semanticFamily)) {
-      observationsBySemanticFamily.set(observation.semanticFamily, []);
-    }
-
-    observationsBySemanticFamily.get(observation.semanticFamily).push(observation);
-  }
+  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
 
   return Array.from(observationsBySemanticFamily.entries())
     .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
-    .flatMap(([semanticFamily, familyObservations]) => {
-      const sortedPaths = familyObservations.map(({ path: normalizedPath }) => normalizedPath).sort((a, b) => a.localeCompare(b));
-      const familyEntries = familyObservations.map((observation) => ({
-        observation,
-        placement: classifyScatterPlacement(observation),
-      }));
-      const placements = familyEntries.map(({ placement }) => placement);
-      const structuralHomes = toSortedUnique(placements.map((placement) => placement.structuralHome));
-      const semanticContainerIdentities = toSortedUnique(
-        placements
-          .filter((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
-          .map((placement) => placement.semanticContainerIdentity),
-      );
-      const localFirstInterpretation = interpretFamilyLocalFirst(familyEntries);
-      const allPlacementsInOneSemanticContainer =
-        semanticContainerIdentities.length === 1 &&
-        placements.every((placement) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
+    .flatMap(([semanticFamily, familyEntries]) => {
+      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
 
-      const allCrossContainerPlacementsCoveredByAllowedRules = placements.every((leftPlacement, leftIndex) =>
-        placements
+      const allCrossContainerPlacementsCoveredByAllowedRules = familyAnalysis.placements.every((leftPlacement, leftIndex) =>
+        familyAnalysis.placements
           .slice(leftIndex + 1)
           .every((rightPlacement) => isAllowedCrossContainerPlacementPair(leftPlacement, rightPlacement)),
       );
 
       if (
-        sortedPaths.length < FAMILY_SCATTER_MIN_FILES ||
-        structuralHomes.length < FAMILY_SCATTER_MIN_STRUCTURAL_HOMES ||
-        localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.EXPECTED_LOCAL_PRESENCE ||
-        localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST ||
-        localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST ||
-        allPlacementsInOneSemanticContainer ||
+        familyAnalysis.sortedPaths.length < FAMILY_SCATTER_MIN_FILES ||
+        familyAnalysis.structuralHomes.length < FAMILY_SCATTER_MIN_STRUCTURAL_HOMES ||
+        familyAnalysis.localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.EXPECTED_LOCAL_PRESENCE ||
+        familyAnalysis.localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST ||
+        familyAnalysis.localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST ||
+        familyAnalysis.allEntriesInsideOneSemanticContainer ||
         allCrossContainerPlacementsCoveredByAllowedRules
       ) {
         return [];
@@ -575,19 +600,19 @@ const collectFamilyScatterFindings = (observations) => {
         {
           code: 'TREE_FAMILY_SCATTERED',
           severity: 'info',
-          path: sortedPaths[0],
+          path: familyAnalysis.sortedPaths[0],
           classification: 'advisory-structure',
           message:
             'Naming-owned semantic-family evidence is spread across multiple structural homes and may benefit from clearer semantic-first grouping.',
           ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
           details: {
             semanticFamily,
-            observedPaths: sortedPaths,
-            observedStructuralHomes: structuralHomes,
-            observedStructuralRoots: toSortedUnique(placements.map((placement) => placement.structuralRoot)),
-            observedContainerIdentities: semanticContainerIdentities,
-            observedStructuralRootKinds: toSortedUnique(placements.map((placement) => placement.structuralRootKind)),
-            localFirstInterpretation,
+            observedPaths: familyAnalysis.sortedPaths,
+            observedStructuralHomes: familyAnalysis.structuralHomes,
+            observedStructuralRoots: toSortedUnique(familyAnalysis.placements.map((placement) => placement.structuralRoot)),
+            observedContainerIdentities: familyAnalysis.semanticContainerIdentities,
+            observedStructuralRootKinds: toSortedUnique(familyAnalysis.placements.map((placement) => placement.structuralRootKind)),
+            localFirstInterpretation: familyAnalysis.localFirstInterpretation,
             allowedCrossContainerPatterns: {
               structuralRootPairings: ALLOWED_STRUCTURAL_ROOT_PAIRINGS,
               canonicalDocAuthorityRuntimePairing: 'calculogic-validator/doc/** <-> calculogic-validator/<semantic-container>/**',
@@ -603,146 +628,69 @@ const collectFamilyScatterFindings = (observations) => {
 };
 
 const collectFamilyClusterFindings = (observations) => {
-  const singularObservations = observations
-    .filter((observation) => isSingularFamilyEvidence(observation))
-    .map((observation) => ({
-      observation,
-      placement: classifyScatterPlacement(observation),
-    }));
-
-  const observationsBySemanticFamily = new Map();
-  for (const entry of singularObservations) {
-    if (!observationsBySemanticFamily.has(entry.observation.semanticFamily)) {
-      observationsBySemanticFamily.set(entry.observation.semanticFamily, []);
-    }
-
-    observationsBySemanticFamily.get(entry.observation.semanticFamily).push(entry);
-  }
+  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
 
   return Array.from(observationsBySemanticFamily.entries())
     .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
     .flatMap(([semanticFamily, familyEntries]) => {
-      const allEntriesHaveSemanticContainer = familyEntries.every(
-        ({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container',
-      );
-
-      const aggregationBuckets = new Map();
-      for (const familyEntry of familyEntries) {
-        const bucketKey = allEntriesHaveSemanticContainer
-          ? `container::${familyEntry.placement.semanticContainerIdentity}`
-          : `family::${semanticFamily}`;
-        if (!aggregationBuckets.has(bucketKey)) {
-          aggregationBuckets.set(bucketKey, []);
-        }
-
-        aggregationBuckets.get(bucketKey).push(familyEntry);
+      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
+      if (familyAnalysis.localFirstInterpretation.classification !== LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST) {
+        return [];
       }
 
-      return Array.from(aggregationBuckets.entries())
-        .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
-        .flatMap(([, bucketEntries]) => {
-          if (bucketEntries.length < FAMILY_CLUSTER_INFO_MIN_FILES) {
-            return [];
-          }
-
-          const sortedPaths = bucketEntries
-            .map(({ observation }) => observation.path)
-            .sort((left, right) => left.localeCompare(right));
-          const semanticContainerIdentity = bucketEntries[0].placement.semanticContainerIdentity ?? null;
-
-          return [
-            {
-              code: 'TREE_OBSERVED_FAMILY_CLUSTER',
-              severity: 'info',
-              path: sortedPaths[0],
-              classification: 'advisory-structure',
-              message:
-                'Naming-owned semantic-family cluster size is high enough to consider a clearer structural grouping surface.',
-              ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
-              details: {
-                semanticFamily,
-                semanticContainerIdentity,
-                aggregationUnit: semanticContainerIdentity ? 'semanticFamily-in-container' : 'semanticFamily',
-                observedCount: bucketEntries.length,
-                observedPaths: sortedPaths,
-                threshold: {
-                  minFamilyFilesForClusterObservation: FAMILY_CLUSTER_INFO_MIN_FILES,
-                },
-              },
+      return [
+        {
+          code: 'TREE_OBSERVED_FAMILY_CLUSTER',
+          severity: 'info',
+          path: familyAnalysis.sortedPaths[0],
+          classification: 'advisory-structure',
+          message:
+            'Naming-owned semantic-family cluster size is high enough to consider a clearer structural grouping surface.',
+          ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
+          details: {
+            semanticFamily,
+            semanticContainerIdentity: familyAnalysis.semanticContainerIdentities[0] ?? null,
+            aggregationUnit: familyAnalysis.semanticContainerIdentities.length === 1 ? 'semanticFamily-in-container' : 'semanticFamily',
+            observedCount: familyAnalysis.sortedPaths.length,
+            observedPaths: familyAnalysis.sortedPaths,
+            localFirstInterpretation: familyAnalysis.localFirstInterpretation,
+            threshold: {
+              minFamilyFilesForClusterObservation: FAMILY_CLUSTER_INFO_MIN_FILES,
             },
-          ];
-        });
+          },
+        },
+      ];
     });
 };
 
 const collectFamilySubgroupOpportunityFindings = (observations) => {
-  const singularObservations = observations
-    .filter((observation) => isSingularFamilyEvidence(observation))
-    .map((observation) => ({
-      observation,
-      placement: classifyScatterPlacement(observation),
-    }));
-
-  const observationsBySemanticFamily = new Map();
-  for (const entry of singularObservations) {
-    if (!observationsBySemanticFamily.has(entry.observation.semanticFamily)) {
-      observationsBySemanticFamily.set(entry.observation.semanticFamily, []);
-    }
-
-    observationsBySemanticFamily.get(entry.observation.semanticFamily).push(entry);
-  }
+  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
 
   return Array.from(observationsBySemanticFamily.entries())
     .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
     .flatMap(([semanticFamily, familyEntries]) => {
-      const semanticContainerIdentities = toSortedUnique(
-        familyEntries
-          .filter(({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container')
-          .map(({ placement }) => placement.semanticContainerIdentity),
-      );
-      const allEntriesInsideOneSemanticContainer =
-        semanticContainerIdentities.length === 1 &&
-        familyEntries.every(({ placement }) => placement.semanticContainerRole === 'naming-aligned-semantic-container');
-
-      if (!allEntriesInsideOneSemanticContainer) {
+      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
+      if (familyAnalysis.localFirstInterpretation.classification !== LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST) {
         return [];
       }
 
-      const sortedPaths = familyEntries
-        .map(({ observation }) => observation.path)
-        .sort((left, right) => left.localeCompare(right));
-      const observedContainerLocalHomes = toSortedUnique(
-        familyEntries.map(({ placement }) => toContainerLocalHome(placement)),
-      );
-      const lowerLevelGroupingSignalPresent = familyEntries.some(({ observation }) => hasLowerLevelGroupingSignal(observation));
-      const groupingSignalRequiredAndMissing =
-        FAMILY_SUBGROUP_OPPORTUNITY_REQUIRES_LOWER_LEVEL_GROUPING_SIGNAL && !lowerLevelGroupingSignalPresent;
-
-      if (
-        sortedPaths.length < FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER ||
-        observedContainerLocalHomes.length < FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES ||
-        groupingSignalRequiredAndMissing
-      ) {
-        return [];
-      }
-
-      const semanticContainerIdentity = semanticContainerIdentities[0];
       return [
         {
           code: 'TREE_FAMILY_SUBGROUP_OPPORTUNITY',
           severity: 'info',
-          path: sortedPaths[0],
+          path: familyAnalysis.sortedPaths[0],
           classification: 'advisory-structure',
           message:
             'Naming-owned semantic-family evidence is dense inside one naming-aligned semantic container and may benefit from a lower-level subgroup folder.',
           ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
           details: {
             semanticFamily,
-            semanticContainerIdentity,
-            observedCount: sortedPaths.length,
-            observedPaths: sortedPaths,
-            observedContainerLocalHomes,
-            lowerLevelGroupingSignalPresent,
+            semanticContainerIdentity: familyAnalysis.semanticContainerIdentities[0],
+            observedCount: familyAnalysis.sortedPaths.length,
+            observedPaths: familyAnalysis.sortedPaths,
+            observedContainerLocalHomes: familyAnalysis.observedContainerLocalHomes,
+            lowerLevelGroupingSignalPresent: familyAnalysis.lowerLevelGroupingSignalPresent,
+            localFirstInterpretation: familyAnalysis.localFirstInterpretation,
             thresholds: {
               minFilesInContainer: FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER,
               minDistinctContainerLocalHomes: FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES,

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -406,7 +406,7 @@ test('tree naming bridge contributor treats one naming-aligned semantic containe
         semanticFamily: 'tree-family',
       },
       {
-        path: 'calculogic-validator/tree/test/tree-family.test.mjs',
+        path: 'calculogic-validator/tree/src/tests/tree-family.test.mjs',
         semanticName: 'tree-family',
         familyRoot: 'tree',
         semanticFamily: 'tree-family',
@@ -415,9 +415,11 @@ test('tree naming bridge contributor treats one naming-aligned semantic containe
   });
 
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), false);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), false);
 });
 
-test('tree naming bridge contributor evaluates lower-level density in one semantic container before broad scatter', () => {
+test('tree naming bridge contributor treats local-subgroup-first as the primary local signal before broad scatter', () => {
   const findings = collectNamingSemanticFamilyBridgeFindings({
     observations: [
       {
@@ -452,7 +454,7 @@ test('tree naming bridge contributor evaluates lower-level density in one semant
   });
 
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
-  assert.equal(findings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), true);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), false);
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), true);
 });
 
@@ -541,28 +543,28 @@ test('tree naming bridge contributor keeps local-density-first families out of b
   const payload = {
     observations: [
       {
-        path: 'calculogic-validator/tree/src/local-density/tree-density.logic.mjs',
-        semanticName: 'tree-density',
+        path: 'calculogic-validator/tree/src/local-density/density-pack.logic.mjs',
+        semanticName: 'density-pack',
         familyRoot: 'tree',
-        semanticFamily: 'tree-density',
+        semanticFamily: 'density-pack',
       },
       {
-        path: 'calculogic-validator/tree/src/local-density/tree-density.results.mjs',
-        semanticName: 'tree-density',
+        path: 'calculogic-validator/tree/src/local-density/density-pack.results.mjs',
+        semanticName: 'density-pack',
         familyRoot: 'tree',
-        semanticFamily: 'tree-density',
+        semanticFamily: 'density-pack',
       },
       {
-        path: 'calculogic-validator/tree/test/local-density/tree-density.test.mjs',
-        semanticName: 'tree-density',
+        path: 'calculogic-validator/tree/test/local-density/density-pack.test.mjs',
+        semanticName: 'density-pack',
         familyRoot: 'tree',
-        semanticFamily: 'tree-density',
+        semanticFamily: 'density-pack',
       },
       {
-        path: 'calculogic-validator/tree/src/local-density/tree-density.knowledge.mjs',
-        semanticName: 'tree-density',
+        path: 'calculogic-validator/tree/src/local-density/density-pack.knowledge.mjs',
+        semanticName: 'density-pack',
         familyRoot: 'tree',
-        semanticFamily: 'tree-density',
+        semanticFamily: 'density-pack',
       },
     ],
   };
@@ -572,6 +574,7 @@ test('tree naming bridge contributor keeps local-density-first families out of b
   assert.deepEqual(first, second);
   assert.equal(first.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
   assert.equal(first.some((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER'), true);
+  assert.equal(first.some((finding) => finding.code === 'TREE_FAMILY_SUBGROUP_OPPORTUNITY'), false);
 });
 
 test('tree naming bridge contributor keeps local-subgroup-first families out of broad scatter', () => {
@@ -675,32 +678,32 @@ test('tree naming bridge contributor keeps no-local-semantic-explanation familie
 });
 
 
-test('tree naming bridge contributor emits one cluster finding for dense family in one semantic container', () => {
+test('tree naming bridge contributor emits one cluster finding for local-density-first family in one semantic container', () => {
   const findings = collectNamingSemanticFamilyBridgeFindings({
     observations: [
       {
-        path: 'calculogic-validator/tree/src/cluster/tree-observed-family.logic.mjs',
-        semanticName: 'tree-observed-family',
+        path: 'calculogic-validator/tree/src/cluster/observed-family.logic.mjs',
+        semanticName: 'observed-family',
         familyRoot: 'tree',
-        semanticFamily: 'tree-observed-family',
+        semanticFamily: 'observed-family',
       },
       {
-        path: 'calculogic-validator/tree/src/cluster/tree-observed-family.results.mjs',
-        semanticName: 'tree-observed-family',
+        path: 'calculogic-validator/tree/src/cluster/observed-family.results.mjs',
+        semanticName: 'observed-family',
         familyRoot: 'tree',
-        semanticFamily: 'tree-observed-family',
+        semanticFamily: 'observed-family',
       },
       {
-        path: 'calculogic-validator/tree/src/cluster/tree-observed-family.knowledge.mjs',
-        semanticName: 'tree-observed-family',
+        path: 'calculogic-validator/tree/src/cluster/observed-family.knowledge.mjs',
+        semanticName: 'observed-family',
         familyRoot: 'tree',
-        semanticFamily: 'tree-observed-family',
+        semanticFamily: 'observed-family',
       },
       {
-        path: 'calculogic-validator/tree/test/tree-observed-family.test.mjs',
-        semanticName: 'tree-observed-family',
+        path: 'calculogic-validator/tree/test/observed-family.test.mjs',
+        semanticName: 'observed-family',
         familyRoot: 'tree',
-        semanticFamily: 'tree-observed-family',
+        semanticFamily: 'observed-family',
       },
     ],
   });
@@ -805,11 +808,8 @@ test('tree naming bridge contributor can emit distinct cluster observations acro
   });
 
   const clusterFindings = findings.filter((finding) => finding.code === 'TREE_OBSERVED_FAMILY_CLUSTER');
-  assert.equal(clusterFindings.length, 2);
-  assert.deepEqual(
-    clusterFindings.map((finding) => finding.details.semanticContainerIdentity),
-    ['calculogic-validator/naming/tree-multi-container', 'calculogic-validator/tree'],
-  );
+  assert.equal(clusterFindings.length, 0);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), true);
 });
 
 test('tree naming bridge contributor emits subgroup opportunity for dense lower-level family inside one semantic container', () => {
@@ -1037,7 +1037,7 @@ test('tree naming bridge contributor keeps ambiguity-only dense families as non-
   assert.equal(findings.some((finding) => finding.severity === 'warn'), false);
 });
 
-test('tree naming bridge contributor emits deterministic cluster count and ordering for same input', () => {
+test('tree naming bridge contributor keeps local-first routing deterministic when dense evidence spans multiple semantic containers', () => {
   const payload = {
     observations: [
       {
@@ -1099,6 +1099,13 @@ test('tree naming bridge contributor emits deterministic cluster count and order
     .map((finding) => ({ path: finding.path, container: finding.details.semanticContainerIdentity }));
 
   assert.deepEqual(first, second);
-  assert.equal(first.length, 2);
-  assert.deepEqual(first.map((entry) => entry.container), ['calculogic-validator/naming/tree-ordering-family', 'calculogic-validator/tree']);
+  assert.equal(first.length, 0);
+  const firstScatter = collectNamingSemanticFamilyBridgeFindings(payload)
+    .filter((finding) => finding.code === 'TREE_FAMILY_SCATTERED')
+    .map((finding) => finding.path);
+  const secondScatter = collectNamingSemanticFamilyBridgeFindings(payload)
+    .filter((finding) => finding.code === 'TREE_FAMILY_SCATTERED')
+    .map((finding) => finding.path);
+  assert.deepEqual(firstScatter, secondScatter);
+  assert.equal(firstScatter.length, 1);
 });


### PR DESCRIPTION
### Motivation

- Consolidate family-level routing so `interpretFamilyLocalFirst` becomes the single, bounded upstream authority for cluster, subgroup, and scatter decisions while preserving existing finding families and naming ownership.
- Keep the local-first interpretation explicit, deterministic, inspectable, and limited to the specified local-family outcomes without adding new finding codes or broader frameworking.

### Description

- Updated the tree NL-first doc `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to document that local-first family interpretation (`interpretFamilyLocalFirst`) is the shared decision spine for `expected-local-presence`, `local-density-first`, `local-subgroup-first`, `local-divergence-needs-broader-review`, and `no-local-semantic-explanation` before emitting family findings.
- Refactored the naming→tree bridge contributor by adding a shared family-analysis path (`toSingularFamilyEntriesBySemanticFamily` and `toFamilyLocalFirstAnalysis`) and routing collectors to consume `localFirstInterpretation` rather than re-deciding the same local-first outcome in each collector.
- Rewrote `collectFamilyScatterFindings`, `collectFamilyClusterFindings`, and `collectFamilySubgroupOpportunityFindings` in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` to use the shared analysis and to route findings according to the local-first classification (suppress scatter for local-first local outcomes and enable cluster/subgroup where appropriate).
- Preserved naming ownership (`familyRoot`, `semanticFamily`, optional `familySubgroup`) and existing finding codes (`TREE_FAMILY_SCATTERED`, `TREE_OBSERVED_FAMILY_CLUSTER`, `TREE_FAMILY_SUBGROUP_OPPORTUNITY`) and kept the interpretation bounded and inspectable in the contributor details payload.

### Testing

- Ran the focused contributor test suite with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and all tests passed (previously failing cases were adjusted to reflect consolidated routing).
- Tests updated/added to assert that: `expected-local-presence` emits neither broad scatter nor forced cluster/subgroup, `local-density-first` yields cluster as the primary local signal and suppresses scatter-first, `local-subgroup-first` yields subgroup opportunity as the primary signal and suppresses scatter-first, divergence/no-local-semantic-explanation remain eligible for broad scatter, and repeated identical inputs remain deterministic.
- Changed files: `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`, `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, and `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`.
- Incidental finding-output change: intentional suppression of some previously emitted cluster outcomes when the shared local-first interpretation does not classify the family as `local-density-first`, which is covered by the updated tests and spec note.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf9c9abcc8331af98d0123023772e)