### PR TITLE
Add Tree structural-home signal policy registry and shape test (slice #472)

### DIFF
--- a/calculogic-validator/tree/src/registries/_builtin/structural-home-signal-policy.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/structural-home-signal-policy.registry.json
@@ -1,0 +1,128 @@
+{
+  "version": "1",
+  "structuralHomeSignalPolicy": [
+    {
+      "token": "src",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for source/runtime implementation roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "app",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for application-centric implementation roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "doc",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for documentation-focused organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "test",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for test-oriented organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "scripts",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for scripted automation roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "config",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for configuration organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "data",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for data-oriented organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "ops",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for operations-oriented organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "assets",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for asset-focused organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "generated",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for generated artifact organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "vendor",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for vendored dependency organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "examples",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for example-oriented organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "experimental",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for experimental-work organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {
+      "token": "compat",
+      "signalCategory": "strong",
+      "status": "active",
+      "definition": "Strong evidence signal for compatibility-layer organization roots.",
+      "evidenceMeaning": "May support Structural Home interpretation when lineage and scope context agree.",
+      "notes": "Evidence only; not final placement truth."
+    },
+    {"token":"lib","signalCategory":"contextual","status":"active","definition":"Contextual evidence signal often used for library scope.","evidenceMeaning":"May support Structural Home interpretation only with supporting lineage or convention context.","notes":"Evidence only; not final placement truth."},
+    {"token":"core","signalCategory":"contextual","status":"active","definition":"Contextual evidence signal often used for central implementation scope.","evidenceMeaning":"May support Structural Home interpretation only with supporting lineage or convention context.","notes":"Evidence only; not final placement truth."},
+    {"token":"shared","signalCategory":"contextual","status":"active","definition":"Contextual evidence signal often used for shared ownership scope.","evidenceMeaning":"May support Structural Home interpretation only with supporting lineage or convention context.","notes":"Evidence only; not final placement truth."},
+    {"token":"internal","signalCategory":"contextual","status":"active","definition":"Contextual evidence signal often used for internal-visibility scope.","evidenceMeaning":"May support Structural Home interpretation only with supporting lineage or convention context.","notes":"Evidence only; not final placement truth."},
+    {"token":"public","signalCategory":"contextual","status":"active","definition":"Contextual evidence signal often used for outward-facing scope.","evidenceMeaning":"May support Structural Home interpretation only with supporting lineage or convention context.","notes":"Evidence only; not final placement truth."},
+    {"token":"tools","signalCategory":"contextual","status":"active","definition":"Contextual evidence signal often used for tooling or support scope.","evidenceMeaning":"May support Structural Home interpretation only with supporting lineage or convention context.","notes":"Evidence only; not final placement truth."},
+    {"token":"utils","signalCategory":"weak","status":"active","definition":"Weak evidence signal commonly used as a broad helper bucket.","evidenceMeaning":"Should not be treated as strong Structural Home evidence on its own.","notes":"Evidence only; not final placement truth."},
+    {"token":"helpers","signalCategory":"weak","status":"active","definition":"Weak evidence signal commonly used for mixed helper content.","evidenceMeaning":"Should not be treated as strong Structural Home evidence on its own.","notes":"Evidence only; not final placement truth."},
+    {"token":"common","signalCategory":"weak","status":"active","definition":"Weak evidence signal commonly used as an ambiguous shared bucket.","evidenceMeaning":"Should not be treated as strong Structural Home evidence on its own.","notes":"Evidence only; not final placement truth."},
+    {"token":"misc","signalCategory":"anti-pattern","status":"active","definition":"Anti-pattern evidence signal that often indicates unclear ownership boundaries.","evidenceMeaning":"May indicate low structural specificity and should trigger caution in interpretation.","notes":"Evidence only; not final placement truth."},
+    {"token":"old","signalCategory":"anti-pattern","status":"active","definition":"Anti-pattern evidence signal that often indicates stale or unclear structural ownership.","evidenceMeaning":"May indicate low structural specificity and should trigger caution in interpretation.","notes":"Evidence only; not final placement truth."}
+  ]
+}

--- a/calculogic-validator/tree/test/structural-home-signal-policy.registry.test.mjs
+++ b/calculogic-validator/tree/test/structural-home-signal-policy.registry.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'node:test';
+
+const STRUCTURAL_HOME_SIGNAL_POLICY_REGISTRY_PATH = new URL(
+  '../src/registries/_builtin/structural-home-signal-policy.registry.json',
+  import.meta.url,
+);
+
+const ALLOWED_SIGNAL_CATEGORIES = new Set(['strong', 'contextual', 'weak', 'anti-pattern']);
+const ALLOWED_STATUSES = new Set(['active']);
+
+test('structural-home-signal-policy registry has deterministic shape and coverage', () => {
+  const payload = JSON.parse(fs.readFileSync(STRUCTURAL_HOME_SIGNAL_POLICY_REGISTRY_PATH, 'utf8'));
+
+  assert.equal(typeof payload.version, 'string');
+  assert.equal(payload.version.length > 0, true);
+  assert.equal(Array.isArray(payload.structuralHomeSignalPolicy), true);
+  assert.equal(payload.structuralHomeSignalPolicy.length > 0, true);
+
+  const seenTokens = new Set();
+  const seenCategories = new Set();
+
+  payload.structuralHomeSignalPolicy.forEach((entry, index) => {
+    assert.equal(typeof entry.token, 'string', `structuralHomeSignalPolicy[${index}].token should be a string`);
+    assert.equal(entry.token.length > 0, true, `structuralHomeSignalPolicy[${index}].token should not be empty`);
+    assert.equal(
+      seenTokens.has(entry.token),
+      false,
+      `structuralHomeSignalPolicy[${index}].token should be unique`,
+    );
+    seenTokens.add(entry.token);
+
+    assert.equal(
+      ALLOWED_SIGNAL_CATEGORIES.has(entry.signalCategory),
+      true,
+      `structuralHomeSignalPolicy[${index}].signalCategory should be an allowed category`,
+    );
+    seenCategories.add(entry.signalCategory);
+
+    assert.equal(
+      ALLOWED_STATUSES.has(entry.status),
+      true,
+      `structuralHomeSignalPolicy[${index}].status should be an allowed status`,
+    );
+
+    assert.equal(
+      typeof entry.definition,
+      'string',
+      `structuralHomeSignalPolicy[${index}].definition should be a string`,
+    );
+    assert.equal(
+      entry.definition.length > 0,
+      true,
+      `structuralHomeSignalPolicy[${index}].definition should not be empty`,
+    );
+    assert.equal(
+      typeof entry.evidenceMeaning,
+      'string',
+      `structuralHomeSignalPolicy[${index}].evidenceMeaning should be a string`,
+    );
+    assert.equal(
+      entry.evidenceMeaning.length > 0,
+      true,
+      `structuralHomeSignalPolicy[${index}].evidenceMeaning should not be empty`,
+    );
+    assert.equal(typeof entry.notes, 'string', `structuralHomeSignalPolicy[${index}].notes should be a string`);
+    assert.equal(entry.notes.length > 0, true, `structuralHomeSignalPolicy[${index}].notes should not be empty`);
+  });
+
+  ALLOWED_SIGNAL_CATEGORIES.forEach((category) => {
+    assert.equal(
+      seenCategories.has(category),
+      true,
+      `structuralHomeSignalPolicy should include at least one ${category} entry`,
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce a Tree-owned, data-only registry that captures deterministic evidence-oriented signals for folder-token structural-home inference without altering runtime behavior. 
- Provide a conservative initial vocabulary and shape so future runtime work can consume consistent evidence categories (strong, contextual, weak, anti-pattern) while preserving current ownership boundaries.

### Description
- Added `calculogic-validator/tree/src/registries/_builtin/structural-home-signal-policy.registry.json` containing `version` and a `structuralHomeSignalPolicy` array with tokens categorized as `strong`, `contextual`, `weak`, or `anti-pattern` and explicit evidence-only wording. 
- Added focused shape tests at `calculogic-validator/tree/test/structural-home-signal-policy.registry.test.mjs` that validate parseability, required fields, allowed category/status vocabularies, token uniqueness, and coverage for all four categories. 
- The registry uses a small, conservative initial token vocabulary aligned with existing Tree registry style and explicitly does not claim placement truth, Structural Home identity, folder kind vocabulary, or any runtime interpretation. 
- No runtime wiring, loader changes, report/CLI modifications, or other registry JSON files were altered in this slice (Refs #472, Refs #452, optional Refs #457, Refs #469). 

### Testing
- Ran `git diff -- calculogic-validator/tree/src/registries calculogic-validator/tree/test calculogic-validator/doc/ValidatorSpecs calculogic-validator/doc/ConventionRoutines` to confirm the scoped diff; the new files appear in the diff output. 
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/tree` and the naming validation completed successfully with expected naming/info outputs for the new registry and tests. 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and the tree validator completed successfully but reported pre-existing advisory findings (`TREE_SHIM_SURFACE_PRESENT`, `TREE_OBSERVED_FAMILY_CLUSTER`) that are unrelated to this slice. 
- Ran `node --test calculogic-validator/tree/test/structural-home-signal-policy.registry.test.mjs` and the new registry shape test passed (1 test, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe184373648331acd3d457acf39502)