### PR TITLE
Prepare tree occurrence classification parity evidence in advisor input wiring

### DIFF
--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -15,6 +15,8 @@ import { prepareTreeKnownRootsCompatibilityEvidence } from './tree-known-roots-c
 import { prepareTreeStructuralHomeEvidence } from './tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from './tree-semantic-home-evidence.logic.mjs';
 import { prepareTreeFolderKindEvidence } from './tree-folder-kind-evidence.logic.mjs';
+import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.logic.mjs';
+import { prepareTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-evidence.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
@@ -82,6 +84,16 @@ export const prepareTreeStructureAdvisorInputs = (
     addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
     namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
   });
+  const treeFolderKindEvidence = prepareTreeFolderKindEvidence({
+    addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+    treeStructuralHomeEvidence,
+    treeSemanticHomeEvidence,
+    folderKindsRegistry,
+  });
+  const currentOccurrenceClassificationRecords = classifyTreeOccurrenceRecords({
+    occurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+    treeKnownRoots: treeKnownRootsRegistry,
+  });
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -97,11 +109,13 @@ export const prepareTreeStructureAdvisorInputs = (
       }),
       treeStructuralHomeEvidence,
       treeSemanticHomeEvidence,
-      treeFolderKindEvidence: prepareTreeFolderKindEvidence({
+      treeFolderKindEvidence,
+      treeOccurrenceClassificationParityEvidence: prepareTreeOccurrenceClassificationParityEvidence({
         addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+        currentOccurrenceClassificationRecords,
         treeStructuralHomeEvidence,
         treeSemanticHomeEvidence,
-        folderKindsRegistry,
+        treeFolderKindEvidence,
       }),
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -14,6 +14,8 @@ import { prepareTreeKnownRootsCompatibilityEvidence } from '../src/tree-known-ro
 import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evidence.logic.mjs';
 import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.logic.mjs';
+import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classification.logic.mjs';
+import { prepareTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-evidence.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -165,6 +167,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeStructuralHomeEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeSemanticHomeEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeFolderKindEvidence);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -196,6 +199,19 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         folderKindsRegistry: getBuiltinFolderKindsRegistry(),
       }),
     );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence,
+      prepareTreeOccurrenceClassificationParityEvidence({
+        addressedOccurrenceRecords: snapshot.occurrenceRecords,
+        currentOccurrenceClassificationRecords: classifyTreeOccurrenceRecords({
+          occurrenceRecords: snapshot.occurrenceRecords,
+          treeKnownRoots: getBuiltinTreeKnownRoots(),
+        }),
+        treeStructuralHomeEvidence: preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
+        treeSemanticHomeEvidence: preparedInputs.preparedDependencies.treeSemanticHomeEvidence,
+        treeFolderKindEvidence: preparedInputs.preparedDependencies.treeFolderKindEvidence,
+      }),
+    );
     const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;
     assert.equal(Array.isArray(structuralHomeEvidenceRecords), true);
     assert.equal(structuralHomeEvidenceRecords.some((record) => record.path === 'src'), true);
@@ -219,6 +235,15 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
       false,
     );
     assert.deepEqual(preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords, []);
+    const parityEvidence = preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence;
+    assert.equal(Array.isArray(parityEvidence.parityRecords), true);
+    assert.equal(typeof parityEvidence.summary, 'object');
+    assert.equal(
+      parityEvidence.parityRecords.some((record) =>
+        ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) =>
+          Object.hasOwn(record, key))),
+      false,
+    );
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Provide a non-observable prepared dependency that computes parity between the current known-roots-backed occurrence classification and staged Tree-owned evidence lanes so parity can be inspected before any behavior replacement. 
- Wire this parity preparation into Tree advisor input preparation without changing advisor output or current occurrence-classification runtime truth. 

### Description
- Import `classifyTreeOccurrenceRecords` and `prepareTreeOccurrenceClassificationParityEvidence` and compute `currentOccurrenceClassificationRecords` by calling `classifyTreeOccurrenceRecords(...)` on the structural address snapshot. 
- Prepare `treeOccurrenceClassificationParityEvidence` inside `prepareTreeStructureAdvisorInputs(...)` (returned as `preparedDependencies.treeOccurrenceClassificationParityEvidence`) by calling `prepareTreeOccurrenceClassificationParityEvidence(...)` with `addressedOccurrenceRecords`, `currentOccurrenceClassificationRecords`, `treeStructuralHomeEvidence`, `treeSemanticHomeEvidence`, and `treeFolderKindEvidence`. 
- Preserve existing behavior by reusing the current `classifyTreeOccurrenceRecords(...)` path as input only and by keeping the parity result evidence-only (no findings or advisor-visible changes). 
- Extend/adjust wiring tests in `tree/test/tree-structure-advisor.test.mjs` to assert the prepared dependency exists, matches the standalone helper output, and contains evidence-only parity records and summary. 

### Testing
- Ran focused unit tests: `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-structural-home-evidence.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs`; all tests passed. 
- Ran validators: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`; both completed successfully. 
- Verification confirms that advisor runtime output is unchanged and the prepared parity evidence is present, matches helper output, and remains evidence-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e88d5bd248331bf3fc16c3fbbdf6c)