### PR TITLE
Add data-only agnostic-core meaning vectors to builtin category-role perspective registry

### DIFF
--- a/calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json
@@ -3,139 +3,277 @@
   "rolesByCategory": {
     "architecture-support": [
       {
-        "role": "boundary"
+        "role": "boundary",
+        "meanings": [
+          "structure"
+        ]
       },
       {
-        "role": "cli"
+        "role": "cli",
+        "meanings": [
+          "behavior",
+          "presentation"
+        ]
       },
       {
-        "role": "contracts"
+        "role": "contracts",
+        "meanings": [
+          "reference",
+          "structure"
+        ]
       },
       {
-        "role": "wiring"
+        "role": "wiring",
+        "meanings": [
+          "structure"
+        ]
       }
     ],
     "concern-core": [
       {
-        "role": "build"
+        "role": "build",
+        "meanings": [
+          "structure"
+        ]
       },
       {
-        "role": "knowledge"
+        "role": "knowledge",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "logic"
+        "role": "logic",
+        "meanings": [
+          "behavior"
+        ]
       },
       {
-        "role": "results"
+        "role": "results",
+        "meanings": [
+          "output"
+        ]
       }
     ],
     "concern-style": [
       {
-        "role": "build-style"
+        "role": "build-style",
+        "meanings": [
+          "presentation",
+          "structure"
+        ]
       },
       {
-        "role": "results-style"
+        "role": "results-style",
+        "meanings": [
+          "presentation",
+          "output"
+        ]
       }
     ],
     "data-model": [
       {
-        "role": "dto"
+        "role": "dto",
+        "meanings": [
+          "output",
+          "structure"
+        ]
       },
       {
-        "role": "schema"
+        "role": "schema",
+        "meanings": [
+          "reference",
+          "structure"
+        ]
       },
       {
-        "role": "types"
+        "role": "types",
+        "meanings": [
+          "reference",
+          "structure"
+        ]
       }
     ],
     "deprecated": [
       {
-        "role": "view"
+        "role": "view",
+        "meanings": [
+          "presentation"
+        ]
       }
     ],
     "documentation": [
       {
-        "role": "audit"
+        "role": "audit",
+        "meanings": [
+          "reference",
+          "output"
+        ]
       },
       {
-        "role": "healthcheck"
+        "role": "healthcheck",
+        "meanings": [
+          "reference",
+          "output"
+        ]
       },
       {
-        "role": "plan"
+        "role": "plan",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "policy"
+        "role": "policy",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "spec"
+        "role": "spec",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "workflow"
+        "role": "workflow",
+        "meanings": [
+          "reference",
+          "behavior"
+        ]
       }
     ],
     "indexing-registry": [
       {
-        "role": "anchor"
+        "role": "anchor",
+        "meanings": [
+          "reference",
+          "structure"
+        ]
       },
       {
-        "role": "catalog"
+        "role": "catalog",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "ids"
+        "role": "ids",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "index"
+        "role": "index",
+        "meanings": [
+          "reference",
+          "structure"
+        ]
       },
       {
-        "role": "manifest"
+        "role": "manifest",
+        "meanings": [
+          "reference",
+          "structure"
+        ]
       },
       {
-        "role": "registry"
+        "role": "registry",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "tokens"
+        "role": "tokens",
+        "meanings": [
+          "reference"
+        ]
       }
     ],
     "integration-adapter": [
       {
-        "role": "adapter"
+        "role": "adapter",
+        "meanings": [
+          "behavior",
+          "structure"
+        ]
       },
       {
-        "role": "client"
+        "role": "client",
+        "meanings": [
+          "behavior"
+        ]
       },
       {
-        "role": "gateway"
+        "role": "gateway",
+        "meanings": [
+          "behavior",
+          "structure"
+        ]
       },
       {
-        "role": "mapper"
+        "role": "mapper",
+        "meanings": [
+          "behavior",
+          "output"
+        ]
       },
       {
-        "role": "resolver"
+        "role": "resolver",
+        "meanings": [
+          "behavior",
+          "reference"
+        ]
       }
     ],
     "quality-support": [
       {
-        "role": "benchmark"
+        "role": "benchmark",
+        "meanings": [
+          "reference",
+          "output"
+        ]
       },
       {
-        "role": "fixture"
+        "role": "fixture",
+        "meanings": [
+          "reference"
+        ]
       },
       {
-        "role": "mock"
+        "role": "mock",
+        "meanings": [
+          "behavior"
+        ]
       },
       {
-        "role": "test"
+        "role": "test",
+        "meanings": [
+          "behavior",
+          "output"
+        ]
       }
     ],
     "surface-system": [
       {
-        "role": "entry"
+        "role": "entry",
+        "meanings": [
+          "structure",
+          "behavior"
+        ]
       },
       {
-        "role": "host"
+        "role": "host",
+        "meanings": [
+          "structure"
+        ]
       },
       {
-        "role": "router"
+        "role": "router",
+        "meanings": [
+          "behavior",
+          "structure"
+        ]
       }
     ]
   }

--- a/calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json
@@ -4,27 +4,27 @@
     "architecture-support": [
       {
         "role": "boundary",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "structure"
         ]
       },
       {
         "role": "cli",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "presentation"
         ]
       },
       {
         "role": "contracts",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "structure"
         ]
       },
       {
         "role": "wiring",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "structure"
         ]
       }
@@ -32,25 +32,25 @@
     "concern-core": [
       {
         "role": "build",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "structure"
         ]
       },
       {
         "role": "knowledge",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "logic",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior"
         ]
       },
       {
         "role": "results",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "output"
         ]
       }
@@ -58,37 +58,57 @@
     "concern-style": [
       {
         "role": "build-style",
-        "meanings": [
-          "presentation",
+        "inheritsFrom": {
+          "category": "concern-core",
+          "role": "build"
+        },
+        "baseMeanings": [
           "structure"
+        ],
+        "overlayMeanings": [
+          "presentation"
+        ],
+        "agnosticCoreMeanings": [
+          "structure",
+          "presentation"
         ]
       },
       {
         "role": "results-style",
-        "meanings": [
-          "presentation",
+        "inheritsFrom": {
+          "category": "concern-core",
+          "role": "results"
+        },
+        "baseMeanings": [
           "output"
+        ],
+        "overlayMeanings": [
+          "presentation"
+        ],
+        "agnosticCoreMeanings": [
+          "output",
+          "presentation"
         ]
       }
     ],
     "data-model": [
       {
         "role": "dto",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "output",
           "structure"
         ]
       },
       {
         "role": "schema",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "structure"
         ]
       },
       {
         "role": "types",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "structure"
         ]
@@ -97,7 +117,7 @@
     "deprecated": [
       {
         "role": "view",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "presentation"
         ]
       }
@@ -105,39 +125,39 @@
     "documentation": [
       {
         "role": "audit",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "output"
         ]
       },
       {
         "role": "healthcheck",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "output"
         ]
       },
       {
         "role": "plan",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "policy",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "spec",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "workflow",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "behavior"
         ]
@@ -146,46 +166,46 @@
     "indexing-registry": [
       {
         "role": "anchor",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "structure"
         ]
       },
       {
         "role": "catalog",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "ids",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "index",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "structure"
         ]
       },
       {
         "role": "manifest",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "structure"
         ]
       },
       {
         "role": "registry",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "tokens",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       }
@@ -193,34 +213,34 @@
     "integration-adapter": [
       {
         "role": "adapter",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "structure"
         ]
       },
       {
         "role": "client",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior"
         ]
       },
       {
         "role": "gateway",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "structure"
         ]
       },
       {
         "role": "mapper",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "output"
         ]
       },
       {
         "role": "resolver",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "reference"
         ]
@@ -229,26 +249,26 @@
     "quality-support": [
       {
         "role": "benchmark",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference",
           "output"
         ]
       },
       {
         "role": "fixture",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "reference"
         ]
       },
       {
         "role": "mock",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior"
         ]
       },
       {
         "role": "test",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "output"
         ]
@@ -257,20 +277,20 @@
     "surface-system": [
       {
         "role": "entry",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "structure",
           "behavior"
         ]
       },
       {
         "role": "host",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "structure"
         ]
       },
       {
         "role": "router",
-        "meanings": [
+        "agnosticCoreMeanings": [
           "behavior",
           "structure"
         ]


### PR DESCRIPTION
### Motivation

- Provide a bounded, data-only enrichment to the builtin Category → Role perspective so role-in-category records carry agnostic-core meaning vectors for downstream indexing, inspection, generated views, and future exports without changing runtime validation behavior.
- Preserve current runtime truth and deterministic registry shape while aligning the codebase with the living document’s contextual perspective model.
- Preserve the concern-style distinction as a presentation overlay over concern-core base meanings rather than flattening style roles into independent base lanes.

### Description

- Updated `calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json` to add `agnosticCoreMeanings` arrays to every existing builtin role entry.
- Used only known meaning IDs from `agnostic-core-meanings.registry.json`: `structure`, `behavior`, `reference`, `output`, and `presentation`.
- Preserved the top-level `version`, top-level `rolesByCategory`, all category names, all role names, Category → Role membership, and deterministic ordering.
- Preserved the concern-style overlay distinction:
  - `build-style` now inherits from `concern-core` / `build`, has `baseMeanings: ["structure"]`, `overlayMeanings: ["presentation"]`, and `agnosticCoreMeanings: ["structure", "presentation"]`.
  - `results-style` now inherits from `concern-core` / `results`, has `baseMeanings: ["output"]`, `overlayMeanings: ["presentation"]`, and `agnosticCoreMeanings: ["output", "presentation"]`.
- Did not re-add `status` fields.
- Did not add role definitions or category definitions to the perspective payload.
- Did not modify `agnostic-core-meanings.registry.json`, `roles.registry.json`, or `categories.registry.json`.
- No runtime code, loader behavior, CLI behavior, report output, Tree behavior, bridge logic, custom overlays, or legacy compatibility behavior was changed.
- Meaning vectors remain data-only.

### Testing

- Ran `git diff -- calculogic-validator/naming/src/registries calculogic-validator/naming/test`.
  - Outcome: confirmed the change is limited to the targeted builtin category-role perspective registry file.
- Ran `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-case-rules-registry.test.mjs`.
  - Outcome: all focused tests passed.
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/naming/src/registries`.
  - Outcome: validation completed and exited non-zero due to pre-existing scoped warnings in `_custom` registry files and one legacy exception unrelated to this change; no task-specific regression was introduced.

Refs #440
Refs #427

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c608721c8331b27c92abfba28246)