### PR TITLE
Add Tree surface→structural-home perspective registry (issue #459 slice)

### DIFF
--- a/calculogic-validator/tree/src/registries/_builtin/surface-structural-home-perspective.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/surface-structural-home-perspective.registry.json
@@ -1,0 +1,101 @@
+{
+  "version": "1",
+  "surfaceStructuralHomePerspective": [
+    {
+      "surface": "runtime",
+      "structuralHome": "src",
+      "signalStrength": "strong",
+      "rationale": "Runtime artifacts commonly live under source or implementation homes."
+    },
+    {
+      "surface": "runtime",
+      "structuralHome": "app",
+      "signalStrength": "contextual",
+      "rationale": "Application frameworks may place runtime route, layout, host, or entry structures under app homes."
+    },
+    {
+      "surface": "runtime",
+      "structuralHome": "compat",
+      "signalStrength": "contextual",
+      "rationale": "Compatibility and adapter materials may support runtime behavior without becoming the primary runtime home."
+    },
+    {
+      "surface": "ui-facing",
+      "structuralHome": "app",
+      "signalStrength": "strong",
+      "rationale": "UI-facing application composition often lives under app homes."
+    },
+    {
+      "surface": "ui-facing",
+      "structuralHome": "src",
+      "signalStrength": "contextual",
+      "rationale": "UI-facing implementation may also live under source homes depending on framework structure."
+    },
+    {
+      "surface": "quality",
+      "structuralHome": "test",
+      "signalStrength": "strong",
+      "rationale": "Quality-support artifacts align with the current repo's singular test structural home."
+    },
+    {
+      "surface": "docs",
+      "structuralHome": "doc",
+      "signalStrength": "strong",
+      "rationale": "Documentation surfaces align with documentation homes."
+    },
+    {
+      "surface": "tooling",
+      "structuralHome": "scripts",
+      "signalStrength": "strong",
+      "rationale": "Tooling automation commonly lives under scripts homes."
+    },
+    {
+      "surface": "config",
+      "structuralHome": "config",
+      "signalStrength": "strong",
+      "rationale": "Configuration surfaces align with configuration homes."
+    },
+    {
+      "surface": "data",
+      "structuralHome": "data",
+      "signalStrength": "strong",
+      "rationale": "Data surfaces align with structured data homes."
+    },
+    {
+      "surface": "ops",
+      "structuralHome": "ops",
+      "signalStrength": "strong",
+      "rationale": "Operational surfaces align with operations homes."
+    },
+    {
+      "surface": "assets",
+      "structuralHome": "assets",
+      "signalStrength": "strong",
+      "rationale": "Asset surfaces align with static asset homes."
+    },
+    {
+      "surface": "generated",
+      "structuralHome": "generated",
+      "signalStrength": "strong",
+      "rationale": "Generated surfaces align with generated output homes."
+    },
+    {
+      "surface": "vendor",
+      "structuralHome": "vendor",
+      "signalStrength": "strong",
+      "rationale": "Vendor surfaces align with third-party or externally maintained homes."
+    },
+    {
+      "surface": "examples",
+      "structuralHome": "examples",
+      "signalStrength": "strong",
+      "rationale": "Example surfaces align with demo, sample, or tutorial homes."
+    },
+    {
+      "surface": "experimental",
+      "structuralHome": "experimental",
+      "signalStrength": "strong",
+      "rationale": "Experimental surfaces align with prototype or exploratory homes."
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, data-only Surface → Structural Home perspective registry so Tree has explicit evidence records for surface→home mapping without changing runtime behavior.
- Chose Tree-local authority placement to align with current implementation reality that Tree owns structural-home identity and registry consumption.
- Treated `tree-structure-advisor` spec and `ValidatorLoaderConverterRuntimeOwnership-Contract.md` as runtime authority, `tree-documentation-map-and-reorg-inventory.md` as navigation-only, and `FileNamingMasterList-V1_1.md` as the naming/filename grammar authority for this slice.

### Description
- Added `calculogic-validator/tree/src/registries/_builtin/surface-structural-home-perspective.registry.json` containing `version: "1"` and the requested `surfaceStructuralHomePerspective` array with the exact entries from the issue (including `quality -> test` singular). 
- File is data-only and placed under the Tree-local `_builtin` registries per the preferred authority/path rule, with no loader/wiring/runtime changes. 
- Preserved all ownership and forbidden-change boundaries (no `surfaces.registry.json`, no policy registries, no structural-homes changes, and no runtime behavior modifications). 
- Refs #459
- Refs #452

### Testing
- Ran scoped diff to verify only intended files were changed: `git diff -- calculogic-validator/src/registries calculogic-validator/tree/src/registries calculogic-validator/tree/test calculogic-validator/test calculogic-validator/doc/ValidatorSpecs calculogic-validator/doc/ConventionRoutines` — Outcome: scoped diff showed only the new Tree registry file in-scope. 
- Ran naming validation: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree` — Outcome: passed (exit 0) and the new registry filename was classified `canonical` by the naming validator. 
- Ran tree validation: `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` — Outcome: passed (exit 0) with advisory findings only and no change to runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa86d93a1883318303e9df5072bdca)