### PR TITLE
Add Tree semantic-home policy registry (data-only) with shape tests

### DIFF
--- a/calculogic-validator/tree/src/registries/_builtin/semantic-home-policy.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/semantic-home-policy.registry.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "semanticHomePolicy": [
+    {
+      "policyId": "folder-context",
+      "inputLane": "folder-context",
+      "status": "active",
+      "definition": "Folder token and local folder context may contribute Semantic Home evidence.",
+      "derivationMeaning": "May support Semantic Home derivation when combined with lineage and other bounded evidence.",
+      "guardrails": "Evidence only; not final placement truth and not Naming ownership."
+    },
+    {
+      "policyId": "parent-lineage",
+      "inputLane": "parent-lineage",
+      "status": "active",
+      "definition": "Parent chain context may contribute nested semantic interpretation evidence.",
+      "derivationMeaning": "May support Semantic Home derivation only when parent lineage context remains coherent with nearby structure.",
+      "guardrails": "Evidence only; not final placement truth and not Structural Home identity by itself."
+    },
+    {
+      "policyId": "naming-bridge",
+      "inputLane": "naming-bridge",
+      "status": "active",
+      "definition": "Naming bridge outputs may contribute semantic-name or semantic-family evidence.",
+      "derivationMeaning": "May support Semantic Home derivation only through bounded bridge interpretation inside Tree-owned advisory reasoning.",
+      "guardrails": "Naming retains ownership of semantic-name and semantic-family interpretation; this lane consumes bounded evidence only."
+    },
+    {
+      "policyId": "structural-home-boundary",
+      "inputLane": "structural-home-boundary",
+      "status": "active",
+      "definition": "Structural Home context may contribute boundary evidence around candidate semantic interpretation.",
+      "derivationMeaning": "May constrain or contextualize Semantic Home derivation without becoming Semantic Home truth by itself.",
+      "guardrails": "Structural Home identity remains separately owned and must not be replaced by Semantic Home guidance."
+    },
+    {
+      "policyId": "structural-signal-boundary",
+      "inputLane": "structural-signal-boundary",
+      "status": "active",
+      "definition": "Structural-home signal policy outputs may provide weak or contextual boundary evidence.",
+      "derivationMeaning": "Must remain bounded as supporting evidence and must not become standalone Semantic Home truth.",
+      "guardrails": "Does not replace structural-home signal policy registry ownership and remains evidence only."
+    },
+    {
+      "policyId": "known-root-compatibility-boundary",
+      "inputLane": "known-root-compatibility-boundary",
+      "status": "active",
+      "definition": "Known-root compatibility context may provide boundary checks for semantic interpretation.",
+      "derivationMeaning": "May gate or contextualize interpretation but must not become canonical Semantic Home truth.",
+      "guardrails": "Known-root compatibility ownership remains in the known-roots registry as current runtime truth."
+    }
+  ]
+}

--- a/calculogic-validator/tree/test/semantic-home-policy.registry.test.mjs
+++ b/calculogic-validator/tree/test/semantic-home-policy.registry.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'node:test';
+
+const SEMANTIC_HOME_POLICY_REGISTRY_PATH = new URL(
+  '../src/registries/_builtin/semantic-home-policy.registry.json',
+  import.meta.url,
+);
+
+const ALLOWED_INPUT_LANES = new Set([
+  'folder-context',
+  'parent-lineage',
+  'naming-bridge',
+  'structural-home-boundary',
+  'structural-signal-boundary',
+  'known-root-compatibility-boundary',
+]);
+const ALLOWED_STATUSES = new Set(['active']);
+
+test('semantic-home-policy registry has deterministic shape and boundary coverage', () => {
+  const payload = JSON.parse(fs.readFileSync(SEMANTIC_HOME_POLICY_REGISTRY_PATH, 'utf8'));
+
+  assert.equal(typeof payload.version, 'string');
+  assert.equal(payload.version.length > 0, true);
+  assert.equal(Array.isArray(payload.semanticHomePolicy), true);
+  assert.equal(payload.semanticHomePolicy.length > 0, true);
+
+  const seenPolicyIds = new Set();
+  const seenInputLanes = new Set();
+
+  payload.semanticHomePolicy.forEach((entry, index) => {
+    assert.equal(typeof entry.policyId, 'string', `semanticHomePolicy[${index}].policyId should be a string`);
+    assert.equal(entry.policyId.length > 0, true, `semanticHomePolicy[${index}].policyId should not be empty`);
+    assert.equal(seenPolicyIds.has(entry.policyId), false, `semanticHomePolicy[${index}].policyId should be unique`);
+    seenPolicyIds.add(entry.policyId);
+
+    assert.equal(typeof entry.inputLane, 'string', `semanticHomePolicy[${index}].inputLane should be a string`);
+    assert.equal(entry.inputLane.length > 0, true, `semanticHomePolicy[${index}].inputLane should not be empty`);
+    assert.equal(
+      ALLOWED_INPUT_LANES.has(entry.inputLane),
+      true,
+      `semanticHomePolicy[${index}].inputLane should be an allowed vocabulary value`,
+    );
+    seenInputLanes.add(entry.inputLane);
+
+    assert.equal(ALLOWED_STATUSES.has(entry.status), true, `semanticHomePolicy[${index}].status should be allowed`);
+
+    assert.equal(typeof entry.definition, 'string', `semanticHomePolicy[${index}].definition should be a string`);
+    assert.equal(entry.definition.length > 0, true, `semanticHomePolicy[${index}].definition should not be empty`);
+
+    assert.equal(
+      typeof entry.derivationMeaning,
+      'string',
+      `semanticHomePolicy[${index}].derivationMeaning should be a string`,
+    );
+    assert.equal(
+      entry.derivationMeaning.length > 0,
+      true,
+      `semanticHomePolicy[${index}].derivationMeaning should not be empty`,
+    );
+
+    assert.equal(typeof entry.guardrails, 'string', `semanticHomePolicy[${index}].guardrails should be a string`);
+    assert.equal(entry.guardrails.length > 0, true, `semanticHomePolicy[${index}].guardrails should not be empty`);
+  });
+
+  assert.equal(seenInputLanes.has('naming-bridge'), true, 'registry should include naming-bridge evidence lane');
+  assert.equal(
+    seenInputLanes.has('known-root-compatibility-boundary'),
+    true,
+    'registry should preserve known-root compatibility boundary lane',
+  );
+  assert.equal(
+    seenInputLanes.has('structural-home-boundary'),
+    true,
+    'registry should preserve structural-home boundary lane',
+  );
+});


### PR DESCRIPTION
### Motivation
- Provide a Tree-owned, data-only registry that encodes deterministic policy lanes to guide future Semantic Home derivation while preserving ownership and boundary guardrails. 
- Deliver a minimal, conservative initial vocabulary and clear evidence-only wording so this slice remains advisory and does not change current runtime truth or Naming/Structural Home ownership.

### Description
- Add `calculogic-validator/tree/src/registries/_builtin/semantic-home-policy.registry.json` defining a simple deterministic JSON shape with entries containing `policyId`, `inputLane`, `status`, `definition`, `derivationMeaning`, and `guardrails` and an initial set of lanes: `folder-context`, `parent-lineage`, `naming-bridge`, `structural-home-boundary`, `structural-signal-boundary`, and `known-root-compatibility-boundary`.
- Add focused shape test `calculogic-validator/tree/test/semantic-home-policy.registry.test.mjs` that validates parseability, `version`, non-empty top-level collection, required fields per entry, unique `policyId`s, allowed `status` and `inputLane` vocabulary, and presence of naming/known-root/structural-home boundary coverage.
- Keep scope narrow and data-only: no runtime wiring, no changes to other builtin registries, and no changes to Naming or Tree runtime behavior.

### Testing
- Ran `git diff -- calculogic-validator/tree/src/registries calculogic-validator/tree/test calculogic-validator/doc/ValidatorSpecs calculogic-validator/doc/ConventionRoutines` which produced no output (command reports tracked diffs only).
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/tree` which completed successfully (validator run produced expected naming/info outputs).
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` which completed successfully and reported existing advisory findings (e.g., `TREE_SHIM_SURFACE_PRESENT`, `TREE_OBSERVED_FAMILY_CLUSTER`) that were pre-existing and outside this slice.
- Ran `node --test calculogic-validator/tree/test/semantic-home-policy.registry.test.mjs` which passed (1 test, 0 failures).

Refs #474
Refs #452
Refs #469
Refs #472

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1ff6f8c48331bd1c341b986e2d19)