### PR TITLE
Add Tree known-roots compatibility evidence adapter

### DIFF
--- a/calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs
@@ -1,0 +1,92 @@
+const SOURCE_ID = 'tree-known-roots-compatibility';
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree known-roots compatibility evidence input must be an object.');
+  }
+
+  if (!input.addressedTreeSnapshot || typeof input.addressedTreeSnapshot !== 'object' || Array.isArray(input.addressedTreeSnapshot)) {
+    throw new Error('Tree known-roots compatibility evidence input must include addressedTreeSnapshot object.');
+  }
+
+  if (!Array.isArray(input.addressedTreeSnapshot.occurrenceRecords)) {
+    throw new Error('Tree known-roots compatibility evidence addressedTreeSnapshot.occurrenceRecords must be an array.');
+  }
+
+  if (!input.knownRootsRegistry || typeof input.knownRootsRegistry !== 'object' || Array.isArray(input.knownRootsRegistry)) {
+    throw new Error('Tree known-roots compatibility evidence input must include knownRootsRegistry object.');
+  }
+
+  if (!Array.isArray(input.knownRootsRegistry.topRoots)) {
+    throw new Error('Tree known-roots compatibility evidence knownRootsRegistry.topRoots must be an array.');
+  }
+};
+
+const toTopRootLookup = (topRoots) => {
+  const lookup = new Map();
+  for (const topRoot of topRoots) {
+    if (!topRoot || typeof topRoot !== 'object' || Array.isArray(topRoot)) {
+      continue;
+    }
+
+    if (typeof topRoot.root !== 'string' || topRoot.root.length === 0 || lookup.has(topRoot.root)) {
+      continue;
+    }
+
+    lookup.set(topRoot.root, {
+      knownRoot: topRoot.root,
+      knownRootKind: topRoot.kind ?? null,
+      knownRootOwnershipSource: topRoot.ownershipSource ?? null,
+      ...(typeof topRoot.styleClass === 'string' && topRoot.styleClass.length > 0
+        ? { knownRootStyleClass: topRoot.styleClass }
+        : {}),
+    });
+  }
+
+  return lookup;
+};
+
+const toEvidenceRecord = (occurrenceRecord, knownRootMetadata) => ({
+  addressPath: occurrenceRecord.addressPath,
+  path: occurrenceRecord.path,
+  name: occurrenceRecord.name,
+  occurrenceType: occurrenceRecord.occurrenceType,
+  knownRoot: knownRootMetadata.knownRoot,
+  knownRootKind: knownRootMetadata.knownRootKind,
+  knownRootOwnershipSource: knownRootMetadata.knownRootOwnershipSource,
+  compatibilityRole: 'known-root',
+  evidenceStrength: 'compatibility',
+  rationale: 'Matched current Tree known-roots compatibility vocabulary.',
+  ...(Object.hasOwn(knownRootMetadata, 'knownRootStyleClass')
+    ? { knownRootStyleClass: knownRootMetadata.knownRootStyleClass }
+    : {}),
+});
+
+export const prepareTreeKnownRootsCompatibilityEvidence = (input) => {
+  assertValidInput(input);
+
+  const topRootLookup = toTopRootLookup(input.knownRootsRegistry.topRoots);
+  const evidenceRecords = [];
+
+  for (const occurrenceRecord of input.addressedTreeSnapshot.occurrenceRecords) {
+    if (!occurrenceRecord || typeof occurrenceRecord !== 'object' || Array.isArray(occurrenceRecord)) {
+      continue;
+    }
+
+    if (occurrenceRecord.occurrenceType !== 'folder') {
+      continue;
+    }
+
+    const knownRootMetadata = topRootLookup.get(occurrenceRecord.name);
+    if (!knownRootMetadata) {
+      continue;
+    }
+
+    evidenceRecords.push(toEvidenceRecord(occurrenceRecord, knownRootMetadata));
+  }
+
+  return {
+    source: SOURCE_ID,
+    evidenceRecords,
+  };
+};

--- a/calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs
@@ -46,6 +46,12 @@ const toTopRootLookup = (topRoots) => {
   return lookup;
 };
 
+const isScopeTopFolderOccurrence = (occurrenceRecord) =>
+  occurrenceRecord.occurrenceType === 'folder'
+  && occurrenceRecord.depth === 1
+  && typeof occurrenceRecord.parentAddressPath === 'string'
+  && occurrenceRecord.parentAddressPath.length > 0;
+
 const toEvidenceRecord = (occurrenceRecord, knownRootMetadata) => ({
   addressPath: occurrenceRecord.addressPath,
   path: occurrenceRecord.path,
@@ -73,7 +79,7 @@ export const prepareTreeKnownRootsCompatibilityEvidence = (input) => {
       continue;
     }
 
-    if (occurrenceRecord.occurrenceType !== 'folder') {
+    if (!isScopeTopFolderOccurrence(occurrenceRecord)) {
       continue;
     }
 

--- a/calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs
@@ -46,11 +46,21 @@ const toTopRootLookup = (topRoots) => {
   return lookup;
 };
 
-const isScopeTopFolderOccurrence = (occurrenceRecord) =>
+const toRepoTopToken = (occurrencePath) => {
+  if (typeof occurrencePath !== 'string' || occurrencePath.length === 0) {
+    return null;
+  }
+
+  if (occurrencePath.includes('/') || occurrencePath.includes('\\')) {
+    return null;
+  }
+
+  return occurrencePath;
+};
+
+const isRepoTopFolderOccurrence = (occurrenceRecord) =>
   occurrenceRecord.occurrenceType === 'folder'
-  && occurrenceRecord.depth === 1
-  && typeof occurrenceRecord.parentAddressPath === 'string'
-  && occurrenceRecord.parentAddressPath.length > 0;
+  && toRepoTopToken(occurrenceRecord.path) !== null;
 
 const toEvidenceRecord = (occurrenceRecord, knownRootMetadata) => ({
   addressPath: occurrenceRecord.addressPath,
@@ -79,11 +89,12 @@ export const prepareTreeKnownRootsCompatibilityEvidence = (input) => {
       continue;
     }
 
-    if (!isScopeTopFolderOccurrence(occurrenceRecord)) {
+    if (!isRepoTopFolderOccurrence(occurrenceRecord)) {
       continue;
     }
 
-    const knownRootMetadata = topRootLookup.get(occurrenceRecord.name);
+    const repoTopToken = toRepoTopToken(occurrenceRecord.path);
+    const knownRootMetadata = topRootLookup.get(repoTopToken);
     if (!knownRootMetadata) {
       continue;
     }

--- a/calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs
@@ -21,9 +21,10 @@ test('matches folder occurrence names against known-roots compatibility data and
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
       occurrenceRecords: [
-        { addressPath: 'A', path: 'repo/src', name: 'src', occurrenceType: 'folder' },
-        { addressPath: 'A.1', path: 'repo/src/index.js', name: 'index.js', occurrenceType: 'file' },
-        { addressPath: 'B', path: 'repo/test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'repo', name: 'repo', occurrenceType: 'folder' },
+        { addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/src', name: 'src', occurrenceType: 'folder' },
+        { addressPath: 'A.A.A', parentAddressPath: 'A.A', depth: 2, path: 'repo/src/test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'A.1', parentAddressPath: 'A', depth: 1, path: 'repo/readme.md', name: 'readme.md', occurrenceType: 'file' },
       ],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
@@ -34,7 +35,7 @@ test('matches folder occurrence names against known-roots compatibility data and
     }),
   });
 
-  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A', 'B']);
+  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A.A']);
   assert.equal(result.evidenceRecords.some((record) => record.occurrenceType === 'file'), false);
   assert.equal(result.evidenceRecords[0].path, 'repo/src');
   assert.equal(result.evidenceRecords[0].name, 'src');
@@ -48,8 +49,9 @@ test('preserves current known-root values without test/tests normalization', () 
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
       occurrenceRecords: [
-        { addressPath: 'A', path: 'repo/test', name: 'test', occurrenceType: 'folder' },
-        { addressPath: 'B', path: 'repo/tests', name: 'tests', occurrenceType: 'folder' },
+        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'repo', name: 'repo', occurrenceType: 'folder' },
+        { addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'A.B', parentAddressPath: 'A', depth: 1, path: 'repo/tests', name: 'tests', occurrenceType: 'folder' },
       ],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
@@ -63,7 +65,7 @@ test('preserves current known-root values without test/tests normalization', () 
 test('does not emit findings, severity, placement verdicts, confidence scores, or validation report fields', () => {
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
-      occurrenceRecords: [{ addressPath: 'A', path: 'repo/src', name: 'src', occurrenceType: 'folder' }],
+      occurrenceRecords: [{ addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/src', name: 'src', occurrenceType: 'folder' }],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
       topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
@@ -114,4 +116,23 @@ test('consumes an addressed snapshot prepared by prepareTreeCodebaseAddressedSna
   assert.equal(result.evidenceRecords.length, 1);
   assert.equal(result.evidenceRecords[0].name, 'src');
   assert.equal(result.evidenceRecords[0].addressPath, 'A.A');
+});
+
+
+test('matches only scope-top folder children and excludes scope root nested folders and files', () => {
+  const result = prepareTreeKnownRootsCompatibilityEvidence({
+    addressedTreeSnapshot: {
+      occurrenceRecords: [
+        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'repo/src', name: 'src', occurrenceType: 'folder' },
+        { addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/src', name: 'src', occurrenceType: 'folder' },
+        { addressPath: 'A.A.A', parentAddressPath: 'A.A', depth: 2, path: 'repo/src/src', name: 'src', occurrenceType: 'folder' },
+        { addressPath: 'A.1', parentAddressPath: 'A', depth: 1, path: 'repo/src.js', name: 'src', occurrenceType: 'file' },
+      ],
+    },
+    knownRootsRegistry: normalizeKnownRootsRegistry({
+      topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
+    }),
+  });
+
+  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A.A']);
 });

--- a/calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs
@@ -17,14 +17,14 @@ test('returns empty evidence for empty addressed occurrence records', () => {
   assert.deepEqual(result, { source: 'tree-known-roots-compatibility', evidenceRecords: [] });
 });
 
-test('matches folder occurrence names against known-roots compatibility data and preserves deterministic ordering', () => {
+test('matches repo-top folder paths against known-roots compatibility data and preserves deterministic ordering', () => {
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
       occurrenceRecords: [
-        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'repo', name: 'repo', occurrenceType: 'folder' },
-        { addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/src', name: 'src', occurrenceType: 'folder' },
-        { addressPath: 'A.A.A', parentAddressPath: 'A.A', depth: 2, path: 'repo/src/test', name: 'test', occurrenceType: 'folder' },
-        { addressPath: 'A.1', parentAddressPath: 'A', depth: 1, path: 'repo/readme.md', name: 'readme.md', occurrenceType: 'file' },
+        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'src', name: 'src', occurrenceType: 'folder' },
+        { addressPath: 'B', parentAddressPath: null, depth: 0, path: 'test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'C', parentAddressPath: null, depth: 0, path: 'docs/test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'D', parentAddressPath: null, depth: 0, path: 'src/index.js', name: 'index.js', occurrenceType: 'file' },
       ],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
@@ -35,9 +35,9 @@ test('matches folder occurrence names against known-roots compatibility data and
     }),
   });
 
-  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A.A']);
+  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A', 'B']);
   assert.equal(result.evidenceRecords.some((record) => record.occurrenceType === 'file'), false);
-  assert.equal(result.evidenceRecords[0].path, 'repo/src');
+  assert.equal(result.evidenceRecords[0].path, 'src');
   assert.equal(result.evidenceRecords[0].name, 'src');
   assert.equal(result.evidenceRecords[0].occurrenceType, 'folder');
   assert.equal(result.evidenceRecords[0].knownRootKind, 'structural');
@@ -49,9 +49,8 @@ test('preserves current known-root values without test/tests normalization', () 
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
       occurrenceRecords: [
-        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'repo', name: 'repo', occurrenceType: 'folder' },
-        { addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/test', name: 'test', occurrenceType: 'folder' },
-        { addressPath: 'A.B', parentAddressPath: 'A', depth: 1, path: 'repo/tests', name: 'tests', occurrenceType: 'folder' },
+        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'B', parentAddressPath: null, depth: 0, path: 'tests', name: 'tests', occurrenceType: 'folder' },
       ],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
@@ -65,7 +64,7 @@ test('preserves current known-root values without test/tests normalization', () 
 test('does not emit findings, severity, placement verdicts, confidence scores, or validation report fields', () => {
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
-      occurrenceRecords: [{ addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/src', name: 'src', occurrenceType: 'folder' }],
+      occurrenceRecords: [{ addressPath: 'A', parentAddressPath: null, depth: 0, path: 'src', name: 'src', occurrenceType: 'folder' }],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
       topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
@@ -95,12 +94,12 @@ test('consumes an addressed snapshot prepared by prepareTreeCodebaseAddressedSna
   const addressedTreeSnapshot = prepareTreeCodebaseAddressedSnapshot({
     scopeRoots: [
       {
-        name: 'repo',
-        path: 'repo',
+        name: 'src',
+        path: 'src',
         occurrenceType: 'folder',
         children: [
-          { name: 'src', path: 'repo/src', occurrenceType: 'folder', children: [] },
-          { name: 'file.txt', path: 'repo/file.txt', occurrenceType: 'file' },
+          { name: 'core', path: 'src/core', occurrenceType: 'folder', children: [] },
+          { name: 'file.txt', path: 'src/file.txt', occurrenceType: 'file' },
         ],
       },
     ],
@@ -115,24 +114,27 @@ test('consumes an addressed snapshot prepared by prepareTreeCodebaseAddressedSna
 
   assert.equal(result.evidenceRecords.length, 1);
   assert.equal(result.evidenceRecords[0].name, 'src');
-  assert.equal(result.evidenceRecords[0].addressPath, 'A.A');
+  assert.equal(result.evidenceRecords[0].addressPath, 'A');
 });
 
-
-test('matches only scope-top folder children and excludes scope root nested folders and files', () => {
+test('repo-top path-shape guard excludes scoped and nested known-root name matches', () => {
   const result = prepareTreeKnownRootsCompatibilityEvidence({
     addressedTreeSnapshot: {
       occurrenceRecords: [
-        { addressPath: 'A', parentAddressPath: null, depth: 0, path: 'repo/src', name: 'src', occurrenceType: 'folder' },
-        { addressPath: 'A.A', parentAddressPath: 'A', depth: 1, path: 'repo/src', name: 'src', occurrenceType: 'folder' },
-        { addressPath: 'A.A.A', parentAddressPath: 'A.A', depth: 2, path: 'repo/src/src', name: 'src', occurrenceType: 'folder' },
-        { addressPath: 'A.1', parentAddressPath: 'A', depth: 1, path: 'repo/src.js', name: 'src', occurrenceType: 'file' },
+        { addressPath: 'A', path: 'src', name: 'src', occurrenceType: 'folder', depth: 0, parentAddressPath: null },
+        { addressPath: 'A.A', path: 'calculogic-validator/src', name: 'src', occurrenceType: 'folder', depth: 1, parentAddressPath: 'A' },
+        { addressPath: 'A.B', path: 'docs/test', name: 'test', occurrenceType: 'folder', depth: 1, parentAddressPath: 'A' },
+        { addressPath: 'A.C', path: 'packages/foo/src', name: 'src', occurrenceType: 'folder', depth: 2, parentAddressPath: 'A.B' },
+        { addressPath: 'A.1', path: 'src.ts', name: 'src', occurrenceType: 'file', depth: 1, parentAddressPath: 'A' },
       ],
     },
     knownRootsRegistry: normalizeKnownRootsRegistry({
-      topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
+      topRoots: [
+        { root: 'src', kind: 'structural', ownershipSource: 'builtin' },
+        { root: 'test', kind: 'structural', ownershipSource: 'builtin' },
+      ],
     }),
   });
 
-  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A.A']);
+  assert.deepEqual(result.evidenceRecords.map((record) => record.path), ['src']);
 });

--- a/calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeKnownRootsCompatibilityEvidence } from '../src/tree-known-roots-compatibility-evidence.logic.mjs';
+import { normalizeTreeKnownRootsRegistryPayload } from '../src/registries/tree-known-roots-registry.logic.mjs';
+import { prepareTreeCodebaseAddressedSnapshot } from '../../structural-addressing/src/structural-addressing-tree-codebase.logic.mjs';
+
+const normalizeKnownRootsRegistry = (payload) => normalizeTreeKnownRootsRegistryPayload(payload);
+
+test('returns empty evidence for empty addressed occurrence records', () => {
+  const result = prepareTreeKnownRootsCompatibilityEvidence({
+    addressedTreeSnapshot: { occurrenceRecords: [] },
+    knownRootsRegistry: normalizeKnownRootsRegistry({
+      topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
+    }),
+  });
+
+  assert.deepEqual(result, { source: 'tree-known-roots-compatibility', evidenceRecords: [] });
+});
+
+test('matches folder occurrence names against known-roots compatibility data and preserves deterministic ordering', () => {
+  const result = prepareTreeKnownRootsCompatibilityEvidence({
+    addressedTreeSnapshot: {
+      occurrenceRecords: [
+        { addressPath: 'A', path: 'repo/src', name: 'src', occurrenceType: 'folder' },
+        { addressPath: 'A.1', path: 'repo/src/index.js', name: 'index.js', occurrenceType: 'file' },
+        { addressPath: 'B', path: 'repo/test', name: 'test', occurrenceType: 'folder' },
+      ],
+    },
+    knownRootsRegistry: normalizeKnownRootsRegistry({
+      topRoots: [
+        { root: 'src', kind: 'structural', ownershipSource: 'builtin', styleClass: 'generic-builtin' },
+        { root: 'test', kind: 'structural', ownershipSource: 'builtin' },
+      ],
+    }),
+  });
+
+  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A', 'B']);
+  assert.equal(result.evidenceRecords.some((record) => record.occurrenceType === 'file'), false);
+  assert.equal(result.evidenceRecords[0].path, 'repo/src');
+  assert.equal(result.evidenceRecords[0].name, 'src');
+  assert.equal(result.evidenceRecords[0].occurrenceType, 'folder');
+  assert.equal(result.evidenceRecords[0].knownRootKind, 'structural');
+  assert.equal(result.evidenceRecords[0].knownRootOwnershipSource, 'builtin');
+  assert.equal(result.evidenceRecords[0].knownRootStyleClass, 'generic-builtin');
+});
+
+test('preserves current known-root values without test/tests normalization', () => {
+  const result = prepareTreeKnownRootsCompatibilityEvidence({
+    addressedTreeSnapshot: {
+      occurrenceRecords: [
+        { addressPath: 'A', path: 'repo/test', name: 'test', occurrenceType: 'folder' },
+        { addressPath: 'B', path: 'repo/tests', name: 'tests', occurrenceType: 'folder' },
+      ],
+    },
+    knownRootsRegistry: normalizeKnownRootsRegistry({
+      topRoots: [{ root: 'test', kind: 'structural', ownershipSource: 'builtin' }],
+    }),
+  });
+
+  assert.deepEqual(result.evidenceRecords.map((record) => record.name), ['test']);
+});
+
+test('does not emit findings, severity, placement verdicts, confidence scores, or validation report fields', () => {
+  const result = prepareTreeKnownRootsCompatibilityEvidence({
+    addressedTreeSnapshot: {
+      occurrenceRecords: [{ addressPath: 'A', path: 'repo/src', name: 'src', occurrenceType: 'folder' }],
+    },
+    knownRootsRegistry: normalizeKnownRootsRegistry({
+      topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
+    }),
+  });
+
+  const evidenceRecord = result.evidenceRecords[0];
+  const forbiddenKeys = ['findingCode', 'severity', 'placementVerdict', 'confidenceScore', 'report'];
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(evidenceRecord, forbiddenKey), false);
+  }
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => prepareTreeKnownRootsCompatibilityEvidence(), /input must be an object/u);
+  assert.throws(
+    () => prepareTreeKnownRootsCompatibilityEvidence({ addressedTreeSnapshot: { occurrenceRecords: [] } }),
+    /must include knownRootsRegistry object/u,
+  );
+  assert.throws(
+    () => prepareTreeKnownRootsCompatibilityEvidence({ knownRootsRegistry: { topRoots: [] } }),
+    /must include addressedTreeSnapshot object/u,
+  );
+});
+
+test('consumes an addressed snapshot prepared by prepareTreeCodebaseAddressedSnapshot', () => {
+  const addressedTreeSnapshot = prepareTreeCodebaseAddressedSnapshot({
+    scopeRoots: [
+      {
+        name: 'repo',
+        path: 'repo',
+        occurrenceType: 'folder',
+        children: [
+          { name: 'src', path: 'repo/src', occurrenceType: 'folder', children: [] },
+          { name: 'file.txt', path: 'repo/file.txt', occurrenceType: 'file' },
+        ],
+      },
+    ],
+  });
+
+  const result = prepareTreeKnownRootsCompatibilityEvidence({
+    addressedTreeSnapshot,
+    knownRootsRegistry: normalizeKnownRootsRegistry({
+      topRoots: [{ root: 'src', kind: 'structural', ownershipSource: 'builtin' }],
+    }),
+  });
+
+  assert.equal(result.evidenceRecords.length, 1);
+  assert.equal(result.evidenceRecords[0].name, 'src');
+  assert.equal(result.evidenceRecords[0].addressPath, 'A.A');
+});


### PR DESCRIPTION
### Motivation
- Refs #505
- This adds a Tree-owned known-roots compatibility evidence adapter.
- The adapter consumes Structural Addressing-style addressed occurrence records and maps current Tree known-roots compatibility vocabulary onto addressed folder occurrences.
- The adapter output is evidence-only.
- It does not change Tree advisor behavior, findings, severity, report output, registry payloads, Structural Addressing runtime logic, or validate:addressing behavior.
- Implementation follows the core ownership rule: Structural Addressing V0 owns deterministic addressed occurrence production and `tree-known-roots` remains current runtime compatibility truth while the adapter maps compatibility evidence only.

### Description
- Added `calculogic-validator/tree/src/tree-known-roots-compatibility-evidence.logic.mjs` exporting `prepareTreeKnownRootsCompatibilityEvidence(input)` which accepts `{ addressedTreeSnapshot, knownRootsRegistry }`, validates inputs, and produces an evidence-only envelope `{ source, evidenceRecords }`.
- The adapter conservatively matches only `folder` occurrence records by `name` against `knownRootsRegistry.topRoots`, preserves `addressPath`, `path`, `name`, `occurrenceType`, preserves deterministic ordering, and emits compatibility-only fields (`knownRoot`, `knownRootKind`, `knownRootOwnershipSource`, optional `knownRootStyleClass`, `compatibilityRole`, `evidenceStrength`, `rationale`).
- No advisor wiring or runtime behavior changes were added and no registry JSONs were modified.
- Added focused unit tests at `calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs` covering empty inputs, folder-only matching, ordering preservation, `test`/`tests` non-normalization, absence of finding/severity/report fields, deterministic rejection of invalid input, and an integration-style test consuming `prepareTreeCodebaseAddressedSnapshot(...)` output.

### Testing
- `node --test calculogic-validator/tree/test/tree-known-roots-compatibility-evidence.logic.test.mjs` — passed (all tests green).
- `node --test calculogic-validator/tree/test/*.test.mjs` — passed (suite passed).
- `node --test calculogic-validator/structural-addressing/test/*.test.mjs` — passed (suite passed).
- `npm run validate:naming -- --scope=validator --target calculogic-validator/tree --target calculogic-validator/structural-addressing --target calculogic-validator/doc/ValidatorSpecs/tree-known-roots-structural-addressing-bridge.spec.md` — passed (validator run succeeded).
- `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` — passed (validator run succeeded).
- `npm run validate:all -- --scope=validator` — returned non-zero due to existing unrelated repo-wide findings/legacy exceptions outside the scope of this slice and did not block this adapter change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09efeb25888331b083678aaedb7200)