### PR TITLE
Wire tree structural-home evidence into advisor prepared dependencies

### DIFF
--- a/calculogic-validator/tree/src/registries/tree-structural-homes-registry.logic.mjs
+++ b/calculogic-validator/tree/src/registries/tree-structural-homes-registry.logic.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
+
+export const BUILTIN_STRUCTURAL_HOMES_REGISTRY_PATH = fileURLToPath(
+  new URL('structural-homes.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+let cachedBuiltinStructuralHomesRegistry = null;
+
+const normalizeStructuralHomesRegistryPayload = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Invalid builtin structural-homes registry: expected object payload.');
+  }
+
+  if (!Array.isArray(payload.structuralHomes)) {
+    throw new Error('Invalid builtin structural-homes registry: structuralHomes must be an array.');
+  }
+
+  return payload;
+};
+
+const loadBuiltinStructuralHomesRegistry = () => {
+  const payload = JSON.parse(fs.readFileSync(BUILTIN_STRUCTURAL_HOMES_REGISTRY_PATH, 'utf8'));
+  return normalizeStructuralHomesRegistryPayload(payload);
+};
+
+export const getBuiltinStructuralHomesRegistry = () => {
+  if (cachedBuiltinStructuralHomesRegistry === null) {
+    cachedBuiltinStructuralHomesRegistry = loadBuiltinStructuralHomesRegistry();
+  }
+
+  return cachedBuiltinStructuralHomesRegistry;
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -12,7 +12,9 @@ import {
 import { prepareTreeOccurrenceSnapshot } from './tree-occurrence-snapshot.logic.mjs';
 import { prepareTreeStructuralAddressSnapshot } from './tree-structural-address-snapshot.logic.mjs';
 import { prepareTreeKnownRootsCompatibilityEvidence } from './tree-known-roots-compatibility-evidence.logic.mjs';
+import { prepareTreeStructuralHomeEvidence } from './tree-structural-home-evidence.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
+import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
 const WALK_EXCLUDED_DIRECTORIES = new Set([
@@ -62,6 +64,7 @@ export const prepareTreeStructureAdvisorInputs = (
     },
   });
   const treeKnownRootsRegistry = getBuiltinTreeKnownRoots();
+  const structuralHomesRegistry = getBuiltinStructuralHomesRegistry();
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -74,6 +77,10 @@ export const prepareTreeStructureAdvisorInputs = (
       treeKnownRootsCompatibilityEvidence: prepareTreeKnownRootsCompatibilityEvidence({
         addressedTreeSnapshot: structuralAddressSnapshot,
         knownRootsRegistry: treeKnownRootsRegistry,
+      }),
+      treeStructuralHomeEvidence: prepareTreeStructuralHomeEvidence({
+        addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+        structuralHomesRegistry,
       }),
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -11,7 +11,9 @@ import { prepareTreeStructureAdvisorInputs } from '../src/tree-structure-advisor
 import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../src/tree-structure-advisor.logic.mjs';
 import { collectShimCompatFindings } from '../src/tree-shim-detection.logic.mjs';
 import { prepareTreeKnownRootsCompatibilityEvidence } from '../src/tree-known-roots-compatibility-evidence.logic.mjs';
+import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
+import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { listRegisteredValidators } from '../../src/core/validator-registry.knowledge.mjs';
 import { getValidatorScopeProfile } from '../../src/core/validator-scopes.logic.mjs';
 
@@ -156,12 +158,29 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     );
     assert.ok(preparedInputs.preparedDependencies);
     assert.ok(preparedInputs.preparedDependencies.treeKnownRootsCompatibilityEvidence);
+    assert.ok(preparedInputs.preparedDependencies.treeStructuralHomeEvidence);
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
+      prepareTreeStructuralHomeEvidence({
+        addressedOccurrenceRecords: snapshot.occurrenceRecords,
+        structuralHomesRegistry: getBuiltinStructuralHomesRegistry(),
+      }),
+    );
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeKnownRootsCompatibilityEvidence,
       prepareTreeKnownRootsCompatibilityEvidence({
         addressedTreeSnapshot: snapshot,
         knownRootsRegistry: getBuiltinTreeKnownRoots(),
       }),
+    );
+    const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;
+    assert.equal(Array.isArray(structuralHomeEvidenceRecords), true);
+    assert.equal(structuralHomeEvidenceRecords.some((record) => record.path === 'src'), true);
+    assert.equal(structuralHomeEvidenceRecords.some((record) => record.path === 'calculogic-validator/src'), false);
+    assert.equal(
+      structuralHomeEvidenceRecords.some((record) =>
+        ['findingCode', 'severity', 'placementVerdict', 'confidenceScore', 'report', 'isKnownTopRoot', 'isStructuralRoot', 'isSemanticRoot', 'structuralClass', 'structuralKind'].some((key) => Object.hasOwn(record, key))),
+      false,
     );
     const evidenceRecords = preparedInputs.preparedDependencies.treeKnownRootsCompatibilityEvidence.evidenceRecords;
     assert.equal(Array.isArray(evidenceRecords), true);


### PR DESCRIPTION
### Motivation
- Prepare Tree-owned structural-home evidence alongside existing Tree advisor inputs as a non-observable prepared dependency so later replacement slices can consume it without changing advisor output. 
- Preserve current known-roots runtime dependency and advisor behavior while staging a behavior-preserving handoff path for structural-home evidence. 
- Treated `tree-structure-advisor-validator.spec.md` as the runtime authority for advisor behavior and used the tree documentation map only as navigation/context for placement decisions. 

### Description
- Add a small Tree-owned builtin registry loader `getBuiltinStructuralHomesRegistry` at `calculogic-validator/tree/src/registries/tree-structural-homes-registry.logic.mjs`. 
- Wire `prepareTreeStructuralHomeEvidence(...)` into `prepareTreeStructureAdvisorInputs(...)` as `preparedDependencies.treeStructuralHomeEvidence`, sourcing `structuralAddressSnapshot.occurrenceRecords` and the builtin structural-homes registry, and keep `treeKnownRootsCompatibilityEvidence` unchanged. 
- Extend advisor wiring tests in `calculogic-validator/tree/test/tree-structure-advisor.test.mjs` to assert presence, evidence-only shape, matching helper output, and exclusion of nested-basename false positives, without changing registry JSON payloads or runtime findings. 
- Refs #516 and Refs #527. 

### Testing
- Ran `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs` which completed successfully with 6 tests passing. 
- Ran `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` which completed successfully with 40 tests passing. 
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` which completed successfully (exit 0) and produced the naming validation report. 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` which completed successfully (exit 0) and produced the tree validation report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd63086088331b31124f7fabafdd6)