### PR TITLE
Stage tree occurrence classification replacement-readiness helper

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-replacement-readiness.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-replacement-readiness.logic.mjs
@@ -1,0 +1,97 @@
+const SOURCE_ID = 'tree-occurrence-classification-replacement-readiness';
+
+const assertObject = (value, label) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+};
+
+const toNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+const toSummary = ({ treeOccurrenceClassificationParitySummary, treeOccurrenceClassificationShadowReport }) => {
+  const paritySummary = treeOccurrenceClassificationParitySummary;
+  const shadowSummary = treeOccurrenceClassificationShadowReport?.summary ?? {};
+
+  return {
+    comparableRecords: toNumber(paritySummary?.comparableRecords),
+    matchedRecords: toNumber(paritySummary?.matchedRecords),
+    differedRecords: toNumber(paritySummary?.differedRecords),
+    insufficientEvidenceRecords: toNumber(paritySummary?.insufficientEvidenceRecords),
+    notApplicableRecords: toNumber(paritySummary?.notApplicableRecords),
+    parityCoverageRatio: toNumber(paritySummary?.parityCoverageRatio),
+    parityMatchRatio: toNumber(paritySummary?.parityMatchRatio),
+    replacementReadinessStatus: paritySummary?.replacementReadinessStatus ?? null,
+    shadowComparisonStatus: shadowSummary?.shadowComparisonStatus ?? null,
+  };
+};
+
+const toGates = (summary) => ({
+  hasComparableRecords: summary.comparableRecords > 0,
+  hasNoInsufficientEvidence: summary.insufficientEvidenceRecords === 0,
+  hasNoDifferences: summary.differedRecords === 0,
+  hasCandidateReadyParitySummary: summary.replacementReadinessStatus === 'candidate-ready',
+  hasAlignedShadowComparison: summary.shadowComparisonStatus === 'aligned',
+});
+
+const toDecision = (summary, gates) => {
+  if (
+    summary.comparableRecords === 0 ||
+    summary.insufficientEvidenceRecords > 0 ||
+    summary.replacementReadinessStatus === 'not-ready' ||
+    summary.shadowComparisonStatus === 'not-ready'
+  ) {
+    return 'blocked';
+  }
+
+  if (
+    summary.differedRecords > 0 ||
+    summary.replacementReadinessStatus === 'needs-review' ||
+    summary.shadowComparisonStatus === 'needs-review' ||
+    summary.shadowComparisonStatus !== 'aligned'
+  ) {
+    return 'review-required';
+  }
+
+  if (
+    gates.hasComparableRecords &&
+    gates.hasNoInsufficientEvidence &&
+    gates.hasNoDifferences &&
+    summary.matchedRecords === summary.comparableRecords &&
+    gates.hasCandidateReadyParitySummary &&
+    gates.hasAlignedShadowComparison
+  ) {
+    return 'candidate-ready';
+  }
+
+  return 'review-required';
+};
+
+const toRationale = (replacementDecision) => {
+  if (replacementDecision === 'blocked') {
+    return 'Replacement-readiness is blocked because parity/shadow evidence is incomplete or explicitly not-ready.';
+  }
+
+  if (replacementDecision === 'review-required') {
+    return 'Replacement-readiness requires review because parity/shadow evidence has differences, review flags, or non-aligned status.';
+  }
+
+  return 'Replacement-readiness is candidate-ready because parity/shadow evidence is complete, matched, and aligned.';
+};
+
+export const evaluateTreeOccurrenceClassificationReplacementReadiness = (input) => {
+  assertObject(input, 'Tree occurrence classification replacement readiness input');
+  assertObject(input.treeOccurrenceClassificationParitySummary, 'Tree occurrence classification replacement readiness input treeOccurrenceClassificationParitySummary');
+  assertObject(input.treeOccurrenceClassificationShadowReport, 'Tree occurrence classification replacement readiness input treeOccurrenceClassificationShadowReport');
+
+  const summary = toSummary(input);
+  const gates = toGates(summary);
+  const replacementDecision = toDecision(summary, gates);
+
+  return {
+    source: SOURCE_ID,
+    replacementDecision,
+    gates,
+    summary,
+    rationale: toRationale(replacementDecision),
+  };
+};

--- a/calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { evaluateTreeOccurrenceClassificationReplacementReadiness } from '../src/tree-occurrence-classification-replacement-readiness.logic.mjs';
+
+const baseInput = () => ({
+  treeOccurrenceClassificationParitySummary: {
+    source: 'tree-occurrence-classification-parity-summary',
+    comparableRecords: 2,
+    matchedRecords: 2,
+    differedRecords: 0,
+    insufficientEvidenceRecords: 0,
+    notApplicableRecords: 1,
+    parityCoverageRatio: 1,
+    parityMatchRatio: 1,
+    replacementReadinessStatus: 'candidate-ready',
+  },
+  treeOccurrenceClassificationShadowReport: {
+    source: 'tree-occurrence-classification-shadow-report',
+    summary: {
+      shadowComparisonStatus: 'aligned',
+    },
+  },
+});
+
+test('returns candidate-ready when all gates pass', () => {
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(baseInput());
+  assert.equal(result.replacementDecision, 'candidate-ready');
+});
+
+test('returns blocked when comparableRecords is zero', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.comparableRecords = 0;
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'blocked');
+});
+
+test('returns blocked when insufficientEvidenceRecords is greater than zero', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.insufficientEvidenceRecords = 1;
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'blocked');
+});
+
+test('returns blocked when replacementReadinessStatus is not-ready', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.replacementReadinessStatus = 'not-ready';
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'blocked');
+});
+
+test('returns blocked when shadowComparisonStatus is not-ready', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'not-ready';
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'blocked');
+});
+
+test('returns review-required when differedRecords is greater than zero', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.differedRecords = 1;
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'review-required');
+});
+
+test('returns review-required when replacementReadinessStatus is needs-review', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.replacementReadinessStatus = 'needs-review';
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'review-required');
+});
+
+test('returns review-required when shadowComparisonStatus is needs-review', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'needs-review';
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'review-required');
+});
+
+test('blocked wins over review-required', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.insufficientEvidenceRecords = 1;
+  input.treeOccurrenceClassificationParitySummary.differedRecords = 1;
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'blocked');
+});
+
+test('review-required wins over candidate-ready', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'mismatch';
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+  assert.equal(result.replacementDecision, 'review-required');
+});
+
+test('emits deterministic gates and summary fields, does not mutate input or emit advisor fields', () => {
+  const input = baseInput();
+  const before = structuredClone(input);
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness(input);
+
+  assert.deepEqual(input, before);
+  assert.deepEqual(result.gates, {
+    hasComparableRecords: true,
+    hasNoInsufficientEvidence: true,
+    hasNoDifferences: true,
+    hasCandidateReadyParitySummary: true,
+    hasAlignedShadowComparison: true,
+  });
+  assert.deepEqual(result.summary, {
+    comparableRecords: 2,
+    matchedRecords: 2,
+    differedRecords: 0,
+    insufficientEvidenceRecords: 0,
+    notApplicableRecords: 1,
+    parityCoverageRatio: 1,
+    parityMatchRatio: 1,
+    replacementReadinessStatus: 'candidate-ready',
+    shadowComparisonStatus: 'aligned',
+  });
+
+  const forbiddenKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(result, forbiddenKey), false);
+    assert.equal(Object.hasOwn(result.summary, forbiddenKey), false);
+  }
+});
+
+test('handles minimal input safely by defaulting missing numeric fields', () => {
+  const result = evaluateTreeOccurrenceClassificationReplacementReadiness({
+    treeOccurrenceClassificationParitySummary: {
+      replacementReadinessStatus: 'not-ready',
+    },
+    treeOccurrenceClassificationShadowReport: {
+      summary: {
+        shadowComparisonStatus: 'not-ready',
+      },
+    },
+  });
+
+  assert.equal(result.replacementDecision, 'blocked');
+  assert.equal(result.summary.comparableRecords, 0);
+  assert.equal(result.summary.parityCoverageRatio, 0);
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => evaluateTreeOccurrenceClassificationReplacementReadiness(), /input must be an object/u);
+  assert.throws(
+    () => evaluateTreeOccurrenceClassificationReplacementReadiness({ treeOccurrenceClassificationShadowReport: {} }),
+    /treeOccurrenceClassificationParitySummary must be an object/u,
+  );
+  assert.throws(
+    () => evaluateTreeOccurrenceClassificationReplacementReadiness({ treeOccurrenceClassificationParitySummary: {}, treeOccurrenceClassificationShadowReport: null }),
+    /treeOccurrenceClassificationShadowReport must be an object/u,
+  );
+});


### PR DESCRIPTION
### Motivation
- Stage a bounded, evidence-only replacement-readiness decision helper for occurrence classification so Tree-owned readiness gates are explicit without changing current runtime truth. 
- The work consumes prepared parity summary and shadow report metadata only and preserves the ownership boundary that Tree owns readiness interpretation while runtime known-roots and advisor behavior remain unchanged. 
- Treated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` as the runtime-spec authority and used `calculogic-validator/doc/ValidatorSpecs/tree-owned/tree-documentation-map-and-reorg-inventory.md` as navigation-only context per tree-slice conventions. 

### Description
- Added `calculogic-validator/tree/src/tree-occurrence-classification-replacement-readiness.logic.mjs` exporting `evaluateTreeOccurrenceClassificationReplacementReadiness(...)` which consumes `treeOccurrenceClassificationParitySummary` and `treeOccurrenceClassificationShadowReport`. 
- The helper computes deterministic `gates`, copies summary fields, and emits an evidence-only `replacementDecision` of `blocked` / `review-required` / `candidate-ready` plus a `rationale` without producing findings, advisor fields, or changing runtime behavior. 
- Implemented deterministic precedence so `blocked` overrides `review-required`, and `review-required` overrides `candidate-ready`, and ensured the helper does not inspect `known-roots` or mutate inputs. 
- Added focused tests in `calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs` that validate gating logic, precedence, summary passthrough, non-mutation, forbidden output fields, minimal input defaults, and invalid-input guards. 

### Testing
- Unit tests: `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs` — all tests passed. 
- Related unit checks: `node --test calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs` and `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs` — all tests passed. 
- End-to-end wiring tests: `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` — tests passed. 
- Validators: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` — both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f99f7de488331956baeaa385dd76e)