### PR TITLE
Add bounded broader-spread interpretation layer before TREE_FAMILY_SCATTERED

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -182,7 +182,8 @@ Tree consumes this normalized bridge payload only. Tree runtime must not parse f
   2. semantic placement,
   3. local placement coherence,
   4. local-first family interpretation lane selection,
-  5. broad scatter eligibility only when local interpretation does not sufficiently explain observed placement,
+  5. bounded broader-spread interpretation for families that survive local-first review,
+  6. broad scatter eligibility only when both local and broader interpretation remain unresolved,
 - family presence confined to one valid naming-aligned semantic container is treated as expected/container-local density/subgroup opportunity first (not immediate broad scatter),
 - bounded allowed cross-container pairings are exempt from broad scatter by default (for example canonical docs authority lane with aligned owned runtime container pairing),
 - broad scatter remains for family spread across unrelated structural homes/containers when no allowed pairing covers the spread.
@@ -199,6 +200,33 @@ Behavior boundary for this slice:
 
 - no new findings/codes are introduced,
 - this slice only refines when existing broad-scatter eligibility (`TREE_FAMILY_SCATTERED`) is allowed after local-first interpretation.
+
+### Bounded broader-spread interpretation layer (Status: Current runtime behavior, bounded)
+
+Classification: Normative
+
+After local-first interpretation, tree now applies a bounded broader-spread interpretation layer before final `TREE_FAMILY_SCATTERED` escalation.
+
+Bounded scope for this layer:
+
+- runs only when local-first interpretation is one of:
+  - `local-divergence-needs-broader-review`
+  - `no-local-semantic-explanation`
+- reuses already-shipped bounded explainable spread rules (for example: same semantic container, allowed structural-root pairing, canonical docs authority/runtime pairing)
+- remains deterministic and inspectable; no fuzzy or open-ended policy expansion
+
+Bounded broader-spread interpretation outcomes:
+
+- `allowed-broader-spread`
+- `docs-runtime-paired-spread`
+- `cross-concern-but-explainable`
+- `unresolved-broader-spread`
+
+Escalation intent:
+
+- local-first local lanes remain the shared decision spine for local family outcomes,
+- broader-spread interpretation is only a review layer for families that survive local-first checks,
+- `TREE_FAMILY_SCATTERED` represents unresolved spread after both local and broader interpretation do not sufficiently explain placement.
 
 ### Shared local-first family interpretation spine for family outcomes (Status: Current runtime behavior, bounded)
 
@@ -218,9 +246,11 @@ The shared local-first interpretation spine routes existing family findings as f
   - enables subgroup-opportunity-first local signaling (`TREE_FAMILY_SUBGROUP_OPPORTUNITY`) using existing bounded thresholds/details
   - suppresses broad scatter-first routing
 - `local-divergence-needs-broader-review`
-  - keeps broad scatter (`TREE_FAMILY_SCATTERED`) eligible under existing bounded scatter thresholds/rules
+  - routes to bounded broader-spread interpretation review first
+  - keeps broad scatter (`TREE_FAMILY_SCATTERED`) eligible only when broader-spread interpretation remains unresolved
 - `no-local-semantic-explanation`
-  - keeps broad scatter (`TREE_FAMILY_SCATTERED`) eligible under existing bounded scatter thresholds/rules
+  - routes to bounded broader-spread interpretation review first
+  - keeps broad scatter (`TREE_FAMILY_SCATTERED`) eligible only when broader-spread interpretation remains unresolved
 
 Boundary notes for this consolidation slice:
 

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -29,6 +29,12 @@ const LOCAL_FIRST_FAMILY_INTERPRETATION = Object.freeze({
   LOCAL_DIVERGENCE_NEEDS_BROADER_REVIEW: 'local-divergence-needs-broader-review',
   NO_LOCAL_SEMANTIC_EXPLANATION: 'no-local-semantic-explanation',
 });
+const BROADER_SPREAD_INTERPRETATION = Object.freeze({
+  ALLOWED_BROADER_SPREAD: 'allowed-broader-spread',
+  DOCS_RUNTIME_PAIRED_SPREAD: 'docs-runtime-paired-spread',
+  CROSS_CONCERN_BUT_EXPLAINABLE: 'cross-concern-but-explainable',
+  UNRESOLVED_BROADER_SPREAD: 'unresolved-broader-spread',
+});
 
 const toSortedUnique = (values) => Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
 
@@ -316,6 +322,26 @@ const isAllowedCrossContainerPlacementPair = (leftPlacement, rightPlacement) => 
   return isAllowedCanonicalDocAuthorityRuntimePairing(leftPlacement, rightPlacement);
 };
 
+const toBroaderSpreadPairInterpretation = (leftPlacement, rightPlacement) => {
+  if (
+    leftPlacement.semanticContainerRole === 'naming-aligned-semantic-container' &&
+    rightPlacement.semanticContainerRole === 'naming-aligned-semantic-container' &&
+    leftPlacement.semanticContainerIdentity === rightPlacement.semanticContainerIdentity
+  ) {
+    return 'same-semantic-container';
+  }
+
+  if (isAllowedStructuralRootPairing(leftPlacement, rightPlacement)) {
+    return 'allowed-structural-root-pairing';
+  }
+
+  if (isAllowedCanonicalDocAuthorityRuntimePairing(leftPlacement, rightPlacement)) {
+    return 'canonical-docs-runtime-pairing';
+  }
+
+  return 'unresolved-pair';
+};
+
 const toNormalizedBridgeObservation = (observation) => {
   if (!observation || typeof observation !== 'object' || Array.isArray(observation)) {
     return null;
@@ -546,6 +572,66 @@ const toFamilyLocalFirstAnalysis = (semanticFamily, familyEntries) => {
   };
 };
 
+const toFamilyBroaderSpreadInterpretation = (familyAnalysis) => {
+  const requiresBroaderSpreadReview =
+    familyAnalysis.localFirstInterpretation.classification ===
+      LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DIVERGENCE_NEEDS_BROADER_REVIEW ||
+    familyAnalysis.localFirstInterpretation.classification ===
+      LOCAL_FIRST_FAMILY_INTERPRETATION.NO_LOCAL_SEMANTIC_EXPLANATION;
+  if (!requiresBroaderSpreadReview) {
+    return null;
+  }
+
+  const pairInterpretations = familyAnalysis.placements.flatMap((leftPlacement, leftIndex) =>
+    familyAnalysis.placements.slice(leftIndex + 1).map((rightPlacement) => ({
+      pair: [leftPlacement.path, rightPlacement.path].sort((left, right) => left.localeCompare(right)),
+      interpretation: toBroaderSpreadPairInterpretation(leftPlacement, rightPlacement),
+    })),
+  );
+  const pairInterpretationSummary = toSortedUnique(pairInterpretations.map(({ interpretation }) => interpretation));
+  const hasUnresolvedPairs = pairInterpretationSummary.includes('unresolved-pair');
+  const hasCanonicalDocsRuntimePairing = pairInterpretationSummary.includes('canonical-docs-runtime-pairing');
+  const hasAllowedStructuralRootPairing = pairInterpretationSummary.includes('allowed-structural-root-pairing');
+
+  if (hasUnresolvedPairs) {
+    return {
+      classification: BROADER_SPREAD_INTERPRETATION.UNRESOLVED_BROADER_SPREAD,
+      details: {
+        pairInterpretationSummary,
+        pairInterpretations,
+      },
+    };
+  }
+
+  if (hasCanonicalDocsRuntimePairing) {
+    return {
+      classification: BROADER_SPREAD_INTERPRETATION.DOCS_RUNTIME_PAIRED_SPREAD,
+      details: {
+        pairInterpretationSummary,
+        pairInterpretations,
+      },
+    };
+  }
+
+  if (hasAllowedStructuralRootPairing) {
+    return {
+      classification: BROADER_SPREAD_INTERPRETATION.ALLOWED_BROADER_SPREAD,
+      details: {
+        pairInterpretationSummary,
+        pairInterpretations,
+      },
+    };
+  }
+
+  return {
+    classification: BROADER_SPREAD_INTERPRETATION.CROSS_CONCERN_BUT_EXPLAINABLE,
+    details: {
+      pairInterpretationSummary,
+      pairInterpretations,
+    },
+  };
+};
+
 const toSharedRootLaneObservation = (observation) => {
   for (const sharedRoot of SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS) {
     const sharedRootPrefix = `${sharedRoot}/`;
@@ -577,7 +663,10 @@ const collectFamilyScatterFindings = (observations) => {
     .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
     .flatMap(([semanticFamily, familyEntries]) => {
       const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
-
+      const broaderSpreadInterpretation = toFamilyBroaderSpreadInterpretation(familyAnalysis);
+      const broaderSpreadResolved =
+        broaderSpreadInterpretation &&
+        broaderSpreadInterpretation.classification !== BROADER_SPREAD_INTERPRETATION.UNRESOLVED_BROADER_SPREAD;
       const allCrossContainerPlacementsCoveredByAllowedRules = familyAnalysis.placements.every((leftPlacement, leftIndex) =>
         familyAnalysis.placements
           .slice(leftIndex + 1)
@@ -591,6 +680,7 @@ const collectFamilyScatterFindings = (observations) => {
         familyAnalysis.localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST ||
         familyAnalysis.localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST ||
         familyAnalysis.allEntriesInsideOneSemanticContainer ||
+        broaderSpreadResolved ||
         allCrossContainerPlacementsCoveredByAllowedRules
       ) {
         return [];
@@ -613,6 +703,7 @@ const collectFamilyScatterFindings = (observations) => {
             observedContainerIdentities: familyAnalysis.semanticContainerIdentities,
             observedStructuralRootKinds: toSortedUnique(familyAnalysis.placements.map((placement) => placement.structuralRootKind)),
             localFirstInterpretation: familyAnalysis.localFirstInterpretation,
+            broaderSpreadInterpretation,
             allowedCrossContainerPatterns: {
               structuralRootPairings: ALLOWED_STRUCTURAL_ROOT_PAIRINGS,
               canonicalDocAuthorityRuntimePairing: 'calculogic-validator/doc/** <-> calculogic-validator/<semantic-container>/**',

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -485,6 +485,87 @@ test('tree naming bridge contributor suppresses broad scatter for bounded allowe
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
 });
 
+test('tree naming bridge contributor applies broader-spread review and keeps explainable src/test spread out of final scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/validator-cli/core/validator-cli.logic.ts',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+      {
+        path: 'src/validator-cli/runtime/validator-cli.results.ts',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+      {
+        path: 'test/validator-cli/validator-cli.test.ts',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
+test('tree naming bridge contributor treats canonical docs/runtime pairings as broader explainable spread before scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-router.spec.md',
+        semanticName: 'tree-router',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-router',
+      },
+      {
+        path: 'calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-router.audit.md',
+        semanticName: 'tree-router',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-router',
+      },
+      {
+        path: 'calculogic-validator/tree/src/tree-router.logic.mjs',
+        semanticName: 'tree-router',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-router',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
+test('tree naming bridge contributor keeps cross-concern but explainable spread out of final scatter', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/tree-occurrence/tree-occurrence.logic.mjs',
+        semanticName: 'tree-occurrence',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-occurrence/tree-occurrence.test.mjs',
+        semanticName: 'tree-occurrence',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+      },
+      {
+        path: 'calculogic-validator/tree/validator-cli/tree-occurrence.host.mjs',
+        semanticName: 'tree-occurrence',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-occurrence',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
 test('tree naming bridge contributor still emits broad scatter for unrelated cross-container spread', () => {
   const findings = collectNamingSemanticFamilyBridgeFindings({
     observations: [
@@ -510,6 +591,8 @@ test('tree naming bridge contributor still emits broad scatter for unrelated cro
   });
 
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), true);
+  const scatterFinding = findings.find((finding) => finding.code === 'TREE_FAMILY_SCATTERED');
+  assert.equal(scatterFinding.details.broaderSpreadInterpretation.classification, 'unresolved-broader-spread');
 });
 
 test('tree naming bridge contributor keeps locally aligned family observations in local-first lanes before broad scatter', () => {
@@ -674,6 +757,41 @@ test('tree naming bridge contributor keeps no-local-semantic-explanation familie
   assert.equal(
     scatterFinding.details.localFirstInterpretation.classification,
     'no-local-semantic-explanation',
+  );
+  assert.equal(scatterFinding.details.broaderSpreadInterpretation.classification, 'unresolved-broader-spread');
+});
+
+test('tree naming bridge contributor keeps broader-spread interpretation deterministic for identical unresolved inputs', () => {
+  const payload = {
+    observations: [
+      {
+        path: 'src/alpha/unrelated.logic.ts',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+      {
+        path: 'tools/beta/unrelated.results.mjs',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+      {
+        path: 'doc/gamma/unrelated.spec.md',
+        semanticName: 'validator-cli',
+        familyRoot: 'validator',
+        semanticFamily: 'validator-cli',
+      },
+    ],
+  };
+  const first = collectNamingSemanticFamilyBridgeFindings(payload);
+  const second = collectNamingSemanticFamilyBridgeFindings(payload);
+  const firstScatter = first.find((finding) => finding.code === 'TREE_FAMILY_SCATTERED');
+  const secondScatter = second.find((finding) => finding.code === 'TREE_FAMILY_SCATTERED');
+
+  assert.deepEqual(
+    firstScatter.details.broaderSpreadInterpretation,
+    secondScatter.details.broaderSpreadInterpretation,
   );
 });
 


### PR DESCRIPTION
### Motivation
- Make broader-spread reasoning explicit and bounded so families that survive local-first review get a deterministic, inspectable broader review before escalating to `TREE_FAMILY_SCATTERED`.
- Preserve existing ownership and finding families while following NL-first workflow by updating the tree spec before code changes.
- Treated `ValidatorSuite-Contracts-And-Modes.md` + `tree-structure-advisor-validator.spec.md` as runtime authority and used `tree-owned/*` docs and `NamingValidatorSpec.md` as navigation/supporting context for the implementation choices.

### Description
- Updated the tree spec (`calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`) to document the new reasoning order: local-first interpretation → bounded broader-spread interpretation → final `TREE_FAMILY_SCATTERED` escalation, and enumerated the bounded broader-spread outcomes.
- Added an explicit, tree-owned broader-spread helper and enum-like outcomes in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` (`BROADER_SPREAD_INTERPRETATION`) plus deterministic pairing logic (`toBroaderSpreadPairInterpretation`) and review function (`toFamilyBroaderSpreadInterpretation`).
- Gated `TREE_FAMILY_SCATTERED` so final scatter is emitted only when: local-first interpretation does not explain placement and broader-spread interpretation classifies the spread as unresolved; explainable broader spread now suppresses scatter.
- Preserved existing finding families and naming ownership (`familyRoot`, `semanticFamily`, `familySubgroup`); added `details.broaderSpreadInterpretation` to `TREE_FAMILY_SCATTERED` findings to keep routing inspectable.
- Files changed: `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`, `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` (tests added/updated to exercise the new layer).

### Testing
- Ran the focused contributor tests with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, which passed (39 tests, all OK).
- Tests exercise: explainable broader spread suppression (src/test and docs/runtime pairings), unresolved broader spread escalation to `TREE_FAMILY_SCATTERED`, cross-concern explainable spread suppression, and deterministic broader-spread interpretation for identical inputs.
- Incidental finding-output change: `TREE_FAMILY_SCATTERED` findings now include an inspectable `details.broaderSpreadInterpretation` object when broader-spread review runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafece3ac4833186f1a0044e67ae7d)