### PR TITLE
Add evidence-only shadow report for occurrence classification parity and wire as prepared dependency

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-shadow-report.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-shadow-report.logic.mjs
@@ -1,0 +1,118 @@
+const SOURCE_ID = 'tree-occurrence-classification-shadow-report';
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree occurrence classification shadow report input must be an object.');
+  }
+
+  if (!input.treeOccurrenceClassificationParityEvidence || typeof input.treeOccurrenceClassificationParityEvidence !== 'object' || Array.isArray(input.treeOccurrenceClassificationParityEvidence)) {
+    throw new Error('Tree occurrence classification shadow report input must include treeOccurrenceClassificationParityEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeOccurrenceClassificationParityEvidence.parityRecords)) {
+    throw new Error('Tree occurrence classification shadow report input treeOccurrenceClassificationParityEvidence.parityRecords must be an array.');
+  }
+
+  if (!input.treeOccurrenceClassificationParitySummary || typeof input.treeOccurrenceClassificationParitySummary !== 'object' || Array.isArray(input.treeOccurrenceClassificationParitySummary)) {
+    throw new Error('Tree occurrence classification shadow report input must include treeOccurrenceClassificationParitySummary object.');
+  }
+}
+
+const toComparisonStatus = (parityStatus) => {
+  if (parityStatus === 'matches') {
+    return 'aligned';
+  }
+
+  if (parityStatus === 'differs') {
+    return 'mismatch';
+  }
+
+  if (parityStatus === 'insufficient-evidence') {
+    return 'insufficient-evidence';
+  }
+
+  if (parityStatus === 'not-applicable') {
+    return 'not-applicable';
+  }
+
+  return 'insufficient-evidence';
+};
+
+const toShadowComparisonStatus = (replacementReadinessStatus) => {
+  if (replacementReadinessStatus === 'candidate-ready') {
+    return 'aligned';
+  }
+
+  if (replacementReadinessStatus === 'needs-review') {
+    return 'needs-review';
+  }
+
+  return 'not-ready';
+};
+
+const toSummaryRationale = (replacementReadinessStatus) => {
+  if (replacementReadinessStatus === 'candidate-ready') {
+    return 'Parity summary replacement readiness is candidate-ready; shadow comparison remains observational evidence only.';
+  }
+
+  if (replacementReadinessStatus === 'needs-review') {
+    return 'Parity summary replacement readiness is needs-review; shadow comparison remains observational evidence only.';
+  }
+
+  return 'Parity summary replacement readiness is not-ready; shadow comparison remains observational evidence only.';
+};
+
+const toShadowRecordRationale = ({ parityStatus, parityRationale }) => {
+  if (typeof parityRationale === 'string' && parityRationale.length > 0) {
+    return parityRationale;
+  }
+
+  return `Parity status ${String(parityStatus)} was mapped to shadow comparison status for observation.`;
+};
+
+export const prepareTreeOccurrenceClassificationShadowReport = (input) => {
+  assertValidInput(input);
+
+  const parityEvidence = input.treeOccurrenceClassificationParityEvidence;
+  const paritySummary = input.treeOccurrenceClassificationParitySummary;
+
+  const shadowRecords = parityEvidence.parityRecords.map((parityRecord) => ({
+    addressPath: parityRecord?.addressPath ?? null,
+    parentAddressPath: parityRecord?.parentAddressPath ?? null,
+    path: parityRecord?.path ?? null,
+    name: parityRecord?.name ?? null,
+    occurrenceType: parityRecord?.occurrenceType ?? null,
+    currentStructuralClass: parityRecord?.currentStructuralClass ?? null,
+    currentStructuralKind: parityRecord?.currentStructuralKind ?? null,
+    currentIsKnownTopRoot: parityRecord?.currentIsKnownTopRoot ?? false,
+    currentIsStructuralRoot: parityRecord?.currentIsStructuralRoot ?? false,
+    currentIsSemanticRoot: parityRecord?.currentIsSemanticRoot ?? false,
+    replacementFolderKind: parityRecord?.replacementFolderKind ?? null,
+    replacementStructuralHome: parityRecord?.replacementStructuralHome ?? null,
+    replacementSemanticHome: parityRecord?.replacementSemanticHome ?? null,
+    parityStatus: parityRecord?.parityStatus ?? null,
+    replacementReadinessStatus: paritySummary?.replacementReadinessStatus ?? null,
+    comparisonStatus: toComparisonStatus(parityRecord?.parityStatus),
+    rationale: toShadowRecordRationale({ parityStatus: parityRecord?.parityStatus, parityRationale: parityRecord?.rationale }),
+  }));
+
+  return {
+    source: SOURCE_ID,
+    summary: {
+      source: SOURCE_ID,
+      paritySummarySource: paritySummary?.source ?? null,
+      totalRecords: paritySummary?.totalRecords ?? 0,
+      comparableRecords: paritySummary?.comparableRecords ?? 0,
+      matchedRecords: paritySummary?.matchedRecords ?? 0,
+      differedRecords: paritySummary?.differedRecords ?? 0,
+      insufficientEvidenceRecords: paritySummary?.insufficientEvidenceRecords ?? 0,
+      notApplicableRecords: paritySummary?.notApplicableRecords ?? 0,
+      parityCoverageRatio: paritySummary?.parityCoverageRatio ?? 0,
+      parityMatchRatio: paritySummary?.parityMatchRatio ?? 0,
+      replacementReadinessStatus: paritySummary?.replacementReadinessStatus ?? null,
+      shadowComparisonStatus: toShadowComparisonStatus(paritySummary?.replacementReadinessStatus),
+      rationale: toSummaryRationale(paritySummary?.replacementReadinessStatus),
+    },
+    shadowRecords,
+  };
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -18,6 +18,7 @@ import { prepareTreeFolderKindEvidence } from './tree-folder-kind-evidence.logic
 import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-evidence.logic.mjs';
 import { summarizeTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-summary.logic.mjs';
+import { prepareTreeOccurrenceClassificationShadowReport } from './tree-occurrence-classification-shadow-report.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
@@ -104,6 +105,12 @@ export const prepareTreeStructureAdvisorInputs = (
     treeFolderKindEvidence,
   });
 
+  const treeOccurrenceClassificationParitySummary = summarizeTreeOccurrenceClassificationParityEvidence(treeOccurrenceClassificationParityEvidence);
+  const treeOccurrenceClassificationShadowReport = prepareTreeOccurrenceClassificationShadowReport({
+    treeOccurrenceClassificationParityEvidence,
+    treeOccurrenceClassificationParitySummary,
+  });
+
   return {
     scope: scopedSnapshotInputs.scope,
     selectedPaths,
@@ -120,7 +127,8 @@ export const prepareTreeStructureAdvisorInputs = (
       treeSemanticHomeEvidence,
       treeFolderKindEvidence,
       treeOccurrenceClassificationParityEvidence,
-      treeOccurrenceClassificationParitySummary: summarizeTreeOccurrenceClassificationParityEvidence(treeOccurrenceClassificationParityEvidence),
+      treeOccurrenceClassificationParitySummary,
+      treeOccurrenceClassificationShadowReport,
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,

--- a/calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { prepareTreeOccurrenceClassificationShadowReport } from '../src/tree-occurrence-classification-shadow-report.logic.mjs';
+
+const baseInput = () => ({
+  treeOccurrenceClassificationParityEvidence: {
+    source: 'tree-occurrence-classification-parity-evidence',
+    parityRecords: [
+      {
+        addressPath: 'A',
+        parentAddressPath: null,
+        path: 'src',
+        name: 'src',
+        occurrenceType: 'folder',
+        currentStructuralClass: 'known-root',
+        currentStructuralKind: 'structural',
+        currentIsKnownTopRoot: true,
+        currentIsStructuralRoot: true,
+        currentIsSemanticRoot: false,
+        replacementFolderKind: 'structural',
+        replacementStructuralHome: 'workspace',
+        replacementSemanticHome: null,
+        parityStatus: 'matches',
+        rationale: 'match rationale',
+      },
+      { path: 'docs', occurrenceType: 'folder', parityStatus: 'differs', rationale: 'diff rationale' },
+      { path: 'tmp', occurrenceType: 'folder', parityStatus: 'insufficient-evidence', rationale: 'insufficient rationale' },
+      { path: 'README.md', occurrenceType: 'file', parityStatus: 'not-applicable', rationale: 'not-applicable rationale' },
+    ],
+  },
+  treeOccurrenceClassificationParitySummary: {
+    source: 'tree-occurrence-classification-parity-summary',
+    totalRecords: 4,
+    comparableRecords: 3,
+    matchedRecords: 1,
+    differedRecords: 1,
+    insufficientEvidenceRecords: 1,
+    notApplicableRecords: 1,
+    parityCoverageRatio: 2 / 3,
+    parityMatchRatio: 1 / 3,
+    replacementReadinessStatus: 'needs-review',
+  },
+});
+
+test('creates deterministic shadow records from parity evidence without mutation', () => {
+  const input = baseInput();
+  const before = structuredClone(input);
+
+  const result = prepareTreeOccurrenceClassificationShadowReport(input);
+
+  assert.deepEqual(input, before);
+  assert.equal(result.source, 'tree-occurrence-classification-shadow-report');
+  assert.equal(result.shadowRecords.length, 4);
+  assert.equal(result.summary.totalRecords, 4);
+  assert.equal(result.summary.paritySummarySource, 'tree-occurrence-classification-parity-summary');
+});
+
+test('maps parity statuses to comparison statuses', () => {
+  const result = prepareTreeOccurrenceClassificationShadowReport(baseInput());
+
+  assert.equal(result.shadowRecords[0].comparisonStatus, 'aligned');
+  assert.equal(result.shadowRecords[1].comparisonStatus, 'mismatch');
+  assert.equal(result.shadowRecords[2].comparisonStatus, 'insufficient-evidence');
+  assert.equal(result.shadowRecords[3].comparisonStatus, 'not-applicable');
+});
+
+test('carries current and replacement fields and replacement readiness metadata unchanged', () => {
+  const result = prepareTreeOccurrenceClassificationShadowReport(baseInput());
+  const record = result.shadowRecords[0];
+
+  assert.equal(record.currentStructuralClass, 'known-root');
+  assert.equal(record.currentStructuralKind, 'structural');
+  assert.equal(record.currentIsKnownTopRoot, true);
+  assert.equal(record.currentIsStructuralRoot, true);
+  assert.equal(record.currentIsSemanticRoot, false);
+  assert.equal(record.replacementFolderKind, 'structural');
+  assert.equal(record.replacementStructuralHome, 'workspace');
+  assert.equal(record.replacementSemanticHome, null);
+  assert.equal(record.replacementReadinessStatus, 'needs-review');
+  assert.equal(result.summary.replacementReadinessStatus, 'needs-review');
+});
+
+test('creates summary metadata from parity summary and keeps evidence-only boundaries', () => {
+  const result = prepareTreeOccurrenceClassificationShadowReport(baseInput());
+
+  assert.equal(result.summary.comparableRecords, 3);
+  assert.equal(result.summary.matchedRecords, 1);
+  assert.equal(result.summary.differedRecords, 1);
+  assert.equal(result.summary.insufficientEvidenceRecords, 1);
+  assert.equal(result.summary.notApplicableRecords, 1);
+  assert.equal(result.summary.parityCoverageRatio, 2 / 3);
+  assert.equal(result.summary.parityMatchRatio, 1 / 3);
+  assert.equal(result.summary.shadowComparisonStatus, 'needs-review');
+
+  const forbiddenKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(result.summary, forbiddenKey), false);
+    assert.equal(result.shadowRecords.some((record) => Object.hasOwn(record, forbiddenKey)), false);
+  }
+});
+
+test('handles empty input safely', () => {
+  const result = prepareTreeOccurrenceClassificationShadowReport({
+    treeOccurrenceClassificationParityEvidence: { source: 'e', parityRecords: [] },
+    treeOccurrenceClassificationParitySummary: {
+      source: 'tree-occurrence-classification-parity-summary',
+      totalRecords: 0,
+      comparableRecords: 0,
+      matchedRecords: 0,
+      differedRecords: 0,
+      insufficientEvidenceRecords: 0,
+      notApplicableRecords: 0,
+      parityCoverageRatio: 0,
+      parityMatchRatio: 0,
+      replacementReadinessStatus: 'not-ready',
+    },
+  });
+
+  assert.deepEqual(result.shadowRecords, []);
+  assert.equal(result.summary.shadowComparisonStatus, 'not-ready');
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => prepareTreeOccurrenceClassificationShadowReport(), /input must be an object/u);
+  assert.throws(
+    () => prepareTreeOccurrenceClassificationShadowReport({ treeOccurrenceClassificationParitySummary: {} }),
+    /must include treeOccurrenceClassificationParityEvidence object/u,
+  );
+  assert.throws(
+    () => prepareTreeOccurrenceClassificationShadowReport({
+      treeOccurrenceClassificationParityEvidence: { parityRecords: [] },
+    }),
+    /must include treeOccurrenceClassificationParitySummary object/u,
+  );
+});

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -17,6 +17,7 @@ import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.
 import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-evidence.logic.mjs';
 import { summarizeTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-summary.logic.mjs';
+import { prepareTreeOccurrenceClassificationShadowReport } from '../src/tree-occurrence-classification-shadow-report.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -170,6 +171,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeFolderKindEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -217,6 +219,13 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
       summarizeTreeOccurrenceClassificationParityEvidence(preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
+      prepareTreeOccurrenceClassificationShadowReport({
+        treeOccurrenceClassificationParityEvidence: preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence,
+        treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      }),
     );
     const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;
     assert.equal(Array.isArray(structuralHomeEvidenceRecords), true);


### PR DESCRIPTION
### Motivation
- Provide a bounded, non-invasive observational layer so Tree-owned replacement evidence can be observed side-by-side with current runtime classification truth. 
- Enable deterministic evidence-only comparison metadata that helps evaluate readiness for a future behavior-preserving replacement without affecting advisor decisions or runtime behavior. 
- Surface parity summary interpretation for visibility while keeping all advisor/finding outputs and runtime classification unchanged. 

### Description
- Add `prepareTreeOccurrenceClassificationShadowReport(...)` at `calculogic-validator/tree/src/tree-occurrence-classification-shadow-report.logic.mjs` that consumes existing parity evidence + parity summary and emits an evidence-only shadow report (`source`, `summary`, `shadowRecords`).
- Map existing parity statuses to comparison statuses (`matches → aligned`, `differs → mismatch`, `insufficient-evidence → insufficient-evidence`, `not-applicable → not-applicable`) and derive `shadowComparisonStatus` from parity `replacementReadinessStatus` without mutating inputs.
- Wire the helper into advisor inputs by adding `preparedDependencies.treeOccurrenceClassificationShadowReport` in `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs` so the shadow report is prepared and available non-observably alongside existing parity evidence/summary.
- Add focused tests at `calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs` and extend `tree-structure-advisor.test.mjs` to assert the prepared dependency exists and matches the standalone helper output, while preserving existing parity evidence/summary assertions and evidence-only boundaries. 

### Testing
- `node --test calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs` — passed (6 tests, 0 failures).
- `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs` — passed (7 tests, 0 failures).
- `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-evidence.logic.test.mjs` — passed (11 tests, 0 failures).
- `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` — passed (41 tests, 0 failures).
- `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` — passed (report-mode naming validation executed; expected findings emitted).
- `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` — passed (report-mode tree validation executed; expected advisory findings emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7c25c5b08331857ff72bf2a61c16)