### PR TITLE
Add root addressing:get-tree npm script wiring for direct host

### DIFF
--- a/calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs
+++ b/calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+
+test('root package script wiring exposes addressing:get-tree direct host command', async () => {
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+
+  assert.equal(
+    packageJson.scripts['addressing:get-tree'],
+    'node --experimental-strip-types calculogic-validator/scripts/addressing-get-tree.host.mjs',
+  );
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "validate:naming:validator:naming": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.host.mjs --scope=validator --target calculogic-validator/naming",
     "validate:naming:validator:tree": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.host.mjs --scope=validator --target calculogic-validator/tree",
     "validate:naming:validator:doc": "node --experimental-strip-types calculogic-validator/scripts/validate-naming.host.mjs --scope=validator --target calculogic-validator/doc",
+    "addressing:get-tree": "node --experimental-strip-types calculogic-validator/scripts/addressing-get-tree.host.mjs",
     "validate:all": "node --experimental-strip-types calculogic-validator/scripts/validate-all.host.mjs",
     "health:validator": "node --experimental-strip-types calculogic-validator/scripts/validator-health-check.host.mjs",
     "report:naming:repo": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix naming-repo -- node --experimental-strip-types calculogic-validator/scripts/validate-naming.host.mjs --scope=repo",


### PR DESCRIPTION
### Motivation
- This adds root npm script wiring for the existing Structural Addressing get-tree V0 direct host; it preserves the direct host behavior while making the command available through the `addressing:*` npm namespace and does not add report capture, `validate:addressing` commands, validator runner integration, Tree advisor behavior, Naming validation, or validator findings/severity. Refs #487 Refs #498

### Description
- Add a new root package script `"addressing:get-tree": "node --experimental-strip-types calculogic-validator/scripts/addressing-get-tree.host.mjs"` to `package.json` and add a focused contract test `calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs` that asserts the script points exactly to the existing direct host, preserving the host invocation and not duplicating or routing through any validator runner or report-capture logic.

### Testing
- Ran verification commands: `node --test calculogic-validator/structural-addressing/test/*.test.mjs` (pass), `node --test calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs` (pass), `npm run addressing:get-tree -- --scope=validator --format=text` (pass), `npm run addressing:get-tree -- --scope=validator --format=json` (pass), `npm run addressing:get-tree -- --scope=validator --format=both` (pass), `npm run addressing:get-tree -- --scope=validator --target calculogic-validator/structural-addressing` (pass), `npm run validate:naming -- --scope=validator --target package.json --target calculogic-validator/scripts/addressing-get-tree.host.mjs --target calculogic-validator/structural-addressing` (pass), `npm run validate:tree -- --scope=validator` (non-zero exit due to existing advisory findings in repository output), and `npm run validate:all -- --scope=validator` (non-zero exit due to existing repository findings); the non-zero exits are pre-existing repository validator outputs and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087b2a69f48331aba6601d3d4b7f6e)