### PR TITLE
Add renderer for structural-addressing snapshots with validation and unit tests

### DIFF
--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -61,20 +61,18 @@ const assertValidOccurrenceRecord = (record) => {
   }
 };
 
-const hasLaterSibling = ({ sortedRecords, record, index }) =>
-  sortedRecords.slice(index + 1).some(
-    (candidate) =>
-      candidate.depth === record.depth &&
-      candidate.parentAddressPath === record.parentAddressPath &&
-      candidate.orderIndex > record.orderIndex,
-  );
+const getSiblingGroupKey = (record) => `${record.parentAddressPath ?? '__ROOT__'}::${record.depth}`;
 
 const buildLaterSiblingMap = (sortedRecords) => {
+  const hasSeenSiblingByGroup = new Map();
   const hasLaterSiblingByAddressPath = new Map();
 
-  for (let index = 0; index < sortedRecords.length; index += 1) {
+  for (let index = sortedRecords.length - 1; index >= 0; index -= 1) {
     const record = sortedRecords[index];
-    hasLaterSiblingByAddressPath.set(record.addressPath, hasLaterSibling({ sortedRecords, record, index }));
+    const siblingGroupKey = getSiblingGroupKey(record);
+
+    hasLaterSiblingByAddressPath.set(record.addressPath, hasSeenSiblingByGroup.has(siblingGroupKey));
+    hasSeenSiblingByGroup.set(siblingGroupKey, true);
   }
 
   return hasLaterSiblingByAddressPath;

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -56,6 +56,18 @@ const assertValidOccurrenceRecord = (record) => {
     throw new Error('Tree-codebase renderedTree occurrence record depth must be a non-negative integer.');
   }
 
+  if (record.parentAddressPath === null && record.depth !== 0) {
+    throw new Error(
+      'Tree-codebase renderedTree occurrence record with null parentAddressPath must have depth 0.',
+    );
+  }
+
+  if (record.parentAddressPath !== null && record.depth === 0) {
+    throw new Error(
+      'Tree-codebase renderedTree occurrence record with parentAddressPath must have depth greater than 0.',
+    );
+  }
+
   if (!Number.isInteger(record.orderIndex) || record.orderIndex < 0) {
     throw new Error('Tree-codebase renderedTree occurrence record orderIndex must be a non-negative integer.');
   }

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -96,7 +96,9 @@ const collectAncestorContinuationState = ({ record, recordByAddressPath, hasLate
 
     const ancestorRecord = recordByAddressPath.get(cursorAddressPath);
     if (!ancestorRecord) {
-      break;
+      throw new Error(
+        `Tree-codebase renderedTree parentAddressPath reference is missing: ${cursorAddressPath}.`,
+      );
     }
 
     if (ancestorRecord.depth > 0) {

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -90,7 +90,84 @@ const buildLaterSiblingMap = (sortedRecords) => {
   return hasLaterSiblingByAddressPath;
 };
 
-const buildRecordByAddressPathMap = (sortedRecords) => new Map(sortedRecords.map((record) => [record.addressPath, record]));
+const buildRecordByAddressPathMap = (sortedRecords) => {
+  const recordByAddressPath = new Map();
+
+  for (const record of sortedRecords) {
+    if (recordByAddressPath.has(record.addressPath)) {
+      throw new Error(
+        `Tree-codebase renderedTree duplicate addressPath is not allowed: ${record.addressPath}.`,
+      );
+    }
+
+    recordByAddressPath.set(record.addressPath, record);
+  }
+
+  return recordByAddressPath;
+};
+
+
+
+const assertNoParentAddressPathCycles = ({ sortedRecords, recordByAddressPath }) => {
+  const walkStateByAddressPath = new Map();
+
+  const visit = (record) => {
+    const state = walkStateByAddressPath.get(record.addressPath);
+
+    if (state === 'visiting') {
+      throw new Error(
+        `Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: ${record.addressPath}.`,
+      );
+    }
+
+    if (state === 'visited') {
+      return;
+    }
+
+    walkStateByAddressPath.set(record.addressPath, 'visiting');
+
+    if (record.parentAddressPath !== null) {
+      const parentRecord = recordByAddressPath.get(record.parentAddressPath);
+      if (!parentRecord) {
+        throw new Error(
+          `Tree-codebase renderedTree parentAddressPath reference is missing: ${record.parentAddressPath}.`,
+        );
+      }
+
+      visit(parentRecord);
+    }
+
+    walkStateByAddressPath.set(record.addressPath, 'visited');
+  };
+
+  for (const record of sortedRecords) {
+    visit(record);
+  }
+};
+
+const assertValidParentDepthRelationships = ({ sortedRecords, recordByAddressPath }) => {
+  for (const record of sortedRecords) {
+    if (record.parentAddressPath === null) {
+      continue;
+    }
+
+    const parentRecord = recordByAddressPath.get(record.parentAddressPath);
+
+    if (!parentRecord) {
+      throw new Error(
+        `Tree-codebase renderedTree parentAddressPath reference is missing: ${record.parentAddressPath}.`,
+      );
+    }
+
+    const expectedDepth = parentRecord.depth + 1;
+
+    if (record.depth !== expectedDepth) {
+      throw new Error(
+        `Tree-codebase renderedTree occurrence record depth must be parent depth + 1 for addressPath: ${record.addressPath}.`,
+      );
+    }
+  }
+};
 
 const collectAncestorContinuationState = ({ record, recordByAddressPath, hasLaterSiblingByAddressPath }) => {
   const ancestorHasLaterSiblings = [];
@@ -152,6 +229,16 @@ export const renderTreeCodebaseAddressedSnapshot = (snapshot) => {
 
   const hasLaterSiblingByAddressPath = buildLaterSiblingMap(sortedRecords);
   const recordByAddressPath = buildRecordByAddressPathMap(sortedRecords);
+
+  assertNoParentAddressPathCycles({
+    sortedRecords,
+    recordByAddressPath,
+  });
+
+  assertValidParentDepthRelationships({
+    sortedRecords,
+    recordByAddressPath,
+  });
 
   const lines = sortedRecords.map((record) =>
     toTreeLine({

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -171,24 +171,10 @@ const assertValidParentDepthRelationships = ({ sortedRecords, recordByAddressPat
 
 const collectAncestorContinuationState = ({ record, recordByAddressPath, hasLaterSiblingByAddressPath }) => {
   const ancestorHasLaterSiblings = [];
-  const visitedAddressPaths = new Set();
   let cursorAddressPath = record.parentAddressPath;
 
   while (cursorAddressPath !== null) {
-    if (visitedAddressPaths.has(cursorAddressPath)) {
-      throw new Error(
-        `Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: ${cursorAddressPath}.`,
-      );
-    }
-
-    visitedAddressPaths.add(cursorAddressPath);
-
     const ancestorRecord = recordByAddressPath.get(cursorAddressPath);
-    if (!ancestorRecord) {
-      throw new Error(
-        `Tree-codebase renderedTree parentAddressPath reference is missing: ${cursorAddressPath}.`,
-      );
-    }
 
     if (ancestorRecord.depth > 0) {
       ancestorHasLaterSiblings.unshift(Boolean(hasLaterSiblingByAddressPath.get(cursorAddressPath)));

--- a/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
+++ b/calculogic-validator/structural-addressing/src/structural-addressing-render-tree.logic.mjs
@@ -1,0 +1,159 @@
+import { STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES } from './structural-addressing-profile.knowledge.mjs';
+
+const assertValidSnapshotInput = (snapshot) => {
+  if (snapshot === undefined) {
+    throw new Error('Tree-codebase renderedTree snapshot input is required.');
+  }
+
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    throw new Error('Tree-codebase renderedTree snapshot input must be an object.');
+  }
+
+  if (!Object.hasOwn(snapshot, 'occurrenceRecords')) {
+    throw new Error('Tree-codebase renderedTree snapshot input must include occurrenceRecords.');
+  }
+
+  if (!Array.isArray(snapshot.occurrenceRecords)) {
+    throw new Error('Tree-codebase renderedTree occurrenceRecords must be an array.');
+  }
+};
+
+const assertValidOccurrenceRecord = (record) => {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error('Tree-codebase renderedTree occurrence record must be an object.');
+  }
+
+  if (typeof record.addressPath !== 'string' || record.addressPath.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record addressPath is required.');
+  }
+
+  if (typeof record.displayMarker !== 'string' || record.displayMarker.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record displayMarker is required.');
+  }
+
+  if (
+    record.occurrenceType !== STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FOLDER &&
+    record.occurrenceType !== STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FILE
+  ) {
+    throw new Error(
+      `Tree-codebase renderedTree occurrence type is unsupported: ${record.occurrenceType ?? '(missing)'}.`,
+    );
+  }
+
+  if (typeof record.name !== 'string' || record.name.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record name is required.');
+  }
+
+  if (typeof record.path !== 'string' || record.path.length === 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record path is required.');
+  }
+
+  if (!(record.parentAddressPath === null || typeof record.parentAddressPath === 'string')) {
+    throw new Error('Tree-codebase renderedTree occurrence record parentAddressPath must be string or null.');
+  }
+
+  if (!Number.isInteger(record.depth) || record.depth < 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record depth must be a non-negative integer.');
+  }
+
+  if (!Number.isInteger(record.orderIndex) || record.orderIndex < 0) {
+    throw new Error('Tree-codebase renderedTree occurrence record orderIndex must be a non-negative integer.');
+  }
+};
+
+const hasLaterSibling = ({ sortedRecords, record, index }) =>
+  sortedRecords.slice(index + 1).some(
+    (candidate) =>
+      candidate.depth === record.depth &&
+      candidate.parentAddressPath === record.parentAddressPath &&
+      candidate.orderIndex > record.orderIndex,
+  );
+
+const buildLaterSiblingMap = (sortedRecords) => {
+  const hasLaterSiblingByAddressPath = new Map();
+
+  for (let index = 0; index < sortedRecords.length; index += 1) {
+    const record = sortedRecords[index];
+    hasLaterSiblingByAddressPath.set(record.addressPath, hasLaterSibling({ sortedRecords, record, index }));
+  }
+
+  return hasLaterSiblingByAddressPath;
+};
+
+const buildRecordByAddressPathMap = (sortedRecords) => new Map(sortedRecords.map((record) => [record.addressPath, record]));
+
+const collectAncestorContinuationState = ({ record, recordByAddressPath, hasLaterSiblingByAddressPath }) => {
+  const ancestorHasLaterSiblings = [];
+  const visitedAddressPaths = new Set();
+  let cursorAddressPath = record.parentAddressPath;
+
+  while (cursorAddressPath !== null) {
+    if (visitedAddressPaths.has(cursorAddressPath)) {
+      throw new Error(
+        `Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: ${cursorAddressPath}.`,
+      );
+    }
+
+    visitedAddressPaths.add(cursorAddressPath);
+
+    const ancestorRecord = recordByAddressPath.get(cursorAddressPath);
+    if (!ancestorRecord) {
+      break;
+    }
+
+    if (ancestorRecord.depth > 0) {
+      ancestorHasLaterSiblings.unshift(Boolean(hasLaterSiblingByAddressPath.get(cursorAddressPath)));
+    }
+
+    cursorAddressPath = ancestorRecord.parentAddressPath;
+  }
+
+  return ancestorHasLaterSiblings;
+};
+
+const toTreeLine = ({ record, isLast, ancestorHasLaterSiblings }) => {
+  const connector = isLast ? '└─' : '├─';
+  const indentation = ancestorHasLaterSiblings.map((hasNext) => (hasNext ? '│  ' : '   ')).join('');
+  const nameToken =
+    record.occurrenceType === STRUCTURAL_ADDRESSING_OCCURRENCE_TYPES.FOLDER ? `${record.name}/` : record.name;
+
+  if (record.depth === 0) {
+    return `${record.displayMarker}: ${nameToken}`;
+  }
+
+  return `${indentation}${connector} ${record.displayMarker}: ${nameToken}`;
+};
+
+export const renderTreeCodebaseAddressedSnapshot = (snapshot) => {
+  assertValidSnapshotInput(snapshot);
+
+  const sortedRecords = [...snapshot.occurrenceRecords]
+    .map((record) => {
+      assertValidOccurrenceRecord(record);
+      return record;
+    })
+    .sort((left, right) => left.orderIndex - right.orderIndex || left.addressPath.localeCompare(right.addressPath));
+
+  if (sortedRecords.length === 0) {
+    return { renderedTree: '' };
+  }
+
+  const hasLaterSiblingByAddressPath = buildLaterSiblingMap(sortedRecords);
+  const recordByAddressPath = buildRecordByAddressPathMap(sortedRecords);
+
+  const lines = sortedRecords.map((record) =>
+    toTreeLine({
+      record,
+      isLast: !hasLaterSiblingByAddressPath.get(record.addressPath),
+      ancestorHasLaterSiblings: collectAncestorContinuationState({
+        record,
+        recordByAddressPath,
+        hasLaterSiblingByAddressPath,
+      }),
+    }),
+  );
+
+  return {
+    renderedTree: lines.join('\n'),
+  };
+};

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -90,6 +90,91 @@ test('last sibling with descendants renders with terminal connector', () => {
 });
 
 
+
+test('duplicate sibling orderIndex values use sorted rendered position for connectors', () => {
+  const snapshot = {
+    occurrenceRecords: [
+      {
+        address: 'A',
+        addressPath: 'A',
+        displayMarker: 'A',
+        occurrenceType: 'folder',
+        name: 'root',
+        path: 'root',
+        parentAddressPath: null,
+        depth: 0,
+        orderIndex: 0,
+      },
+      {
+        address: 'A.A',
+        addressPath: 'A.A',
+        displayMarker: 'A',
+        occurrenceType: 'folder',
+        name: 'folder-a',
+        path: 'root/folder-a',
+        parentAddressPath: 'A',
+        depth: 1,
+        orderIndex: 1,
+      },
+      {
+        address: 'A.B',
+        addressPath: 'A.B',
+        displayMarker: 'B',
+        occurrenceType: 'folder',
+        name: 'folder-b',
+        path: 'root/folder-b',
+        parentAddressPath: 'A',
+        depth: 1,
+        orderIndex: 1,
+      },
+    ],
+  };
+
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+
+  assert.match(result.renderedTree, /^├─ A: folder-a\/$/mu);
+  assert.match(result.renderedTree, /^└─ B: folder-b\/$/mu);
+});
+
+test('subtree siblings keep continuation bars and later sibling connectors', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot({
+    sourceNamespace: 'calculogic-validator',
+    scope: 'validator',
+    target: null,
+    scopeRoots: [
+      {
+        name: 'root',
+        path: 'root',
+        occurrenceType: 'folder',
+        children: [
+          {
+            name: 'folder-a',
+            path: 'root/folder-a',
+            occurrenceType: 'folder',
+            children: [
+              {
+                name: 'nested',
+                path: 'root/folder-a/nested',
+                occurrenceType: 'folder',
+                children: [],
+              },
+            ],
+          },
+          { name: 'folder-b', path: 'root/folder-b', occurrenceType: 'folder', children: [] },
+          { name: 'file-c', path: 'root/file-c', occurrenceType: 'file' },
+        ],
+      },
+    ],
+  });
+
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+
+  assert.match(result.renderedTree, /^├─ A: folder-a\/$/mu);
+  assert.match(result.renderedTree, /^│  └─ A: nested\/$/mu);
+  assert.match(result.renderedTree, /^├─ 1: file-c$/mu);
+  assert.match(result.renderedTree, /^└─ B: folder-b\/$/mu);
+});
+
 test('self-referential parentAddressPath fails deterministically', () => {
   assert.throws(
     () =>

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -177,6 +177,161 @@ test('subtree siblings keep continuation bars and later sibling connectors', () 
 
 
 
+
+test('duplicate addressPath records fail deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'root-a',
+            path: 'root-a',
+            parentAddressPath: null,
+            depth: 0,
+            orderIndex: 0,
+          },
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'root-b',
+            path: 'root-b',
+            parentAddressPath: null,
+            depth: 0,
+            orderIndex: 1,
+          },
+        ],
+      }),
+    /duplicate addressPath is not allowed: A\./u,
+  );
+});
+
+test('child depth greater than parent depth + 1 fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'root',
+            path: 'root',
+            parentAddressPath: null,
+            depth: 0,
+            orderIndex: 0,
+          },
+          {
+            address: 'A.1',
+            addressPath: 'A.1',
+            displayMarker: '1',
+            occurrenceType: 'file',
+            name: 'child.txt',
+            path: 'root/child.txt',
+            parentAddressPath: 'A',
+            depth: 2,
+            orderIndex: 1,
+          },
+        ],
+      }),
+    /depth must be parent depth \+ 1 for addressPath: A\.1\./u,
+  );
+});
+
+test('child depth less than parent depth + 1 fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'R',
+            addressPath: 'R',
+            displayMarker: 'R',
+            occurrenceType: 'folder',
+            name: 'root',
+            path: 'root',
+            parentAddressPath: null,
+            depth: 0,
+            orderIndex: 0,
+          },
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'parent',
+            path: 'root/parent',
+            parentAddressPath: 'R',
+            depth: 1,
+            orderIndex: 1,
+          },
+          {
+            address: 'A.1',
+            addressPath: 'A.1',
+            displayMarker: '1',
+            occurrenceType: 'file',
+            name: 'child.txt',
+            path: 'root/parent/child.txt',
+            parentAddressPath: 'A',
+            depth: 1,
+            orderIndex: 2,
+          },
+        ],
+      }),
+    /depth must be parent depth \+ 1 for addressPath: A\.1\./u,
+  );
+});
+
+test('valid parent depth increments render normally', () => {
+  const result = renderTreeCodebaseAddressedSnapshot({
+    occurrenceRecords: [
+      {
+        address: 'A',
+        addressPath: 'A',
+        displayMarker: 'A',
+        occurrenceType: 'folder',
+        name: 'root',
+        path: 'root',
+        parentAddressPath: null,
+        depth: 0,
+        orderIndex: 0,
+      },
+      {
+        address: 'A.A',
+        addressPath: 'A.A',
+        displayMarker: 'A',
+        occurrenceType: 'folder',
+        name: 'child-folder',
+        path: 'root/child-folder',
+        parentAddressPath: 'A',
+        depth: 1,
+        orderIndex: 1,
+      },
+      {
+        address: 'A.A.1',
+        addressPath: 'A.A.1',
+        displayMarker: '1',
+        occurrenceType: 'file',
+        name: 'grandchild.txt',
+        path: 'root/child-folder/grandchild.txt',
+        parentAddressPath: 'A.A',
+        depth: 2,
+        orderIndex: 2,
+      },
+    ],
+  });
+
+  assert.equal(result.renderedTree, `A: root/
+└─ A: child-folder/
+   └─ 1: grandchild.txt`);
+});
+
 test('null parentAddressPath with depth greater than 0 fails deterministically', () => {
   assert.throws(
     () =>
@@ -314,7 +469,7 @@ test('two-record parentAddressPath cycle fails deterministically', () => {
           },
         ],
       }),
-    /Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: B\./u,
+    /Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: (A|B)\./u,
   );
 });
 

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -175,6 +175,49 @@ test('subtree siblings keep continuation bars and later sibling connectors', () 
   assert.match(result.renderedTree, /^└─ B: folder-b\/$/mu);
 });
 
+
+test('dangling parentAddressPath fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A.1',
+            addressPath: 'A.1',
+            displayMarker: '1',
+            occurrenceType: 'file',
+            name: 'orphan.txt',
+            path: 'root/orphan.txt',
+            parentAddressPath: 'A.MISSING',
+            depth: 1,
+            orderIndex: 0,
+          },
+        ],
+      }),
+    /Tree-codebase renderedTree parentAddressPath reference is missing: A\.MISSING\./u,
+  );
+});
+
+test('null parentAddressPath root records render normally', () => {
+  const result = renderTreeCodebaseAddressedSnapshot({
+    occurrenceRecords: [
+      {
+        address: 'A',
+        addressPath: 'A',
+        displayMarker: 'A',
+        occurrenceType: 'folder',
+        name: 'root',
+        path: 'root',
+        parentAddressPath: null,
+        depth: 0,
+        orderIndex: 0,
+      },
+    ],
+  });
+
+  assert.deepEqual(result, { renderedTree: 'A: root/' });
+});
+
 test('self-referential parentAddressPath fails deterministically', () => {
   assert.throws(
     () =>

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -176,6 +176,51 @@ test('subtree siblings keep continuation bars and later sibling connectors', () 
 });
 
 
+
+test('null parentAddressPath with depth greater than 0 fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A.1',
+            addressPath: 'A.1',
+            displayMarker: '1',
+            occurrenceType: 'file',
+            name: 'orphan.txt',
+            path: 'orphan.txt',
+            parentAddressPath: null,
+            depth: 1,
+            orderIndex: 0,
+          },
+        ],
+      }),
+    /null parentAddressPath must have depth 0\./u,
+  );
+});
+
+test('non-null parentAddressPath with depth 0 fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'root',
+            path: 'root',
+            parentAddressPath: 'ROOT',
+            depth: 0,
+            orderIndex: 0,
+          },
+        ],
+      }),
+    /with parentAddressPath must have depth greater than 0\./u,
+  );
+});
+
 test('dangling parentAddressPath fails deterministically', () => {
   assert.throws(
     () =>
@@ -231,7 +276,7 @@ test('self-referential parentAddressPath fails deterministically', () => {
             name: 'calculogic-validator',
             path: 'calculogic-validator',
             parentAddressPath: 'A',
-            depth: 0,
+            depth: 1,
             orderIndex: 0,
           },
         ],
@@ -253,7 +298,7 @@ test('two-record parentAddressPath cycle fails deterministically', () => {
             name: 'left',
             path: 'left',
             parentAddressPath: 'B',
-            depth: 0,
+            depth: 1,
             orderIndex: 0,
           },
           {
@@ -264,7 +309,7 @@ test('two-record parentAddressPath cycle fails deterministically', () => {
             name: 'right',
             path: 'right',
             parentAddressPath: 'A',
-            depth: 0,
+            depth: 1,
             orderIndex: 1,
           },
         ],

--- a/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
+++ b/calculogic-validator/structural-addressing/test/structural-addressing-render-tree.logic.test.mjs
@@ -1,0 +1,213 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { prepareTreeCodebaseAddressedSnapshot } from '../src/structural-addressing-tree-codebase.logic.mjs';
+import { renderTreeCodebaseAddressedSnapshot } from '../src/structural-addressing-render-tree.logic.mjs';
+
+const buildInput = () => ({
+  sourceNamespace: 'calculogic-validator',
+  scope: 'validator',
+  target: null,
+  scopeRoots: [
+    {
+      name: 'calculogic-validator',
+      path: 'calculogic-validator',
+      occurrenceType: 'folder',
+      children: [
+        { name: 'README.md', path: 'calculogic-validator/README.md', occurrenceType: 'file' },
+        { name: 'LICENSE', path: 'calculogic-validator/LICENSE', occurrenceType: 'file' },
+        {
+          name: 'doc',
+          path: 'calculogic-validator/doc',
+          occurrenceType: 'folder',
+          children: [
+            {
+              name: 'ConventionRoutines',
+              path: 'calculogic-validator/doc/ConventionRoutines',
+              occurrenceType: 'folder',
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const expectedTree = `A: calculogic-validator/
+├─ A: doc/
+│  └─ A: ConventionRoutines/
+├─ 1: LICENSE
+└─ 2: README.md`;
+
+test('renderedTree is produced deterministically from occurrenceRecords with branch glyph format', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.deepEqual(result, { renderedTree: expectedTree });
+});
+
+test('renderer output follows addressed snapshot order and not raw fixture order', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const rawChildOrder = buildInput().scopeRoots[0].children.map((child) => child.name);
+  assert.deepEqual(rawChildOrder, ['README.md', 'LICENSE', 'doc']);
+  assert.match(snapshot.occurrenceRecords.map((record) => record.name).join(','), /doc,ConventionRoutines,LICENSE,README\.md/u);
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.match(result.renderedTree, /├─ A: doc\/\n│  └─ A: ConventionRoutines\/\n├─ 1: LICENSE/u);
+});
+
+test('folder with descendants and a later sibling renders with branch connector and continuation bars', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+
+  assert.match(result.renderedTree, /^├─ A: doc\/$/mu);
+  assert.match(result.renderedTree, /^│  └─ A: ConventionRoutines\/$/mu);
+});
+
+test('last sibling with descendants renders with terminal connector', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot({
+    sourceNamespace: 'calculogic-validator',
+    scope: 'validator',
+    target: null,
+    scopeRoots: [
+      {
+        name: 'root',
+        path: 'root',
+        occurrenceType: 'folder',
+        children: [
+          { name: 'a.txt', path: 'root/a.txt', occurrenceType: 'file' },
+          {
+            name: 'z-doc',
+            path: 'root/z-doc',
+            occurrenceType: 'folder',
+            children: [{ name: 'nested.md', path: 'root/z-doc/nested.md', occurrenceType: 'file' }],
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.match(result.renderedTree, /^└─ A: z-doc\/$/mu);
+});
+
+
+test('self-referential parentAddressPath fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'calculogic-validator',
+            path: 'calculogic-validator',
+            parentAddressPath: 'A',
+            depth: 0,
+            orderIndex: 0,
+          },
+        ],
+      }),
+    /Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: A\./u,
+  );
+});
+
+test('two-record parentAddressPath cycle fails deterministically', () => {
+  assert.throws(
+    () =>
+      renderTreeCodebaseAddressedSnapshot({
+        occurrenceRecords: [
+          {
+            address: 'A',
+            addressPath: 'A',
+            displayMarker: 'A',
+            occurrenceType: 'folder',
+            name: 'left',
+            path: 'left',
+            parentAddressPath: 'B',
+            depth: 0,
+            orderIndex: 0,
+          },
+          {
+            address: 'B',
+            addressPath: 'B',
+            displayMarker: 'B',
+            occurrenceType: 'folder',
+            name: 'right',
+            path: 'right',
+            parentAddressPath: 'A',
+            depth: 0,
+            orderIndex: 1,
+          },
+        ],
+      }),
+    /Tree-codebase renderedTree parentAddressPath cycle detected at addressPath: B\./u,
+  );
+});
+
+test('valid ancestor chains still render and cycle detection does not change expected output', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const result = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.equal(result.renderedTree, expectedTree);
+});
+
+test('render is stable for repeated calls with the same snapshot', () => {
+  const snapshot = prepareTreeCodebaseAddressedSnapshot(buildInput());
+  const first = renderTreeCodebaseAddressedSnapshot(snapshot);
+  const second = renderTreeCodebaseAddressedSnapshot(snapshot);
+  assert.deepEqual(first, second);
+});
+
+test('render handles empty occurrenceRecords deterministically', () => {
+  const result = renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [] });
+  assert.deepEqual(result, { renderedTree: '' });
+});
+
+test('fails deterministically for missing and invalid top-level input/occurrenceRecords', () => {
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot(undefined),
+    /Tree-codebase renderedTree snapshot input is required\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot('invalid'),
+    /Tree-codebase renderedTree snapshot input must be an object\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({}),
+    /Tree-codebase renderedTree snapshot input must include occurrenceRecords\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: 'invalid' }),
+    /Tree-codebase renderedTree occurrenceRecords must be an array\./u,
+  );
+});
+
+test('fails deterministically for missing required record fields and unsupported occurrenceType', () => {
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record addressPath is required\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record displayMarker is required\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence type is unsupported: \(missing\)\./u,
+  );
+});
+
+test('fails deterministically for invalid parentAddressPath, depth, and orderIndex', () => {
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: 1, depth: 0, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record parentAddressPath must be string or null\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: -1, orderIndex: 0 }] }),
+    /Tree-codebase renderedTree occurrence record depth must be a non-negative integer\./u,
+  );
+  assert.throws(
+    () => renderTreeCodebaseAddressedSnapshot({ occurrenceRecords: [{ addressPath: 'A', displayMarker: 'A', occurrenceType: 'folder', name: 'x', path: 'x', parentAddressPath: null, depth: 0, orderIndex: -1 }] }),
+    /Tree-codebase renderedTree occurrence record orderIndex must be a non-negative integer\./u,
+  );
+});


### PR DESCRIPTION
### Motivation

- Provide a deterministic textual tree renderer for structural-addressing snapshots to visualize codebase address trees. 
- Ensure renderer validates snapshot and record shape, detects parent cycles, and follows addressed ordering rather than raw input order.

### Description

- Add `structural-addressing-render-tree.logic.mjs` implementing `renderTreeCodebaseAddressedSnapshot` with input validation (`assertValidSnapshotInput`, `assertValidOccurrenceRecord`), cycle detection, and branch glyph formatting. 
- Implement helpers to sort records, compute later-sibling state (`buildLaterSiblingMap`, `buildRecordByAddressPathMap`, `collectAncestorContinuationState`), and format lines (`toTreeLine`).
- Add comprehensive unit tests in `structural-addressing-render-tree.logic.test.mjs` covering rendering layout, ordering stability, cycle detection, input validation, empty snapshots, and idempotence.

### Testing

- Ran the new unit tests with the Node test runner via `node --test` targeting `structural-addressing-render-tree.logic.test.mjs`. All tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07839c5574833187d521178ed1631f)