### PR TITLE
Prefer canonical roles.registry.json for builtin role status while preserving category membership

### DIFF
--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -10,7 +10,7 @@ import { loadOverlayCapabilitiesFromFile } from './naming-overlay-capabilities-r
 const DEFAULT_REGISTRY_STATE = 'builtin';
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const BUILTIN_REGISTRY_DIR = path.join(MODULE_DIR, '_builtin');
-const LEGACY_GROUPED_ROLES_REGISTRY_FILENAME = 'roles.registry.json';
+const ROLES_REGISTRY_FILENAME = 'roles.registry.json';
 const CATEGORY_ROLE_PERSPECTIVE_REGISTRY_FILENAME = 'category-role-perspective.registry.json';
 const REQUIRED_BUILTIN_REGISTRY_FILES = [
   'categories.registry.json',
@@ -36,7 +36,7 @@ const hasRequiredBuiltinRegistryFiles = ({ builtinRegistryDir }) => {
 
   return (
     fs.existsSync(path.join(builtinRegistryDir, CATEGORY_ROLE_PERSPECTIVE_REGISTRY_FILENAME)) ||
-    fs.existsSync(path.join(builtinRegistryDir, LEGACY_GROUPED_ROLES_REGISTRY_FILENAME))
+    fs.existsSync(path.join(builtinRegistryDir, ROLES_REGISTRY_FILENAME))
   );
 };
 
@@ -197,7 +197,7 @@ function loadJsonFile(filePath) {
 }
 
 const loadCanonicalRoleStatusByRole = ({ builtinRegistryDir }) => {
-  const canonicalRolesPath = path.join(builtinRegistryDir, LEGACY_GROUPED_ROLES_REGISTRY_FILENAME);
+  const canonicalRolesPath = path.join(builtinRegistryDir, ROLES_REGISTRY_FILENAME);
 
   if (!fs.existsSync(canonicalRolesPath)) {
     return null;
@@ -238,11 +238,11 @@ const loadBuiltinRolesPayload = ({ builtinRegistryDir }) => {
     CATEGORY_ROLE_PERSPECTIVE_REGISTRY_FILENAME,
   );
   const hasCategoryRolePerspective = fs.existsSync(categoryRolePerspectivePath);
-  const groupedRolesPath = hasCategoryRolePerspective
+  const membershipSourcePath = hasCategoryRolePerspective
     ? categoryRolePerspectivePath
-    : path.join(builtinRegistryDir, LEGACY_GROUPED_ROLES_REGISTRY_FILENAME);
+    : path.join(builtinRegistryDir, ROLES_REGISTRY_FILENAME);
 
-  const parsed = loadJsonFile(groupedRolesPath);
+  const parsed = loadJsonFile(membershipSourcePath);
   const rolesByCategory = parsed?.rolesByCategory;
 
   if (!rolesByCategory || typeof rolesByCategory !== 'object' || Array.isArray(rolesByCategory)) {

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -196,16 +196,51 @@ function loadJsonFile(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+const loadCanonicalRoleStatusByRole = ({ builtinRegistryDir }) => {
+  const canonicalRolesPath = path.join(builtinRegistryDir, LEGACY_GROUPED_ROLES_REGISTRY_FILENAME);
+
+  if (!fs.existsSync(canonicalRolesPath)) {
+    return null;
+  }
+
+  const parsed = loadJsonFile(canonicalRolesPath);
+  const roles = parsed?.roles;
+
+  if (!Array.isArray(roles)) {
+    return null;
+  }
+
+  const statusByRole = new Map();
+
+  for (const roleEntry of roles) {
+    if (!roleEntry || typeof roleEntry !== 'object' || Array.isArray(roleEntry)) {
+      continue;
+    }
+
+    const role = typeof roleEntry.role === 'string' ? roleEntry.role.trim() : '';
+    const status = typeof roleEntry.status === 'string' ? roleEntry.status.trim() : '';
+
+    if (!role || !status || !ALLOWED_ROLE_STATUSES.has(status)) {
+      continue;
+    }
+
+    if (!statusByRole.has(role)) {
+      statusByRole.set(role, status);
+    }
+  }
+
+  return statusByRole;
+};
+
 const loadBuiltinRolesPayload = ({ builtinRegistryDir }) => {
   const categoryRolePerspectivePath = path.join(
     builtinRegistryDir,
     CATEGORY_ROLE_PERSPECTIVE_REGISTRY_FILENAME,
   );
-  const legacyGroupedRolesPath = path.join(builtinRegistryDir, LEGACY_GROUPED_ROLES_REGISTRY_FILENAME);
-
-  const groupedRolesPath = fs.existsSync(categoryRolePerspectivePath)
+  const hasCategoryRolePerspective = fs.existsSync(categoryRolePerspectivePath);
+  const groupedRolesPath = hasCategoryRolePerspective
     ? categoryRolePerspectivePath
-    : legacyGroupedRolesPath;
+    : path.join(builtinRegistryDir, LEGACY_GROUPED_ROLES_REGISTRY_FILENAME);
 
   const parsed = loadJsonFile(groupedRolesPath);
   const rolesByCategory = parsed?.rolesByCategory;
@@ -213,6 +248,10 @@ const loadBuiltinRolesPayload = ({ builtinRegistryDir }) => {
   if (!rolesByCategory || typeof rolesByCategory !== 'object' || Array.isArray(rolesByCategory)) {
     throw new Error('Invalid builtin roles registry: expected rolesByCategory object.');
   }
+
+  const canonicalStatusByRole = hasCategoryRolePerspective
+    ? loadCanonicalRoleStatusByRole({ builtinRegistryDir })
+    : null;
 
   const flattenedRoles = [];
 
@@ -224,7 +263,10 @@ const loadBuiltinRolesPayload = ({ builtinRegistryDir }) => {
     }
 
     for (const roleEntry of roles) {
-      flattenedRoles.push({ ...roleEntry, category });
+      const role = typeof roleEntry?.role === 'string' ? roleEntry.role.trim() : '';
+      const canonicalStatus = role ? canonicalStatusByRole?.get(role) : undefined;
+      const status = canonicalStatus ?? roleEntry?.status;
+      flattenedRoles.push({ ...roleEntry, category, status });
     }
   }
 

--- a/calculogic-validator/naming/src/registries/registry-state.logic.mjs
+++ b/calculogic-validator/naming/src/registries/registry-state.logic.mjs
@@ -203,7 +203,14 @@ const loadCanonicalRoleStatusByRole = ({ builtinRegistryDir }) => {
     return null;
   }
 
-  const parsed = loadJsonFile(canonicalRolesPath);
+  let parsed;
+
+  try {
+    parsed = loadJsonFile(canonicalRolesPath);
+  } catch {
+    return null;
+  }
+
   const roles = parsed?.roles;
 
   if (!Array.isArray(roles)) {

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -125,13 +125,20 @@ test('builtin resolution loads roles and reportable extensions from _builtin JSO
   const builtinRolesRegistry = JSON.parse(
     fs.readFileSync(path.join(REGISTRY_MODULE_ROOT, '_builtin', 'category-role-perspective.registry.json'), 'utf8'),
   );
+  const canonicalRolesRegistry = JSON.parse(
+    fs.readFileSync(path.join(REGISTRY_MODULE_ROOT, '_builtin', 'roles.registry.json'), 'utf8'),
+  );
+  const canonicalStatusByRole = new Map(
+    canonicalRolesRegistry.roles.map((entry) => [entry.role.trim(), entry.status.trim()]),
+  );
+
   const expectedRoles = Object.entries(builtinRolesRegistry.rolesByCategory)
     .flatMap(([category, entries]) =>
       entries.map((entry) => {
         const normalized = {
           role: entry.role.trim(),
           category,
-          status: entry.status.trim(),
+          status: canonicalStatusByRole.get(entry.role.trim()) ?? entry.status.trim(),
         };
 
         if (typeof entry.notes === 'string' && entry.notes.trim()) {
@@ -401,6 +408,69 @@ test('registryRootDir prefers category-role-perspective over legacy grouped role
   }
 });
 
+
+
+test('builtin resolution prefers canonical roles.registry.json status over category-role perspective status', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'category-role-perspective.registry.json'), {
+      rolesByCategory: {
+        'architecture-support': [{ role: 'host', status: 'deprecated' }],
+      },
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      roles: [{ role: 'host', status: 'active', definition: 'host role' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), { reportableExtensions: ['.ts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), { reportableRootFiles: ['package.json'] });
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), { classificationBuckets: ['canonical'], secondaryBucketFamilies: ['codeCounts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), { missingRolePatterns: [] });
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), { outcomes: { canonical: { code: 'TEMP_CANONICAL', severity: 'info', classification: 'canonical', message: 'Temporary canonical policy.', ruleRef: 'temp-rule-ref' } } });
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), DEFAULT_OVERLAY_CAPABILITIES_REGISTRY);
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), { semanticName: { style: 'kebab-case' } });
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.deepEqual(result.roles, [{ role: 'host', category: 'architecture-support', status: 'active' }]);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('legacy grouped roles fallback keeps legacy status when category-role perspective is missing', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'roles.registry.json'), {
+      rolesByCategory: {
+        'architecture-support': [{ role: 'host', status: 'deprecated' }],
+      },
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), { reportableExtensions: ['.ts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), { reportableRootFiles: ['package.json'] });
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), { classificationBuckets: ['canonical'], secondaryBucketFamilies: ['codeCounts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), { missingRolePatterns: [] });
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), { outcomes: { canonical: { code: 'TEMP_CANONICAL', severity: 'info', classification: 'canonical', message: 'Temporary canonical policy.', ruleRef: 'temp-rule-ref' } } });
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), DEFAULT_OVERLAY_CAPABILITIES_REGISTRY);
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), { semanticName: { style: 'kebab-case' } });
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.deepEqual(result.roles, [{ role: 'host', category: 'architecture-support', status: 'deprecated' }]);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
 test('registryRootDir falls back to module _builtin when temp _builtin is incomplete', () => {
   const tempRoot = makeTempRegistryRoot();
 

--- a/calculogic-validator/naming/test/registry-state.logic.test.mjs
+++ b/calculogic-validator/naming/test/registry-state.logic.test.mjs
@@ -471,6 +471,62 @@ test('legacy grouped roles fallback keeps legacy status when category-role persp
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
+
+
+test('category-role perspective membership remains authoritative when canonical roles registry is malformed', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+
+    writeJson(path.join(tempRoot, '_builtin', 'category-role-perspective.registry.json'), {
+      rolesByCategory: {
+        'architecture-support': [{ role: 'host', status: 'deprecated' }],
+      },
+    });
+
+    fs.writeFileSync(path.join(tempRoot, '_builtin', 'roles.registry.json'), '{ not valid json');
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), { reportableExtensions: ['.ts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), { reportableRootFiles: ['package.json'] });
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), { classificationBuckets: ['canonical'], secondaryBucketFamilies: ['codeCounts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), { missingRolePatterns: [] });
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), { outcomes: { canonical: { code: 'TEMP_CANONICAL', severity: 'info', classification: 'canonical', message: 'Temporary canonical policy.', ruleRef: 'temp-rule-ref' } } });
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), DEFAULT_OVERLAY_CAPABILITIES_REGISTRY);
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), { semanticName: { style: 'kebab-case' } });
+
+    const result = resolveNamingRegistryInputs({ registryRootDir: tempRoot });
+    assert.deepEqual(result.roles, [{ role: 'host', category: 'architecture-support', status: 'deprecated' }]);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('legacy grouped roles registry remains strict membership source when category-role perspective is absent', () => {
+  const tempRoot = makeTempRegistryRoot();
+
+  try {
+    writeJson(path.join(tempRoot, '_builtin', 'categories.registry.json'), {
+      categories: [{ category: 'architecture-support' }],
+    });
+
+    fs.writeFileSync(path.join(tempRoot, '_builtin', 'roles.registry.json'), '{ malformed legacy membership source');
+
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-extensions.registry.json'), { reportableExtensions: ['.ts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'reportable-root-files.registry.json'), { reportableRootFiles: ['package.json'] });
+    writeJson(path.join(tempRoot, '_builtin', 'summary-buckets.registry.json'), { classificationBuckets: ['canonical'], secondaryBucketFamilies: ['codeCounts'] });
+    writeJson(path.join(tempRoot, '_builtin', 'missing-role-patterns.registry.json'), { missingRolePatterns: [] });
+    writeJson(path.join(tempRoot, '_builtin', 'finding-policy.registry.json'), { outcomes: { canonical: { code: 'TEMP_CANONICAL', severity: 'info', classification: 'canonical', message: 'Temporary canonical policy.', ruleRef: 'temp-rule-ref' } } });
+    writeJson(path.join(tempRoot, '_builtin', 'overlay-capabilities.registry.json'), DEFAULT_OVERLAY_CAPABILITIES_REGISTRY);
+    writeJson(path.join(tempRoot, '_builtin', 'case-rules.registry.json'), { semanticName: { style: 'kebab-case' } });
+
+    assert.throws(() => resolveNamingRegistryInputs({ registryRootDir: tempRoot }), SyntaxError);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
 test('registryRootDir falls back to module _builtin when temp _builtin is incomplete', () => {
   const tempRoot = makeTempRegistryRoot();
 


### PR DESCRIPTION
### Motivation
- Align runtime role status sourcing so builtin role status comes from the canonical `roles.registry.json` while preserving category membership from `category-role-perspective.registry.json` to satisfy a bounded runtime compatibility slice for issue #432. 
- Preserve current consumer-facing normalized role shape and maintain backwards compatibility for custom overlays and legacy grouped `roles.registry.json` fallback behavior. 
- Keep canonical role definitions data-only so they do not affect validation behavior or role/category semantics.

### Description

- Added `loadCanonicalRoleStatusByRole` and updated `loadBuiltinRolesPayload` in `calculogic-validator/naming/src/registries/registry-state.logic.mjs` to use canonical `roles.registry.json` statuses when `category-role-perspective.registry.json` is present, while still flattening membership from the perspective file.
- Kept canonical role definitions data-only; only `role` and `status` are used for the runtime status override.
- Treated canonical `roles.registry.json` as an optional status override: malformed, missing, or non-canonical-shaped canonical role data now degrades to no canonical override instead of breaking membership loading.
- Kept membership loading strict: when `category-role-perspective.registry.json` is absent, legacy grouped `roles.registry.json` remains the membership source and malformed membership data still fails.
- Preserved legacy grouped `roles.registry.json` fallback behavior for external registry roots.
- Preserved custom overlay behavior and continued to allow overlay records to include `status` for compatibility.
- Updated focused tests in `calculogic-validator/naming/test/registry-state.logic.test.mjs` to assert canonical status precedence, optional canonical-status fallback, strict legacy membership fallback, and legacy grouped status behavior.

### Testing

- Ran `git diff -- calculogic-validator/naming/src/registries calculogic-validator/naming/test`.
  - Outcome: changes are confined to `registry-state.logic.mjs` and focused registry-state tests.
- Ran `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-case-rules-registry.test.mjs`.
  - Outcome: passed, 34 tests passed, 0 failed.
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/naming/src/registries`.
  - Outcome: produced validator report output and returned non-zero per current validator policy/report findings, consistent with current implementation reality.

Refs #432
Refs #427

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f772be098883318d7f6b49afa84f5e)