### PR TITLE
Add Tree structural-home evidence preparation over addressed occurrences

### DIFF
--- a/calculogic-validator/tree/src/tree-structural-home-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structural-home-evidence.logic.mjs
@@ -1,0 +1,105 @@
+const SOURCE_ID = 'tree-structural-home-evidence';
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree structural-home evidence input must be an object.');
+  }
+
+  if (!Array.isArray(input.addressedOccurrenceRecords)) {
+    throw new Error('Tree structural-home evidence input addressedOccurrenceRecords must be an array.');
+  }
+
+  if (!input.structuralHomesRegistry || typeof input.structuralHomesRegistry !== 'object' || Array.isArray(input.structuralHomesRegistry)) {
+    throw new Error('Tree structural-home evidence input must include structuralHomesRegistry object.');
+  }
+
+  if (!Array.isArray(input.structuralHomesRegistry.structuralHomes)) {
+    throw new Error('Tree structural-home evidence structuralHomesRegistry.structuralHomes must be an array.');
+  }
+};
+
+const toStructuralHomeLookup = (structuralHomes) => {
+  const lookup = new Map();
+
+  for (const structuralHomeEntry of structuralHomes) {
+    if (!structuralHomeEntry || typeof structuralHomeEntry !== 'object' || Array.isArray(structuralHomeEntry)) {
+      continue;
+    }
+
+    if (typeof structuralHomeEntry.structuralHome !== 'string' || structuralHomeEntry.structuralHome.length === 0) {
+      continue;
+    }
+
+    if (lookup.has(structuralHomeEntry.structuralHome)) {
+      continue;
+    }
+
+    lookup.set(structuralHomeEntry.structuralHome, {
+      structuralHome: structuralHomeEntry.structuralHome,
+      structuralHomeStatus: structuralHomeEntry.status ?? null,
+      structuralHomeDefinition: structuralHomeEntry.definition ?? null,
+    });
+  }
+
+  return lookup;
+};
+
+const toRepoTopToken = (pathValue) => {
+  if (typeof pathValue !== 'string' || pathValue.length === 0) {
+    return null;
+  }
+
+  if (pathValue.includes('/') || pathValue.includes('\\')) {
+    return null;
+  }
+
+  return pathValue;
+};
+
+const toEvidenceRecord = (occurrenceRecord, structuralHomeMetadata) => ({
+  addressPath: occurrenceRecord.addressPath ?? null,
+  parentAddressPath: occurrenceRecord.parentAddressPath ?? null,
+  path: occurrenceRecord.path ?? null,
+  name: occurrenceRecord.name ?? null,
+  occurrenceType: occurrenceRecord.occurrenceType ?? null,
+  structuralHome: structuralHomeMetadata.structuralHome,
+  structuralHomeSource: SOURCE_ID,
+  structuralHomeEvidenceStrength: 'direct-repo-top-match',
+  rationale: 'Repo-top folder token matches a Tree structural-home registry entry.',
+  structuralHomeStatus: structuralHomeMetadata.structuralHomeStatus,
+  structuralHomeDefinition: structuralHomeMetadata.structuralHomeDefinition,
+});
+
+export const prepareTreeStructuralHomeEvidence = (input) => {
+  assertValidInput(input);
+
+  const structuralHomeLookup = toStructuralHomeLookup(input.structuralHomesRegistry.structuralHomes);
+  const evidenceRecords = [];
+
+  for (const occurrenceRecord of input.addressedOccurrenceRecords) {
+    if (!occurrenceRecord || typeof occurrenceRecord !== 'object' || Array.isArray(occurrenceRecord)) {
+      continue;
+    }
+
+    if (occurrenceRecord.occurrenceType !== 'folder') {
+      continue;
+    }
+
+    const repoTopToken = toRepoTopToken(occurrenceRecord.path);
+    if (!repoTopToken) {
+      continue;
+    }
+
+    const structuralHomeMetadata = structuralHomeLookup.get(repoTopToken);
+    if (!structuralHomeMetadata) {
+      continue;
+    }
+
+    evidenceRecords.push(toEvidenceRecord(occurrenceRecord, structuralHomeMetadata));
+  }
+
+  return {
+    source: SOURCE_ID,
+    evidenceRecords,
+  };
+};

--- a/calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
+
+const structuralHomesRegistryFixture = {
+  version: '1',
+  structuralHomes: [
+    { structuralHome: 'src', status: 'active', definition: 'source home' },
+    { structuralHome: 'tests', status: 'active', definition: 'tests home' },
+  ],
+};
+
+test('returns empty evidence for empty addressed occurrence records', () => {
+  const result = prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords: [],
+    structuralHomesRegistry: structuralHomesRegistryFixture,
+  });
+
+  assert.deepEqual(result, { source: 'tree-structural-home-evidence', evidenceRecords: [] });
+});
+
+test('returns evidence-only records using repo-top folder matches and preserves ordering', () => {
+  const result = prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+      { addressPath: 'B', parentAddressPath: null, path: 'docs', name: 'docs', occurrenceType: 'folder' },
+      { addressPath: 'C', parentAddressPath: null, path: 'tests', name: 'tests', occurrenceType: 'folder' },
+    ],
+    structuralHomesRegistry: structuralHomesRegistryFixture,
+  });
+
+  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A', 'C']);
+  assert.deepEqual(Object.keys(result.evidenceRecords[0]).sort(), [
+    'addressPath',
+    'name',
+    'occurrenceType',
+    'parentAddressPath',
+    'path',
+    'rationale',
+    'structuralHome',
+    'structuralHomeDefinition',
+    'structuralHomeEvidenceStrength',
+    'structuralHomeSource',
+    'structuralHomeStatus',
+  ]);
+});
+
+test('does not emit findings/verdict or known-roots replacement fields', () => {
+  const result = prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+    ],
+    structuralHomesRegistry: structuralHomesRegistryFixture,
+  });
+
+  const evidenceRecord = result.evidenceRecords[0];
+  const forbiddenKeys = [
+    'finding',
+    'findingCode',
+    'severity',
+    'verdict',
+    'placementVerdict',
+    'isKnownTopRoot',
+    'isStructuralRoot',
+    'isSemanticRoot',
+    'structuralClass',
+    'structuralKind',
+  ];
+
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(evidenceRecord, forbiddenKey), false);
+  }
+});
+
+test('does not mutate structural homes registry input', () => {
+  const inputRegistry = {
+    version: '1',
+    structuralHomes: [{ structuralHome: 'src', status: 'active', definition: 'source home' }],
+  };
+  const inputRegistrySnapshot = JSON.parse(JSON.stringify(inputRegistry));
+
+  prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+    ],
+    structuralHomesRegistry: inputRegistry,
+  });
+
+  assert.deepEqual(inputRegistry, inputRegistrySnapshot);
+});
+
+test('handles non-folder occurrences and nested basename matches safely', () => {
+  const result = prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+      { addressPath: 'A.1', parentAddressPath: 'A', path: 'src/index.mjs', name: 'index.mjs', occurrenceType: 'file' },
+      { addressPath: 'B', parentAddressPath: null, path: 'calculogic-validator/src', name: 'src', occurrenceType: 'folder' },
+    ],
+    structuralHomesRegistry: structuralHomesRegistryFixture,
+  });
+
+  assert.deepEqual(result.evidenceRecords.map((record) => record.path), ['src']);
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => prepareTreeStructuralHomeEvidence(), /input must be an object/u);
+  assert.throws(
+    () => prepareTreeStructuralHomeEvidence({ addressedOccurrenceRecords: [] }),
+    /must include structuralHomesRegistry object/u,
+  );
+  assert.throws(
+    () => prepareTreeStructuralHomeEvidence({ structuralHomesRegistry: { structuralHomes: [] } }),
+    /addressedOccurrenceRecords must be an array/u,
+  );
+});


### PR DESCRIPTION
### Motivation
- Provide a Tree-owned preparation path that derives structural-home evidence from addressed occurrence records without changing current advisor output or replacing `tree-known-roots` runtime dependencies, Refs #516 and Refs #525. 
- Prepare a bounded evidence-only artefact to enable future behavior-preserving replacement slices and bridge work.

### Description
- Add `calculogic-validator/tree/src/tree-structural-home-evidence.logic.mjs` exporting `prepareTreeStructuralHomeEvidence(input)` which validates inputs and maps repo-top folder addressed occurrences to structural-home evidence using the builtin `structural-homes.registry.json`. 
- The helper emits evidence-only records containing `addressPath`, `parentAddressPath`, `path`, `name`, `occurrenceType`, `structuralHome`, `structuralHomeSource`, `structuralHomeEvidenceStrength`, `rationale` and registry-derived `structuralHomeStatus`/`structuralHomeDefinition`, and it explicitly omits findings, verdicts, severities, known-roots classification fields, or advisor decisions. 
- Add focused tests at `calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs` covering empty input, deterministic ordering, forbidden fields, registry immutability, nested/non-folder safety, and invalid-input guards. 
- This change does not modify registry JSON payloads, does not alter Structural Addressing runtime logic, and does not replace or remove existing known-roots wiring or advisor behavior. 

### Testing
- Executed `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs`, which passed all tests (6 passed, 0 failed). 
- Executed `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`, which completed in report mode with informational findings and no errors. 
- Executed `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`, which completed in report mode with existing advisory findings and no errors. 
- All automated checks above completed successfully and no advisor/runtime behavior was changed by this slice.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c041f39888331a1b7af93506cde83)