### PR TITLE
docs: clarify PR reference usage & verification logging in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ Use docs-first, deterministic, ownership-aligned changes.
 - Issues hold planning context, deferred scope, roadmap notes, ADR context, and explicit “not this PR” boundaries.
 - PRs hold durable repository changes only.
 - Do not copy broad issue-planning language into repo docs unless it is stable implementation truth.
-- Use `Closes #...` only when the PR completes the whole issue; otherwise use `Refs #...` or `Implements part of #...`.
-- For partial-scope delivery or manual-close workflows, prefer `Refs #...` in the PR body.
+- Default to `Refs #...` or `Implements part of #...` in PR bodies.
+- Do not use closing keywords such as `Closes #...`, `Fixes #...`, or `Resolves #...` unless the human owner explicitly asks for automatic issue closure.
+- Let the human owner close planning, architecture, roadmap, registry, and validator alignment issues manually after review.
 
 ## Baseline References
 1. `calculogic-validator/doc/ConventionRoutines/CCPP.md`
@@ -82,6 +83,10 @@ Follow this sequence:
 4. loader compatibility bridges
 5. runtime behavior migration
 6. extraction preparation
+
+## Docs Task Fidelity
+- For docs tasks with required sections or acceptance criteria, preserve each required section unless it conflicts with current repo truth.
+- Do not satisfy a structural docs task with wording cleanup only unless the issue explicitly asks for wording cleanup only.
 
 ## Task Boundaries and Verification
 - Keep PRs narrowly scoped to the requested issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Use docs-first, deterministic, ownership-aligned changes.
 - PRs hold durable repository changes only.
 - Do not copy broad issue-planning language into repo docs unless it is stable implementation truth.
 - Use `Closes #...` only when the PR completes the whole issue; otherwise use `Refs #...` or `Implements part of #...`.
+- For partial-scope delivery or manual-close workflows, prefer `Refs #...` in the PR body.
 
 ## Baseline References
 1. `calculogic-validator/doc/ConventionRoutines/CCPP.md`
@@ -87,3 +88,4 @@ Follow this sequence:
 - Do not modify runtime code, registry payloads, loaders, workflows, templates, or existing specs unless explicitly requested.
 - Run the narrowest relevant checks for touched files.
 - If target filtering excludes touched files, note the limitation and do not broaden scope.
+- If any verification command is run, record the exact command and outcome in the PR body or PR comment.


### PR DESCRIPTION
### Motivation

- Refine `AGENTS.md` so Codex defaults to non-closing issue references and leaves planning, architecture, roadmap, registry, and validator alignment issue closure to the human owner.
- Improve PR recordkeeping by requiring exact verification commands and outcomes to be recorded when commands are run.
- Prevent structural documentation tasks from being reduced to wording cleanup when the issue includes required sections or acceptance criteria.

### Description

- Updated `AGENTS.md` so PR bodies default to `Refs #...` or `Implements part of #...`.
- Added guidance not to use closing keywords such as `Closes #...`, `Fixes #...`, or `Resolves #...` unless the human owner explicitly asks for automatic issue closure.
- Added guidance that the human owner closes planning, architecture, roadmap, registry, and validator alignment issues manually after review.
- Added a `Docs Task Fidelity` section requiring docs tasks with required sections or acceptance criteria to preserve those sections unless they conflict with current repo truth.
- Added guidance not to satisfy structural docs tasks with wording cleanup only unless the issue explicitly asks for wording cleanup only.
- Added verification recordkeeping guidance requiring exact commands and outcomes to be recorded in the PR body or a PR comment.

Refs #425

### Testing

- Ran `git diff -- AGENTS.md`.
  - Outcome: confirmed the PR only changes `AGENTS.md` and adds the issue-reference, docs-task fidelity, and verification-recordkeeping guidance.
- Ran `git status --short`.
  - Outcome: Codex reported `M AGENTS.md` and an unrelated uncommitted workspace change in `calculogic-validator/bin/calculogic-validator-health.host.mjs`; the PR diff and commit include only `AGENTS.md`.
- Ran `nl -ba AGENTS.md | sed -n '1,220p'`.
  - Outcome: confirmed the updated guidance appears in the expected sections.