### PR TITLE
Slice 3: add renderedTree output from addressed occurrence records

### DIFF
--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -61,10 +61,52 @@ const assertValidOccurrenceRecord = (record) => {
   }
 };
 
-const toTreeLine = ({ record, isLast, parentHasNextSiblings }) => {
+const hasLaterSibling = ({ sortedRecords, record, index }) =>
+  sortedRecords.slice(index + 1).some(
+    (candidate) =>
+      candidate.depth === record.depth &&
+      candidate.parentAddressPath === record.parentAddressPath &&
+      candidate.orderIndex > record.orderIndex,
+  );
+
+const buildLaterSiblingMap = (sortedRecords) => {
+  const hasLaterSiblingByAddressPath = new Map();
+
+  for (let index = 0; index < sortedRecords.length; index += 1) {
+    const record = sortedRecords[index];
+    hasLaterSiblingByAddressPath.set(record.addressPath, hasLaterSibling({ sortedRecords, record, index }));
+  }
+
+  return hasLaterSiblingByAddressPath;
+};
+
+const buildRecordByAddressPathMap = (sortedRecords) => new Map(sortedRecords.map((record) => [record.addressPath, record]));
+
+const collectAncestorContinuationState = ({ record, recordByAddressPath, hasLaterSiblingByAddressPath }) => {
+  const ancestorHasLaterSiblings = [];
+  let cursorAddressPath = record.parentAddressPath;
+
+  while (cursorAddressPath !== null) {
+    const ancestorRecord = recordByAddressPath.get(cursorAddressPath);
+    if (!ancestorRecord) {
+      break;
+    }
+
+    if (ancestorRecord.depth > 0) {
+      ancestorHasLaterSiblings.unshift(Boolean(hasLaterSiblingByAddressPath.get(cursorAddressPath)));
+    }
+
+    cursorAddressPath = ancestorRecord.parentAddressPath;
+  }
+
+  return ancestorHasLaterSiblings;
+};
+
+const toTreeLine = ({ record, isLast, ancestorHasLaterSiblings }) => {
   const connector = isLast ? '└─' : '├─';
-  const indentation = parentHasNextSiblings.map((hasNext) => (hasNext ? '│  ' : '   ')).join('');
-  const nameToken = record.occurrenceType === STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FOLDER ? `${record.name}/` : record.name;
+  const indentation = ancestorHasLaterSiblings.map((hasNext) => (hasNext ? '│  ' : '   ')).join('');
+  const nameToken =
+    record.occurrenceType === STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FOLDER ? `${record.name}/` : record.name;
 
   if (record.depth === 0) {
     return `${record.displayMarker}: ${nameToken}`;
@@ -87,25 +129,20 @@ export const renderTreeCodebaseAddressedSnapshot = (snapshot) => {
     return { renderedTree: '' };
   }
 
-  const lines = [];
-  const siblingStateByDepth = [];
+  const hasLaterSiblingByAddressPath = buildLaterSiblingMap(sortedRecords);
+  const recordByAddressPath = buildRecordByAddressPathMap(sortedRecords);
 
-  for (let index = 0; index < sortedRecords.length; index += 1) {
-    const record = sortedRecords[index];
-    const next = sortedRecords[index + 1] ?? null;
-
-    const sameParentNextSibling =
-      next && next.parentAddressPath === record.parentAddressPath && next.depth === record.depth;
-    siblingStateByDepth[record.depth] = Boolean(sameParentNextSibling);
-
-    lines.push(
-      toTreeLine({
+  const lines = sortedRecords.map((record) =>
+    toTreeLine({
+      record,
+      isLast: !hasLaterSiblingByAddressPath.get(record.addressPath),
+      ancestorHasLaterSiblings: collectAncestorContinuationState({
         record,
-        isLast: !sameParentNextSibling,
-        parentHasNextSiblings: siblingStateByDepth.slice(1, record.depth),
+        recordByAddressPath,
+        hasLaterSiblingByAddressPath,
       }),
-    );
-  }
+    }),
+  );
 
   return {
     renderedTree: lines.join('\n'),

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -61,20 +61,17 @@ const assertValidOccurrenceRecord = (record) => {
   }
 };
 
-const hasLaterSibling = ({ sortedRecords, record, index }) =>
-  sortedRecords.slice(index + 1).some(
-    (candidate) =>
-      candidate.depth === record.depth &&
-      candidate.parentAddressPath === record.parentAddressPath &&
-      candidate.orderIndex > record.orderIndex,
-  );
+const getSiblingGroupKey = (record) => `${record.parentAddressPath ?? '__ROOT__'}::${record.depth}`;
 
 const buildLaterSiblingMap = (sortedRecords) => {
+  const hasSeenSiblingByGroup = new Map();
   const hasLaterSiblingByAddressPath = new Map();
 
-  for (let index = 0; index < sortedRecords.length; index += 1) {
+  for (let index = sortedRecords.length - 1; index >= 0; index -= 1) {
     const record = sortedRecords[index];
-    hasLaterSiblingByAddressPath.set(record.addressPath, hasLaterSibling({ sortedRecords, record, index }));
+    const siblingGroupKey = getSiblingGroupKey(record);
+    hasLaterSiblingByAddressPath.set(record.addressPath, hasSeenSiblingByGroup.has(siblingGroupKey));
+    hasSeenSiblingByGroup.set(siblingGroupKey, true);
   }
 
   return hasLaterSiblingByAddressPath;

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -1,0 +1,113 @@
+import { STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES } from './structural-addressing-profile.knowledge.mjs';
+
+const assertValidSnapshotInput = (snapshot) => {
+  if (snapshot === undefined) {
+    throw new Error('Tree-codebase renderedTree snapshot input is required.');
+  }
+
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    throw new Error('Tree-codebase renderedTree snapshot input must be an object.');
+  }
+
+  if (!Object.hasOwn(snapshot, 'occurrenceRecords')) {
+    throw new Error('Tree-codebase renderedTree snapshot input must include occurrenceRecords.');
+  }
+
+  if (!Array.isArray(snapshot.occurrenceRecords)) {
+    throw new Error('Tree-codebase renderedTree occurrenceRecords must be an array.');
+  }
+};
+
+const assertValidOccurrenceRecord = (record) => {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error('Tree-codebase renderedTree occurrence record must be an object.');
+  }
+
+  if (typeof record.addressPath !== 'string' || record.addressPath.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record addressPath is required.');
+  }
+
+  if (typeof record.displayMarker !== 'string' || record.displayMarker.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record displayMarker is required.');
+  }
+
+  if (
+    record.occurrenceType !== STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FOLDER &&
+    record.occurrenceType !== STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FILE
+  ) {
+    throw new Error(
+      `Tree-codebase renderedTree occurrence type is unsupported: ${record.occurrenceType ?? '(missing)'}.`,
+    );
+  }
+
+  if (typeof record.name !== 'string' || record.name.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record name is required.');
+  }
+
+  if (typeof record.path !== 'string' || record.path.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record path is required.');
+  }
+
+  if (!(record.parentAddressPath === null || typeof record.parentAddressPath === 'string')) {
+    throw new Error('Tree-codebase renderedTree occurrence record parentAddressPath must be string or null.');
+  }
+
+  if (!Number.isInteger(record.depth) || record.depth < 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record depth must be a non-negative integer.');
+  }
+
+  if (!Number.isInteger(record.orderIndex) || record.orderIndex < 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record orderIndex must be a non-negative integer.');
+  }
+};
+
+const toTreeLine = ({ record, isLast, parentHasNextSiblings }) => {
+  const connector = isLast ? '└─' : '├─';
+  const indentation = parentHasNextSiblings.map((hasNext) => (hasNext ? '│  ' : '   ')).join('');
+  const nameToken = record.occurrenceType === STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FOLDER ? `${record.name}/` : record.name;
+
+  if (record.depth === 0) {
+    return `${record.displayMarker}: ${nameToken}`;
+  }
+
+  return `${indentation}${connector} ${record.displayMarker}: ${nameToken}`;
+};
+
+export const renderTreeCodebaseAddressedSnapshot = (snapshot) => {
+  assertValidSnapshotInput(snapshot);
+
+  const sortedRecords = [...snapshot.occurrenceRecords]
+    .map((record) => {
+      assertValidOccurrenceRecord(record);
+      return record;
+    })
+    .sort((left, right) => left.orderIndex - right.orderIndex || left.addressPath.localeCompare(right.addressPath));
+
+  if (sortedRecords.length === 0) {
+    return { renderedTree: '' };
+  }
+
+  const lines = [];
+  const siblingStateByDepth = [];
+
+  for (let index = 0; index < sortedRecords.length; index += 1) {
+    const record = sortedRecords[index];
+    const next = sortedRecords[index + 1] ?? null;
+
+    const sameParentNextSibling =
+      next && next.parentAddressPath === record.parentAddressPath && next.depth === record.depth;
+    siblingStateByDepth[record.depth] = Boolean(sameParentNextSibling);
+
+    lines.push(
+      toTreeLine({
+        record,
+        isLast: !sameParentNextSibling,
+        parentHasNextSiblings: siblingStateByDepth.slice(1, record.depth),
+      }),
+    );
+  }
+
+  return {
+    renderedTree: lines.join('\n'),
+  };
+};

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -34,8 +34,8 @@ const buildInput = () => ({
 });
 
 const expectedTree = `A: calculogic-validator/
-└─ A: doc/
-   └─ A: ConventionRoutines/
+├─ A: doc/
+│  └─ A: ConventionRoutines/
 ├─ 1: LICENSE
 └─ 2: README.md`;
 
@@ -51,7 +51,42 @@ test('renderer output follows addressed snapshot order and not raw fixture order
   assert.deepEqual(rawChildOrder, ['README.md', 'LICENSE', 'doc']);
   assert.match(snapshot.occurrenceRecords.map((record) => record.name).join(','), /doc,ConventionRoutines,LICENSE,README\.md/u);
   const result = renderTreeCodebaseAddressedSnapshot(snapshot);
-  assert.match(result.renderedTree, /└─ A: doc\/\n   └─ A: ConventionRoutines\/\n├─ 1: LICENSE/u);
+  assert.match(result.renderedTree, /├─ A: doc\/\n│  └─ A: ConventionRoutines\/\n├─ 1: LICENSE/u);
+});
+
+test('folder with descendants and a later sibling renders with branch connector and continuation bars', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+
+  assert.match(result.renderedTree, /^├─ A: doc\/$/mu);
+  assert.match(result.renderedTree, /^│  └─ A: ConventionRoutines\/$/mu);
+});
+
+test('last sibling with descendants renders with terminal connector', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot({
+    sourceNamespace: 'calculogic-validator',
+    scope: 'validator',
+    target: null,
+    scopeRoots: [
+      {
+        name: 'root',
+        path: 'root',
+        occurrenceType: 'folder',
+        children: [
+          { name: 'a.txt', path: 'root/a.txt', occurrenceType: 'file' },
+          {
+            name: 'z-doc',
+            path: 'root/z-doc',
+            occurrenceType: 'folder',
+            children: [{ name: 'nested.md', path: 'root/z-doc/nested.md', occurrenceType: 'file' }],
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.match(result.renderedTree, /^└─ A: z-doc\/$/mu);
 });
 
 test('render is stable for repeated calls with the same snapshot', () => {

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { prepareTreeCodebaseAddressedSnapshot } from '../src/structural-addressing-tree-codebase.logic.mjs';
+import { renderTreeCodebaseAddressedSnapshot } from '../src/structural-addressing-render-tree.logic.mjs';
+
+const buildInput = () => ({
+  sourceNamespace: 'calculogic-validator',
+  scope: 'validator',
+  target: null,
+  scopeRoots: [
+    {
+      name: 'calculogic-validator',
+      path: 'calculogic-validator',
+      occurrenceType: 'folder',
+      children: [
+        { name: 'README.md', path: 'calculogic-validator/README.md', occurrenceType: 'file' },
+        { name: 'LICENSE', path: 'calculogic-validator/LICENSE', occurrenceType: 'file' },
+        {
+          name: 'doc',
+          path: 'calculogic-validator/doc',
+          occurrenceType: 'folder',
+          children: [
+            {
+              name: 'ConventionRoutines',
+              path: 'calculogic-validator/doc/ConventionRoutines',
+              occurrenceType: 'folder',
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const expectedTree = `A: calculogic-validator/
+└─ A: doc/
+   └─ A: ConventionRoutines/
+├─ 1: LICENSE
+└─ 2: README.md`;
+
+test('renderedTree is produced deterministically from occurrenceRecords with branch glyph format', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.deepEqual(result, { renderedTree: expectedTree });
+});
+
+test('renderer output follows addressed snapshot order and not raw fixture order', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const rawChildOrder = buildInput().scopeRoots[0].children.map((child) => child.name);
+  assert.deepEqual(rawChildOrder, ['README.md', 'LICENSE', 'doc']);
+  assert.match(snapshot.occurrenceRecords.map((record) => record.name).join(','), /doc,ConventionRoutines,LICENSE,README\.md/u);
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.match(result.renderedTree, /└─ A: doc\/\n   └─ A: ConventionRoutines\/\n├─ 1: LICENSE/u);
+});
+
+test('render is stable for repeated calls with the same snapshot', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const first = renderTreeCodebaseAddressedSnapshot(snapshot);
+  const second = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.deepEqual(first, second);
+});
+
+test('render handles empty occurrenceRecords deterministically', () => {
+  const result = renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [] });
+  assert.deepEqual(result, { renderedTree: '' });
+});
+
+test('fails deterministically for missing and invalid top-level input/occurrenceRecords', () => {
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot(undefined),
+    /Tree-codebase renderedTree snapshot input is required\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot('invalid'),
+    /Tree-codebase renderedTree snapshot input must be an object\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({}),
+    /Tree-codebase renderedTree snapshot input must include occurrenceRecords\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: 'invalid' }),
+    /Tree-codebase renderedTree occurrenceRecords must be an array\./u,
+  );
+});
+
+test('fails deterministically for missing required record fields and unsupported occurrenceType', () => {
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record addressPath is required\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record displayMarker is required\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence type is unsupported: \(missing\)\./u,
+  );
+});
+
+test('fails deterministically for invalid parentAddressPath, depth, and orderIndex', () => {
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: 1, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record parentAddressPath must be string or null\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: -1, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record depth must be a non-negative integer\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: -1 }] }),
+    /Tree-codebase renderedTree occurrence record orderIndex must be a non-negative integer\./u,
+  );
+});

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -62,6 +62,40 @@ test('folder with descendants and a later sibling renders with branch connector 
   assert.match(result.renderedTree, /^│  └─ A: ConventionRoutines\/$/mu);
 });
 
+
+
+test('later-sibling detection stays correct across non-adjacent preorder subtree boundaries', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot({
+    sourceNamespace: 'calculogic-validator',
+    scope: 'validator',
+    target: null,
+    scopeRoots: [
+      {
+        name: 'root',
+        path: 'root',
+        occurrenceType: 'folder',
+        children: [
+          {
+            name: 'folder-a',
+            path: 'root/folder-a',
+            occurrenceType: 'folder',
+            children: [
+              { name: 'nested', path: 'root/folder-a/nested', occurrenceType: 'folder', children: [] },
+            ],
+          },
+          { name: 'folder-b', path: 'root/folder-b', occurrenceType: 'folder', children: [] },
+          { name: 'z-file-c', path: 'root/z-file-c', occurrenceType: 'file' },
+        ],
+      },
+    ],
+  });
+
+  const { renderedTree } = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.match(renderedTree, /^├─ A: folder-a\/$/mu);
+  assert.match(renderedTree, /^│  └─ A: nested\/$/mu);
+  assert.match(renderedTree, /^├─ B: folder-b\/$/mu);
+  assert.match(renderedTree, /^└─ 1: z-file-c$/mu);
+});
 test('last sibling with descendants renders with terminal connector', () => {
   const snapshot = prepareTreeCodebaseAddressedSnapshot({
     sourceNamespace: 'calculogic-validator',


### PR DESCRIPTION
### Motivation
- This adds deterministic `renderedTree` output derived from the `occurrenceRecords` produced by the addressed-tree snapshot flow for the Structural Addressing V0 profile.  
- The renderer is intentionally pure and must use occurrenceRecords as the sole source-of-truth so output is stable and repeatable.  
- This change is focused and does not implement CLI behavior, report capture, filesystem walking, Tree advisor integration, Naming validation changes, or any runtime report findings.

### Description
- Added `calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs` exporting `renderTreeCodebaseAddressedSnapshot(snapshot)`.  
- The renderer validates snapshot and record fields deterministically and fails with stable error messages for missing/invalid inputs.  
- Rendering uses only `occurrenceRecords` (respecting `orderIndex`, `depth`, `parentAddressPath`, and `displayMarker`) and emits a branch-glyph text tree, returning `{ renderedTree: string }` and `{ renderedTree: '' }` for empty records.  
- A focused test file `calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs` proves deterministic output, orderIndex respect, nested/folder/file markings, stability across repeated calls, empty behavior, composition with `prepareTreeCodebaseAddressedSnapshot(input)`, and deterministic failure cases.

### Testing
- Ran `node --test calculogic-validator/structural-addressing/test/*.test.mjs` and the structural-addressing test suite passed.  
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/structural-addressing` and the naming validator run completed successfully for the added files.  
- Ran `npm run validate:tree -- --scope=validator` and it executed in report-mode producing advisory findings (report-mode output observed).  
- Ran `npm run validate:all -- --scope=validator` which produced repo-wide validator output and exited non-zero due to existing findings outside this slice (not introduced by this change).  
- Ran `npm test` to exercise the wider suite and observed test output as part of verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07839c5574833187d521178ed1631f)