### PR TITLE
Add canonical builtin roles registry data slice

### DIFF
--- a/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "roles": [
+    {
+      "role": "adapter",
+      "status": "active"
+    }
+  ]
+}

--- a/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
@@ -3,7 +3,194 @@
   "roles": [
     {
       "role": "adapter",
-      "status": "active"
+      "status": "active",
+      "definition": "Integration role for adapting one interface, contract, or system shape to another."
+    },
+    {
+      "role": "anchor",
+      "status": "active",
+      "definition": "Registry indexing role for stable anchor/address tokens used for deterministic references."
+    },
+    {
+      "role": "audit",
+      "status": "active",
+      "definition": "Documentation role for point-in-time audit and reconciliation findings."
+    },
+    {
+      "role": "benchmark",
+      "status": "active",
+      "definition": "Quality-support role for benchmark artifacts used to evaluate performance characteristics."
+    },
+    {
+      "role": "build",
+      "status": "active",
+      "definition": "Concern-core role for local UI structure and content construction."
+    },
+    {
+      "role": "build-style",
+      "status": "active",
+      "definition": "Concern-style role for style/layout rules paired to build concern structure."
+    },
+    {
+      "role": "catalog",
+      "status": "active",
+      "definition": "Registry indexing role for bounded inventories/listings without runtime resolution execution."
+    },
+    {
+      "role": "cli",
+      "status": "active",
+      "definition": "Architecture-support role for command-line entrypoints and command surface orchestration."
+    },
+    {
+      "role": "client",
+      "status": "active",
+      "definition": "Integration role for outbound system clients that consume external interfaces."
+    },
+    {
+      "role": "contracts",
+      "status": "active",
+      "definition": "Architecture-support role for stable contract boundary definitions, parsing/normalization, and shape guards."
+    },
+    {
+      "role": "dto",
+      "status": "active",
+      "definition": "Data-model role for explicit data transfer object shape boundaries."
+    },
+    {
+      "role": "entry",
+      "status": "active",
+      "definition": "Surface-system role for runtime entry composition points."
+    },
+    {
+      "role": "fixture",
+      "status": "active",
+      "definition": "Quality-support role for deterministic fixture artifacts."
+    },
+    {
+      "role": "gateway",
+      "status": "active",
+      "definition": "Integration role for boundary gateways coordinating calls across external/internal systems."
+    },
+    {
+      "role": "healthcheck",
+      "status": "active",
+      "definition": "Documentation role for recurring health/status checks."
+    },
+    {
+      "role": "host",
+      "status": "active",
+      "definition": "Architecture-support role for structural host/composition and placement orchestration."
+    },
+    {
+      "role": "ids",
+      "status": "active",
+      "definition": "Registry indexing role for stable identifier constants/tokens/key sets for bounded targets."
+    },
+    {
+      "role": "index",
+      "status": "active",
+      "definition": "Registry indexing role for canonical index surfaces."
+    },
+    {
+      "role": "knowledge",
+      "status": "active",
+      "definition": "Concern-core role for static knowledge/config/schema/reference data."
+    },
+    {
+      "role": "logic",
+      "status": "active",
+      "definition": "Concern-core role for interaction/state/behavior logic."
+    },
+    {
+      "role": "manifest",
+      "status": "active",
+      "definition": "Registry indexing role for manifest/list artifacts that enumerate bounded payload membership."
+    },
+    {
+      "role": "mapper",
+      "status": "active",
+      "definition": "Integration role for deterministic mapping between source and target representations."
+    },
+    {
+      "role": "mock",
+      "status": "active",
+      "definition": "Quality-support role for mocks and stubs used in isolated testing."
+    },
+    {
+      "role": "plan",
+      "status": "active",
+      "definition": "Documentation role for forward-looking planning artifacts."
+    },
+    {
+      "role": "policy",
+      "status": "active",
+      "definition": "Documentation role for governance and rule-setting decisions."
+    },
+    {
+      "role": "registry",
+      "status": "active",
+      "definition": "Registry indexing role for canonical registry payload surfaces."
+    },
+    {
+      "role": "resolver",
+      "status": "active",
+      "definition": "Integration role for deterministic resolution across bounded candidate sets."
+    },
+    {
+      "role": "results",
+      "status": "active",
+      "definition": "Concern-core role for result-layer output shaping/mapping/preparation."
+    },
+    {
+      "role": "results-style",
+      "status": "active",
+      "definition": "Concern-style role for style/layout rules paired to results concern outputs."
+    },
+    {
+      "role": "router",
+      "status": "active",
+      "definition": "Surface-system role for runtime route and path dispatch composition."
+    },
+    {
+      "role": "schema",
+      "status": "active",
+      "definition": "Data-model role for schema authority and deterministic shape declarations."
+    },
+    {
+      "role": "spec",
+      "status": "active",
+      "definition": "Documentation role for canonical specification/contract references."
+    },
+    {
+      "role": "test",
+      "status": "active",
+      "definition": "Quality-support role for deterministic test artifacts."
+    },
+    {
+      "role": "tokens",
+      "status": "active",
+      "definition": "Registry indexing role for token vocabularies used by deterministic interpretation routines."
+    },
+    {
+      "role": "types",
+      "status": "active",
+      "definition": "Data-model role for type declarations and typed shape boundaries."
+    },
+    {
+      "role": "view",
+      "status": "deprecated",
+      "definition": "Historical pre-current concern split role retained for detection and migration guidance.",
+      "notes": "Manual migration required."
+    },
+    {
+      "role": "wiring",
+      "status": "active",
+      "definition": "Architecture-support role for integration glue connecting modules/contracts/adapters."
+    },
+    {
+      "role": "workflow",
+      "status": "active",
+      "definition": "Documentation role for repeatable procedural routines and sequences."
     }
   ]
 }

--- a/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
@@ -9,188 +9,303 @@
     {
       "role": "anchor",
       "status": "active",
-      "definition": "Registry indexing role for stable anchor/address tokens used for deterministic references."
+      "definition": "Reference role for stable addressing, linking, or anchoring within a registry or index."
     },
     {
       "role": "audit",
       "status": "active",
-      "definition": "Documentation role for point-in-time audit and reconciliation findings."
+      "definition": "Documentation role for review, inspection, or evaluation records."
+    },
+    {
+      "role": "auth",
+      "status": "active",
+      "definition": "Security role for authentication, authorization, session identity, or access-control responsibility."
     },
     {
       "role": "benchmark",
       "status": "active",
-      "definition": "Quality-support role for benchmark artifacts used to evaluate performance characteristics."
+      "definition": "Quality role for performance or comparison measurement artifacts."
+    },
+    {
+      "role": "boundary",
+      "status": "active",
+      "definition": "Architecture-support role for defining or protecting responsibility, module, or integration boundaries."
     },
     {
       "role": "build",
       "status": "active",
-      "definition": "Concern-core role for local UI structure and content construction."
+      "definition": "Role for structure and assembly of user-visible artifacts or interface units."
     },
     {
       "role": "build-style",
       "status": "active",
-      "definition": "Concern-style role for style/layout rules paired to build concern structure."
+      "definition": "Style role for presentation-layer mutations of composed user-visible structure."
+    },
+    {
+      "role": "buildsys",
+      "status": "active",
+      "definition": "Build-system role for build pipeline, compilation, bundling, or build-tool automation responsibility."
+    },
+    {
+      "role": "cache",
+      "status": "active",
+      "definition": "Persistence role for cache behavior, retained computed state, or temporary storage policy."
     },
     {
       "role": "catalog",
       "status": "active",
-      "definition": "Registry indexing role for bounded inventories/listings without runtime resolution execution."
+      "definition": "Indexing-registry role for organized reference listings or discoverable item collections."
     },
     {
       "role": "cli",
       "status": "active",
-      "definition": "Architecture-support role for command-line entrypoints and command surface orchestration."
+      "definition": "Architecture-support role for command-line entrypoints or command orchestration."
     },
     {
       "role": "client",
       "status": "active",
-      "definition": "Integration role for outbound system clients that consume external interfaces."
+      "definition": "Integration role for consuming or calling an external or internal service boundary."
+    },
+    {
+      "role": "config",
+      "status": "active",
+      "definition": "Configuration role for structured options, setup policy, or configurable runtime/tooling values."
     },
     {
       "role": "contracts",
       "status": "active",
-      "definition": "Architecture-support role for stable contract boundary definitions, parsing/normalization, and shape guards."
+      "definition": "Architecture-support role for shared contracts, interfaces, schemas, or behavioral agreements."
+    },
+    {
+      "role": "crypto",
+      "status": "active",
+      "definition": "Security role for cryptographic behavior, key handling, hashing, signing, or encryption responsibility."
+    },
+    {
+      "role": "deploy",
+      "status": "active",
+      "definition": "Operations-support role for deployment behavior, release movement, or environment rollout responsibility."
     },
     {
       "role": "dto",
       "status": "active",
-      "definition": "Data-model role for explicit data transfer object shape boundaries."
+      "definition": "Data-model role for transfer-shaped output or structured exchange payloads."
     },
     {
       "role": "entry",
       "status": "active",
-      "definition": "Surface-system role for runtime entry composition points."
+      "definition": "Surface-system role for entrypoints into a runtime, UI, app, or execution surface."
+    },
+    {
+      "role": "env",
+      "status": "active",
+      "definition": "Configuration role for environment variables, environment-specific setup, or runtime environment contracts."
     },
     {
       "role": "fixture",
       "status": "active",
-      "definition": "Quality-support role for deterministic fixture artifacts."
+      "definition": "Quality-support role for stable test or validation data."
     },
     {
       "role": "gateway",
       "status": "active",
-      "definition": "Integration role for boundary gateways coordinating calls across external/internal systems."
+      "definition": "Integration role for mediating access to a system, service, or boundary."
     },
     {
       "role": "healthcheck",
       "status": "active",
-      "definition": "Documentation role for recurring health/status checks."
+      "definition": "Documentation role for status, health, or readiness review artifacts."
     },
     {
       "role": "host",
       "status": "active",
-      "definition": "Architecture-support role for structural host/composition and placement orchestration."
+      "definition": "Surface-system role for hosting, mounting, or containing a runtime/UI/system surface."
+    },
+    {
+      "role": "i18n",
+      "status": "active",
+      "definition": "Localization role for internationalization structures, translation wiring, or language-aware runtime support."
     },
     {
       "role": "ids",
       "status": "active",
-      "definition": "Registry indexing role for stable identifier constants/tokens/key sets for bounded targets."
+      "definition": "Indexing-registry role for stable identifiers."
     },
     {
       "role": "index",
       "status": "active",
-      "definition": "Registry indexing role for canonical index surfaces."
+      "definition": "Indexing-registry role for lookup or discovery structures."
+    },
+    {
+      "role": "infra",
+      "status": "active",
+      "definition": "Operations-support role for infrastructure shape, infrastructure policy, or environment resource structure."
     },
     {
       "role": "knowledge",
       "status": "active",
-      "definition": "Concern-core role for static knowledge/config/schema/reference data."
+      "definition": "Role for static reference meaning, domain reference content, or declarative support data."
+    },
+    {
+      "role": "locale",
+      "status": "active",
+      "definition": "Localization role for locale-specific messages, formatting, translation payloads, or audience-localized data."
     },
     {
       "role": "logic",
       "status": "active",
-      "definition": "Concern-core role for interaction/state/behavior logic."
+      "definition": "Role for behavior, state, decisions, and response."
+    },
+    {
+      "role": "logging",
+      "status": "active",
+      "definition": "Observability role for emitted logs, logging behavior, or diagnostic event output."
     },
     {
       "role": "manifest",
       "status": "active",
-      "definition": "Registry indexing role for manifest/list artifacts that enumerate bounded payload membership."
+      "definition": "Indexing-registry role for declared inventory, package, or structural listing metadata."
     },
     {
       "role": "mapper",
       "status": "active",
-      "definition": "Integration role for deterministic mapping between source and target representations."
+      "definition": "Integration role for transforming one data, domain, or interface shape into another."
+    },
+    {
+      "role": "migration",
+      "status": "active",
+      "definition": "Migration role for transition, conversion, version-shift, or one-time state/schema movement work."
     },
     {
       "role": "mock",
       "status": "active",
-      "definition": "Quality-support role for mocks and stubs used in isolated testing."
+      "definition": "Quality-support role for simulated behavior or replacement test doubles."
+    },
+    {
+      "role": "monitoring",
+      "status": "active",
+      "definition": "Operations or observability role for monitoring signals, health visibility, or operational watch behavior."
+    },
+    {
+      "role": "packaging",
+      "status": "active",
+      "definition": "Build-system role for package assembly, distribution shape, bundling output, or publishable artifact structure."
+    },
+    {
+      "role": "perf",
+      "status": "active",
+      "definition": "Performance role for performance-sensitive behavior, measurement output, or optimization evidence."
     },
     {
       "role": "plan",
       "status": "active",
-      "definition": "Documentation role for forward-looking planning artifacts."
+      "definition": "Documentation role for intended work, sequencing, or implementation direction."
     },
     {
       "role": "policy",
       "status": "active",
-      "definition": "Documentation role for governance and rule-setting decisions."
+      "definition": "Documentation role for governing rules, constraints, or decision policy."
+    },
+    {
+      "role": "provider",
+      "status": "active",
+      "definition": "Integration role for supplying a bounded capability, dependency, service, or value source to a consumer context."
     },
     {
       "role": "registry",
       "status": "active",
-      "definition": "Registry indexing role for canonical registry payload surfaces."
+      "definition": "Indexing-registry role for canonical registered data."
     },
     {
       "role": "resolver",
       "status": "active",
-      "definition": "Integration role for deterministic resolution across bounded candidate sets."
+      "definition": "Integration role for resolving references, lookups, routing decisions, or context mappings."
     },
     {
       "role": "results",
       "status": "active",
-      "definition": "Concern-core role for result-layer output shaping/mapping/preparation."
+      "definition": "Role for output shaping and consumer-ready result modeling."
     },
     {
       "role": "results-style",
       "status": "active",
-      "definition": "Concern-style role for style/layout rules paired to results concern outputs."
+      "definition": "Style role for presentation-layer mutations of user-visible result output."
     },
     {
       "role": "router",
       "status": "active",
-      "definition": "Surface-system role for runtime route and path dispatch composition."
+      "definition": "Surface-system role for route, path, or dispatch behavior."
     },
     {
       "role": "schema",
       "status": "active",
-      "definition": "Data-model role for schema authority and deterministic shape declarations."
+      "definition": "Data-model role for structural validation, shape definition, or data contract modeling."
+    },
+    {
+      "role": "secrets",
+      "status": "active",
+      "definition": "Security role for secret references, secret access policy, credential handling, or protected configuration."
+    },
+    {
+      "role": "settings",
+      "status": "active",
+      "definition": "Configuration role for user, system, runtime, or tool settings that tune behavior without owning behavior itself."
     },
     {
       "role": "spec",
       "status": "active",
-      "definition": "Documentation role for canonical specification/contract references."
+      "definition": "Documentation role for formal specification."
+    },
+    {
+      "role": "storage",
+      "status": "active",
+      "definition": "Persistence role for stored state, storage access, persistence contracts, or retained data behavior."
+    },
+    {
+      "role": "telemetry",
+      "status": "active",
+      "definition": "Observability role for emitted measurements, traces, metrics, or runtime visibility payloads."
     },
     {
       "role": "test",
       "status": "active",
-      "definition": "Quality-support role for deterministic test artifacts."
+      "definition": "Quality-support role for executable or documented verification."
     },
     {
       "role": "tokens",
       "status": "active",
-      "definition": "Registry indexing role for token vocabularies used by deterministic interpretation routines."
+      "definition": "Indexing-registry role for reusable lexical, design, semantic, or symbolic tokens."
+    },
+    {
+      "role": "transport",
+      "status": "active",
+      "definition": "Networking role for transport behavior, protocol exchange, message movement, or communication boundary mechanics."
     },
     {
       "role": "types",
       "status": "active",
-      "definition": "Data-model role for type declarations and typed shape boundaries."
+      "definition": "Data-model role for type definitions."
     },
     {
       "role": "view",
       "status": "deprecated",
-      "definition": "Historical pre-current concern split role retained for detection and migration guidance.",
+      "definition": "Historical role from pre-current concern split.",
       "notes": "Manual migration required."
     },
     {
       "role": "wiring",
       "status": "active",
-      "definition": "Architecture-support role for integration glue connecting modules/contracts/adapters."
+      "definition": "Architecture-support role for connecting modules, dependencies, or system parts."
+    },
+    {
+      "role": "worker",
+      "status": "active",
+      "definition": "Concurrency role for asynchronous, parallel, queued, or background execution behavior."
     },
     {
       "role": "workflow",
       "status": "active",
-      "definition": "Documentation role for repeatable procedural routines and sequences."
+      "definition": "Documentation role for process, sequence, or operating procedure."
     }
   ]
 }


### PR DESCRIPTION
### Motivation

- Implement the bounded data-only canonical Role entity registry required by the Naming registry cleanup track.
- Provide a canonical place to host Role entities using a top-level `roles` array while preserving `category-role-perspective.registry.json` as the runtime grouped role source.
- Add the full target canonical Role registry payload without changing runtime loading, status lookup, Tree behavior, bridge logic, CLI behavior, or report output.

### Description

- Added `calculogic-validator/naming/src/registries/_builtin/roles.registry.json` as a data-only canonical Role entity registry.
- Added the full canonical Role registry payload with `version` and top-level `roles` array.
- Included role records with `role`, `status`, and `definition`.
- Preserved `view` as `deprecated` with `notes: "Manual migration required."`.
- Did not add `rolesByCategory`.
- Did not encode category membership in the canonical Role registry.
- Did not add agnostic-core meanings or meaning vectors.
- Did not modify `category-role-perspective.registry.json`.
- Did not remove `status` from `category-role-perspective.registry.json`.
- Did not repoint role status lookup.
- Did not make canonical `roles.registry.json` runtime-active.
- Did not change loader/runtime behavior, custom overlays, Tree work, bridge logic, CLI behavior, or report output.

### Testing

- Ran `git diff -- calculogic-validator/naming/src/registries`.
  - Outcome: confirmed the PR adds the data-only canonical `roles.registry.json` payload.
- Ran `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-case-rules-registry.test.mjs`.
  - Outcome: passed, 28 tests passed, 0 failed.
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/naming/src/registries`.
  - Outcome: command executed and exited non-zero due to existing scoped naming findings unrelated to this data-only slice; no validator code or runtime loader changes were made.

Refs #430
Refs #427