### PR TITLE
Stage Tree folder-kind evidence preparation path

### DIFF
--- a/calculogic-validator/tree/src/registries/tree-folder-kinds-registry.logic.mjs
+++ b/calculogic-validator/tree/src/registries/tree-folder-kinds-registry.logic.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
+
+export const BUILTIN_FOLDER_KINDS_REGISTRY_PATH = fileURLToPath(
+  new URL('folder-kinds.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+let cachedBuiltinFolderKindsRegistry = null;
+
+const normalizeFolderKindsRegistryPayload = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Invalid builtin folder-kinds registry: expected object payload.');
+  }
+
+  if (!Array.isArray(payload.folderKinds)) {
+    throw new Error('Invalid builtin folder-kinds registry: folderKinds must be an array.');
+  }
+
+  return payload;
+};
+
+const loadBuiltinFolderKindsRegistry = () => {
+  const payload = JSON.parse(fs.readFileSync(BUILTIN_FOLDER_KINDS_REGISTRY_PATH, 'utf8'));
+  return normalizeFolderKindsRegistryPayload(payload);
+};
+
+export const getBuiltinFolderKindsRegistry = () => {
+  if (cachedBuiltinFolderKindsRegistry === null) {
+    cachedBuiltinFolderKindsRegistry = loadBuiltinFolderKindsRegistry();
+  }
+
+  return cachedBuiltinFolderKindsRegistry;
+};

--- a/calculogic-validator/tree/src/tree-folder-kind-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-folder-kind-evidence.logic.mjs
@@ -1,0 +1,155 @@
+const SOURCE_ID = 'tree-folder-kind-evidence';
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree folder-kind evidence input must be an object.');
+  }
+
+  if (!Array.isArray(input.addressedOccurrenceRecords)) {
+    throw new Error('Tree folder-kind evidence input addressedOccurrenceRecords must be an array.');
+  }
+
+  if (!input.folderKindsRegistry || typeof input.folderKindsRegistry !== 'object' || Array.isArray(input.folderKindsRegistry)) {
+    throw new Error('Tree folder-kind evidence input must include folderKindsRegistry object.');
+  }
+
+  if (!Array.isArray(input.folderKindsRegistry.folderKinds)) {
+    throw new Error('Tree folder-kind evidence folderKindsRegistry.folderKinds must be an array.');
+  }
+
+  if (!input.treeStructuralHomeEvidence || typeof input.treeStructuralHomeEvidence !== 'object' || Array.isArray(input.treeStructuralHomeEvidence)) {
+    throw new Error('Tree folder-kind evidence input must include treeStructuralHomeEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeStructuralHomeEvidence.evidenceRecords)) {
+    throw new Error('Tree folder-kind evidence treeStructuralHomeEvidence.evidenceRecords must be an array.');
+  }
+
+  if (!input.treeSemanticHomeEvidence || typeof input.treeSemanticHomeEvidence !== 'object' || Array.isArray(input.treeSemanticHomeEvidence)) {
+    throw new Error('Tree folder-kind evidence input must include treeSemanticHomeEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeSemanticHomeEvidence.evidenceRecords)) {
+    throw new Error('Tree folder-kind evidence treeSemanticHomeEvidence.evidenceRecords must be an array.');
+  }
+};
+
+const toSupportedFolderKindSet = (folderKinds) =>
+  new Set(
+    folderKinds
+      .filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry))
+      .map((entry) => entry.folderKind)
+      .filter((folderKind) => typeof folderKind === 'string' && folderKind.length > 0),
+  );
+
+const toPathLookup = (evidenceRecords, evidenceKey) => {
+  const lookup = new Map();
+
+  for (const evidenceRecord of evidenceRecords) {
+    if (!evidenceRecord || typeof evidenceRecord !== 'object' || Array.isArray(evidenceRecord)) {
+      continue;
+    }
+
+    if (typeof evidenceRecord.path !== 'string' || evidenceRecord.path.length === 0) {
+      continue;
+    }
+
+    if (lookup.has(evidenceRecord.path)) {
+      continue;
+    }
+
+    lookup.set(evidenceRecord.path, evidenceRecord[evidenceKey] ?? null);
+  }
+
+  return lookup;
+};
+
+const toEvidenceRecord = ({ occurrenceRecord, folderKind, folderKindSource, folderKindEvidenceStrength, structuralHome, semanticHome, rationale }) => ({
+  addressPath: occurrenceRecord.addressPath ?? null,
+  parentAddressPath: occurrenceRecord.parentAddressPath ?? null,
+  path: occurrenceRecord.path ?? null,
+  name: occurrenceRecord.name ?? null,
+  occurrenceType: occurrenceRecord.occurrenceType ?? null,
+  folderKind,
+  folderKindSource,
+  folderKindEvidenceStrength,
+  structuralHome,
+  semanticHome,
+  rationale,
+});
+
+export const prepareTreeFolderKindEvidence = (input) => {
+  assertValidInput(input);
+
+  const supportedFolderKinds = toSupportedFolderKindSet(input.folderKindsRegistry.folderKinds);
+  const structuralHomeByPath = toPathLookup(input.treeStructuralHomeEvidence.evidenceRecords, 'structuralHome');
+  const semanticHomeByPath = toPathLookup(input.treeSemanticHomeEvidence.evidenceRecords, 'semanticHome');
+
+  const evidenceRecords = [];
+
+  for (const occurrenceRecord of input.addressedOccurrenceRecords) {
+    if (!occurrenceRecord || typeof occurrenceRecord !== 'object' || Array.isArray(occurrenceRecord)) {
+      continue;
+    }
+
+    if (occurrenceRecord.occurrenceType !== 'folder') {
+      continue;
+    }
+
+    if (typeof occurrenceRecord.path !== 'string' || occurrenceRecord.path.length === 0) {
+      continue;
+    }
+
+    const structuralHome = structuralHomeByPath.get(occurrenceRecord.path) ?? null;
+    const semanticHome = semanticHomeByPath.get(occurrenceRecord.path) ?? null;
+
+    if (structuralHome && supportedFolderKinds.has('structural')) {
+      evidenceRecords.push(
+        toEvidenceRecord({
+          occurrenceRecord,
+          folderKind: 'structural',
+          folderKindSource: SOURCE_ID,
+          folderKindEvidenceStrength: 'derived-from-structural-home-evidence',
+          structuralHome,
+          semanticHome,
+          rationale: 'Tree structural-home evidence linked this folder path to a structural home.',
+        }),
+      );
+      continue;
+    }
+
+    if (semanticHome && supportedFolderKinds.has('semantic')) {
+      evidenceRecords.push(
+        toEvidenceRecord({
+          occurrenceRecord,
+          folderKind: 'semantic',
+          folderKindSource: SOURCE_ID,
+          folderKindEvidenceStrength: 'derived-from-semantic-home-evidence',
+          structuralHome,
+          semanticHome,
+          rationale: 'Tree semantic-home evidence linked this folder path to a semantic home.',
+        }),
+      );
+      continue;
+    }
+
+    if (supportedFolderKinds.has('unspecified')) {
+      evidenceRecords.push(
+        toEvidenceRecord({
+          occurrenceRecord,
+          folderKind: 'unspecified',
+          folderKindSource: SOURCE_ID,
+          folderKindEvidenceStrength: 'insufficient-tree-owned-evidence',
+          structuralHome,
+          semanticHome,
+          rationale: 'Tree-owned structural-home and semantic-home evidence did not resolve a stronger folder kind.',
+        }),
+      );
+    }
+  }
+
+  return {
+    source: SOURCE_ID,
+    evidenceRecords,
+  };
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -14,9 +14,11 @@ import { prepareTreeStructuralAddressSnapshot } from './tree-structural-address-
 import { prepareTreeKnownRootsCompatibilityEvidence } from './tree-known-roots-compatibility-evidence.logic.mjs';
 import { prepareTreeStructuralHomeEvidence } from './tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from './tree-semantic-home-evidence.logic.mjs';
+import { prepareTreeFolderKindEvidence } from './tree-folder-kind-evidence.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
+import { getBuiltinFolderKindsRegistry } from './registries/tree-folder-kinds-registry.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
 const WALK_EXCLUDED_DIRECTORIES = new Set([
@@ -67,9 +69,19 @@ export const prepareTreeStructureAdvisorInputs = (
   });
   const treeKnownRootsRegistry = getBuiltinTreeKnownRoots();
   const structuralHomesRegistry = getBuiltinStructuralHomesRegistry();
+  const folderKindsRegistry = getBuiltinFolderKindsRegistry();
   const namingSemanticEvidenceBridge = namingSemanticFamilyBridge
     ? prepareNamingSemanticEvidenceBridge(namingSemanticFamilyBridge)
     : { observations: [] };
+
+  const treeStructuralHomeEvidence = prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+    structuralHomesRegistry,
+  });
+  const treeSemanticHomeEvidence = prepareTreeSemanticHomeEvidence({
+    addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+    namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+  });
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -83,13 +95,13 @@ export const prepareTreeStructureAdvisorInputs = (
         addressedTreeSnapshot: structuralAddressSnapshot,
         knownRootsRegistry: treeKnownRootsRegistry,
       }),
-      treeStructuralHomeEvidence: prepareTreeStructuralHomeEvidence({
+      treeStructuralHomeEvidence,
+      treeSemanticHomeEvidence,
+      treeFolderKindEvidence: prepareTreeFolderKindEvidence({
         addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
-        structuralHomesRegistry,
-      }),
-      treeSemanticHomeEvidence: prepareTreeSemanticHomeEvidence({
-        addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
-        namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+        treeStructuralHomeEvidence,
+        treeSemanticHomeEvidence,
+        folderKindsRegistry,
       }),
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({

--- a/calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.logic.mjs';
+
+const folderKindsRegistryFixture = {
+  version: '1',
+  folderKinds: [
+    { folderKind: 'structural', status: 'active' },
+    { folderKind: 'semantic', status: 'active' },
+    { folderKind: 'unspecified', status: 'active' },
+  ],
+};
+
+test('returns deterministic evidence-only records from tree-owned inputs', () => {
+  const addressedOccurrenceRecords = [
+    { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+    { addressPath: 'A.1', parentAddressPath: 'A', path: 'src/runtime', name: 'runtime', occurrenceType: 'folder' },
+    { addressPath: 'A.2', parentAddressPath: 'A', path: 'src/readme.md', name: 'readme.md', occurrenceType: 'file' },
+  ];
+
+  const structuralEvidence = {
+    source: 'tree-structural-home-evidence',
+    evidenceRecords: [{ path: 'src', structuralHome: 'src' }],
+  };
+  const semanticEvidence = {
+    source: 'tree-semantic-home-evidence',
+    evidenceRecords: [{ path: 'src/runtime', semanticHome: 'runtime-core' }],
+  };
+
+  const beforeAddressed = structuredClone(addressedOccurrenceRecords);
+  const beforeStructural = structuredClone(structuralEvidence);
+  const beforeSemantic = structuredClone(semanticEvidence);
+  const beforeRegistry = structuredClone(folderKindsRegistryFixture);
+
+  const result = prepareTreeFolderKindEvidence({
+    addressedOccurrenceRecords,
+    treeStructuralHomeEvidence: structuralEvidence,
+    treeSemanticHomeEvidence: semanticEvidence,
+    folderKindsRegistry: folderKindsRegistryFixture,
+  });
+
+  assert.deepEqual(addressedOccurrenceRecords, beforeAddressed);
+  assert.deepEqual(structuralEvidence, beforeStructural);
+  assert.deepEqual(semanticEvidence, beforeSemantic);
+  assert.deepEqual(folderKindsRegistryFixture, beforeRegistry);
+  assert.deepEqual(result.evidenceRecords.map((record) => record.path), ['src', 'src/runtime']);
+  assert.deepEqual(result.evidenceRecords.map((record) => record.folderKind), ['structural', 'semantic']);
+  assert.deepEqual(Object.keys(result.evidenceRecords[0]).sort(), [
+    'addressPath',
+    'folderKind',
+    'folderKindEvidenceStrength',
+    'folderKindSource',
+    'name',
+    'occurrenceType',
+    'parentAddressPath',
+    'path',
+    'rationale',
+    'semanticHome',
+    'structuralHome',
+  ]);
+});
+
+test('does not emit findings/verdict or known-roots classification fields', () => {
+  const result = prepareTreeFolderKindEvidence({
+    addressedOccurrenceRecords: [{ addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' }],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'src', structuralHome: 'src' }] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    folderKindsRegistry: folderKindsRegistryFixture,
+  });
+
+  const forbiddenKeys = [
+    'finding',
+    'findingCode',
+    'severity',
+    'verdict',
+    'placementVerdict',
+    'advisorDecision',
+    'isKnownTopRoot',
+    'isStructuralRoot',
+    'isSemanticRoot',
+    'structuralClass',
+    'structuralKind',
+  ];
+
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(result.evidenceRecords[0], forbiddenKey), false);
+  }
+});
+
+test('skips unlinked evidence and handles empty input safely without basename inference', () => {
+  const result = prepareTreeFolderKindEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src/semantic', name: 'semantic', occurrenceType: 'folder' },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    folderKindsRegistry: {
+      version: '1',
+      folderKinds: [
+        { folderKind: 'structural', status: 'active' },
+        { folderKind: 'semantic', status: 'active' },
+      ],
+    },
+  });
+
+  assert.deepEqual(result, { source: 'tree-folder-kind-evidence', evidenceRecords: [] });
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => prepareTreeFolderKindEvidence(), /input must be an object/u);
+  assert.throws(
+    () => prepareTreeFolderKindEvidence({ addressedOccurrenceRecords: [] }),
+    /must include folderKindsRegistry object/u,
+  );
+  assert.throws(
+    () => prepareTreeFolderKindEvidence({
+      addressedOccurrenceRecords: [],
+      folderKindsRegistry: { folderKinds: [] },
+      treeStructuralHomeEvidence: { evidenceRecords: [] },
+    }),
+    /must include treeSemanticHomeEvidence object/u,
+  );
+});

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -13,8 +13,10 @@ import { collectShimCompatFindings } from '../src/tree-shim-detection.logic.mjs'
 import { prepareTreeKnownRootsCompatibilityEvidence } from '../src/tree-known-roots-compatibility-evidence.logic.mjs';
 import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evidence.logic.mjs';
+import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
+import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { listRegisteredValidators } from '../../src/core/validator-registry.knowledge.mjs';
 import { getValidatorScopeProfile } from '../../src/core/validator-scopes.logic.mjs';
@@ -162,6 +164,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeKnownRootsCompatibilityEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeStructuralHomeEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeSemanticHomeEvidence);
+    assert.ok(preparedInputs.preparedDependencies.treeFolderKindEvidence);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -181,6 +184,16 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
       prepareTreeSemanticHomeEvidence({
         addressedOccurrenceRecords: snapshot.occurrenceRecords,
         namingSemanticEvidenceRecords: [],
+      }),
+    );
+
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeFolderKindEvidence,
+      prepareTreeFolderKindEvidence({
+        addressedOccurrenceRecords: snapshot.occurrenceRecords,
+        treeStructuralHomeEvidence: preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
+        treeSemanticHomeEvidence: preparedInputs.preparedDependencies.treeSemanticHomeEvidence,
+        folderKindsRegistry: getBuiltinFolderKindsRegistry(),
       }),
     );
     const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;


### PR DESCRIPTION
### Motivation
- Stage a Tree-owned folder-kind evidence lane needed before replacing known-roots occurrence classification while preserving current advisor behavior. Refs #516 Refs #539.
- Keep the change strictly evidence-only and Tree-owned without touching advisor policy, known-roots payloads, or runtime classification decisions.

### Description
- Add `prepareTreeFolderKindEvidence` helper that consumes `addressedOccurrenceRecords`, Tree `structural-home` and `semantic-home` evidence, and the `folder-kinds` registry to emit deterministic, evidence-only folder-kind records (`calculogic-validator/tree/src/tree-folder-kind-evidence.logic.mjs`).
- Add a minimal builtin registry loader `getBuiltinFolderKindsRegistry` for `folder-kinds.registry.json` (`calculogic-validator/tree/src/registries/tree-folder-kinds-registry.logic.mjs`).
- Wire a non-observable prepared dependency `preparedDependencies.treeFolderKindEvidence` in the Tree advisor input preparation without changing runtime advisor logic (`calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs`).
- Add focused unit tests for the helper and extend wiring tests to assert parity between the prepared dependency and standalone helper output (`calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs` and updated `tree-structure-advisor.test.mjs`).
- No registry JSON payloads were changed and no advisor findings, verdicts, or occurrence-classification behavior were modified.

### Testing
- Ran helper unit tests with `node --test calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs` and they passed (all tests succeeded).
- Re-ran existing Tree tests with `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, and all tests passed (no failures).
- Executed naming and tree validators: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`, both completed successfully with expected report-only outputs.
- Tests verify the prepared folder-kind evidence is deterministic, evidence-only, uses only Tree-owned inputs and builtin `folder-kinds` registry, preserves input immutability, and that advisor output remains unchanged by the new prepared dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4dfd62b883319cb39613c0bf3981)