### PR TITLE
Add grouped surface-structural-home perspective registry (Refs #463)

### DIFF
--- a/calculogic-validator/tree/src/registries/_builtin/surface-structural-home-perspective.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/surface-structural-home-perspective.registry.json
@@ -1,0 +1,127 @@
+{
+  "version": "1",
+  "structuralHomesBySurface": {
+    "runtime": [
+      {
+        "structuralHome": "src",
+        "relationshipStatus": "current-known-root-aligned",
+        "signalStrength": "strong",
+        "rationale": "Runtime artifacts commonly live under source or implementation homes."
+      },
+      {
+        "structuralHome": "app",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "contextual",
+        "rationale": "Application frameworks may place runtime route, layout, host, or entry structures under app homes."
+      },
+      {
+        "structuralHome": "compat",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "contextual",
+        "rationale": "Compatibility and adapter materials may support runtime behavior without becoming the primary runtime home."
+      }
+    ],
+    "ui-facing": [
+      {
+        "structuralHome": "app",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "UI-facing application composition often lives under app homes."
+      },
+      {
+        "structuralHome": "src",
+        "relationshipStatus": "current-known-root-aligned",
+        "signalStrength": "contextual",
+        "rationale": "UI-facing implementation may also live under source homes depending on framework structure."
+      }
+    ],
+    "quality": [
+      {
+        "structuralHome": "test",
+        "relationshipStatus": "current-known-root-aligned",
+        "signalStrength": "strong",
+        "rationale": "Quality-support artifacts align with the current repo's singular test known root."
+      }
+    ],
+    "docs": [
+      {
+        "structuralHome": "doc",
+        "relationshipStatus": "current-known-root-aligned",
+        "signalStrength": "strong",
+        "rationale": "Documentation surfaces align with documentation homes."
+      }
+    ],
+    "tooling": [
+      {
+        "structuralHome": "scripts",
+        "relationshipStatus": "current-known-root-aligned",
+        "signalStrength": "strong",
+        "rationale": "Tooling automation commonly lives under scripts homes."
+      }
+    ],
+    "config": [
+      {
+        "structuralHome": "config",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Configuration surfaces align with configuration homes."
+      }
+    ],
+    "data": [
+      {
+        "structuralHome": "data",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Data surfaces align with structured data homes."
+      }
+    ],
+    "ops": [
+      {
+        "structuralHome": "ops",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Operational surfaces align with operations homes."
+      }
+    ],
+    "assets": [
+      {
+        "structuralHome": "assets",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Asset surfaces align with static asset homes."
+      }
+    ],
+    "generated": [
+      {
+        "structuralHome": "generated",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Generated surfaces align with generated output homes."
+      }
+    ],
+    "vendor": [
+      {
+        "structuralHome": "vendor",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Vendor surfaces align with third-party or externally maintained homes."
+      }
+    ],
+    "examples": [
+      {
+        "structuralHome": "examples",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Example surfaces align with demo, sample, or tutorial homes."
+      }
+    ],
+    "experimental": [
+      {
+        "structuralHome": "experimental",
+        "relationshipStatus": "target-structural-home",
+        "signalStrength": "strong",
+        "rationale": "Experimental surfaces align with prototype or exploratory homes."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Tree-local registry slice that records surface→structural-home affinity/evidence using the Slice 4 replacement model from checkpoint #461. 
- Preserve data-only, non-runtime behavior intent while hardening repository structural guidance for downstream Tree work. 
- Treat validator-owned tree-spec docs (e.g., `ValidatorSuite-Contracts-And-Modes.md`, `tree-structure-advisor-validator.spec.md`, `NamingValidatorSpec.md`) as runtime authority for shape and vocabulary, and treat the tree documentation map as navigation-only supporting context. 

### Description
- Added the new data-only registry file `calculogic-validator/tree/src/registries/_builtin/surface-structural-home-perspective.registry.json` using the grouped top-level key `structuralHomesBySurface`. 
- Populated grouped surface entries (e.g., `runtime`, `ui-facing`, `quality`, `docs`, `tooling`, `config`, `data`, `ops`, `assets`, `generated`, `vendor`, `examples`, `experimental`) following the recommended shape and evidence fields `signalStrength` and `rationale`. 
- Used the explicit relationship vocabulary `current-known-root-aligned` and `target-structural-home` and applied `quality -> test` per checkpoint guidance without changing existing `structural-homes.registry.json` or runtime logic. 
- Kept the change strictly Tree-local and data-only with no runtime wiring, no new relationship registries, and no structural-homes edits. 

### Testing
- Ran `git diff -- calculogic-validator/tree/src/registries calculogic-validator/tree/test calculogic-validator/doc/ValidatorSpecs calculogic-validator/doc/ConventionRoutines` to verify the diff shows only the intended registry addition, and the command completed successfully. 
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/tree` and the naming validator completed successfully (report mode). 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and the tree validator completed successfully (report mode). 

Refs #463
Refs #459
Refs #452

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabd8e13fc8331ac646a054ded696c)