### PR TITLE
Wire Tree semantic-home evidence into advisor prepared dependencies (non-observable)

### DIFF
--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -13,6 +13,8 @@ import { prepareTreeOccurrenceSnapshot } from './tree-occurrence-snapshot.logic.
 import { prepareTreeStructuralAddressSnapshot } from './tree-structural-address-snapshot.logic.mjs';
 import { prepareTreeKnownRootsCompatibilityEvidence } from './tree-known-roots-compatibility-evidence.logic.mjs';
 import { prepareTreeStructuralHomeEvidence } from './tree-structural-home-evidence.logic.mjs';
+import { prepareTreeSemanticHomeEvidence } from './tree-semantic-home-evidence.logic.mjs';
+import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
 
@@ -65,6 +67,9 @@ export const prepareTreeStructureAdvisorInputs = (
   });
   const treeKnownRootsRegistry = getBuiltinTreeKnownRoots();
   const structuralHomesRegistry = getBuiltinStructuralHomesRegistry();
+  const namingSemanticEvidenceBridge = namingSemanticFamilyBridge
+    ? prepareNamingSemanticEvidenceBridge(namingSemanticFamilyBridge)
+    : { observations: [] };
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -81,6 +86,10 @@ export const prepareTreeStructureAdvisorInputs = (
       treeStructuralHomeEvidence: prepareTreeStructuralHomeEvidence({
         addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
         structuralHomesRegistry,
+      }),
+      treeSemanticHomeEvidence: prepareTreeSemanticHomeEvidence({
+        addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+        namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
       }),
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -12,8 +12,10 @@ import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../sr
 import { collectShimCompatFindings } from '../src/tree-shim-detection.logic.mjs';
 import { prepareTreeKnownRootsCompatibilityEvidence } from '../src/tree-known-roots-compatibility-evidence.logic.mjs';
 import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
+import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evidence.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
+import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { listRegisteredValidators } from '../../src/core/validator-registry.knowledge.mjs';
 import { getValidatorScopeProfile } from '../../src/core/validator-scopes.logic.mjs';
 
@@ -159,6 +161,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies);
     assert.ok(preparedInputs.preparedDependencies.treeKnownRootsCompatibilityEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeStructuralHomeEvidence);
+    assert.ok(preparedInputs.preparedDependencies.treeSemanticHomeEvidence);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -171,6 +174,13 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
       prepareTreeKnownRootsCompatibilityEvidence({
         addressedTreeSnapshot: snapshot,
         knownRootsRegistry: getBuiltinTreeKnownRoots(),
+      }),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeSemanticHomeEvidence,
+      prepareTreeSemanticHomeEvidence({
+        addressedOccurrenceRecords: snapshot.occurrenceRecords,
+        namingSemanticEvidenceRecords: [],
       }),
     );
     const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;
@@ -195,6 +205,81 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         ['findingCode', 'severity', 'placementVerdict', 'confidenceScore', 'report'].some((key) => Object.hasOwn(record, key))),
       false,
     );
+    assert.deepEqual(preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords, []);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree-structure-advisor wiring prepares semantic-home evidence using naming semantic bridge inputs without changing runtime output', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-semantic-home-evidence-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.writeFile(
+      path.join(fixtureDir, 'src', 'semantic-family.topic-core.logic.mjs'),
+      'export const semantic = true\n',
+      'utf8',
+    );
+
+    const namingSemanticFamilyBridge = {
+      observations: [
+        {
+          path: 'src',
+          occurrenceType: 'folder',
+          semanticName: 'src',
+          semanticFamily: 'workspace-root',
+          familyRoot: 'workspace',
+          familySubgroup: 'root',
+        },
+        {
+          path: 'src/semantic-family.topic-core.logic.mjs',
+          occurrenceType: 'file',
+          semanticName: 'semantic-family',
+          semanticFamily: 'topic-core',
+          familyRoot: 'topic',
+        },
+      ],
+    };
+
+    const preparedInputs = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'repo', namingSemanticFamilyBridge });
+    const namingSemanticEvidenceBridge = prepareNamingSemanticEvidenceBridge(namingSemanticFamilyBridge);
+    const expectedSemanticHomeEvidence = prepareTreeSemanticHomeEvidence({
+      addressedOccurrenceRecords: preparedInputs.structuralAddressSnapshot.occurrenceRecords,
+      namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+    });
+
+    assert.deepEqual(preparedInputs.preparedDependencies.treeSemanticHomeEvidence, expectedSemanticHomeEvidence);
+    assert.equal(
+      preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords.some((record) => record.path === 'src'),
+      true,
+    );
+    assert.equal(
+      preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords.some(
+        (record) => record.path === 'src/semantic-family.topic-core.logic.mjs',
+      ),
+      true,
+    );
+    assert.equal(
+      preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords.some(
+        (record) => !Object.hasOwn(record, 'addressPath') || !Object.hasOwn(record, 'parentAddressPath'),
+      ),
+      false,
+    );
+    assert.equal(
+      preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords.some(
+        (record) =>
+          ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision', 'isKnownTopRoot', 'isStructuralRoot', 'isSemanticRoot', 'structuralClass', 'structuralKind'].some((key) =>
+            Object.hasOwn(record, key)),
+      ),
+      false,
+    );
+
+    const runtimeWithBridge = runTreeStructureAdvisorRuntime(preparedInputs);
+    const runtimeWithoutBridge = runTreeStructureAdvisorRuntime(
+      prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'repo' }),
+    );
+    assert.deepEqual(runtimeWithBridge, runtimeWithoutBridge);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Refs #516 and Refs #537: make `prepareTreeSemanticHomeEvidence(...)` available as a non-observable prepared dependency for the Tree advisor input wiring without changing advisor output or replacing known-roots runtime dependencies. 
- Preserve ownership boundaries so Naming remains the source of semantic-name/family signals and Tree joins that evidence to addressed occurrences for evidence-only consumption.

### Description
- Wired `prepareTreeSemanticHomeEvidence(...)` into `prepareTreeStructureAdvisorInputs(...)` so `preparedDependencies.treeSemanticHomeEvidence` is produced alongside `treeKnownRootsCompatibilityEvidence` and `treeStructuralHomeEvidence`. 
- Integrated the Naming bridge projection via `prepareNamingSemanticEvidenceBridge(...)` and defaulted to an empty observations payload when the bridge input is absent so the prepared dependency is safely empty. 
- The prepared dependency is evidence-only and carries `addressPath` / `parentAddressPath` from addressed occurrence records and `semanticName` / `semanticFamily` / `familyRoot` from Naming-prepared records only, and it does not introduce any advisor-visible fields or findings. 
- Kept runtime advisor behavior unchanged and preserved known-roots & structural-home prepared dependencies and policies.

### Testing
- Ran the focused unit tests: `node --test calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs`, `node --test calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, and all tests passed. 
- Ran validator checks: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`, and both completed (report-mode advisory findings only as expected). 
- Tests verify that `preparedDependencies.treeSemanticHomeEvidence` exists when inputs are prepared, matches the standalone helper output, consumes Naming-prepared evidence, includes addressed `addressPath`/`parentAddressPath`, remains evidence-only, and does not change advisor output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e44e71e6c8331b2677b361cb0c2e3)