### PR TITLE
Slice 10: prepare Tree semantic-home evidence from Naming bridge payload

### DIFF
--- a/calculogic-validator/tree/src/tree-semantic-home-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-semantic-home-evidence.logic.mjs
@@ -1,0 +1,124 @@
+const SOURCE_ID = 'tree-semantic-home-evidence';
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree semantic-home evidence input must be an object.');
+  }
+
+  if (!Array.isArray(input.addressedOccurrenceRecords)) {
+    throw new Error('Tree semantic-home evidence input addressedOccurrenceRecords must be an array.');
+  }
+
+  if (!Array.isArray(input.namingSemanticEvidenceRecords)) {
+    throw new Error('Tree semantic-home evidence input namingSemanticEvidenceRecords must be an array.');
+  }
+};
+
+const toDeterministicNamingRecordsByPath = (namingSemanticEvidenceRecords) => {
+  const recordsByPath = new Map();
+
+  for (const record of namingSemanticEvidenceRecords) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+      continue;
+    }
+
+    if (typeof record.path !== 'string' || record.path.length === 0) {
+      continue;
+    }
+
+    if (
+      typeof record.semanticName !== 'string' ||
+      record.semanticName.length === 0 ||
+      typeof record.semanticFamily !== 'string' ||
+      record.semanticFamily.length === 0 ||
+      typeof record.familyRoot !== 'string' ||
+      record.familyRoot.length === 0
+    ) {
+      continue;
+    }
+
+    if (!recordsByPath.has(record.path)) {
+      recordsByPath.set(record.path, []);
+    }
+
+    recordsByPath.get(record.path).push(record);
+  }
+
+  for (const pathRecords of recordsByPath.values()) {
+    pathRecords.sort((left, right) => {
+      if ((left.occurrenceType ?? '') !== (right.occurrenceType ?? '')) {
+        return (left.occurrenceType ?? '').localeCompare(right.occurrenceType ?? '');
+      }
+      if (left.semanticName !== right.semanticName) {
+        return left.semanticName.localeCompare(right.semanticName);
+      }
+      return left.semanticFamily.localeCompare(right.semanticFamily);
+    });
+  }
+
+  return recordsByPath;
+};
+
+const pickSafePathMatch = (occurrenceRecord, pathMatches) => {
+  if (!Array.isArray(pathMatches) || pathMatches.length === 0) {
+    return null;
+  }
+
+  const occurrenceTypeMatches = pathMatches.filter(
+    (record) => typeof record.occurrenceType === 'string' && record.occurrenceType === occurrenceRecord.occurrenceType,
+  );
+
+  if (occurrenceTypeMatches.length > 0) {
+    return occurrenceTypeMatches[0];
+  }
+
+  return pathMatches[0];
+};
+
+const toEvidenceRecord = (occurrenceRecord, namingRecord) => ({
+  addressPath: occurrenceRecord.addressPath ?? null,
+  parentAddressPath: occurrenceRecord.parentAddressPath ?? null,
+  path: occurrenceRecord.path,
+  name: occurrenceRecord.name ?? null,
+  occurrenceType: occurrenceRecord.occurrenceType ?? null,
+  semanticHome: namingRecord.semanticFamily,
+  semanticHomeSource: SOURCE_ID,
+  semanticHomeEvidenceStrength: namingRecord.evidenceStrength ?? 'bounded',
+  semanticName: namingRecord.semanticName,
+  semanticFamily: namingRecord.semanticFamily,
+  familyRoot: namingRecord.familyRoot,
+  ...(typeof namingRecord.familySubgroup === 'string' && namingRecord.familySubgroup.length > 0
+    ? { familySubgroup: namingRecord.familySubgroup }
+    : {}),
+  namingEvidenceSource: namingRecord.evidenceSource ?? 'namingSemanticFamilyBridge',
+  rationale: 'Tree joined addressed occurrence path with Naming-prepared semantic evidence path.',
+});
+
+export const prepareTreeSemanticHomeEvidence = (input) => {
+  assertValidInput(input);
+
+  const namingRecordsByPath = toDeterministicNamingRecordsByPath(input.namingSemanticEvidenceRecords);
+  const evidenceRecords = [];
+
+  for (const occurrenceRecord of input.addressedOccurrenceRecords) {
+    if (!occurrenceRecord || typeof occurrenceRecord !== 'object' || Array.isArray(occurrenceRecord)) {
+      continue;
+    }
+
+    if (typeof occurrenceRecord.path !== 'string' || occurrenceRecord.path.length === 0) {
+      continue;
+    }
+
+    const safeMatch = pickSafePathMatch(occurrenceRecord, namingRecordsByPath.get(occurrenceRecord.path));
+    if (!safeMatch) {
+      continue;
+    }
+
+    evidenceRecords.push(toEvidenceRecord(occurrenceRecord, safeMatch));
+  }
+
+  return {
+    source: SOURCE_ID,
+    evidenceRecords,
+  };
+};

--- a/calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evidence.logic.mjs';
+
+const namingSemanticEvidenceFixture = [
+  {
+    path: 'src/app-shell.logic.ts',
+    semanticName: 'app-shell',
+    semanticFamily: 'app-shell',
+    familyRoot: 'app',
+    familySubgroup: 'shell',
+    evidenceSource: 'namingSemanticFamilyBridge',
+    evidenceStrength: 'high',
+  },
+  {
+    path: 'test/tree-structure-advisor.test.mjs',
+    semanticName: 'tree-structure-advisor',
+    semanticFamily: 'tree-structure-advisor',
+    familyRoot: 'tree',
+    evidenceSource: 'namingSemanticFamilyBridge',
+    evidenceStrength: 'bounded',
+    occurrenceType: 'file',
+  },
+];
+
+test('returns deterministic evidence-only records joined by path and preserves addressed ordering', () => {
+  const addressedOccurrenceRecords = [
+    { addressPath: 'A', parentAddressPath: null, path: 'src/app-shell.logic.ts', name: 'app-shell.logic.ts', occurrenceType: 'file' },
+    { addressPath: 'B', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+    { addressPath: 'C', parentAddressPath: null, path: 'test/tree-structure-advisor.test.mjs', name: 'tree-structure-advisor.test.mjs', occurrenceType: 'file' },
+  ];
+
+  const beforeAddressed = structuredClone(addressedOccurrenceRecords);
+  const beforeNaming = structuredClone(namingSemanticEvidenceFixture);
+  const result = prepareTreeSemanticHomeEvidence({ addressedOccurrenceRecords, namingSemanticEvidenceRecords: namingSemanticEvidenceFixture });
+
+  assert.deepEqual(addressedOccurrenceRecords, beforeAddressed);
+  assert.deepEqual(namingSemanticEvidenceFixture, beforeNaming);
+  assert.deepEqual(result.evidenceRecords.map((record) => record.addressPath), ['A', 'C']);
+  assert.equal(result.evidenceRecords[0].addressPath, 'A');
+  assert.equal(result.evidenceRecords[0].parentAddressPath, null);
+  assert.equal(result.evidenceRecords[0].path, 'src/app-shell.logic.ts');
+  assert.equal(result.evidenceRecords[0].semanticName, 'app-shell');
+  assert.equal(result.evidenceRecords[0].semanticFamily, 'app-shell');
+  assert.equal(result.evidenceRecords[0].familyRoot, 'app');
+  assert.equal(result.evidenceRecords[0].familySubgroup, 'shell');
+});
+
+test('does not emit finding/verdict/advisor or known-roots classification fields', () => {
+  const result = prepareTreeSemanticHomeEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src/app-shell.logic.ts', name: 'app-shell.logic.ts', occurrenceType: 'file' },
+    ],
+    namingSemanticEvidenceRecords: namingSemanticEvidenceFixture,
+  });
+
+  const evidenceRecord = result.evidenceRecords[0];
+  const forbiddenKeys = [
+    'finding',
+    'findingCode',
+    'severity',
+    'verdict',
+    'placementVerdict',
+    'advisorDecision',
+    'isKnownTopRoot',
+    'isStructuralRoot',
+    'isSemanticRoot',
+    'structuralClass',
+    'structuralKind',
+  ];
+
+  for (const key of forbiddenKeys) {
+    assert.equal(Object.hasOwn(evidenceRecord, key), false);
+  }
+});
+
+test('safely skips unlinked naming evidence and unlinked addressed occurrences', () => {
+  const result = prepareTreeSemanticHomeEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src/only-addressed.logic.ts', name: 'only-addressed.logic.ts', occurrenceType: 'file' },
+    ],
+    namingSemanticEvidenceRecords: [
+      { path: 'src/only-naming.logic.ts', semanticName: 'only-naming', semanticFamily: 'only-naming', familyRoot: 'only' },
+    ],
+  });
+
+  assert.deepEqual(result, { source: 'tree-semantic-home-evidence', evidenceRecords: [] });
+});
+
+test('handles empty inputs and deterministically rejects invalid payloads', () => {
+  assert.deepEqual(
+    prepareTreeSemanticHomeEvidence({ addressedOccurrenceRecords: [], namingSemanticEvidenceRecords: [] }),
+    { source: 'tree-semantic-home-evidence', evidenceRecords: [] },
+  );
+
+  assert.throws(() => prepareTreeSemanticHomeEvidence(), /input must be an object/u);
+  assert.throws(
+    () => prepareTreeSemanticHomeEvidence({ addressedOccurrenceRecords: [] }),
+    /namingSemanticEvidenceRecords must be an array/u,
+  );
+  assert.throws(
+    () => prepareTreeSemanticHomeEvidence({ namingSemanticEvidenceRecords: [] }),
+    /addressedOccurrenceRecords must be an array/u,
+  );
+});


### PR DESCRIPTION
### Motivation
- Implement a Tree-owned, deterministic, evidence-only preparer to join Naming-prepared semantic evidence with addressed occurrence records so Tree can produce semantic-home evidence without changing advisor behavior or known-roots dependencies.  
- Treated validator specs for the Tree known-roots/semantic-home contracts and the Naming→Tree bridge as runtime authority, treated the Tree documentation map as navigation-only, and used the Naming bridge implementation files as task-scoped supporting context.  
- This slice preserves ownership boundaries: Naming supplies semantic fields, Structural Addressing supplies addressed occurrences, and Tree prepares semantic-home evidence only.

### Description
- Added `calculogic-validator/tree/src/tree-semantic-home-evidence.logic.mjs` exporting `prepareTreeSemanticHomeEvidence`, which deterministically joins `addressedOccurrenceRecords` with `namingSemanticEvidenceRecords` by `path` and prefers occurrence-type-safe matches.  
- The helper emits evidence-only records carrying `addressPath`/`parentAddressPath` from addressed occurrences and `semanticName`/`semanticFamily`/`familyRoot`/optional `familySubgroup` from Naming-prepared records, and it does not emit findings/verdict/advisor/known-roots fields.  
- Added focused unit tests in `calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs` validating deterministic ordering, safe linkage, immutability, empty/invalid inputs, and evidence-only boundaries.  
- Kept the helper standalone (no runtime wiring changes) to ensure non-observable behavior and avoid ambiguous composition with current advisor inputs.

### Testing
- Ran unit tests: `node --test calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs`, `node --test calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs`, and all tests passed (exit 0).  
- Ran naming validation: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` which completed successfully and produced naming info/classification findings (expected).  
- Ran tree validation: `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` which completed successfully and returned advisory/info findings (e.g., `TREE_SHIM_SURFACE_PRESENT`, `TREE_OBSERVED_FAMILY_CLUSTER`) that are existing, expected advisory outputs and not introduced by this change.

Refs #516
Refs #535

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2ac7c8b48331a0843102f75311fb)