### PR TITLE
Stage tree occurrence-classification parity summary evidence metadata

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-parity-summary.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-parity-summary.logic.mjs
@@ -1,0 +1,112 @@
+const SOURCE_ID = 'tree-occurrence-classification-parity-summary';
+
+const VALID_PARITY_STATUSES = new Set(['matches', 'differs', 'insufficient-evidence', 'not-applicable']);
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree occurrence classification parity summary input must be an object.');
+  }
+
+  if (!Array.isArray(input.parityRecords)) {
+    throw new Error('Tree occurrence classification parity summary input parityRecords must be an array.');
+  }
+};
+
+const countByParityStatus = (parityRecords) => {
+  const counts = {
+    matches: 0,
+    differs: 0,
+    'insufficient-evidence': 0,
+    'not-applicable': 0,
+  };
+
+  for (const record of parityRecords) {
+    const parityStatus = record?.parityStatus;
+
+    if (!VALID_PARITY_STATUSES.has(parityStatus)) {
+      continue;
+    }
+
+    counts[parityStatus] += 1;
+  }
+
+  return counts;
+};
+
+const toReplacementReadinessStatus = ({ comparableRecords, insufficientEvidenceRecords, differedRecords, matchedRecords }) => {
+  if (comparableRecords === 0 || insufficientEvidenceRecords > 0) {
+    return 'not-ready';
+  }
+
+  if (differedRecords > 0) {
+    return 'needs-review';
+  }
+
+  if (matchedRecords === comparableRecords) {
+    return 'candidate-ready';
+  }
+
+  return 'needs-review';
+};
+
+const toRationale = ({ replacementReadinessStatus, comparableRecords, insufficientEvidenceRecords, differedRecords, matchedRecords }) => {
+  if (replacementReadinessStatus === 'not-ready' && comparableRecords === 0) {
+    return 'No comparable parity records were available after excluding not-applicable records.';
+  }
+
+  if (replacementReadinessStatus === 'not-ready' && insufficientEvidenceRecords > 0) {
+    return 'One or more comparable parity records were insufficient-evidence; replacement confidence cannot be observed as ready.';
+  }
+
+  if (replacementReadinessStatus === 'needs-review' && differedRecords > 0) {
+    return 'One or more comparable parity records differed and need review before any behavior-preserving replacement decision.';
+  }
+
+  if (replacementReadinessStatus === 'candidate-ready' && matchedRecords === comparableRecords) {
+    return 'All comparable parity records matched with no insufficient-evidence records.';
+  }
+
+  return 'Parity evidence summary indicates review is required before replacement confidence can be considered ready.';
+};
+
+export const summarizeTreeOccurrenceClassificationParityEvidence = (parityEvidence) => {
+  assertValidInput(parityEvidence);
+
+  const counts = countByParityStatus(parityEvidence.parityRecords);
+  const totalRecords = parityEvidence.parityRecords.length;
+  const notApplicableRecords = counts['not-applicable'];
+  const comparableRecords = totalRecords - notApplicableRecords;
+  const matchedRecords = counts.matches;
+  const differedRecords = counts.differs;
+  const insufficientEvidenceRecords = counts['insufficient-evidence'];
+  const parityCoverageRatio = comparableRecords === 0 ? 0 : (matchedRecords + differedRecords) / comparableRecords;
+  const parityMatchRatio = comparableRecords === 0 ? 0 : matchedRecords / comparableRecords;
+
+  const replacementReadinessStatus = toReplacementReadinessStatus({
+    comparableRecords,
+    insufficientEvidenceRecords,
+    differedRecords,
+    matchedRecords,
+  });
+
+  return {
+    source: SOURCE_ID,
+    parityEvidenceSource: parityEvidence.source ?? null,
+    totalRecords,
+    comparableRecords,
+    matchedRecords,
+    differedRecords,
+    insufficientEvidenceRecords,
+    notApplicableRecords,
+    parityCoverageRatio,
+    parityMatchRatio,
+    replacementReadinessStatus,
+    rationale: toRationale({
+      replacementReadinessStatus,
+      comparableRecords,
+      insufficientEvidenceRecords,
+      differedRecords,
+      matchedRecords,
+    }),
+  };
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -17,6 +17,7 @@ import { prepareTreeSemanticHomeEvidence } from './tree-semantic-home-evidence.l
 import { prepareTreeFolderKindEvidence } from './tree-folder-kind-evidence.logic.mjs';
 import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-evidence.logic.mjs';
+import { summarizeTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-summary.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
@@ -95,6 +96,14 @@ export const prepareTreeStructureAdvisorInputs = (
     treeKnownRoots: treeKnownRootsRegistry,
   });
 
+  const treeOccurrenceClassificationParityEvidence = prepareTreeOccurrenceClassificationParityEvidence({
+    addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+    currentOccurrenceClassificationRecords,
+    treeStructuralHomeEvidence,
+    treeSemanticHomeEvidence,
+    treeFolderKindEvidence,
+  });
+
   return {
     scope: scopedSnapshotInputs.scope,
     selectedPaths,
@@ -110,13 +119,8 @@ export const prepareTreeStructureAdvisorInputs = (
       treeStructuralHomeEvidence,
       treeSemanticHomeEvidence,
       treeFolderKindEvidence,
-      treeOccurrenceClassificationParityEvidence: prepareTreeOccurrenceClassificationParityEvidence({
-        addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
-        currentOccurrenceClassificationRecords,
-        treeStructuralHomeEvidence,
-        treeSemanticHomeEvidence,
-        treeFolderKindEvidence,
-      }),
+      treeOccurrenceClassificationParityEvidence,
+      treeOccurrenceClassificationParitySummary: summarizeTreeOccurrenceClassificationParityEvidence(treeOccurrenceClassificationParityEvidence),
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,

--- a/calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { summarizeTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-summary.logic.mjs';
+
+const baseEvidence = () => ({
+  source: 'tree-occurrence-classification-parity-evidence',
+  parityRecords: [
+    { path: 'a', parityStatus: 'matches' },
+    { path: 'b', parityStatus: 'differs' },
+    { path: 'c', parityStatus: 'insufficient-evidence' },
+    { path: 'd', parityStatus: 'not-applicable' },
+  ],
+  summary: { matches: 1, differs: 1, 'insufficient-evidence': 1, 'not-applicable': 1 },
+});
+
+test('summarizes parity evidence counts deterministically without mutation', () => {
+  const evidence = baseEvidence();
+  const before = structuredClone(evidence);
+  const result = summarizeTreeOccurrenceClassificationParityEvidence(evidence);
+
+  assert.deepEqual(evidence, before);
+  assert.equal(result.totalRecords, 4);
+  assert.equal(result.comparableRecords, 3);
+  assert.equal(result.matchedRecords, 1);
+  assert.equal(result.differedRecords, 1);
+  assert.equal(result.insufficientEvidenceRecords, 1);
+  assert.equal(result.notApplicableRecords, 1);
+  assert.equal(result.parityCoverageRatio, 2 / 3);
+  assert.equal(result.parityMatchRatio, 1 / 3);
+});
+
+test('returns not-ready when comparable records are zero', () => {
+  const result = summarizeTreeOccurrenceClassificationParityEvidence({
+    source: 'tree-occurrence-classification-parity-evidence',
+    parityRecords: [{ path: 'x', parityStatus: 'not-applicable' }],
+    summary: { matches: 0, differs: 0, 'insufficient-evidence': 0, 'not-applicable': 1 },
+  });
+
+  assert.equal(result.replacementReadinessStatus, 'not-ready');
+});
+
+test('returns not-ready when insufficient-evidence exists', () => {
+  const result = summarizeTreeOccurrenceClassificationParityEvidence(baseEvidence());
+  assert.equal(result.replacementReadinessStatus, 'not-ready');
+});
+
+test('returns needs-review when differs exists without insufficient-evidence', () => {
+  const result = summarizeTreeOccurrenceClassificationParityEvidence({
+    source: 'tree-occurrence-classification-parity-evidence',
+    parityRecords: [
+      { path: 'a', parityStatus: 'matches' },
+      { path: 'b', parityStatus: 'differs' },
+    ],
+    summary: { matches: 1, differs: 1, 'insufficient-evidence': 0, 'not-applicable': 0 },
+  });
+
+  assert.equal(result.replacementReadinessStatus, 'needs-review');
+});
+
+test('returns candidate-ready when all comparable records match', () => {
+  const result = summarizeTreeOccurrenceClassificationParityEvidence({
+    source: 'tree-occurrence-classification-parity-evidence',
+    parityRecords: [
+      { path: 'a', parityStatus: 'matches' },
+      { path: 'b', parityStatus: 'matches' },
+      { path: 'c', parityStatus: 'not-applicable' },
+    ],
+    summary: { matches: 2, differs: 0, 'insufficient-evidence': 0, 'not-applicable': 1 },
+  });
+
+  assert.equal(result.replacementReadinessStatus, 'candidate-ready');
+  assert.equal(result.parityCoverageRatio, 1);
+  assert.equal(result.parityMatchRatio, 1);
+});
+
+test('does not emit findings or advisor decision fields and handles empty input', () => {
+  const result = summarizeTreeOccurrenceClassificationParityEvidence({
+    source: 'tree-occurrence-classification-parity-evidence',
+    parityRecords: [],
+    summary: { matches: 0, differs: 0, 'insufficient-evidence': 0, 'not-applicable': 0 },
+  });
+
+  assert.deepEqual(result, {
+    source: 'tree-occurrence-classification-parity-summary',
+    parityEvidenceSource: 'tree-occurrence-classification-parity-evidence',
+    totalRecords: 0,
+    comparableRecords: 0,
+    matchedRecords: 0,
+    differedRecords: 0,
+    insufficientEvidenceRecords: 0,
+    notApplicableRecords: 0,
+    parityCoverageRatio: 0,
+    parityMatchRatio: 0,
+    replacementReadinessStatus: 'not-ready',
+    rationale: 'No comparable parity records were available after excluding not-applicable records.',
+  });
+
+  const forbiddenKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(result, forbiddenKey), false);
+  }
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => summarizeTreeOccurrenceClassificationParityEvidence(), /input must be an object/u);
+  assert.throws(
+    () => summarizeTreeOccurrenceClassificationParityEvidence({ source: 'x' }),
+    /parityRecords must be an array/u,
+  );
+});

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -16,6 +16,7 @@ import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evide
 import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.logic.mjs';
 import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-evidence.logic.mjs';
+import { summarizeTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-summary.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -168,6 +169,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeSemanticHomeEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeFolderKindEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -211,6 +213,10 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         treeSemanticHomeEvidence: preparedInputs.preparedDependencies.treeSemanticHomeEvidence,
         treeFolderKindEvidence: preparedInputs.preparedDependencies.treeFolderKindEvidence,
       }),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      summarizeTreeOccurrenceClassificationParityEvidence(preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence),
     );
     const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;
     assert.equal(Array.isArray(structuralHomeEvidenceRecords), true);


### PR DESCRIPTION
### Motivation
- Provide a deterministic, evidence-only summary of occurrence-classification parity so replacement readiness and coverage can be observed without changing runtime occurrence-classification behavior. 
- Keep parity summary strictly as Tree-owned metadata and ensure it does not emit findings, advisor decisions, or affect advisor behavior. 
- Stage the summary alongside existing prepared parity evidence so callers can inspect readiness before any behavior-preserving replacement is considered. 

### Description
- Added `summarizeTreeOccurrenceClassificationParityEvidence(...)` as a pure, deterministic helper that consumes parity evidence records and returns coverage/match counts, ratios, a replacement readiness label (`not-ready` / `needs-review` / `candidate-ready`), and a rationale; the helper lives at `calculogic-validator/tree/src/tree-occurrence-classification-parity-summary.logic.mjs`. 
- Staged non-observable wiring to produce `preparedDependencies.treeOccurrenceClassificationParitySummary` in `prepareTreeStructureAdvisorInputs` while keeping the original `treeOccurrenceClassificationParityEvidence` behavior intact; the wiring change is in `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs`. 
- Added focused tests at `calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs` that cover deterministic counts, comparable-record exclusion, coverage/match ratios, readiness-label rules, empty input, invalid-input guards, non-mutation, and evidence-only boundary guarantees. 
- Extended the tree wiring test `calculogic-validator/tree/test/tree-structure-advisor.test.mjs` to assert the prepared parity summary exists and matches the helper output while preserving existing assertions that advisor runtime output is unchanged. 

### Testing
- Ran unit tests for the new helper: `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs` — all tests passed. 
- Re-ran related parity/evidence tests: `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs` — all tests passed. 
- Re-ran related folder-kind tests: `node --test calculogic-validator/tree/test/tree-folder-kind-evidence.logic.test.mjs` — all tests passed. 
- Re-ran tree wiring/integration tests: `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` — all tests passed. 
- Ran validators: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` — both validator runs completed successfully. 

Refs #516
Refs #545

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e929b12f48331b880d60199178071)