### PR TITLE
Tree: Add neutral structural-address snapshot producer

### DIFF
--- a/calculogic-validator/tree/src/tree-structural-address-snapshot.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structural-address-snapshot.logic.mjs
@@ -1,18 +1,55 @@
 import { prepareTreeOccurrenceSnapshot } from './tree-occurrence-snapshot.logic.mjs';
 
+const POSIX_SEPARATOR = '/';
+
+const normalizeRelativePath = (relativePath) =>
+  String(relativePath ?? '')
+    .replaceAll('\\', POSIX_SEPARATOR)
+    .replace(/^\.\//u, '')
+    .replace(/\/$/u, '');
+
 const normalizeScopeRootPath = (scopeRoots = []) => scopeRoots[0] ?? '.';
 
-const inferTargetKind = (targets = []) => {
+const normalizeTargetDescriptor = (targetDescriptor) => {
+  if (typeof targetDescriptor === 'string') {
+    return {
+      kind: null,
+      relPath: normalizeRelativePath(targetDescriptor),
+    };
+  }
+
+  return {
+    kind: targetDescriptor?.kind ?? null,
+    relPath: normalizeRelativePath(targetDescriptor?.relPath ?? ''),
+  };
+};
+
+const inferTargetKind = (targets = [], selectedPaths = []) => {
   if (targets.length !== 1) {
     return 'mixed';
   }
 
-  const targetKind = targets[0]?.kind;
-  if (targetKind === 'dir' || targetKind === 'file') {
-    return targetKind;
+  const targetDescriptor = normalizeTargetDescriptor(targets[0]);
+  if (targetDescriptor.kind === 'dir' || targetDescriptor.kind === 'file') {
+    return targetDescriptor.kind;
   }
 
-  return 'mixed';
+  if (!targetDescriptor.relPath || targetDescriptor.relPath === '.') {
+    return 'mixed';
+  }
+
+  const selectedPathSet = new Set(
+    selectedPaths.map((selectedPath) => normalizeRelativePath(selectedPath)).filter(Boolean),
+  );
+  const hasNestedMatch = [...selectedPathSet].some((selectedPath) =>
+    selectedPath.startsWith(`${targetDescriptor.relPath}${POSIX_SEPARATOR}`),
+  );
+
+  if (hasNestedMatch) {
+    return 'dir';
+  }
+
+  return selectedPathSet.has(targetDescriptor.relPath) ? 'file' : 'dir';
 };
 
 export const prepareTreeStructuralAddressSnapshot = ({
@@ -31,7 +68,7 @@ export const prepareTreeStructuralAddressSnapshot = ({
   return {
     scope: {
       scopeRootPath: scope?.scopeRootPath ?? normalizeScopeRootPath(occurrenceSnapshot.scopeRoots),
-      targetKind: scope?.targetKind ?? inferTargetKind(targets),
+      targetKind: scope?.targetKind ?? inferTargetKind(targets, selectedPaths),
       source: scope?.source ?? source,
     },
     scopeRoots: occurrenceSnapshot.scopeRoots,

--- a/calculogic-validator/tree/src/tree-structural-address-snapshot.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structural-address-snapshot.logic.mjs
@@ -1,0 +1,40 @@
+import { prepareTreeOccurrenceSnapshot } from './tree-occurrence-snapshot.logic.mjs';
+
+const normalizeScopeRootPath = (scopeRoots = []) => scopeRoots[0] ?? '.';
+
+const inferTargetKind = (targets = []) => {
+  if (targets.length !== 1) {
+    return 'mixed';
+  }
+
+  const targetKind = targets[0]?.kind;
+  if (targetKind === 'dir' || targetKind === 'file') {
+    return targetKind;
+  }
+
+  return 'mixed';
+};
+
+export const prepareTreeStructuralAddressSnapshot = ({
+  selectedPaths = [],
+  targets = [],
+  includeRoots = [],
+  scope = null,
+  source = 'tree-occurrence-snapshot',
+} = {}) => {
+  const occurrenceSnapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths,
+    targets,
+    includeRoots,
+  });
+
+  return {
+    scope: {
+      scopeRootPath: scope?.scopeRootPath ?? normalizeScopeRootPath(occurrenceSnapshot.scopeRoots),
+      targetKind: scope?.targetKind ?? inferTargetKind(targets),
+      source: scope?.source ?? source,
+    },
+    scopeRoots: occurrenceSnapshot.scopeRoots,
+    occurrenceRecords: occurrenceSnapshot.occurrenceRecords,
+  };
+};

--- a/calculogic-validator/tree/test/tree-structural-address-snapshot.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-structural-address-snapshot.logic.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeStructuralAddressSnapshot } from '../src/tree-structural-address-snapshot.logic.mjs';
+
+const byResolvedPath = (occurrenceRecords) =>
+  Object.fromEntries(occurrenceRecords.map((record) => [record.resolvedPath, record]));
+
+test('structural-address snapshot returns neutral evidence envelope shape', () => {
+  const snapshot = prepareTreeStructuralAddressSnapshot({
+    selectedPaths: ['calculogic-validator/tree/src/tree-structure-advisor.logic.mjs'],
+    includeRoots: ['calculogic-validator'],
+  });
+
+  assert.deepEqual(Object.keys(snapshot).sort(), ['occurrenceRecords', 'scope', 'scopeRoots']);
+  assert.deepEqual(Object.keys(snapshot.scope).sort(), ['scopeRootPath', 'source', 'targetKind']);
+  assert.equal(Array.isArray(snapshot.scopeRoots), true);
+  assert.equal(Array.isArray(snapshot.occurrenceRecords), true);
+  assert.equal(snapshot.occurrenceRecords.some((record) => Object.hasOwn(record, 'resolvedPath')), true);
+  assert.equal(snapshot.occurrenceRecords.some((record) => Object.hasOwn(record, 'code')), false);
+  assert.equal(snapshot.occurrenceRecords.some((record) => Object.hasOwn(record, 'severity')), false);
+  assert.equal(snapshot.occurrenceRecords.some((record) => Object.hasOwn(record, 'placementConfidence')), false);
+});
+
+test('structural-address snapshot markers preserve deterministic folder/file addressing semantics', () => {
+  const snapshot = prepareTreeStructuralAddressSnapshot({
+    selectedPaths: [
+      'root/folder-a/file-a-1.txt',
+      'root/folder-a/file-a-2.txt',
+      'root/folder-b/sub-a/file-b-1.txt',
+      'root/folder-b/sub-b/file-b-2.txt',
+      'root/folder-b/sub-b/file-b-3.txt',
+    ],
+    includeRoots: ['root'],
+    scope: { targetKind: 'dir', source: 'test-fixture' },
+  });
+
+  const records = byResolvedPath(snapshot.occurrenceRecords);
+
+  assert.equal(records.root.occurrenceMarker, 'A');
+  assert.equal(records['root/folder-a'].occurrenceMarker, 'A.A');
+  assert.equal(records['root/folder-b'].occurrenceMarker, 'A.B');
+  assert.equal(records['root/folder-a/file-a-1.txt'].occurrenceMarker, 'A.A.1');
+  assert.equal(records['root/folder-a/file-a-2.txt'].occurrenceMarker, 'A.A.2');
+  assert.equal(records['root/folder-b/sub-a'].occurrenceMarker, 'A.B.A');
+  assert.equal(records['root/folder-b/sub-b'].occurrenceMarker, 'A.B.B');
+  assert.equal(records['root/folder-b/sub-a/file-b-1.txt'].occurrenceMarker, 'A.B.A.1');
+  assert.equal(records['root/folder-b/sub-b/file-b-2.txt'].occurrenceMarker, 'A.B.B.1');
+  assert.equal(records['root/folder-b/sub-b/file-b-3.txt'].occurrenceMarker, 'A.B.B.2');
+  assert.equal(records['root/folder-b/sub-b/file-b-2.txt'].resolvedPath, 'root/folder-b/sub-b/file-b-2.txt');
+  assert.deepEqual(records['root/folder-b/sub-b/file-b-3.txt'].markerSegments, ['A', 'B', 'B', '2']);
+});

--- a/calculogic-validator/tree/test/tree-structural-address-snapshot.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-structural-address-snapshot.logic.test.mjs
@@ -49,3 +49,21 @@ test('structural-address snapshot markers preserve deterministic folder/file add
   assert.equal(records['root/folder-b/sub-b/file-b-2.txt'].resolvedPath, 'root/folder-b/sub-b/file-b-2.txt');
   assert.deepEqual(records['root/folder-b/sub-b/file-b-3.txt'].markerSegments, ['A', 'B', 'B', '2']);
 });
+
+test('structural-address snapshot infers target kind for single string file target', () => {
+  const snapshot = prepareTreeStructuralAddressSnapshot({
+    selectedPaths: ['root/folder/file.txt'],
+    targets: ['root/folder/file.txt'],
+  });
+
+  assert.equal(snapshot.scope.targetKind, 'file');
+});
+
+test('structural-address snapshot infers target kind for single string directory target', () => {
+  const snapshot = prepareTreeStructuralAddressSnapshot({
+    selectedPaths: ['root/folder/file.txt'],
+    targets: ['root/folder'],
+  });
+
+  assert.equal(snapshot.scope.targetKind, 'dir');
+});


### PR DESCRIPTION
### Motivation

- Refs #482
- Refs #452
- Implement the first Tree-owned runtime-safe structural-addressing slice: a neutral structural-address snapshot based on the existing occurrence snapshot substrate.
- Produce a prepared addressed-tree evidence envelope for future consumers without changing Tree report/finding/CLI behavior or Naming/registry semantics.
- Runtime authority is the existing `tree-occurrence-snapshot` substrate plus the Tree-owned contract in `tree-structural-address-probe-contract.spec.md`.
- Supporting/navigation context includes `tree-documentation-map-and-reorg-inventory.md` and `DeterministicStructuralAddressingSpec-Draft.md`.

### Description

- Added `calculogic-validator/tree/src/tree-structural-address-snapshot.logic.mjs`.
- The new helper wraps `prepareTreeOccurrenceSnapshot` and returns a neutral envelope:

```js
{ scope, scopeRoots, occurrenceRecords }
```

- Added deterministic defaults for `scopeRootPath`, `targetKind`, and `source` without changing occurrence snapshot semantics.
- Added lightweight `normalizeScopeRootPath`, target descriptor normalization, and `inferTargetKind` helpers to keep the snapshot envelope stable.
- Addressed review feedback by inferring `targetKind` for plain string targets as well as object targets:
  - single selected string file target resolves to `file`;
  - single selected string directory target resolves to `dir`;
  - multi-target or unclear target scope remains `mixed`.
- Added focused tests in `calculogic-validator/tree/test/tree-structural-address-snapshot.logic.test.mjs`.
- Tests validate:
  - envelope shape;
  - neutrality / no finding, severity, report, or placement-confidence fields;
  - A-based folder markers;
  - numeric file markers;
  - per-parent rebasing;
  - lineage-style markers;
  - resolved paths remain present;
  - string target-kind inference for file and directory targets.
- This change is intentionally bounded to a Tree-owned structural-address snapshot producer.
- It does not alter validator findings, CLI/report output, registry payloads, Naming behavior, bridge behavior, or loader/normalization logic.

### Testing

- Ran scoped diff check:

```bash
git diff -- calculogic-validator/tree/src calculogic-validator/tree/test calculogic-validator/doc/ValidatorSpecs calculogic-validator/doc/ConventionRoutines
```

  The PR changes are limited to the intended Tree source/test files:
  - `calculogic-validator/tree/src/tree-structural-address-snapshot.logic.mjs`
  - `calculogic-validator/tree/test/tree-structural-address-snapshot.logic.test.mjs`

- Re-ran focused verification after the `targetKind` review fix:

```bash
node --test calculogic-validator/tree/test/*.test.mjs
```

  Result: passed.

```bash
npm run validate:naming -- --scope=validator --target calculogic-validator/tree
```

  Result: passed / completed successfully without introducing new naming failures.

```bash
npm run validate:tree -- --scope=validator --target calculogic-validator/tree
```

  Result: passed / completed successfully with existing advisory findings unchanged.

- Codex also recorded an empty follow-up verification commit on the branch:
  `9e5997d` — `chore: rerun focused tree verification`.

### Scope boundaries

This PR does not:

- add a get-tree command;
- add debug output;
- expose structural addresses in CLI output or normal reports;
- change Tree finding codes, severity, summaries, details, or exit behavior;
- replace known-root compatibility behavior;
- consume new policy registries for reasoning;
- add loader/normalization for policy registries;
- derive Semantic Home truth;
- calculate placement confidence;
- change Naming behavior;
- change the Naming → Tree bridge payload shape;
- change registry JSON files;
- change package scripts;
- fix unrelated validator findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe8840bea48331bfa38fc5ae7f0609)