### PR TITLE
Add Tree structural homes builtin registry (minimal hardening slice)

### DIFF
--- a/calculogic-validator/tree/src/registries/_builtin/structural-homes.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/structural-homes.registry.json
@@ -1,0 +1,75 @@
+{
+  "version": "1",
+  "structuralHomes": [
+    {
+      "structuralHome": "src",
+      "status": "active",
+      "definition": "Primary source or implementation home for shipped or executed code."
+    },
+    {
+      "structuralHome": "app",
+      "status": "active",
+      "definition": "Application composition or framework-level app home for route, layout, host, or entry structures."
+    },
+    {
+      "structuralHome": "doc",
+      "status": "active",
+      "definition": "Human-facing documentation home."
+    },
+    {
+      "structuralHome": "tests",
+      "status": "active",
+      "definition": "Quality-support home for tests, fixtures, mocks, benchmarks, or validation artifacts."
+    },
+    {
+      "structuralHome": "scripts",
+      "status": "active",
+      "definition": "Tooling automation home for scripts, CLIs, migrations, codegen, or repository tasks."
+    },
+    {
+      "structuralHome": "config",
+      "status": "active",
+      "definition": "Configuration and environment-oriented setup home."
+    },
+    {
+      "structuralHome": "data",
+      "status": "active",
+      "definition": "Structured payload, registry-data, fixture-data, or reusable data home."
+    },
+    {
+      "structuralHome": "ops",
+      "status": "active",
+      "definition": "Operations, infrastructure, deployment, monitoring, or CI/CD home."
+    },
+    {
+      "structuralHome": "assets",
+      "status": "active",
+      "definition": "Static asset or shipped resource home."
+    },
+    {
+      "structuralHome": "generated",
+      "status": "active",
+      "definition": "Machine-generated output home where generated status is structurally important."
+    },
+    {
+      "structuralHome": "vendor",
+      "status": "active",
+      "definition": "Third-party, vendored, or externally maintained material home."
+    },
+    {
+      "structuralHome": "examples",
+      "status": "active",
+      "definition": "Demo, tutorial, sample, or demonstrative material home."
+    },
+    {
+      "structuralHome": "experimental",
+      "status": "active",
+      "definition": "Prototype, spike, playground, or relaxed-rule exploratory home."
+    },
+    {
+      "structuralHome": "compat",
+      "status": "active",
+      "definition": "Compatibility, shim, adapter, or transition-support home."
+    }
+  ]
+}

--- a/calculogic-validator/tree/test/structural-homes.registry.test.mjs
+++ b/calculogic-validator/tree/test/structural-homes.registry.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'node:test';
+
+const STRUCTURAL_HOMES_REGISTRY_PATH = new URL(
+  '../src/registries/_builtin/structural-homes.registry.json',
+  import.meta.url,
+);
+
+const EXPECTED_STRUCTURAL_HOMES = [
+  'src',
+  'app',
+  'doc',
+  'tests',
+  'scripts',
+  'config',
+  'data',
+  'ops',
+  'assets',
+  'generated',
+  'vendor',
+  'examples',
+  'experimental',
+  'compat',
+];
+
+test('structural-homes registry provides deterministic active structural-home identities', () => {
+  const payload = JSON.parse(fs.readFileSync(STRUCTURAL_HOMES_REGISTRY_PATH, 'utf8'));
+
+  assert.equal(payload.version, '1');
+  assert.deepEqual(
+    payload.structuralHomes.map((entry) => entry.structuralHome),
+    EXPECTED_STRUCTURAL_HOMES,
+  );
+
+  payload.structuralHomes.forEach((entry, index) => {
+    assert.equal(entry.status, 'active', `structuralHomes[${index}] should be active`);
+    assert.equal(typeof entry.definition, 'string');
+    assert.equal(entry.definition.length > 0, true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Harden the Tree registry surface by adding a minimal data-only Structural Home registry per issue #457 while preserving current Tree runtime truth and ownership boundaries. 
- Use existing Tree-local authority and conventions so Structural Home remains distinct from Folder Kind, Semantic Home, and Surface while avoiding runtime changes. 

### Description
- Add `calculogic-validator/tree/src/registries/_builtin/structural-homes.registry.json` with `version: "1"` and the requested `structuralHomes` identity set as data-only builtin content. 
- Add a focused shape/identity test at `calculogic-validator/tree/test/structural-homes.registry.test.mjs` that asserts deterministic ordering, `version` value, `status: "active"` for entries, and non-empty `definition` strings. 
- No runtime code, wiring, or behavior was changed and existing repo-known-root spelling (`test` present in `tree-known-roots.registry.json`) was preserved rather than altered. 
- Refs #457 and Refs #452

### Testing
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/tree` and it completed successfully. 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and it completed successfully. 
- Ran `node --test calculogic-validator/tree/test/structural-homes.registry.test.mjs` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa741225ec83319bde51146a4302a2)