### PR TITLE
Add builtin agnostic-core meanings registry data slice

### DIFF
--- a/calculogic-validator/naming/src/registries/_builtin/agnostic-core-meanings.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/agnostic-core-meanings.registry.json
@@ -1,0 +1,30 @@
+{
+  "version": "1",
+  "meanings": [
+    {
+      "meaning": "structure",
+      "status": "active",
+      "definition": "Composition, arrangement, and assembly of parts into a coherent whole."
+    },
+    {
+      "meaning": "behavior",
+      "status": "active",
+      "definition": "Actions, responses, decisions, state, and change over time."
+    },
+    {
+      "meaning": "reference",
+      "status": "active",
+      "definition": "Declarative meaning, static knowledge, reusable facts, or domain reference content."
+    },
+    {
+      "meaning": "output",
+      "status": "active",
+      "definition": "Consumer-ready result shaping."
+    },
+    {
+      "meaning": "presentation",
+      "status": "active",
+      "definition": "How information, capabilities, or deliverables are surfaced, arranged, formatted, or made usable."
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Add a bounded, data-only builtin registry slice to capture shared canonical agnostic-core meaning records so the naming slice can reference a stable, repo-owned source-of-truth for core meaning identities.

### Description
- Add `calculogic-validator/naming/src/registries/_builtin/agnostic-core-meanings.registry.json` containing the exact payload (version, five meanings with identities, statuses, definitions, and ordering) and make no other code, loader, runtime, CLI, report, or registry mapping changes; Refs #438 and Refs #427.

### Testing
- Ran `git diff -- calculogic-validator/naming/src/registries calculogic-validator/naming/test` (showed the new file), ran `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-case-rules-registry.test.mjs` (all tests passed), and ran `npm run validate:naming -- --scope=validator --target calculogic-validator/naming/src/registries` (validation executed and reported the new file as canonical, but the command exited non-zero due to pre-existing unrelated findings in the targeted registry scope).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bf8976ac833192fce2456ec1794d)