### PR TITLE
Stage tree occurrence classification replacement recommendation reporting helper

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-replacement-recommendation.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-replacement-recommendation.logic.mjs
@@ -1,0 +1,109 @@
+const SOURCE_ID = 'tree-occurrence-classification-replacement-recommendation';
+
+const assertObject = (value, label) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+};
+
+const toNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+const toSummary = ({
+  treeOccurrenceClassificationReplacementReadiness,
+  treeOccurrenceClassificationShadowReport,
+  treeOccurrenceClassificationParitySummary,
+}) => ({
+  replacementDecision: treeOccurrenceClassificationReplacementReadiness?.replacementDecision ?? null,
+  replacementReadinessStatus:
+    treeOccurrenceClassificationReplacementReadiness?.summary?.replacementReadinessStatus
+    ?? treeOccurrenceClassificationParitySummary?.replacementReadinessStatus
+    ?? null,
+  shadowComparisonStatus:
+    treeOccurrenceClassificationShadowReport?.summary?.shadowComparisonStatus ?? null,
+  parityCoverageRatio: toNumber(treeOccurrenceClassificationParitySummary?.parityCoverageRatio),
+  parityMatchRatio: toNumber(treeOccurrenceClassificationParitySummary?.parityMatchRatio),
+  comparableRecords: toNumber(treeOccurrenceClassificationParitySummary?.comparableRecords),
+  matchedRecords: toNumber(treeOccurrenceClassificationParitySummary?.matchedRecords),
+  differedRecords: toNumber(treeOccurrenceClassificationParitySummary?.differedRecords),
+  insufficientEvidenceRecords: toNumber(treeOccurrenceClassificationParitySummary?.insufficientEvidenceRecords),
+});
+
+const toRecommendation = (summary) => {
+  if (summary.replacementDecision === 'blocked') {
+    return 'do-not-replace';
+  }
+
+  if (summary.replacementDecision === 'review-required') {
+    return 'review-before-replacement';
+  }
+
+  if (
+    summary.replacementDecision === 'candidate-ready'
+    && summary.parityMatchRatio === 1
+    && summary.shadowComparisonStatus === 'aligned'
+  ) {
+    return 'replacement-candidate';
+  }
+
+  return 'review-before-replacement';
+};
+
+const toConfidence = (recommendation, summary) => {
+  if (recommendation === 'do-not-replace') {
+    return 'low';
+  }
+
+  if (recommendation === 'review-before-replacement') {
+    return 'medium';
+  }
+
+  if (
+    summary.parityCoverageRatio === 1
+    && summary.parityMatchRatio === 1
+    && summary.shadowComparisonStatus === 'aligned'
+  ) {
+    return 'high';
+  }
+
+  return 'medium';
+};
+
+const toRationale = (recommendation) => {
+  if (recommendation === 'do-not-replace') {
+    return 'Replacement recommendation is do-not-replace because replacement decision is blocked by readiness evidence.';
+  }
+
+  if (recommendation === 'review-before-replacement') {
+    return 'Replacement recommendation is review-before-replacement because replacement decision requires additional review evidence.';
+  }
+
+  return 'Replacement recommendation is replacement-candidate because replacement decision and parity/shadow gates are fully aligned.';
+};
+
+export const recommendTreeOccurrenceClassificationReplacement = (input) => {
+  assertObject(input, 'Tree occurrence classification replacement recommendation input');
+  assertObject(
+    input.treeOccurrenceClassificationReplacementReadiness,
+    'Tree occurrence classification replacement recommendation input treeOccurrenceClassificationReplacementReadiness',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationShadowReport,
+    'Tree occurrence classification replacement recommendation input treeOccurrenceClassificationShadowReport',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationParitySummary,
+    'Tree occurrence classification replacement recommendation input treeOccurrenceClassificationParitySummary',
+  );
+
+  const summary = toSummary(input);
+  const recommendation = toRecommendation(summary);
+  const confidence = toConfidence(recommendation, summary);
+
+  return {
+    source: SOURCE_ID,
+    recommendation,
+    confidence,
+    summary,
+    rationale: toRationale(recommendation),
+  };
+};

--- a/calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { recommendTreeOccurrenceClassificationReplacement } from '../src/tree-occurrence-classification-replacement-recommendation.logic.mjs';
+
+const baseInput = () => ({
+  treeOccurrenceClassificationReplacementReadiness: {
+    source: 'tree-occurrence-classification-replacement-readiness',
+    replacementDecision: 'candidate-ready',
+    summary: {
+      replacementReadinessStatus: 'candidate-ready',
+    },
+  },
+  treeOccurrenceClassificationShadowReport: {
+    source: 'tree-occurrence-classification-shadow-report',
+    summary: {
+      shadowComparisonStatus: 'aligned',
+    },
+  },
+  treeOccurrenceClassificationParitySummary: {
+    source: 'tree-occurrence-classification-parity-summary',
+    comparableRecords: 2,
+    matchedRecords: 2,
+    differedRecords: 0,
+    insufficientEvidenceRecords: 0,
+    parityCoverageRatio: 1,
+    parityMatchRatio: 1,
+    replacementReadinessStatus: 'candidate-ready',
+  },
+});
+
+test('returns do-not-replace when replacementDecision is blocked', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'blocked';
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+  assert.equal(result.recommendation, 'do-not-replace');
+});
+
+test('returns review-before-replacement when replacementDecision is review-required', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'review-required';
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+  assert.equal(result.recommendation, 'review-before-replacement');
+});
+
+test('returns replacement-candidate when candidate-ready parity/shadow gates are aligned', () => {
+  const result = recommendTreeOccurrenceClassificationReplacement(baseInput());
+  assert.equal(result.recommendation, 'replacement-candidate');
+});
+
+test('does not return replacement-candidate when parityMatchRatio is below 1', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationParitySummary.parityMatchRatio = 0.5;
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+  assert.notEqual(result.recommendation, 'replacement-candidate');
+  assert.equal(result.recommendation, 'review-before-replacement');
+});
+
+test('does not return replacement-candidate when shadowComparisonStatus is not aligned', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'needs-review';
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+  assert.notEqual(result.recommendation, 'replacement-candidate');
+  assert.equal(result.recommendation, 'review-before-replacement');
+});
+
+test('returns low confidence for do-not-replace', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'blocked';
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+  assert.equal(result.confidence, 'low');
+});
+
+test('returns medium confidence for review-before-replacement', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'review-required';
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+  assert.equal(result.confidence, 'medium');
+});
+
+test('returns high confidence for replacement-candidate only when coverage/match/shadow gates pass', () => {
+  const result = recommendTreeOccurrenceClassificationReplacement(baseInput());
+  assert.equal(result.recommendation, 'replacement-candidate');
+  assert.equal(result.confidence, 'high');
+
+  const degraded = baseInput();
+  degraded.treeOccurrenceClassificationParitySummary.parityCoverageRatio = 0.5;
+  const degradedResult = recommendTreeOccurrenceClassificationReplacement(degraded);
+  assert.equal(degradedResult.recommendation, 'replacement-candidate');
+  assert.notEqual(degradedResult.confidence, 'high');
+});
+
+test('copies summary fields from input metadata and does not mutate input', () => {
+  const input = baseInput();
+  const before = structuredClone(input);
+  const result = recommendTreeOccurrenceClassificationReplacement(input);
+
+  assert.deepEqual(input, before);
+  assert.deepEqual(result.summary, {
+    replacementDecision: 'candidate-ready',
+    replacementReadinessStatus: 'candidate-ready',
+    shadowComparisonStatus: 'aligned',
+    parityCoverageRatio: 1,
+    parityMatchRatio: 1,
+    comparableRecords: 2,
+    matchedRecords: 2,
+    differedRecords: 0,
+    insufficientEvidenceRecords: 0,
+  });
+});
+
+test('does not emit findings/severity/verdict/advisor fields', () => {
+  const result = recommendTreeOccurrenceClassificationReplacement(baseInput());
+  const forbiddenKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+  for (const forbiddenKey of forbiddenKeys) {
+    assert.equal(Object.hasOwn(result, forbiddenKey), false);
+    assert.equal(Object.hasOwn(result.summary, forbiddenKey), false);
+  }
+});
+
+test('handles minimal input safely when required objects exist', () => {
+  const result = recommendTreeOccurrenceClassificationReplacement({
+    treeOccurrenceClassificationReplacementReadiness: {
+      replacementDecision: 'blocked',
+      summary: {},
+    },
+    treeOccurrenceClassificationShadowReport: {
+      summary: {},
+    },
+    treeOccurrenceClassificationParitySummary: {},
+  });
+
+  assert.equal(result.recommendation, 'do-not-replace');
+  assert.equal(result.summary.parityCoverageRatio, 0);
+  assert.equal(result.summary.parityMatchRatio, 0);
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => recommendTreeOccurrenceClassificationReplacement(), /input must be an object/u);
+  assert.throws(
+    () => recommendTreeOccurrenceClassificationReplacement({ treeOccurrenceClassificationShadowReport: {}, treeOccurrenceClassificationParitySummary: {} }),
+    /treeOccurrenceClassificationReplacementReadiness must be an object/u,
+  );
+  assert.throws(
+    () => recommendTreeOccurrenceClassificationReplacement({
+      treeOccurrenceClassificationReplacementReadiness: {},
+      treeOccurrenceClassificationParitySummary: {},
+      treeOccurrenceClassificationShadowReport: null,
+    }),
+    /treeOccurrenceClassificationShadowReport must be an object/u,
+  );
+});


### PR DESCRIPTION
### Motivation
- Provide a deterministic, evidence-only helper that stages non-authoritative replacement recommendations derived from existing parity, readiness, and shadow-comparison evidence without altering runtime behavior. 
- Keep replacement recommendation metadata advisory-only and prevent any advisor/finding or runtime replacement side-effects in this slice. 
- Preserve ownership boundaries: consume prepared inputs from the tree slice and do not inspect or change known-roots or advisor outputs. 

### Description
- Adds `calculogic-validator/tree/src/tree-occurrence-classification-replacement-recommendation.logic.mjs` exporting `recommendTreeOccurrenceClassificationReplacement(...)` which consumes `treeOccurrenceClassificationReplacementReadiness`, `treeOccurrenceClassificationShadowReport`, and `treeOccurrenceClassificationParitySummary` and returns `{ source, recommendation, confidence, summary, rationale }`. 
- Implements deterministic mapping rules for recommendations (`do-not-replace`, `review-before-replacement`, `replacement-candidate`) and confidence (`low`, `medium`, `high`) based on the provided evidence and gates, following the evidence-only boundary. 
- Adds focused tests at `calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs` that cover recommendation states, confidence rules, gate degradation, summary passthrough, immutability, forbidden output fields, minimal-safe input, and invalid-input guards. 
- Keeps the change standalone with no advisor wiring or runtime behavior changes and no registry/structural-address/runtime replacement switches modified. 

### Testing
- Ran unit tests: `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs` (pass). 
- Re-ran related unit tests: `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs` (pass), `node --test calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs` (pass), `node --test calculogic-validator/tree/test/tree-occurrence-classification-parity-summary.logic.test.mjs` (pass), and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` (pass). 
- Ran validators: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` (pass) and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` (pass). 

Refs #516
Refs #551

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0faf932f6883319b44dd3aa4209f86)