### PR TITLE
Add inventory and note roles to builtin naming registries

### DIFF
--- a/calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json
@@ -138,6 +138,19 @@
         ]
       },
       {
+        "role": "inventory",
+        "agnosticCoreMeanings": [
+          "reference",
+          "structure"
+        ]
+      },
+      {
+        "role": "note",
+        "agnosticCoreMeanings": [
+          "reference"
+        ]
+      },
+      {
         "role": "plan",
         "agnosticCoreMeanings": [
           "reference"

--- a/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
@@ -157,14 +157,14 @@
       "definition": "Localization role for locale-specific messages, formatting, translation payloads, or audience-localized data."
     },
     {
-      "role": "logging",
-      "status": "active",
-      "definition": "Observability role for emitted logs, logging behavior, or diagnostic event output."
-    },
-    {
       "role": "logic",
       "status": "active",
       "definition": "Role for behavior, state, decisions, and response."
+    },
+    {
+      "role": "logging",
+      "status": "active",
+      "definition": "Observability role for emitted logs, logging behavior, or diagnostic event output."
     },
     {
       "role": "manifest",

--- a/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
+++ b/calculogic-validator/naming/src/registries/_builtin/roles.registry.json
@@ -142,6 +142,11 @@
       "definition": "Operations-support role for infrastructure shape, infrastructure policy, or environment resource structure."
     },
     {
+      "role": "inventory",
+      "status": "active",
+      "definition": "Documentation role for enumerating existing artifacts, migration state, classification status, or cleanup targets without itself defining policy, formal specification, workflow, or execution behavior."
+    },
+    {
       "role": "knowledge",
       "status": "active",
       "definition": "Role for static reference meaning, domain reference content, or declarative support data."
@@ -152,14 +157,14 @@
       "definition": "Localization role for locale-specific messages, formatting, translation payloads, or audience-localized data."
     },
     {
-      "role": "logic",
-      "status": "active",
-      "definition": "Role for behavior, state, decisions, and response."
-    },
-    {
       "role": "logging",
       "status": "active",
       "definition": "Observability role for emitted logs, logging behavior, or diagnostic event output."
+    },
+    {
+      "role": "logic",
+      "status": "active",
+      "definition": "Role for behavior, state, decisions, and response."
     },
     {
       "role": "manifest",
@@ -185,6 +190,11 @@
       "role": "monitoring",
       "status": "active",
       "definition": "Operations or observability role for monitoring signals, health visibility, or operational watch behavior."
+    },
+    {
+      "role": "note",
+      "status": "active",
+      "definition": "Documentation role for bounded explanatory or implementation notes that clarify context without defining policy, formal specification, workflow, audit findings, or planned work."
     },
     {
       "role": "packaging",


### PR DESCRIPTION
### Motivation
- Provide honest documentation roles so later filename cleanup can use `inventory` and `note` instead of forcing files into misleading existing roles.
- Keep the change strictly bounded to registry vocabulary (no runtime, Tree, or `_custom` edits) per the issue scope and human-approved decisions.
- Preserve deterministic ordering and existing registry conventions while adding two active documentation roles.

### Description
- Added `inventory` and `note` entries to `calculogic-validator/naming/src/registries/_builtin/roles.registry.json` with the exact approved definitions.
- Added both roles under `rolesByCategory.documentation` in `calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json` with agnostic-core meaning vectors `inventory: ["reference","structure"]` and `note: ["reference"]`.
- Inserted entries in deterministic alphabetical/order positions without adding overlays, `inheritsFrom`, `baseMeanings`, `overlayMeanings`, new agnostic meanings, or any `runtime` role.
- No filename validation behavior, runtime behavior, Tree registries, `_custom` registries, or file renames were changed.

### Testing
- Ran `git diff -- calculogic-validator/naming/src/registries calculogic-validator/naming/test calculogic-validator/doc/Audits` and confirmed the diff is limited to the two `_builtin` naming registry JSON updates.
- Ran `node --test calculogic-validator/naming/test/registry-state.logic.test.mjs calculogic-validator/naming/test/naming-case-rules-registry.test.mjs` and observed all tests passed (`34` tests, `0` failures).
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/naming/src/registries` which exited non-zero due to pre-existing unrelated naming findings in `_custom` registry filenames and `registry-state.json`, and this limitation is recorded without broadening scope.
- Change scope and verification reference: `calculogic-validator/naming/src/registries/_builtin/roles.registry.json` and `calculogic-validator/naming/src/registries/_builtin/category-role-perspective.registry.json`; Refs #445; Refs #443; Refs #442

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9457095b88331be8524e9f2a6c75a)