### PR TITLE
Stage occurrence classification parity evidence against topRoots kind

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs
@@ -92,6 +92,10 @@ const lookupFirstAvailable = (lookup, record, fallback = null) => {
 };
 
 const toCurrentClassLabel = (record) => {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return null;
+  }
+
   if (record?.isStructuralRoot === true) {
     return 'structural-root';
   }
@@ -123,12 +127,28 @@ const toReplacementClassLabel = ({ replacementFolderKind, replacementStructuralH
   return 'insufficient-evidence';
 };
 
-const toParityStatus = ({ occurrenceType, currentClassLabel, replacementClassLabel }) => {
-  if (occurrenceType !== 'folder') {
+const isTopRootCandidateOccurrence = (occurrenceRecord, currentRecord) => {
+  if (occurrenceRecord?.occurrenceType !== 'folder') {
+    return false;
+  }
+
+  if (currentRecord?.isKnownTopRoot === true || currentRecord?.isStructuralRoot === true || currentRecord?.isSemanticRoot === true) {
+    return true;
+  }
+
+  if (occurrenceRecord?.isScopeTopOccurrence === true || occurrenceRecord?.depth === 0 || occurrenceRecord?.parentAddressPath === null) {
+    return true;
+  }
+
+  return false;
+};
+
+const toParityStatus = ({ occurrenceType, isTopRootCandidate, hasCurrentClassification, replacementClassLabel, currentClassLabel }) => {
+  if (occurrenceType !== 'folder' || isTopRootCandidate !== true) {
     return 'not-applicable';
   }
 
-  if (replacementClassLabel === 'insufficient-evidence') {
+  if (!hasCurrentClassification || replacementClassLabel === 'insufficient-evidence' || currentClassLabel === null) {
     return 'insufficient-evidence';
   }
 
@@ -188,6 +208,8 @@ export const prepareTreeOccurrenceClassificationParityEvidence = (input) => {
     const replacementSemanticHome = lookupFirstAvailable(semanticHomeLookup, occurrenceRecord);
 
     const currentClassLabel = toCurrentClassLabel(currentRecord);
+    const isTopRootCandidate = isTopRootCandidateOccurrence(occurrenceRecord, currentRecord);
+    const hasCurrentClassification = currentRecord && typeof currentRecord === 'object' && !Array.isArray(currentRecord);
     const replacementClassLabel = toReplacementClassLabel({
       replacementFolderKind,
       replacementStructuralHome,
@@ -196,6 +218,8 @@ export const prepareTreeOccurrenceClassificationParityEvidence = (input) => {
 
     const parityStatus = toParityStatus({
       occurrenceType: occurrenceRecord?.occurrenceType ?? null,
+      isTopRootCandidate,
+      hasCurrentClassification,
       currentClassLabel,
       replacementClassLabel,
     });

--- a/calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs
@@ -1,0 +1,220 @@
+const SOURCE_ID = 'tree-occurrence-classification-parity-evidence';
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree occurrence classification parity evidence input must be an object.');
+  }
+
+  if (!Array.isArray(input.addressedOccurrenceRecords)) {
+    throw new Error('Tree occurrence classification parity evidence input addressedOccurrenceRecords must be an array.');
+  }
+
+  if (!Array.isArray(input.currentOccurrenceClassificationRecords)) {
+    throw new Error('Tree occurrence classification parity evidence input currentOccurrenceClassificationRecords must be an array.');
+  }
+
+  if (!input.treeStructuralHomeEvidence || typeof input.treeStructuralHomeEvidence !== 'object' || Array.isArray(input.treeStructuralHomeEvidence)) {
+    throw new Error('Tree occurrence classification parity evidence input must include treeStructuralHomeEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeStructuralHomeEvidence.evidenceRecords)) {
+    throw new Error('Tree occurrence classification parity evidence treeStructuralHomeEvidence.evidenceRecords must be an array.');
+  }
+
+  if (!input.treeSemanticHomeEvidence || typeof input.treeSemanticHomeEvidence !== 'object' || Array.isArray(input.treeSemanticHomeEvidence)) {
+    throw new Error('Tree occurrence classification parity evidence input must include treeSemanticHomeEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeSemanticHomeEvidence.evidenceRecords)) {
+    throw new Error('Tree occurrence classification parity evidence treeSemanticHomeEvidence.evidenceRecords must be an array.');
+  }
+
+  if (!input.treeFolderKindEvidence || typeof input.treeFolderKindEvidence !== 'object' || Array.isArray(input.treeFolderKindEvidence)) {
+    throw new Error('Tree occurrence classification parity evidence input must include treeFolderKindEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeFolderKindEvidence.evidenceRecords)) {
+    throw new Error('Tree occurrence classification parity evidence treeFolderKindEvidence.evidenceRecords must be an array.');
+  }
+};
+
+const toIdentityKey = (record) => {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return null;
+  }
+
+  if (typeof record.addressPath === 'string' && record.addressPath.length > 0) {
+    return `address:${record.addressPath}`;
+  }
+
+  if (
+    typeof record.path === 'string' &&
+    record.path.length > 0 &&
+    typeof record.occurrenceType === 'string' &&
+    record.occurrenceType.length > 0
+  ) {
+    return `path-type:${record.path}::${record.occurrenceType}`;
+  }
+
+  if (typeof record.path === 'string' && record.path.length > 0) {
+    return `path:${record.path}`;
+  }
+
+  return null;
+};
+
+const toEvidenceLookup = (evidenceRecords, evidenceKey) => {
+  const lookup = new Map();
+
+  for (const evidenceRecord of evidenceRecords) {
+    const key = toIdentityKey(evidenceRecord);
+    if (!key || lookup.has(key)) {
+      continue;
+    }
+
+    lookup.set(key, evidenceRecord[evidenceKey] ?? null);
+  }
+
+  return lookup;
+};
+
+const toCurrentClassLabel = (record) => {
+  if (record?.isStructuralRoot === true) {
+    return 'structural-root';
+  }
+
+  if (record?.isSemanticRoot === true) {
+    return 'semantic-root';
+  }
+
+  if (record?.isKnownTopRoot === true) {
+    return 'known-top-root';
+  }
+
+  return 'non-root-or-unknown';
+};
+
+const toReplacementClassLabel = ({ replacementFolderKind, replacementStructuralHome, replacementSemanticHome }) => {
+  if (replacementFolderKind === 'structural' || replacementStructuralHome) {
+    return 'structural-root';
+  }
+
+  if (replacementFolderKind === 'semantic' || replacementSemanticHome) {
+    return 'semantic-root';
+  }
+
+  if (replacementFolderKind === 'unspecified') {
+    return 'non-root-or-unknown';
+  }
+
+  return 'insufficient-evidence';
+};
+
+const toParityStatus = ({ occurrenceType, currentClassLabel, replacementClassLabel }) => {
+  if (occurrenceType !== 'folder') {
+    return 'not-applicable';
+  }
+
+  if (replacementClassLabel === 'insufficient-evidence') {
+    return 'insufficient-evidence';
+  }
+
+  return currentClassLabel === replacementClassLabel ? 'matches' : 'differs';
+};
+
+const toRationale = ({ parityStatus, currentClassLabel, replacementClassLabel }) => {
+  if (parityStatus === 'not-applicable') {
+    return 'Occurrence is not a folder; root classification parity comparison is not applicable.';
+  }
+
+  if (parityStatus === 'insufficient-evidence') {
+    return 'Tree-owned folder-kind/structural-home/semantic-home evidence did not safely resolve a replacement class.';
+  }
+
+  if (parityStatus === 'matches') {
+    return `Current class ${currentClassLabel} matched Tree-owned replacement evidence class ${replacementClassLabel}.`;
+  }
+
+  return `Current class ${currentClassLabel} differed from Tree-owned replacement evidence class ${replacementClassLabel}.`;
+};
+
+const sortByPathThenAddress = (left, right) => {
+  const byPath = String(left.path ?? '').localeCompare(String(right.path ?? ''));
+  if (byPath !== 0) {
+    return byPath;
+  }
+
+  return String(left.addressPath ?? '').localeCompare(String(right.addressPath ?? ''));
+};
+
+export const prepareTreeOccurrenceClassificationParityEvidence = (input) => {
+  assertValidInput(input);
+
+  const structuralHomeLookup = toEvidenceLookup(input.treeStructuralHomeEvidence.evidenceRecords, 'structuralHome');
+  const semanticHomeLookup = toEvidenceLookup(input.treeSemanticHomeEvidence.evidenceRecords, 'semanticHome');
+  const folderKindLookup = toEvidenceLookup(input.treeFolderKindEvidence.evidenceRecords, 'folderKind');
+
+  const currentByIdentity = new Map();
+  for (const record of input.currentOccurrenceClassificationRecords) {
+    const identityKey = toIdentityKey(record);
+    if (!identityKey || currentByIdentity.has(identityKey)) {
+      continue;
+    }
+
+    currentByIdentity.set(identityKey, record);
+  }
+
+  const parityRecords = [];
+
+  for (const occurrenceRecord of input.addressedOccurrenceRecords) {
+    const identityKey = toIdentityKey(occurrenceRecord);
+    const currentRecord = identityKey ? currentByIdentity.get(identityKey) ?? null : null;
+
+    const replacementFolderKind = identityKey ? folderKindLookup.get(identityKey) ?? null : null;
+    const replacementStructuralHome = identityKey ? structuralHomeLookup.get(identityKey) ?? null : null;
+    const replacementSemanticHome = identityKey ? semanticHomeLookup.get(identityKey) ?? null : null;
+
+    const currentClassLabel = toCurrentClassLabel(currentRecord);
+    const replacementClassLabel = toReplacementClassLabel({
+      replacementFolderKind,
+      replacementStructuralHome,
+      replacementSemanticHome,
+    });
+
+    const parityStatus = toParityStatus({
+      occurrenceType: occurrenceRecord?.occurrenceType ?? null,
+      currentClassLabel,
+      replacementClassLabel,
+    });
+
+    parityRecords.push({
+      addressPath: occurrenceRecord?.addressPath ?? null,
+      parentAddressPath: occurrenceRecord?.parentAddressPath ?? null,
+      path: occurrenceRecord?.path ?? null,
+      name: occurrenceRecord?.name ?? null,
+      occurrenceType: occurrenceRecord?.occurrenceType ?? null,
+      currentStructuralClass: currentRecord?.structuralClass ?? null,
+      currentStructuralKind: currentRecord?.structuralKind ?? null,
+      currentIsKnownTopRoot: currentRecord?.isKnownTopRoot ?? false,
+      currentIsStructuralRoot: currentRecord?.isStructuralRoot ?? false,
+      currentIsSemanticRoot: currentRecord?.isSemanticRoot ?? false,
+      replacementFolderKind,
+      replacementStructuralHome,
+      replacementSemanticHome,
+      parityStatus,
+      rationale: toRationale({ parityStatus, currentClassLabel, replacementClassLabel }),
+    });
+  }
+
+  const orderedParityRecords = [...parityRecords].sort(sortByPathThenAddress);
+  const summary = orderedParityRecords.reduce(
+    (counts, parityRecord) => ({ ...counts, [parityRecord.parityStatus]: (counts[parityRecord.parityStatus] ?? 0) + 1 }),
+    { matches: 0, differs: 0, 'insufficient-evidence': 0, 'not-applicable': 0 },
+  );
+
+  return {
+    source: SOURCE_ID,
+    parityRecords: orderedParityRecords,
+    summary,
+  };
+};

--- a/calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs
@@ -38,13 +38,15 @@ const assertValidInput = (input) => {
   }
 };
 
-const toIdentityKey = (record) => {
+const toIdentityKeys = (record) => {
   if (!record || typeof record !== 'object' || Array.isArray(record)) {
-    return null;
+    return [];
   }
 
+  const keys = [];
+
   if (typeof record.addressPath === 'string' && record.addressPath.length > 0) {
-    return `address:${record.addressPath}`;
+    keys.push(`address:${record.addressPath}`);
   }
 
   if (
@@ -53,29 +55,40 @@ const toIdentityKey = (record) => {
     typeof record.occurrenceType === 'string' &&
     record.occurrenceType.length > 0
   ) {
-    return `path-type:${record.path}::${record.occurrenceType}`;
+    keys.push(`path-type:${record.path}::${record.occurrenceType}`);
   }
 
   if (typeof record.path === 'string' && record.path.length > 0) {
-    return `path:${record.path}`;
+    keys.push(`path:${record.path}`);
   }
 
-  return null;
+  return keys;
 };
 
 const toEvidenceLookup = (evidenceRecords, evidenceKey) => {
   const lookup = new Map();
 
   for (const evidenceRecord of evidenceRecords) {
-    const key = toIdentityKey(evidenceRecord);
-    if (!key || lookup.has(key)) {
-      continue;
-    }
+    for (const key of toIdentityKeys(evidenceRecord)) {
+      if (lookup.has(key)) {
+        continue;
+      }
 
-    lookup.set(key, evidenceRecord[evidenceKey] ?? null);
+      lookup.set(key, evidenceRecord[evidenceKey] ?? null);
+    }
   }
 
   return lookup;
+};
+
+const lookupFirstAvailable = (lookup, record, fallback = null) => {
+  for (const key of toIdentityKeys(record)) {
+    if (lookup.has(key)) {
+      return lookup.get(key);
+    }
+  }
+
+  return fallback;
 };
 
 const toCurrentClassLabel = (record) => {
@@ -156,23 +169,23 @@ export const prepareTreeOccurrenceClassificationParityEvidence = (input) => {
 
   const currentByIdentity = new Map();
   for (const record of input.currentOccurrenceClassificationRecords) {
-    const identityKey = toIdentityKey(record);
-    if (!identityKey || currentByIdentity.has(identityKey)) {
-      continue;
-    }
+    for (const key of toIdentityKeys(record)) {
+      if (currentByIdentity.has(key)) {
+        continue;
+      }
 
-    currentByIdentity.set(identityKey, record);
+      currentByIdentity.set(key, record);
+    }
   }
 
   const parityRecords = [];
 
   for (const occurrenceRecord of input.addressedOccurrenceRecords) {
-    const identityKey = toIdentityKey(occurrenceRecord);
-    const currentRecord = identityKey ? currentByIdentity.get(identityKey) ?? null : null;
+    const currentRecord = lookupFirstAvailable(currentByIdentity, occurrenceRecord);
 
-    const replacementFolderKind = identityKey ? folderKindLookup.get(identityKey) ?? null : null;
-    const replacementStructuralHome = identityKey ? structuralHomeLookup.get(identityKey) ?? null : null;
-    const replacementSemanticHome = identityKey ? semanticHomeLookup.get(identityKey) ?? null : null;
+    const replacementFolderKind = lookupFirstAvailable(folderKindLookup, occurrenceRecord);
+    const replacementStructuralHome = lookupFirstAvailable(structuralHomeLookup, occurrenceRecord);
+    const replacementSemanticHome = lookupFirstAvailable(semanticHomeLookup, occurrenceRecord);
 
     const currentClassLabel = toCurrentClassLabel(currentRecord);
     const replacementClassLabel = toReplacementClassLabel({

--- a/calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs
@@ -80,3 +80,85 @@ test('rejects invalid input deterministically', () => {
     /currentOccurrenceClassificationRecords must be an array/u,
   );
 });
+
+test('falls back from addressPath to path+occurrenceType for current and replacement evidence lookup', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'Z.9', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+    ],
+    currentOccurrenceClassificationRecords: [
+      { path: 'src', occurrenceType: 'folder', structuralClass: 'repo-top-structural-root', structuralKind: 'top-root-structural', isKnownTopRoot: true, isStructuralRoot: true, isSemanticRoot: false },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'src', occurrenceType: 'folder', structuralHome: 'src' }] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [{ path: 'src', occurrenceType: 'folder', folderKind: 'structural' }] },
+  });
+
+  assert.equal(result.parityRecords[0].currentIsStructuralRoot, true);
+  assert.equal(result.parityRecords[0].replacementFolderKind, 'structural');
+  assert.equal(result.parityRecords[0].parityStatus, 'matches');
+});
+
+test('falls back to path when only path evidence exists and preserves precedence ordering', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'Z.1', parentAddressPath: null, path: 'docs', name: 'docs', occurrenceType: 'folder' },
+      { addressPath: 'Z.2', parentAddressPath: null, path: 'lib', name: 'lib', occurrenceType: 'folder' },
+    ],
+    currentOccurrenceClassificationRecords: [
+      { path: 'docs', structuralClass: 'repo-top-semantic-root', structuralKind: 'semantic-root', isKnownTopRoot: true, isStructuralRoot: false, isSemanticRoot: true },
+      { path: 'lib', occurrenceType: 'folder', structuralClass: 'repo-top-structural-root', structuralKind: 'top-root-structural', isKnownTopRoot: true, isStructuralRoot: true, isSemanticRoot: false },
+      { path: 'lib', structuralClass: 'repo-top-semantic-root', structuralKind: 'semantic-root', isKnownTopRoot: true, isStructuralRoot: false, isSemanticRoot: true },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'lib', structuralHome: 'lib' }] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'docs', semanticHome: 'documentation' }] },
+    treeFolderKindEvidence: {
+      source: 'x',
+      evidenceRecords: [
+        { path: 'docs', folderKind: 'semantic' },
+        { path: 'lib', occurrenceType: 'folder', folderKind: 'structural' },
+        { path: 'lib', folderKind: 'semantic' },
+      ],
+    },
+  });
+
+  const docsRecord = result.parityRecords.find((record) => record.path === 'docs');
+  const libRecord = result.parityRecords.find((record) => record.path === 'lib');
+
+  assert.equal(docsRecord.currentIsSemanticRoot, true);
+  assert.equal(docsRecord.replacementFolderKind, 'semantic');
+  assert.equal(libRecord.currentIsStructuralRoot, true);
+  assert.equal(libRecord.replacementFolderKind, 'structural');
+});
+
+test('addressPath match wins and avoids opportunistic file/folder merge when occurrenceType-safe evidence exists', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'pkg', name: 'pkg', occurrenceType: 'folder' },
+      { addressPath: 'A.1', parentAddressPath: 'A', path: 'pkg', name: 'pkg', occurrenceType: 'file' },
+    ],
+    currentOccurrenceClassificationRecords: [
+      { addressPath: 'A', path: 'pkg', occurrenceType: 'folder', structuralClass: 'repo-top-structural-root', structuralKind: 'top-root-structural', isKnownTopRoot: true, isStructuralRoot: true, isSemanticRoot: false },
+      { path: 'pkg', occurrenceType: 'folder', structuralClass: 'repo-top-semantic-root', structuralKind: 'semantic-root', isKnownTopRoot: true, isStructuralRoot: false, isSemanticRoot: true },
+      { path: 'pkg', occurrenceType: 'file', structuralClass: 'unclassified', structuralKind: 'unknown', isKnownTopRoot: false, isStructuralRoot: false, isSemanticRoot: false },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'pkg', occurrenceType: 'folder', structuralHome: 'pkg' }] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'pkg', occurrenceType: 'file', semanticHome: 'file-semantic' }] },
+    treeFolderKindEvidence: {
+      source: 'x',
+      evidenceRecords: [
+        { addressPath: 'A', path: 'pkg', occurrenceType: 'folder', folderKind: 'structural' },
+        { path: 'pkg', occurrenceType: 'file', folderKind: 'semantic' },
+      ],
+    },
+  });
+
+  const folderRecord = result.parityRecords.find((record) => record.addressPath === 'A');
+  const fileRecord = result.parityRecords.find((record) => record.addressPath === 'A.1');
+
+  assert.equal(folderRecord.currentIsStructuralRoot, true);
+  assert.equal(folderRecord.replacementFolderKind, 'structural');
+  assert.equal(fileRecord.currentIsStructuralRoot, false);
+  assert.equal(fileRecord.replacementFolderKind, 'semantic');
+  assert.equal(fileRecord.parityStatus, 'not-applicable');
+});

--- a/calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-evidence.logic.mjs';
+
+const baseInput = () => ({
+  addressedOccurrenceRecords: [
+    { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder' },
+    { addressPath: 'B', parentAddressPath: null, path: 'docs', name: 'docs', occurrenceType: 'folder' },
+    { addressPath: 'C', parentAddressPath: null, path: 'feature', name: 'feature', occurrenceType: 'folder' },
+    { addressPath: 'D', parentAddressPath: null, path: 'README.md', name: 'README.md', occurrenceType: 'file' },
+  ],
+  currentOccurrenceClassificationRecords: [
+    { addressPath: 'A', path: 'src', occurrenceType: 'folder', structuralClass: 'repo-top-structural-root', structuralKind: 'top-root-structural', isKnownTopRoot: true, isStructuralRoot: true, isSemanticRoot: false },
+    { addressPath: 'B', path: 'docs', occurrenceType: 'folder', structuralClass: 'repo-top-semantic-root', structuralKind: 'semantic-root', isKnownTopRoot: true, isStructuralRoot: false, isSemanticRoot: true },
+    { addressPath: 'C', path: 'feature', occurrenceType: 'folder', structuralClass: 'unclassified', structuralKind: 'unknown', isKnownTopRoot: false, isStructuralRoot: false, isSemanticRoot: false },
+    { addressPath: 'D', path: 'README.md', occurrenceType: 'file', structuralClass: 'unclassified', structuralKind: 'unknown', isKnownTopRoot: false, isStructuralRoot: false, isSemanticRoot: false },
+  ],
+  treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [{ addressPath: 'A', path: 'src', occurrenceType: 'folder', structuralHome: 'src' }] },
+  treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [{ addressPath: 'B', path: 'docs', occurrenceType: 'folder', semanticHome: 'documentation' }] },
+  treeFolderKindEvidence: {
+    source: 'x',
+    evidenceRecords: [
+      { addressPath: 'A', path: 'src', occurrenceType: 'folder', folderKind: 'structural' },
+      { addressPath: 'B', path: 'docs', occurrenceType: 'folder', folderKind: 'semantic' },
+      { addressPath: 'C', path: 'feature', occurrenceType: 'folder', folderKind: 'structural' },
+    ],
+  },
+});
+
+test('returns deterministic evidence-only parity records and summary', () => {
+  const input = baseInput();
+  const before = structuredClone(input);
+
+  const result = prepareTreeOccurrenceClassificationParityEvidence(input);
+
+  assert.deepEqual(input, before);
+  assert.equal(result.source, 'tree-occurrence-classification-parity-evidence');
+  assert.deepEqual(result.parityRecords.map((record) => record.path), ['docs', 'feature', 'README.md', 'src']);
+  assert.deepEqual(result.parityRecords.map((record) => record.parityStatus), ['matches', 'differs', 'not-applicable', 'matches']);
+  assert.deepEqual(result.summary, { matches: 2, differs: 1, 'insufficient-evidence': 0, 'not-applicable': 1 });
+});
+
+test('records insufficient-evidence without guessing and omits advisor output fields', () => {
+  const input = baseInput();
+  input.treeFolderKindEvidence = { source: 'x', evidenceRecords: [] };
+  input.treeStructuralHomeEvidence = { source: 'x', evidenceRecords: [] };
+  input.treeSemanticHomeEvidence = { source: 'x', evidenceRecords: [] };
+
+  const result = prepareTreeOccurrenceClassificationParityEvidence(input);
+  const docsRecord = result.parityRecords.find((record) => record.path === 'docs');
+
+  assert.equal(docsRecord.parityStatus, 'insufficient-evidence');
+
+  const forbiddenKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(docsRecord, forbiddenKey), false);
+  }
+});
+
+test('handles empty input safely', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [],
+    currentOccurrenceClassificationRecords: [],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [] },
+  });
+
+  assert.deepEqual(result, {
+    source: 'tree-occurrence-classification-parity-evidence',
+    parityRecords: [],
+    summary: { matches: 0, differs: 0, 'insufficient-evidence': 0, 'not-applicable': 0 },
+  });
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => prepareTreeOccurrenceClassificationParityEvidence(), /input must be an object/u);
+  assert.throws(
+    () => prepareTreeOccurrenceClassificationParityEvidence({ addressedOccurrenceRecords: [] }),
+    /currentOccurrenceClassificationRecords must be an array/u,
+  );
+});

--- a/calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs
@@ -162,3 +162,77 @@ test('addressPath match wins and avoids opportunistic file/folder merge when occ
   assert.equal(fileRecord.replacementFolderKind, 'semantic');
   assert.equal(fileRecord.parityStatus, 'not-applicable');
 });
+
+
+test('nested folder with replacement folder-kind evidence remains not-applicable', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A.B', parentAddressPath: 'A', path: 'src/nested', name: 'nested', occurrenceType: 'folder', depth: 1 },
+    ],
+    currentOccurrenceClassificationRecords: [
+      { path: 'src/nested', occurrenceType: 'folder', structuralClass: 'unclassified', structuralKind: 'unknown', isKnownTopRoot: false, isStructuralRoot: false, isSemanticRoot: false },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [{ path: 'src/nested', occurrenceType: 'folder', folderKind: 'structural' }] },
+  });
+
+  assert.equal(result.parityRecords[0].parityStatus, 'not-applicable');
+});
+
+test('nested folder with semantic-home evidence remains not-applicable', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A.B', parentAddressPath: 'A', path: 'docs/guide', name: 'guide', occurrenceType: 'folder', depth: 1 },
+    ],
+    currentOccurrenceClassificationRecords: [
+      { path: 'docs/guide', occurrenceType: 'folder', structuralClass: 'unclassified', structuralKind: 'unknown', isKnownTopRoot: false, isStructuralRoot: false, isSemanticRoot: false },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'docs/guide', occurrenceType: 'folder', semanticHome: 'documentation' }] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [{ path: 'docs/guide', occurrenceType: 'folder', folderKind: 'semantic' }] },
+  });
+
+  assert.equal(result.parityRecords[0].parityStatus, 'not-applicable');
+});
+
+test('top-root candidate with missing current classification becomes insufficient-evidence', () => {
+  const result = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'src', name: 'src', occurrenceType: 'folder', depth: 0 },
+    ],
+    currentOccurrenceClassificationRecords: [],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [{ path: 'src', occurrenceType: 'folder', structuralHome: 'src' }] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [{ path: 'src', occurrenceType: 'folder', folderKind: 'structural' }] },
+  });
+
+  assert.equal(result.parityRecords[0].parityStatus, 'insufficient-evidence');
+});
+
+test('matched current non-root remains distinguishable from missing current classification', () => {
+  const matchedCurrent = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'feature', name: 'feature', occurrenceType: 'folder', depth: 0 },
+    ],
+    currentOccurrenceClassificationRecords: [
+      { path: 'feature', occurrenceType: 'folder', structuralClass: 'unclassified', structuralKind: 'unknown', isKnownTopRoot: false, isStructuralRoot: false, isSemanticRoot: false },
+    ],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [{ path: 'feature', occurrenceType: 'folder', folderKind: 'unspecified' }] },
+  });
+
+  const missingCurrent = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: [
+      { addressPath: 'A', parentAddressPath: null, path: 'feature', name: 'feature', occurrenceType: 'folder', depth: 0 },
+    ],
+    currentOccurrenceClassificationRecords: [],
+    treeStructuralHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeSemanticHomeEvidence: { source: 'x', evidenceRecords: [] },
+    treeFolderKindEvidence: { source: 'x', evidenceRecords: [{ path: 'feature', occurrenceType: 'folder', folderKind: 'unspecified' }] },
+  });
+
+  assert.equal(matchedCurrent.parityRecords[0].parityStatus, 'matches');
+  assert.equal(missingCurrent.parityRecords[0].parityStatus, 'insufficient-evidence');
+});


### PR DESCRIPTION
### Motivation
- Refs #516 and Refs #541: prepare bounded parity-evidence showing whether Tree-owned evidence lanes (folder-kind, structural-home, semantic-home) reach the same top-root classification conclusions currently supplied by `topRoots[].kind` without replacing runtime behavior. 
- Provide a deterministic, evidence-only helper to compare current known-roots-backed occurrence classification output against Tree-owned replacement evidence lanes for future retirement planning of known-roots. 
- Preserve ownership boundaries and non-observability: this slice must only emit parity evidence and must not alter advisor behavior, findings, or existing occurrence-classification runtime truth. 

### Description
- Added `prepareTreeOccurrenceClassificationParityEvidence(...)` in `calculogic-validator/tree/src/tree-occurrence-classification-parity-evidence.logic.mjs` which validates inputs, deterministically matches occurrences by identity (`addressPath`, then `path+occurrenceType`, then `path`), and joins current classification to replacement evidence. 
- The helper maps replacement evidence into replacement class labels, computes a `parityStatus` (`matches`, `differs`, `insufficient-evidence`, `not-applicable`), and returns ordered `parityRecords` plus a `summary` counts object. 
- Implemented deterministic ordering (sort by `path` then `addressPath`), safe insufficient-evidence handling (no guessing), and strict evidence-only output that omits any finding/verdict/severity/advisor fields. 
- Added focused tests at `calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs` covering deterministic output, insufficient-evidence behavior, empty input, invalid-input guards, and evidence-only boundary; no runtime wiring or registry payloads were changed. 

### Testing
- Ran `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs` and the test suite passed. 
- Ran focused unit tests `node --test calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` and each command passed. 
- Ran repository validators `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and both validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5f25c7908331bc33df2c12d1389c)