### PR TITLE
Stage Naming semantic evidence payload bridge for Tree consumption

### DIFF
--- a/calculogic-validator/naming/src/naming-semantic-evidence-bridge.logic.mjs
+++ b/calculogic-validator/naming/src/naming-semantic-evidence-bridge.logic.mjs
@@ -1,0 +1,67 @@
+const toSortedUniqueStringValues = (values) =>
+  Array.from(
+    new Set(values.filter((value) => typeof value === 'string' && value.length > 0)),
+  ).sort((left, right) => left.localeCompare(right));
+
+const toNamingSemanticEvidenceRecord = (observation) => {
+  if (!observation || typeof observation !== 'object' || Array.isArray(observation)) {
+    return null;
+  }
+
+  if (typeof observation.path !== 'string' || observation.path.length === 0) {
+    return null;
+  }
+
+  if (
+    typeof observation.semanticName !== 'string' ||
+    observation.semanticName.length === 0 ||
+    typeof observation.semanticFamily !== 'string' ||
+    observation.semanticFamily.length === 0 ||
+    typeof observation.familyRoot !== 'string' ||
+    observation.familyRoot.length === 0
+  ) {
+    return null;
+  }
+
+  const splitMarkers = toSortedUniqueStringValues([
+    ...(Array.isArray(observation.ambiguityFlags) ? observation.ambiguityFlags : []),
+    ...(Array.isArray(observation.splitFamilyFlags) ? observation.splitFamilyFlags : []),
+  ]);
+
+  return {
+    path: observation.path,
+    semanticName: observation.semanticName,
+    semanticFamily: observation.semanticFamily,
+    familyRoot: observation.familyRoot,
+    ...(typeof observation.familySubgroup === 'string' && observation.familySubgroup.length > 0
+      ? { familySubgroup: observation.familySubgroup }
+      : {}),
+    semanticNameSource: 'naming-canonical-finding',
+    semanticFamilySource: 'naming-family-derivation',
+    evidenceSource: 'namingSemanticFamilyBridge',
+    evidenceStrength: splitMarkers.length === 0 ? 'high' : 'bounded',
+    ambiguityStatus: splitMarkers.length === 0 ? 'none' : 'present',
+    ...(splitMarkers.length > 0 ? { splitMarkers } : {}),
+  };
+};
+
+export const prepareNamingSemanticEvidenceBridge = (namingSemanticFamilyBridge = {}) => {
+  if (
+    !namingSemanticFamilyBridge ||
+    typeof namingSemanticFamilyBridge !== 'object' ||
+    Array.isArray(namingSemanticFamilyBridge)
+  ) {
+    throw new Error('Naming semantic evidence bridge requires an object payload.');
+  }
+
+  const observations = Array.isArray(namingSemanticFamilyBridge.observations)
+    ? namingSemanticFamilyBridge.observations
+    : [];
+
+  return {
+    observations: observations
+      .map(toNamingSemanticEvidenceRecord)
+      .filter(Boolean)
+      .sort((left, right) => left.path.localeCompare(right.path) || left.semanticName.localeCompare(right.semanticName)),
+  };
+};

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -21,6 +21,7 @@ import {
   summarizeFindings as summarizeFindingsRuntime,
 } from './naming-validator.logic.mjs';
 import { projectNamingSemanticFamilyBridge } from './naming-semantic-family-bridge-projection.logic.mjs';
+import { prepareNamingSemanticEvidenceBridge } from './naming-semantic-evidence-bridge.logic.mjs';
 import {
   normalizePath,
   resolveScopedTargets,
@@ -117,4 +118,5 @@ export {
   listNamingValidatorScopes,
   getScopeProfile,
   projectNamingSemanticFamilyBridge,
+  prepareNamingSemanticEvidenceBridge,
 };

--- a/calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs
+++ b/calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { prepareNamingSemanticEvidenceBridge } from '../src/naming-semantic-evidence-bridge.logic.mjs';
+
+test('prepareNamingSemanticEvidenceBridge returns deterministic evidence-only observations with stable ordering', () => {
+  const input = {
+    observations: [
+      {
+        path: 'src/z/order-payment.logic.ts',
+        semanticName: 'order-payment',
+        semanticFamily: 'order-payment',
+        familyRoot: 'order',
+        familySubgroup: 'payment',
+        ambiguityFlags: ['family-boundary-heuristic', 'family-boundary-heuristic'],
+      },
+      {
+        path: 'src/a/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        semanticFamily: 'build-surface',
+        familyRoot: 'build',
+        splitFamilyFlags: ['family-root-observed-multiple-families'],
+      },
+    ],
+  };
+
+  const before = structuredClone(input);
+  const result = prepareNamingSemanticEvidenceBridge(input);
+
+  assert.deepEqual(input, before);
+  assert.deepEqual(result, {
+    observations: [
+      {
+        path: 'src/a/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        semanticFamily: 'build-surface',
+        familyRoot: 'build',
+        semanticNameSource: 'naming-canonical-finding',
+        semanticFamilySource: 'naming-family-derivation',
+        evidenceSource: 'namingSemanticFamilyBridge',
+        evidenceStrength: 'bounded',
+        ambiguityStatus: 'present',
+        splitMarkers: ['family-root-observed-multiple-families'],
+      },
+      {
+        path: 'src/z/order-payment.logic.ts',
+        semanticName: 'order-payment',
+        semanticFamily: 'order-payment',
+        familyRoot: 'order',
+        familySubgroup: 'payment',
+        semanticNameSource: 'naming-canonical-finding',
+        semanticFamilySource: 'naming-family-derivation',
+        evidenceSource: 'namingSemanticFamilyBridge',
+        evidenceStrength: 'bounded',
+        ambiguityStatus: 'present',
+        splitMarkers: ['family-boundary-heuristic'],
+      },
+    ],
+  });
+
+  for (const observation of result.observations) {
+    assert.equal('findingCode' in observation, false);
+    assert.equal('severity' in observation, false);
+    assert.equal('verdict' in observation, false);
+    assert.equal('placementVerdict' in observation, false);
+    assert.equal('addressPath' in observation, false);
+    assert.equal('parentAddressPath' in observation, false);
+    assert.equal('isKnownTopRoot' in observation, false);
+    assert.equal('structuralClass' in observation, false);
+  }
+});
+
+test('prepareNamingSemanticEvidenceBridge returns empty observations for empty payload', () => {
+  assert.deepEqual(prepareNamingSemanticEvidenceBridge({}), { observations: [] });
+});
+
+test('prepareNamingSemanticEvidenceBridge deterministically rejects non-object payload', () => {
+  assert.throws(
+    () => prepareNamingSemanticEvidenceBridge([]),
+    /requires an object payload/u,
+  );
+});


### PR DESCRIPTION
### Motivation
- Implement Slice 9 to stage a Naming-owned, deterministic semantic evidence payload that Tree can consume without moving Naming parsing or adding Structural Addressing fields. 
- Current Naming internals support projecting Naming-owned semantic-family observations into a stable evidence-only shape, so this PR adds a bounded helper rather than a docs-only blocker. 
- Refs #516
- Refs #533

### Description
- Added `calculogic-validator/naming/src/naming-semantic-evidence-bridge.logic.mjs` exporting `prepareNamingSemanticEvidenceBridge(...)`, which projects Naming observations into deterministic, evidence-only records containing `path`, `semanticName`, `semanticFamily`, `familyRoot`, optional `familySubgroup`, normalized ambiguity/split metadata, and bounded source/strength fields. 
- Exported the helper via `calculogic-validator/naming/src/naming-validator.wiring.mjs` so downstream Tree slices can import it from the Naming host surface. 
- Added focused tests in `calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs` to assert deterministic ordering, input immutability, empty-input behavior, rejection of invalid payloads, and that no findings/advisor/addressing fields are emitted. 
- The helper intentionally does not emit `addressPath`, `parentAddressPath`, findings, verdicts, or Tree classification/advisor fields to preserve ownership boundaries and avoid changing Tree behavior.

### Testing
- Ran the unit tests with `node --test calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs` and the test suite passed (3 tests, all ✓). 
- Ran the Naming validator check with `npm run validate:naming -- --scope=validator --target calculogic-validator/naming/src --target calculogic-validator/naming/test` which produced the validator report but exited with code `2` due to pre-existing validator-scope findings in the targeted set (legacy/invalid entries); the new helper and its file are reported as canonical in the output. 
- Ran the Tree validator check with `npm run validate:tree -- --scope=validator --target calculogic-validator/naming/src --target calculogic-validator/naming/test` and it completed successfully (exit `0`) with no regressions attributable to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1baf3a78833190e33a074e50b09c)