### PR TITLE
Add Tree folder-kinds builtin registry (issue #455 slice)

### DIFF
--- a/calculogic-validator/tree/src/registries/_builtin/folder-kinds.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/folder-kinds.registry.json
@@ -1,0 +1,20 @@
+{
+  "version": "1",
+  "folderKinds": [
+    {
+      "folderKind": "structural",
+      "status": "active",
+      "definition": "Folder whose primary meaning comes from a recognized structural or concern-oriented home."
+    },
+    {
+      "folderKind": "semantic",
+      "status": "active",
+      "definition": "Folder whose primary meaning comes from semantic-family or semantic-root alignment."
+    },
+    {
+      "folderKind": "unspecified",
+      "status": "active",
+      "definition": "Folder whose meaning is not yet strong enough to classify confidently as structural or semantic."
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Add a minimal Tree-owned, data-only folder-kind registry to provide an explicit, stable vocabulary for folder-kind advisory reasoning while preserving current Tree runtime behavior.

### Description
- Created `calculogic-validator/tree/src/registries/_builtin/folder-kinds.registry.json` containing the minimal vocabulary `structural`, `semantic`, and `unspecified` (each `status: "active"`) and treated the Tree validator spec as the runtime authority, tree-owned docs as navigation-only context, and naming docs as supporting context; Refs #455 and Refs #452.

### Testing
- Ran `git diff -- calculogic-validator/tree/src/registries calculogic-validator/tree/test calculogic-validator/doc/ValidatorSpecs calculogic-validator/doc/ConventionRoutines`, `npm run validate:naming -- --scope=validator --target calculogic-validator/tree`, `npm run validate:tree -- --scope=validator --target calculogic-validator/tree`, and `node --test calculogic-validator/tree/test/tree-known-roots-registry.test.mjs`, and all commands completed successfully with the focused registry test suite passing (all tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa6b85cd1c833183e0eca03a0fbf3a)