### PR TITLE
Route shared-root lane scatter through shared family interpretation spine

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -259,6 +259,26 @@ Boundary notes for this consolidation slice:
 - routing is consolidated so existing family findings derive from one bounded local-first interpretation model,
 - naming ownership remains unchanged (`familyRoot`, `semanticFamily`, optional `familySubgroup` stay naming-owned).
 
+### Shared-root lane spread routing inside the shared family interpretation spine (Status: Current runtime behavior, bounded)
+
+Classification: Normative
+
+`TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` remains an existing bounded code, but its eligibility now routes through the same shared family interpretation spine used by other family outcomes.
+
+Routing and meaning in this slice:
+
+- shared-root lane spread is no longer treated as a separate family-reasoning island,
+- eligibility is evaluated from shared family analysis grouped by naming-owned `semanticFamily`,
+- the same local-first interpretation result used by cluster/subgroup/scatter outcomes is attached to this shared-root outcome,
+- broader-spread interpretation context is reused where relevant rather than bypassed,
+- this consolidation adds no new finding family and does not alter naming ownership boundaries.
+
+Bounded intent:
+
+- preserve the existing finding code (`TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES`),
+- keep shared-root lane spread as a bounded outcome within the existing local-first → broader-spread family reasoning flow,
+- avoid introducing new policy surfaces beyond this routing consolidation slice.
+
 ### Family subgroup opportunity inside one semantic container (Status: Current runtime behavior, bounded)
 
 `TREE_FAMILY_SUBGROUP_OPPORTUNITY` is a bounded, info-level, advisory-only signal for lower-level family grouping opportunity *inside one naming-aligned semantic container*.
@@ -766,7 +786,7 @@ Attached naming-bridge contributor currently ships during normal tree runs:
 
 - `TREE_FAMILY_SCATTERED`
 - `TREE_OBSERVED_FAMILY_CLUSTER`
-- `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` (bounded shared-root lane-first partitions under supported shared roots, using naming-owned bridge observations only)
+- `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` (bounded shared-root lane-first spread outcome emitted from the shared family interpretation spine under supported shared roots, using naming-owned bridge observations only)
 
 ### Current report payload from tree runtime
 

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -572,6 +572,22 @@ const toFamilyLocalFirstAnalysis = (semanticFamily, familyEntries) => {
   };
 };
 
+const toFamilySharedSpineAnalysisEntries = (observations) => {
+  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
+
+  return Array.from(observationsBySemanticFamily.entries())
+    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
+    .map(([semanticFamily, familyEntries]) => {
+      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
+      const broaderSpreadInterpretation = toFamilyBroaderSpreadInterpretation(familyAnalysis);
+
+      return {
+        familyAnalysis,
+        broaderSpreadInterpretation,
+      };
+    });
+};
+
 const toFamilyBroaderSpreadInterpretation = (familyAnalysis) => {
   const requiresBroaderSpreadReview =
     familyAnalysis.localFirstInterpretation.classification ===
@@ -656,14 +672,9 @@ const toSharedRootLaneObservation = (observation) => {
   return null;
 };
 
-const collectFamilyScatterFindings = (observations) => {
-  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
-
-  return Array.from(observationsBySemanticFamily.entries())
-    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
-    .flatMap(([semanticFamily, familyEntries]) => {
-      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
-      const broaderSpreadInterpretation = toFamilyBroaderSpreadInterpretation(familyAnalysis);
+const collectFamilyScatterFindings = (familySharedSpineAnalysisEntries) =>
+  familySharedSpineAnalysisEntries.flatMap(({ familyAnalysis, broaderSpreadInterpretation }) => {
+      const semanticFamily = familyAnalysis.semanticFamily;
       const broaderSpreadResolved =
         broaderSpreadInterpretation &&
         broaderSpreadInterpretation.classification !== BROADER_SPREAD_INTERPRETATION.UNRESOLVED_BROADER_SPREAD;
@@ -716,15 +727,10 @@ const collectFamilyScatterFindings = (observations) => {
         },
       ];
     });
-};
 
-const collectFamilyClusterFindings = (observations) => {
-  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
-
-  return Array.from(observationsBySemanticFamily.entries())
-    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
-    .flatMap(([semanticFamily, familyEntries]) => {
-      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
+const collectFamilyClusterFindings = (familySharedSpineAnalysisEntries) =>
+  familySharedSpineAnalysisEntries.flatMap(({ familyAnalysis }) => {
+      const semanticFamily = familyAnalysis.semanticFamily;
       if (familyAnalysis.localFirstInterpretation.classification !== LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DENSITY_FIRST) {
         return [];
       }
@@ -752,15 +758,10 @@ const collectFamilyClusterFindings = (observations) => {
         },
       ];
     });
-};
 
-const collectFamilySubgroupOpportunityFindings = (observations) => {
-  const observationsBySemanticFamily = toSingularFamilyEntriesBySemanticFamily(observations);
-
-  return Array.from(observationsBySemanticFamily.entries())
-    .sort(([leftFamily], [rightFamily]) => leftFamily.localeCompare(rightFamily))
-    .flatMap(([semanticFamily, familyEntries]) => {
-      const familyAnalysis = toFamilyLocalFirstAnalysis(semanticFamily, familyEntries);
+const collectFamilySubgroupOpportunityFindings = (familySharedSpineAnalysisEntries) =>
+  familySharedSpineAnalysisEntries.flatMap(({ familyAnalysis }) => {
+      const semanticFamily = familyAnalysis.semanticFamily;
       if (familyAnalysis.localFirstInterpretation.classification !== LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_SUBGROUP_FIRST) {
         return [];
       }
@@ -792,71 +793,73 @@ const collectFamilySubgroupOpportunityFindings = (observations) => {
         },
       ];
     });
-};
 
-const collectSharedRootFamilyScatterAcrossLanesFindings = (observations) => {
-  const observationsBySharedRootAndFamily = new Map();
+const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnalysisEntries) =>
+  familySharedSpineAnalysisEntries.flatMap(({ familyAnalysis, broaderSpreadInterpretation }) => {
+    const sharedFamilyObservations = familyAnalysis.familyEntries
+      .map(({ observation }) => toSharedRootLaneObservation(observation))
+      .filter(Boolean);
+    const observationsBySharedRoot = new Map();
 
-  for (const observation of observations) {
-    if (!isSingularFamilyEvidence(observation)) {
-      continue;
-    }
-
-    const sharedRootLaneObservation = toSharedRootLaneObservation(observation);
-    if (!sharedRootLaneObservation) {
-      continue;
-    }
-
-    const mapKey = `${sharedRootLaneObservation.sharedRoot}::${sharedRootLaneObservation.semanticFamily}`;
-    if (!observationsBySharedRootAndFamily.has(mapKey)) {
-      observationsBySharedRootAndFamily.set(mapKey, []);
-    }
-
-    observationsBySharedRootAndFamily.get(mapKey).push(sharedRootLaneObservation);
-  }
-
-  return Array.from(observationsBySharedRootAndFamily.entries())
-    .sort(([leftMapKey], [rightMapKey]) => leftMapKey.localeCompare(rightMapKey))
-    .flatMap(([, sharedFamilyObservations]) => {
-      const sortedPaths = sharedFamilyObservations.map(({ path: normalizedPath }) => normalizedPath).sort((a, b) => a.localeCompare(b));
-      const observedLanePartitions = toSortedUnique(
-        sharedFamilyObservations.map(({ lanePartition }) => lanePartition),
-      );
-
-      if (
-        observedLanePartitions.length < SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS ||
-        sortedPaths.length < SHARED_ROOT_MIN_FAMILY_FILES
-      ) {
-        return [];
+    for (const sharedFamilyObservation of sharedFamilyObservations) {
+      if (!observationsBySharedRoot.has(sharedFamilyObservation.sharedRoot)) {
+        observationsBySharedRoot.set(sharedFamilyObservation.sharedRoot, []);
       }
 
-      const { sharedRoot, semanticFamily } = sharedFamilyObservations[0];
-      return [
-        {
-          code: 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES',
-          severity: 'info',
-          path: sortedPaths[0],
-          classification: 'advisory-structure',
-          message:
-            'Naming-owned semantic-family evidence is spread across lane-first partitions under a shared root and may benefit from semantic-first grouping.',
-          ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
-          details: {
-            sharedRootPath: sharedRoot,
-            semanticFamily,
-            observedLanePartitions,
-            observedPaths: sortedPaths,
-            thresholds: {
-              supportedSharedRoots: SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS,
-              allowedLaneFirstPartitions: SHARED_ROOT_LANE_FIRST_PARTITIONS,
-              minDistinctLanePartitions: SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS,
-              minFamilyFiles: SHARED_ROOT_MIN_FAMILY_FILES,
+      observationsBySharedRoot.get(sharedFamilyObservation.sharedRoot).push(sharedFamilyObservation);
+    }
+
+    return Array.from(observationsBySharedRoot.entries())
+      .sort(([leftSharedRoot], [rightSharedRoot]) => leftSharedRoot.localeCompare(rightSharedRoot))
+      .flatMap(([sharedRoot, sharedRootObservations]) => {
+        const semanticFamily = familyAnalysis.semanticFamily;
+        const localFirstInterpretation = familyAnalysis.localFirstInterpretation;
+        const sortedPaths = sharedRootObservations
+          .map(({ path: normalizedPath }) => normalizedPath)
+          .sort((left, right) => left.localeCompare(right));
+        const observedLanePartitions = toSortedUnique(
+          sharedRootObservations.map(({ lanePartition }) => lanePartition),
+        );
+        const hasSupportedSharedRootLaneSpread =
+          observedLanePartitions.length >= SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS &&
+          sortedPaths.length >= SHARED_ROOT_MIN_FAMILY_FILES;
+
+        if (!hasSupportedSharedRootLaneSpread) {
+          return [];
+        }
+
+        return [
+          {
+            code: 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES',
+            severity: 'info',
+            path: sortedPaths[0],
+            classification: 'advisory-structure',
+            message:
+              'Naming-owned semantic-family evidence is spread across lane-first partitions under a shared root and may benefit from semantic-first grouping.',
+            ruleRef: 'calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md',
+            details: {
+              sharedRootPath: sharedRoot,
+              semanticFamily,
+              observedLanePartitions,
+              observedPaths: sortedPaths,
+              localFirstInterpretation,
+              broaderSpreadInterpretation,
+              familySharedSpineRouting: {
+                model: 'shared-local-first-family-interpretation',
+                sharedRootOutcome: 'bounded-shared-root-lane-spread',
+              },
+              thresholds: {
+                supportedSharedRoots: SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS,
+                allowedLaneFirstPartitions: SHARED_ROOT_LANE_FIRST_PARTITIONS,
+                minDistinctLanePartitions: SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS,
+                minFamilyFiles: SHARED_ROOT_MIN_FAMILY_FILES,
+              },
+              suggestedSemanticTargetRoot: `${sharedRoot}/${semanticFamily}`,
             },
-            suggestedSemanticTargetRoot: `${sharedRoot}/${semanticFamily}`,
           },
-        },
-      ];
-    });
-};
+        ];
+      });
+  });
 
 export const collectNamingSemanticFamilyBridgeFindings = (bridgePayload) => {
   const namingSemanticFamilyBridge = prepareNamingSemanticFamilyBridge(bridgePayload);
@@ -866,10 +869,12 @@ export const collectNamingSemanticFamilyBridgeFindings = (bridgePayload) => {
     return [];
   }
 
+  const familySharedSpineAnalysisEntries = toFamilySharedSpineAnalysisEntries(observations);
+
   return [
-    ...collectFamilyScatterFindings(observations),
-    ...collectFamilySubgroupOpportunityFindings(observations),
-    ...collectFamilyClusterFindings(observations),
-    ...collectSharedRootFamilyScatterAcrossLanesFindings(observations),
+    ...collectFamilyScatterFindings(familySharedSpineAnalysisEntries),
+    ...collectFamilySubgroupOpportunityFindings(familySharedSpineAnalysisEntries),
+    ...collectFamilyClusterFindings(familySharedSpineAnalysisEntries),
+    ...collectSharedRootFamilyScatterAcrossLanesFindings(familySharedSpineAnalysisEntries),
   ];
 };

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -320,11 +320,12 @@ test('tree naming bridge contributor emits bounded shared-root lane scatter advi
     ],
   });
 
-  const sharedRootFindingCodes = findings
-    .filter((finding) => finding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES')
-    .map((finding) => finding.code);
+  const sharedRootFindings = findings.filter((finding) => finding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES');
 
-  assert.deepEqual(sharedRootFindingCodes, ['TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES']);
+  assert.equal(sharedRootFindings.length, 1);
+  assert.equal(sharedRootFindings[0].details.localFirstInterpretation.classification, 'local-divergence-needs-broader-review');
+  assert.equal(sharedRootFindings[0].details.broaderSpreadInterpretation.classification, 'unresolved-broader-spread');
+  assert.equal(sharedRootFindings[0].details.familySharedSpineRouting.model, 'shared-local-first-family-interpretation');
 });
 
 test('tree naming bridge contributor does not emit shared-root lane scatter advisory when family evidence is outside supported shared root', () => {
@@ -388,6 +389,35 @@ test('tree naming bridge contributor keeps shared-root advisory deterministic fo
 
   assert.deepEqual(firstSharedRootFindings, secondSharedRootFindings);
   assert.equal(firstSharedRootFindings.length, 1);
+  assert.equal(firstSharedRootFindings[0].details.familySharedSpineRouting.sharedRootOutcome, 'bounded-shared-root-lane-spread');
+});
+
+test('tree naming bridge contributor keeps non-shared families on shared family spine without emitting shared-root lane spread', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'calculogic-validator/tree/src/logic/tree-spine.logic.mjs',
+        semanticName: 'tree-spine',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-spine',
+      },
+      {
+        path: 'calculogic-validator/tree/src/results/tree-spine.results.mjs',
+        semanticName: 'tree-spine',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-spine',
+      },
+      {
+        path: 'calculogic-validator/tree/test/tree-spine.test.mjs',
+        semanticName: 'tree-spine',
+        familyRoot: 'tree',
+        semanticFamily: 'tree-spine',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES'), false);
+  assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
 });
 
 test('tree naming bridge contributor treats one naming-aligned semantic container as expected presence, not broad scatter', () => {


### PR DESCRIPTION
### Motivation
- Unify shared-root lane spread handling so `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` is interpreted through the same local-first → broader-spread family reasoning spine as other family outcomes rather than as a separate side-path collector. 
- Reduce duplicated spread logic, keep ownership boundaries intact, and make shared-root lane spread deterministic and inspectable within the existing family analysis model.

### Description
- Updated the NL/spec note first by adding a normative doc section in `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` that documents that shared-root lane spread is now a bounded outcome of the shared family interpretation spine and that no new finding family was added. 
- Introduced a shared family analysis pass `toFamilySharedSpineAnalysisEntries` and refactored family collectors to consume that pass so `TREE_FAMILY_SCATTERED`, `TREE_OBSERVED_FAMILY_CLUSTER`, `TREE_FAMILY_SUBGROUP_OPPORTUNITY`, and `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` all derive from the same semantic-family analysis. 
- Reworked the shared-root collector to route eligibility and details through the shared family analysis (it now includes `localFirstInterpretation`, `broaderSpreadInterpretation`, and `familySharedSpineRouting` in `details`) while preserving the existing finding code `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES`. 
- Files changed: `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md`, `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs`, and `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`.

### Testing
- Ran the focused contributor test suite with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs`, and all tests passed (40/40). 
- Tests assert that shared-root lane spread still emits `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES`, that the finding `details` include shared-spine routing context (`localFirstInterpretation` and `broaderSpreadInterpretation`), that non-shared families do not spuriously emit the shared-root finding, and that behavior is deterministic for repeated inputs. 
- No new finding codes were introduced and the change is an internal routing/refactor that enriches `details` for shared-root outputs only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2bff1b48833182db2749045da176)