### PR TITLE
Stage tree advisor prepared replacement recommendation dependency wiring

### DIFF
--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -19,6 +19,8 @@ import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.
 import { prepareTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-evidence.logic.mjs';
 import { summarizeTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-summary.logic.mjs';
 import { prepareTreeOccurrenceClassificationShadowReport } from './tree-occurrence-classification-shadow-report.logic.mjs';
+import { evaluateTreeOccurrenceClassificationReplacementReadiness } from './tree-occurrence-classification-replacement-readiness.logic.mjs';
+import { recommendTreeOccurrenceClassificationReplacement } from './tree-occurrence-classification-replacement-recommendation.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
@@ -110,6 +112,15 @@ export const prepareTreeStructureAdvisorInputs = (
     treeOccurrenceClassificationParityEvidence,
     treeOccurrenceClassificationParitySummary,
   });
+  const treeOccurrenceClassificationReplacementReadiness = evaluateTreeOccurrenceClassificationReplacementReadiness({
+    treeOccurrenceClassificationParitySummary,
+    treeOccurrenceClassificationShadowReport,
+  });
+  const treeOccurrenceClassificationReplacementRecommendation = recommendTreeOccurrenceClassificationReplacement({
+    treeOccurrenceClassificationReplacementReadiness,
+    treeOccurrenceClassificationShadowReport,
+    treeOccurrenceClassificationParitySummary,
+  });
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -129,6 +140,8 @@ export const prepareTreeStructureAdvisorInputs = (
       treeOccurrenceClassificationParityEvidence,
       treeOccurrenceClassificationParitySummary,
       treeOccurrenceClassificationShadowReport,
+      treeOccurrenceClassificationReplacementReadiness,
+      treeOccurrenceClassificationReplacementRecommendation,
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -18,6 +18,8 @@ import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classifica
 import { prepareTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-evidence.logic.mjs';
 import { summarizeTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-summary.logic.mjs';
 import { prepareTreeOccurrenceClassificationShadowReport } from '../src/tree-occurrence-classification-shadow-report.logic.mjs';
+import { evaluateTreeOccurrenceClassificationReplacementReadiness } from '../src/tree-occurrence-classification-replacement-readiness.logic.mjs';
+import { recommendTreeOccurrenceClassificationReplacement } from '../src/tree-occurrence-classification-replacement-recommendation.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -172,6 +174,8 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -226,6 +230,27 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         treeOccurrenceClassificationParityEvidence: preparedInputs.preparedDependencies.treeOccurrenceClassificationParityEvidence,
         treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
       }),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
+      evaluateTreeOccurrenceClassificationReplacementReadiness({
+        treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+        treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
+      }),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation,
+      recommendTreeOccurrenceClassificationReplacement({
+        treeOccurrenceClassificationReplacementReadiness: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
+        treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
+        treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      }),
+    );
+    const replacementRecommendation = preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation;
+    assert.deepEqual(Object.keys(replacementRecommendation).sort(), ['confidence', 'rationale', 'recommendation', 'source', 'summary']);
+    assert.equal(
+      ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) => Object.hasOwn(replacementRecommendation, key)),
+      false,
     );
     const structuralHomeEvidenceRecords = preparedInputs.preparedDependencies.treeStructuralHomeEvidence.evidenceRecords;
     assert.equal(Array.isArray(structuralHomeEvidenceRecords), true);


### PR DESCRIPTION
### Motivation

- Refs #516 and Refs #553; prepare non-authoritative replacement recommendation metadata alongside existing Tree prepared dependencies without changing runtime occurrence classification behavior. 
- Make replacement recommendation metadata available to downstream consumers as deterministic evidence-only prepared dependencies while preserving advisor behavior and runtime truth.

### Description

- Import and compose `evaluateTreeOccurrenceClassificationReplacementReadiness(...)` and `recommendTreeOccurrenceClassificationReplacement(...)` in `prepareTreeStructureAdvisorInputs` and attach their outputs as `preparedDependencies.treeOccurrenceClassificationReplacementReadiness` and `preparedDependencies.treeOccurrenceClassificationReplacementRecommendation`. 
- The recommendation is computed from existing `treeOccurrenceClassificationParitySummary` and `treeOccurrenceClassificationShadowReport` inputs only and is attached as non-observable evidence metadata; no advisor findings, verdicts, or runtime replacement switches are introduced. 
- Extended `calculogic-validator/tree/test/tree-structure-advisor.test.mjs` to assert the new prepared dependencies exist, match the standalone helper outputs deterministically, and that the recommendation payload contains only evidence fields (no `finding`, `findingCode`, `severity`, `verdict`, `placementVerdict`, or `advisorDecision`). 
- No registry, runtime classification, advisor decision logic, or top-level folder policy was changed.

### Testing

- Ran `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs` and it passed (12 tests, 0 failures). 
- Ran `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs` and it passed (13 tests, 0 failures). 
- Ran `node --test calculogic-validator/tree/test/tree-occurrence-classification-shadow-report.logic.test.mjs` and it passed (6 tests, 0 failures). 
- Ran `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` and it passed (41 tests, 0 failures). 
- Ran validators `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and both completed successfully (report-mode outputs produced with expected info-level findings). 

Refs #516
Refs #553

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc5889e58833189c394478587987b)