### PR TITLE
Add folder-kind interpretation before tree naming-bridge home derivation

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -111,21 +111,47 @@ Bounded consumable naming bridge surfaces include:
 
 Tree advisor does **not** re-own naming validity judgments. Naming validity remains owned by naming conventions/specs and the naming validator slice.
 
-### Naming-bridge placement model (Status: Bounded modeling note)
+### Naming-bridge folder-kind interpretation + placement model (Status: Bounded modeling note)
 
 Classification: Informative
 
-Tree now carries a bounded, explicit placement model when consuming naming-bridge observations so structural and semantic placement can be interpreted side-by-side without collapsing them into one field.
+Tree now carries a bounded, explicit folder-kind interpretation layer before placement derivation when consuming naming-bridge observations.
+
+Folder-kind interpretation (bounded in this slice):
+
+- `structural-folder`
+  - structural surfaces and structural utility partitions (for example `src`, `test`, `doc`, `docs`, `scripts`, `tools`)
+- `semantic-folder`
+  - meaning-bearing folder segments interpreted as semantic roots or semantic subhomes
+- `unspecified-folder`
+  - segments currently unresolved by this bounded interpretation layer
+
+Interpretation order in this slice:
+
+1. classify folder segments by folder-kind
+2. derive structural interpretation from structural folders
+3. derive semantic interpretation from semantic folders + naming-owned bridge signals
+
+This bounded tranche is intentionally limited to modeling and home-derivation refinement first. It does not intentionally broaden finding families/codes or redesign thresholds.
+
+Tree consumes naming-owned signals and does not re-own naming semantics:
+
+- naming remains source-of-truth for `familyRoot`, `semanticFamily`, and optional `familySubgroup`
+- tree uses those naming-owned signals plus folder-kind interpretation to derive semantic placement
 
 At minimum, the placement model distinguishes:
 
+- folder-kind breakdown (structural/semantic/unspecified)
+- structural segment chain/surface chain
 - `structuralRoot`
 - `structuralSurface`
 - `structuralHome`
 - `localStructuralHome`
+- `semanticRoot`
 - `semanticContainerIdentity`
 - `semanticHome`
 - `semanticSubhome`
+- unresolved/unspecified segment context
 
 On top of those placement fields, tree also records a bounded local placement-coherence classification so the local relationship between structural and semantic placement is explicit and inspectable.
 
@@ -140,8 +166,8 @@ Bounded local placement-coherence values in this tranche:
 Ownership and interpretation guardrails for this tranche:
 
 - naming still owns `familyRoot`, `semanticFamily`, and optional `familySubgroup`
-- tree consumes those naming-owned signals plus path structure to interpret semantic placement
-- this tranche adds bounded placement modeling plus local structural-vs-semantic coherence classification only
+- tree consumes those naming-owned signals plus folder-kind/path interpretation to interpret semantic placement
+- this tranche adds bounded folder-kind interpretation and placement modeling plus local structural-vs-semantic coherence classification only
 - this tranche does not broaden finding behavior (no new finding families/codes and no intentional threshold/count/severity broadening)
 - semantic placement values in this tranche are folder/subfolder-derived interpretations
   - `semanticContainerIdentity` resolves to a folder/subfolder home, not a filename path

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -8,6 +8,8 @@ const FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES = 2;
 const FAMILY_SUBGROUP_OPPORTUNITY_REQUIRES_LOWER_LEVEL_GROUPING_SIGNAL = true;
 const TREE_STRUCTURAL_ROOT_SURFACES = ['src', 'test', 'doc', 'docs', 'scripts', 'tools', 'bin', 'public', 'calculogic-validator'];
 const TREE_STRUCTURAL_ROOT_SURFACE_SET = new Set(TREE_STRUCTURAL_ROOT_SURFACES);
+const TREE_SEMANTIC_ROOT_FOLDERS = ['tree', 'naming'];
+const TREE_SEMANTIC_ROOT_FOLDER_SET = new Set(TREE_SEMANTIC_ROOT_FOLDERS);
 const ALLOWED_STRUCTURAL_ROOT_PAIRINGS = [
   ['src', 'test'],
   ['doc', 'docs'],
@@ -47,27 +49,6 @@ const toSortedUnique = (values) => Array.from(new Set(values)).sort((left, right
 const toSortedUniqueStringFlags = (flags) =>
   toSortedUnique(flags.filter((flag) => typeof flag === 'string' && flag.length > 0));
 
-const toNormalizedStructuralHome = (normalizedPath) => {
-  const parentDirectory = path.posix.dirname(normalizedPath);
-  if (parentDirectory === '.') {
-    return '.';
-  }
-
-  const segments = parentDirectory.split('/').filter(Boolean);
-  if (segments.length < 2) {
-    return parentDirectory;
-  }
-
-  return segments.slice(0, 2).join('/');
-};
-
-const toLocalStructuralHome = (normalizedPath, structuralHome) => {
-  const parentSegments = path.posix.dirname(normalizedPath).split('/').filter(Boolean);
-  const structuralHomeSegments = structuralHome.split('/').filter(Boolean);
-  const [firstLocalSegment] = parentSegments.slice(structuralHomeSegments.length);
-  return firstLocalSegment ?? '.';
-};
-
 const toSemanticIdentityTokens = (observation) =>
   toSortedUnique(
     [observation.familyRoot, observation.semanticFamily, observation.familySubgroup]
@@ -96,6 +77,19 @@ const toSignalAlignment = (pathSegments, semanticSignal) => {
     return null;
   }
 
+  const exactSignalHit = pathSegments.findIndex(
+    (segment) => segment === semanticSignal || segment.startsWith(`${semanticSignal}-`),
+  );
+  if (exactSignalHit >= 0) {
+    return {
+      signal: semanticSignal,
+      tokenSet: [semanticSignal],
+      segment: pathSegments[exactSignalHit],
+      segmentIndex: exactSignalHit,
+      pathPrefix: pathSegments.slice(0, exactSignalHit + 1).join('/'),
+    };
+  }
+
   const signalTokens = toSortedUnique(semanticSignal.split('-').filter(Boolean).concat(semanticSignal));
   const hit = pathSegments.findIndex(
     (segment) => signalTokens.includes(segment) || signalTokens.some((token) => segment.startsWith(`${token}-`)),
@@ -110,6 +104,48 @@ const toSignalAlignment = (pathSegments, semanticSignal) => {
     segment: pathSegments[hit],
     segmentIndex: hit,
     pathPrefix: pathSegments.slice(0, hit + 1).join('/'),
+  };
+};
+
+export const classifyNamingBridgeFolderKinds = (observation) => {
+  const directorySegments = path.posix.dirname(observation.path).split('/').filter(Boolean);
+  const alignments = {
+    familyRoot: toSignalAlignment(directorySegments, observation.familyRoot),
+    semanticFamily: toSignalAlignment(directorySegments, observation.semanticFamily),
+    familySubgroup: toSignalAlignment(directorySegments, observation.familySubgroup),
+  };
+  const namingAlignedSemanticSegmentIndexes = new Set(
+    [alignments.familyRoot, alignments.semanticFamily, alignments.familySubgroup]
+      .filter(Boolean)
+      .map((alignment) => alignment.segmentIndex),
+  );
+
+  const folderKinds = directorySegments.map((segment, index) => {
+    if (TREE_SEMANTIC_ROOT_FOLDER_SET.has(segment)) {
+      return { segment, index, folderKind: 'semantic-folder', reason: 'semantic-root-folder' };
+    }
+
+    if (namingAlignedSemanticSegmentIndexes.has(index)) {
+      return { segment, index, folderKind: 'semantic-folder', reason: 'naming-signal-aligned-folder' };
+    }
+
+    if (TREE_STRUCTURAL_ROOT_SURFACE_SET.has(segment)) {
+      return { segment, index, folderKind: 'structural-folder', reason: 'structural-surface-folder' };
+    }
+
+    return { segment, index, folderKind: 'unspecified-folder', reason: 'no-bounded-folder-kind-match' };
+  });
+
+  const structuralFolderSegments = folderKinds.filter((entry) => entry.folderKind === 'structural-folder');
+  const semanticFolderSegments = folderKinds.filter((entry) => entry.folderKind === 'semantic-folder');
+  const unspecifiedFolderSegments = folderKinds.filter((entry) => entry.folderKind === 'unspecified-folder');
+
+  return {
+    folderKinds,
+    structuralFolderSegments,
+    semanticFolderSegments,
+    unspecifiedFolderSegments,
+    namingAlignments: alignments,
   };
 };
 
@@ -211,21 +247,31 @@ const classifyLocalPlacementCoherence = ({
 
 export const toNamingBridgePlacementRecord = (observation) => {
   const pathSegments = observation.path.split('/').filter(Boolean);
-  const directorySegments = path.posix.dirname(observation.path).split('/').filter(Boolean);
+  const folderKindInterpretation = classifyNamingBridgeFolderKinds(observation);
+  const directorySegments = folderKindInterpretation.folderKinds.map((entry) => entry.segment);
   const structuralRoot = pathSegments[0] ?? '.';
-  const structuralSurface = pathSegments.slice(0, 2).join('/') || structuralRoot;
-  const structuralHome = toNormalizedStructuralHome(observation.path);
-  const localStructuralHome = toLocalStructuralHome(observation.path, structuralHome);
+  const nonSemanticFolderSegments = folderKindInterpretation.folderKinds.filter((entry) => entry.folderKind !== 'semantic-folder');
+  const structuralSurfaceChain = folderKindInterpretation.structuralFolderSegments.map((entry) => entry.segment);
+  const structuralSegmentChain = nonSemanticFolderSegments.map((entry) => entry.segment);
+  const structuralHomeSegments = structuralSegmentChain.slice(0, 2);
+  const structuralHome = structuralHomeSegments.length > 0 ? structuralHomeSegments.join('/') : '.';
+  const structuralSurface = structuralHome;
+  const structuralHomeLastSegmentIndex = nonSemanticFolderSegments[Math.max(0, structuralHomeSegments.length - 1)]?.index;
+  const localStructuralHome =
+    structuralHomeLastSegmentIndex === undefined
+      ? '.'
+      : directorySegments[structuralHomeLastSegmentIndex + 1] ?? '.';
   const semanticIdentityTokens = toSemanticIdentityTokens(observation);
   const semanticAlignmentHits = toSemanticAlignmentHits(observation, semanticIdentityTokens);
-  const familyRootDirectoryAlignment = toSignalAlignment(directorySegments, observation.familyRoot);
-  const semanticFamilyDirectoryAlignment = toSignalAlignment(directorySegments, observation.semanticFamily);
-  const familySubgroupDirectoryAlignment = toSignalAlignment(directorySegments, observation.familySubgroup);
+  const familyRootDirectoryAlignment = folderKindInterpretation.namingAlignments.familyRoot;
+  const semanticFamilyDirectoryAlignment = folderKindInterpretation.namingAlignments.semanticFamily;
+  const familySubgroupDirectoryAlignment = folderKindInterpretation.namingAlignments.familySubgroup;
   const familyRootAlignment = toSignalAlignment(pathSegments, observation.familyRoot);
   const semanticFamilyAlignment = toSignalAlignment(pathSegments, observation.semanticFamily);
   const familySubgroupAlignment = toSignalAlignment(pathSegments, observation.familySubgroup);
   const semanticContainerIdentity = familyRootDirectoryAlignment?.pathPrefix ?? null;
   const semanticHome = semanticFamilyDirectoryAlignment?.pathPrefix ?? semanticContainerIdentity;
+  const semanticRoot = semanticContainerIdentity;
   const semanticSubhome =
     familySubgroupDirectoryAlignment &&
     semanticHome &&
@@ -246,9 +292,14 @@ export const toNamingBridgePlacementRecord = (observation) => {
     structuralRoot,
     structuralSurface,
     structuralHome,
+    structuralSurfaceChain,
+    structuralSegmentChain,
     localStructuralHome,
     structuralRootKind: TREE_STRUCTURAL_ROOT_SURFACE_SET.has(structuralRoot) ? 'structural-surface' : 'non-structural-surface',
+    folderKindBreakdown: folderKindInterpretation.folderKinds,
+    unresolvedFolderContext: folderKindInterpretation.unspecifiedFolderSegments.map((entry) => entry.segment),
     semanticContainerRole: semanticContainerIdentity ? 'naming-aligned-semantic-container' : 'none',
+    semanticRoot,
     semanticContainerIdentity,
     semanticHome,
     semanticSubhome,

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+  classifyNamingBridgeFolderKinds,
   collectNamingSemanticFamilyBridgeFindings,
   toNamingBridgePlacementRecord,
 } from '../src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs';
@@ -71,11 +72,13 @@ test('tree naming bridge placement model resolves structural home and semantic c
     semanticFamily: 'tree-occurrence',
   });
 
-  assert.equal(placement.structuralHome, 'calculogic-validator/tree');
+  assert.equal(placement.structuralHome, 'calculogic-validator/src');
+  assert.deepEqual(placement.structuralSurfaceChain, ['calculogic-validator', 'src']);
   assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/tree');
   assert.equal(placement.semanticHome, 'calculogic-validator/tree');
-  assert.equal(placement.localStructuralHome, 'src');
-  assert.equal(placement.localPlacementCoherence, 'aligned-local-home');
+  assert.equal(placement.localStructuralHome, 'contributors');
+  assert.equal(placement.localPlacementCoherence, 'divergent-local-placement');
+  assert.equal(placement.localPlacementCoherenceDetails.reason, 'semantic-home-diverges-from-structural-home');
 });
 
 test('tree naming bridge placement model derives semantic placement from naming-owned signals and path alignment', () => {
@@ -118,11 +121,12 @@ test('tree naming bridge placement model can represent semantic subhome from fam
   });
 
   assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/naming');
+  assert.equal(placement.semanticRoot, 'calculogic-validator/naming');
   assert.equal(placement.semanticSubhome, 'calculogic-validator/naming/src/lane');
   assert.equal(placement.localPlacementCoherence, 'divergent-local-placement');
   assert.equal(
     placement.localPlacementCoherenceDetails.reason,
-    'semantic-subhome-signals-lower-local-placement',
+    'semantic-home-diverges-from-structural-home',
   );
 });
 
@@ -189,6 +193,75 @@ test('tree naming bridge placement model stays deterministic for identical input
   const first = toNamingBridgePlacementRecord(observation);
   const second = toNamingBridgePlacementRecord(observation);
   assert.deepEqual(first, second);
+});
+
+test('tree naming bridge folder-kind interpretation classifies structural semantic and unspecified folders deterministically', () => {
+  const observation = {
+    path: 'calculogic-validator/tree/src/contributors/registry/tree-structure-advisor.logic.mjs',
+    semanticName: 'tree-structure-advisor',
+    familyRoot: 'tree',
+    semanticFamily: 'tree-structure-advisor',
+    familySubgroup: 'registry',
+  };
+
+  const first = classifyNamingBridgeFolderKinds(observation);
+  const second = classifyNamingBridgeFolderKinds(observation);
+  assert.deepEqual(first, second);
+  assert.deepEqual(
+    first.folderKinds.map(({ segment, folderKind }) => ({ segment, folderKind })),
+    [
+      { segment: 'calculogic-validator', folderKind: 'structural-folder' },
+      { segment: 'tree', folderKind: 'semantic-folder' },
+      { segment: 'src', folderKind: 'structural-folder' },
+      { segment: 'contributors', folderKind: 'unspecified-folder' },
+      { segment: 'registry', folderKind: 'semantic-folder' },
+    ],
+  );
+});
+
+test('tree naming bridge placement model keeps semantic roots out of structural-home derivation by position', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'calculogic-validator/naming/src/registry/naming-registry.logic.mjs',
+    semanticName: 'naming-registry',
+    familyRoot: 'naming',
+    semanticFamily: 'naming-registry',
+    familySubgroup: 'registry',
+  });
+
+  assert.equal(placement.structuralHome, 'calculogic-validator/src');
+  assert.equal(placement.semanticRoot, 'calculogic-validator/naming');
+  assert.equal(placement.semanticHome, 'calculogic-validator/naming');
+  assert.equal(placement.semanticSubhome, 'calculogic-validator/naming/src/registry');
+});
+
+test('tree naming bridge placement model represents family-root and semantic-family as root plus lower semantic grouping', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'calculogic-validator/tree/src/tree-structure-advisor/report-capture.logic.mjs',
+    semanticName: 'report-capture',
+    familyRoot: 'tree',
+    semanticFamily: 'tree-structure-advisor',
+  });
+
+  assert.equal(placement.semanticRoot, 'calculogic-validator/tree');
+  assert.equal(placement.semanticHome, 'calculogic-validator/tree/src/tree-structure-advisor');
+  assert.equal(placement.semanticContainerIdentity, 'calculogic-validator/tree');
+  assert.equal(placement.semanticHome === placement.semanticRoot, false);
+});
+
+test('tree naming bridge placement model keeps unresolved segments visible in placement record', () => {
+  const placement = toNamingBridgePlacementRecord({
+    path: 'tools/validator-config/runtime/registry/validator-config.logic.mjs',
+    semanticName: 'validator-config',
+    familyRoot: 'validator',
+    semanticFamily: 'validator-config',
+    familySubgroup: 'registry',
+  });
+
+  assert.deepEqual(placement.unresolvedFolderContext, ['runtime']);
+  assert.equal(
+    placement.folderKindBreakdown.some((entry) => entry.folderKind === 'unspecified-folder' && entry.segment === 'runtime'),
+    true,
+  );
 });
 
 test('tree naming bridge contributor does not emit naming validity judgments', () => {


### PR DESCRIPTION
### Motivation
- Close a modeling gap by adding a bounded folder-kind interpretation layer so tree classifies folder segments as `structural-folder` / `semantic-folder` / `unspecified-folder` before deriving structural and semantic homes. 
- Follow NL-first conventions by updating the tree validator spec (`tree-structure-advisor-validator.spec.md`) before code changes and treating the tree spec as runtime authority while consuming naming-owned bridge signals per the naming spec. 
- Limit scope to steps 1–3 from the design: classify folder segments, derive structural interpretation from structural segments, and derive semantic interpretation from semantic segments plus naming-owned signals, without adding findings or broad threshold changes. 

### Description
- Documented the bounded folder-kind interpretation and new interpretation order in `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` with `structural-folder`, `semantic-folder`, and `unspecified-folder`. 
- Added `classifyNamingBridgeFolderKinds` in `calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs` to deterministically label directory segments (exposing reasons, indexes, and naming alignments) and added `TREE_SEMANTIC_ROOT_FOLDERS` to seed semantic-root recognition. 
- Refined `toNamingBridgePlacementRecord` to consume folder-kind interpretation first and extended the placement record with inspectable fields: `folderKindBreakdown`, `structuralSurfaceChain`, `structuralSegmentChain`, `semanticRoot`, and `unresolvedFolderContext`, while keeping existing placement fields and finding routing intact. 
- Improved alignment fidelity by preferring exact semantic-signal segment hits in `toSignalAlignment` before falling back to token-based matching so `familyRoot + semanticFamily (+ subgroup)` can map to root/home/subhome more faithfully. 
- Added focused deterministic tests in `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` validating folder-kind classification, semantic roots not being treated as structural homes by position, semantic root + subhome representation, unresolved segment visibility, and deterministic outputs. 

### Testing
- Ran the tree naming-bridge contributor tests with `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and the test suite passed (all tests succeeded). 
- The change set modified the spec, the contributor logic, and the contributor tests and no new finding codes or thresholds were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3d97cebc8331bef46435d2d9a19c)