### PR TITLE
Route TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES through shared family spine

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -263,20 +263,21 @@ Boundary notes for this consolidation slice:
 
 Classification: Normative
 
-`TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` remains an existing bounded code, but its eligibility now routes through the same shared family interpretation spine used by other family outcomes.
+`TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` remains an existing bounded code, and its emission is now decision-routed by the same shared family interpretation spine used by other family outcomes.
 
 Routing and meaning in this slice:
 
 - shared-root lane spread is no longer treated as a separate family-reasoning island,
 - eligibility is evaluated from shared family analysis grouped by naming-owned `semanticFamily`,
-- the same local-first interpretation result used by cluster/subgroup/scatter outcomes is attached to this shared-root outcome,
-- broader-spread interpretation context is reused where relevant rather than bypassed,
+- shared-root lane counts/partitions remain bounded decision inputs, but they are no longer a standalone threshold collector that emits first and only carries shared-spine context afterward,
+- local-first and broader-spread outcomes from the shared spine now gate whether shared-root lane spread is the selected outcome,
+- emission occurs only when bounded shared-spine interpretation resolves to shared-root lane spread (rather than from lane thresholds alone),
 - this consolidation adds no new finding family and does not alter naming ownership boundaries.
 
 Bounded intent:
 
 - preserve the existing finding code (`TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES`),
-- keep shared-root lane spread as a bounded outcome within the existing local-first → broader-spread family reasoning flow,
+- keep shared-root lane spread as a bounded, explicit, deterministic, inspectable outcome within the existing local-first → broader-spread family reasoning flow,
 - avoid introducing new policy surfaces beyond this routing consolidation slice.
 
 ### Family subgroup opportunity inside one semantic container (Status: Current runtime behavior, bounded)

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -35,6 +35,12 @@ const BROADER_SPREAD_INTERPRETATION = Object.freeze({
   CROSS_CONCERN_BUT_EXPLAINABLE: 'cross-concern-but-explainable',
   UNRESOLVED_BROADER_SPREAD: 'unresolved-broader-spread',
 });
+const SHARED_ROOT_LANE_INTERPRETATION = Object.freeze({
+  SELECT_SHARED_ROOT_LANE_SPREAD: 'select-shared-root-lane-spread',
+  BELOW_SHARED_ROOT_LANE_THRESHOLD: 'below-shared-root-lane-threshold',
+  LOCAL_FIRST_SUPPRESSED: 'local-first-suppressed',
+  BROADER_SPREAD_SUPPRESSED: 'broader-spread-suppressed',
+});
 
 const toSortedUnique = (values) => Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
 
@@ -672,6 +678,72 @@ const toSharedRootLaneObservation = (observation) => {
   return null;
 };
 
+const toSharedRootLaneInterpretation = ({
+  sharedRootObservations,
+  localFirstInterpretation,
+  broaderSpreadInterpretation,
+}) => {
+  const sortedPaths = sharedRootObservations
+    .map(({ path: normalizedPath }) => normalizedPath)
+    .sort((left, right) => left.localeCompare(right));
+  const observedLanePartitions = toSortedUnique(sharedRootObservations.map(({ lanePartition }) => lanePartition));
+  const thresholdQualified =
+    observedLanePartitions.length >= SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS &&
+    sortedPaths.length >= SHARED_ROOT_MIN_FAMILY_FILES;
+
+  if (!thresholdQualified) {
+    return {
+      classification: SHARED_ROOT_LANE_INTERPRETATION.BELOW_SHARED_ROOT_LANE_THRESHOLD,
+      shouldEmit: false,
+      details: {
+        thresholdQualified,
+        localFirstClassification: localFirstInterpretation.classification,
+        broaderSpreadClassification: broaderSpreadInterpretation?.classification ?? null,
+      },
+    };
+  }
+
+  const localFirstAllowsSharedRootLaneSpread =
+    localFirstInterpretation.classification ===
+      LOCAL_FIRST_FAMILY_INTERPRETATION.LOCAL_DIVERGENCE_NEEDS_BROADER_REVIEW ||
+    localFirstInterpretation.classification === LOCAL_FIRST_FAMILY_INTERPRETATION.NO_LOCAL_SEMANTIC_EXPLANATION;
+  if (!localFirstAllowsSharedRootLaneSpread) {
+    return {
+      classification: SHARED_ROOT_LANE_INTERPRETATION.LOCAL_FIRST_SUPPRESSED,
+      shouldEmit: false,
+      details: {
+        thresholdQualified,
+        localFirstClassification: localFirstInterpretation.classification,
+        broaderSpreadClassification: broaderSpreadInterpretation?.classification ?? null,
+      },
+    };
+  }
+
+  const broaderSpreadAllowsSharedRootLaneSpread =
+    broaderSpreadInterpretation?.classification === BROADER_SPREAD_INTERPRETATION.UNRESOLVED_BROADER_SPREAD;
+  if (!broaderSpreadAllowsSharedRootLaneSpread) {
+    return {
+      classification: SHARED_ROOT_LANE_INTERPRETATION.BROADER_SPREAD_SUPPRESSED,
+      shouldEmit: false,
+      details: {
+        thresholdQualified,
+        localFirstClassification: localFirstInterpretation.classification,
+        broaderSpreadClassification: broaderSpreadInterpretation?.classification ?? null,
+      },
+    };
+  }
+
+  return {
+    classification: SHARED_ROOT_LANE_INTERPRETATION.SELECT_SHARED_ROOT_LANE_SPREAD,
+    shouldEmit: true,
+    details: {
+      thresholdQualified,
+      localFirstClassification: localFirstInterpretation.classification,
+      broaderSpreadClassification: broaderSpreadInterpretation.classification,
+    },
+  };
+};
+
 const collectFamilyScatterFindings = (familySharedSpineAnalysisEntries) =>
   familySharedSpineAnalysisEntries.flatMap(({ familyAnalysis, broaderSpreadInterpretation }) => {
       const semanticFamily = familyAnalysis.semanticFamily;
@@ -820,11 +892,13 @@ const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnal
         const observedLanePartitions = toSortedUnique(
           sharedRootObservations.map(({ lanePartition }) => lanePartition),
         );
-        const hasSupportedSharedRootLaneSpread =
-          observedLanePartitions.length >= SHARED_ROOT_MIN_DISTINCT_LANE_PARTITIONS &&
-          sortedPaths.length >= SHARED_ROOT_MIN_FAMILY_FILES;
+        const sharedRootLaneInterpretation = toSharedRootLaneInterpretation({
+          sharedRootObservations,
+          localFirstInterpretation,
+          broaderSpreadInterpretation,
+        });
 
-        if (!hasSupportedSharedRootLaneSpread) {
+        if (!sharedRootLaneInterpretation.shouldEmit) {
           return [];
         }
 
@@ -844,9 +918,10 @@ const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnal
               observedPaths: sortedPaths,
               localFirstInterpretation,
               broaderSpreadInterpretation,
+              sharedRootLaneInterpretation,
               familySharedSpineRouting: {
                 model: 'shared-local-first-family-interpretation',
-                sharedRootOutcome: 'bounded-shared-root-lane-spread',
+                sharedRootOutcome: sharedRootLaneInterpretation.classification,
               },
               thresholds: {
                 supportedSharedRoots: SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS,

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -326,6 +326,11 @@ test('tree naming bridge contributor emits bounded shared-root lane scatter advi
   assert.equal(sharedRootFindings[0].details.localFirstInterpretation.classification, 'local-divergence-needs-broader-review');
   assert.equal(sharedRootFindings[0].details.broaderSpreadInterpretation.classification, 'unresolved-broader-spread');
   assert.equal(sharedRootFindings[0].details.familySharedSpineRouting.model, 'shared-local-first-family-interpretation');
+  assert.equal(
+    sharedRootFindings[0].details.sharedRootLaneInterpretation.classification,
+    'select-shared-root-lane-spread',
+  );
+  assert.equal(sharedRootFindings[0].details.sharedRootLaneInterpretation.details.thresholdQualified, true);
 });
 
 test('tree naming bridge contributor does not emit shared-root lane scatter advisory when family evidence is outside supported shared root', () => {
@@ -389,7 +394,10 @@ test('tree naming bridge contributor keeps shared-root advisory deterministic fo
 
   assert.deepEqual(firstSharedRootFindings, secondSharedRootFindings);
   assert.equal(firstSharedRootFindings.length, 1);
-  assert.equal(firstSharedRootFindings[0].details.familySharedSpineRouting.sharedRootOutcome, 'bounded-shared-root-lane-spread');
+  assert.equal(
+    firstSharedRootFindings[0].details.familySharedSpineRouting.sharedRootOutcome,
+    'select-shared-root-lane-spread',
+  );
 });
 
 test('tree naming bridge contributor keeps non-shared families on shared family spine without emitting shared-root lane spread', () => {
@@ -418,6 +426,33 @@ test('tree naming bridge contributor keeps non-shared families on shared family 
 
   assert.equal(findings.some((finding) => finding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES'), false);
   assert.equal(findings.some((finding) => finding.code === 'TREE_FAMILY_SCATTERED'), false);
+});
+
+test('tree naming bridge contributor does not emit shared-root lane spread when thresholds match but shared spine resolves local expected presence', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({
+    observations: [
+      {
+        path: 'src/shared/logic/shared-local.logic.ts',
+        semanticName: 'shared-local',
+        familyRoot: 'shared',
+        semanticFamily: 'shared-local',
+      },
+      {
+        path: 'src/shared/knowledge/shared-local.knowledge.ts',
+        semanticName: 'shared-local',
+        familyRoot: 'shared',
+        semanticFamily: 'shared-local',
+      },
+      {
+        path: 'src/shared/results/shared-local.results.ts',
+        semanticName: 'shared-local',
+        familyRoot: 'shared',
+        semanticFamily: 'shared-local',
+      },
+    ],
+  });
+
+  assert.equal(findings.some((finding) => finding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES'), false);
 });
 
 test('tree naming bridge contributor treats one naming-aligned semantic container as expected presence, not broad scatter', () => {


### PR DESCRIPTION
### Motivation
- Finish the shared-root lane integration slice so `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` is decision-routed by the shared family interpretation spine rather than emitting from lane/file thresholds alone.
- Follow NL-first: update the tree validator spec before runtime changes to record the routing change and keep ownership boundaries intact.
- For runtime authority I treated `calculogic-validator/doc/ConventionRoutines/ValidatorSuite-Contracts-And-Modes.md` and `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` as the slice runtime authority and treated `calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md` as navigation-only supporting metadata.

### Description
- Added a bounded, deterministic `SHARED_ROOT_LANE_INTERPRETATION` model and `toSharedRootLaneInterpretation(...)` in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` to compute an inspectable routing outcome with a `shouldEmit` flag.
- Changed `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` emission to require the shared-spine routing decision (`sharedRootLaneInterpretation.shouldEmit`) so local-first and broader-spread interpretation now gate emission, and attached `sharedRootLaneInterpretation` plus the routed `familySharedSpineRouting.sharedRootOutcome` into the finding `details`.
- Updated the tree NL/spec first in `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` to document that shared-root lane spread is analyzed and decision-routed by the shared family spine and that lane/file thresholds are bounded inputs, not standalone emit gates.
- Kept the existing finding code and ownership boundaries intact while adding focused tests in `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` that validate spine-based emission, presence of routing context in details, non-shared families not emitting, suppression when spine resolves locally, and deterministic behavior.

### Testing
- Ran `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and the test suite passed (all tests succeeded).
- The updated tests verify deterministic inputs still produce deterministic routing and that shared-spine selection (not thresholds alone) controls `TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES` emission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db32381d4483318b21db53b858d03b)