### PR TITLE
Add report capture script for addressing:get-tree (validator scope)

### DIFF
--- a/calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs
+++ b/calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs
@@ -13,3 +13,21 @@ test('root package script wiring exposes addressing:get-tree direct host command
     'node --experimental-strip-types calculogic-validator/scripts/addressing-get-tree.host.mjs',
   );
 });
+
+test('root package script wiring exposes report:addressing:get-tree:validator capture command', async () => {
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+  const reportScript = packageJson.scripts['report:addressing:get-tree:validator'];
+
+  assert.equal(typeof reportScript, 'string');
+  assert.match(reportScript, /calculogic-report-capture/u);
+  assert.match(reportScript, /--json/u);
+  assert.match(reportScript, /--dir \.\/\.reports/u);
+  assert.match(reportScript, /--keep 20/u);
+  assert.match(reportScript, /--prefix addressing-get-tree-validator/u);
+  assert.match(reportScript, /npm run addressing:get-tree/u);
+  assert.match(reportScript, /npm run addressing:get-tree -- --scope=validator/u);
+  assert.match(reportScript, /--format=both/u);
+  assert.doesNotMatch(reportScript, /validate:addressing/u);
+  assert.doesNotMatch(reportScript, /runValidatorRunnerCli/u);
+  assert.doesNotMatch(reportScript, /runValidatorRunner/u);
+});

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "report:tree:docs": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-docs -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.host.mjs --scope=docs",
     "report:tree:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-validator -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.host.mjs --scope=validator",
     "report:tree:system": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix validate-tree-system -- node --experimental-strip-types calculogic-validator/scripts/validate-tree.host.mjs --scope=system",
-    "report:examples:validator": "node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.host.mjs"
+    "report:examples:validator": "node --experimental-strip-types calculogic-validator/scripts/generate-validator-report-examples.host.mjs",
+    "report:addressing:get-tree:validator": "calculogic-report-capture --json --dir ./.reports --keep 20 --prefix addressing-get-tree-validator -- npm run addressing:get-tree -- --scope=validator --format=both"
   },
   "dependencies": {
     "json-logic-js": "^2.0.5",


### PR DESCRIPTION
### Motivation
- This adds report-capture wiring for the existing Structural Addressing get-tree V0 inspection command and captures the existing `addressing:get-tree` validator-scope output as an inspection artifact; it does not add validate:addressing commands, validator runner integration, Tree advisor behavior, Naming validation, or validator findings/severity.
- Refs #487 and Refs #500 as the slice/issue tracking references for this change.

### Description
- Added a root npm script `report:addressing:get-tree:validator` in `package.json` that uses `calculogic-report-capture --json --dir ./.reports --keep 20 --prefix addressing-get-tree-validator` and forwards to `npm run addressing:get-tree -- --scope=validator --format=both` with the correct npm forwarding separator.
- Extended the package-script contract test `calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs` to assert presence of the new script, use of `calculogic-report-capture`, use of `--json`, target `./.reports`, `--keep 20`, prefix `addressing-get-tree-validator`, correct `npm` forwarding, forwarded `--scope=validator` and `--format=both`, and that it does not invoke `validate:addressing*` or validator runner entrypoints directly.
- Preserved existing host behavior by invoking the existing `addressing:get-tree` script rather than duplicating host logic or routing through validator runners, and did not introduce any `validate:addressing` commands or validator-runner wiring.
- Files changed: `package.json` and `calculogic-validator/test/addressing-get-tree.npm-script.contract.test.mjs`.

### Testing
- Ran `node --test calculogic-validator/structural-addressing/test/*.test.mjs` and the suite passed (all tests passed).
- Ran `node --test calculogic-validator/test/*.test.mjs` and the suite passed (all tests passed).
- Ran `npm run addressing:get-tree -- --scope=validator --format=both` and the command executed successfully and produced the expected combined JSON/text output.
- Ran `npm run report:addressing:get-tree:validator` and the command executed successfully, created a captured report under `./.reports` with prefix `addressing-get-tree-validator`, and preserved the underlying `addressing:get-tree` output.
- Ran `npm run validate:naming -- --scope=validator --target package.json --target calculogic-validator/scripts/addressing-get-tree.host.mjs --target calculogic-validator/structural-addressing` and the command executed successfully (report-mode results returned).
- Ran `npm run validate:tree -- --scope=validator` and the command executed successfully (report-mode results returned).
- Ran `npm run validate:all -- --scope=validator` which exited non-zero (code 2) due to pre-existing repository findings unrelated to this slice; this failure is not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08879c4c908331931067ece1b89b56)