### PR TITLE
Stage tree occurrence runtime evaluation planning metadata (evidence-only)

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs
@@ -1,0 +1,108 @@
+const SOURCE_ID = 'tree-occurrence-classification-runtime-evaluation-plan';
+
+const assertObject = (value, label) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+};
+
+const toNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+const toSummary = ({
+  treeOccurrenceClassificationReplacementRecommendation,
+  treeOccurrenceClassificationReplacementReadiness,
+  treeOccurrenceClassificationShadowReport,
+  treeOccurrenceClassificationParitySummary,
+}) => ({
+  recommendation: treeOccurrenceClassificationReplacementRecommendation?.recommendation ?? null,
+  confidence: treeOccurrenceClassificationReplacementRecommendation?.confidence ?? null,
+  replacementDecision: treeOccurrenceClassificationReplacementReadiness?.replacementDecision ?? null,
+  replacementReadinessStatus:
+    treeOccurrenceClassificationReplacementReadiness?.summary?.replacementReadinessStatus
+    ?? treeOccurrenceClassificationParitySummary?.replacementReadinessStatus
+    ?? null,
+  shadowComparisonStatus:
+    treeOccurrenceClassificationShadowReport?.summary?.shadowComparisonStatus ?? null,
+  parityCoverageRatio: toNumber(treeOccurrenceClassificationParitySummary?.parityCoverageRatio),
+  parityMatchRatio: toNumber(treeOccurrenceClassificationParitySummary?.parityMatchRatio),
+  comparableRecords: toNumber(treeOccurrenceClassificationParitySummary?.comparableRecords),
+  matchedRecords: toNumber(treeOccurrenceClassificationParitySummary?.matchedRecords),
+  differedRecords: toNumber(treeOccurrenceClassificationParitySummary?.differedRecords),
+  insufficientEvidenceRecords: toNumber(treeOccurrenceClassificationParitySummary?.insufficientEvidenceRecords),
+});
+
+const toEvaluationMode = (summary) => {
+  if (summary.recommendation === 'do-not-replace') {
+    return 'compatibility-only';
+  }
+
+  if (
+    summary.recommendation === 'replacement-candidate'
+    && summary.replacementDecision === 'candidate-ready'
+    && summary.shadowComparisonStatus === 'aligned'
+    && summary.confidence === 'high'
+  ) {
+    return 'evaluation-candidate';
+  }
+
+  return 'shadow-evaluation';
+};
+
+const toEvaluationStatus = (evaluationMode) => {
+  if (evaluationMode === 'compatibility-only') {
+    return 'blocked';
+  }
+
+  if (evaluationMode === 'evaluation-candidate') {
+    return 'ready-for-future-evaluation';
+  }
+
+  return 'review-required';
+};
+
+const toRationale = ({ evaluationMode, summary }) => {
+  if (evaluationMode === 'compatibility-only') {
+    return 'Runtime evaluation plan is compatibility-only because replacement recommendation is do-not-replace.';
+  }
+
+  if (evaluationMode === 'evaluation-candidate') {
+    return 'Runtime evaluation plan is evaluation-candidate because replacement recommendation, readiness decision, shadow alignment, and high confidence are fully aligned.';
+  }
+
+  if (summary.recommendation === 'replacement-candidate' && summary.confidence !== 'high') {
+    return 'Runtime evaluation plan remains shadow-evaluation because replacement-candidate recommendation is not high confidence.';
+  }
+
+  return 'Runtime evaluation plan remains shadow-evaluation because recommendation/readiness/shadow evidence requires review before any future runtime evaluation.';
+};
+
+export const planTreeOccurrenceClassificationRuntimeEvaluation = (input) => {
+  assertObject(input, 'Tree occurrence classification runtime evaluation plan input');
+  assertObject(
+    input.treeOccurrenceClassificationReplacementRecommendation,
+    'Tree occurrence classification runtime evaluation plan input treeOccurrenceClassificationReplacementRecommendation',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationReplacementReadiness,
+    'Tree occurrence classification runtime evaluation plan input treeOccurrenceClassificationReplacementReadiness',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationShadowReport,
+    'Tree occurrence classification runtime evaluation plan input treeOccurrenceClassificationShadowReport',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationParitySummary,
+    'Tree occurrence classification runtime evaluation plan input treeOccurrenceClassificationParitySummary',
+  );
+
+  const summary = toSummary(input);
+  const evaluationMode = toEvaluationMode(summary);
+
+  return {
+    source: SOURCE_ID,
+    evaluationMode,
+    evaluationStatus: toEvaluationStatus(evaluationMode),
+    summary,
+    rationale: toRationale({ evaluationMode, summary }),
+  };
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -21,6 +21,7 @@ import { summarizeTreeOccurrenceClassificationParityEvidence } from './tree-occu
 import { prepareTreeOccurrenceClassificationShadowReport } from './tree-occurrence-classification-shadow-report.logic.mjs';
 import { evaluateTreeOccurrenceClassificationReplacementReadiness } from './tree-occurrence-classification-replacement-readiness.logic.mjs';
 import { recommendTreeOccurrenceClassificationReplacement } from './tree-occurrence-classification-replacement-recommendation.logic.mjs';
+import { planTreeOccurrenceClassificationRuntimeEvaluation } from './tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
@@ -121,6 +122,12 @@ export const prepareTreeStructureAdvisorInputs = (
     treeOccurrenceClassificationShadowReport,
     treeOccurrenceClassificationParitySummary,
   });
+  const treeOccurrenceClassificationRuntimeEvaluationPlan = planTreeOccurrenceClassificationRuntimeEvaluation({
+    treeOccurrenceClassificationReplacementRecommendation,
+    treeOccurrenceClassificationReplacementReadiness,
+    treeOccurrenceClassificationShadowReport,
+    treeOccurrenceClassificationParitySummary,
+  });
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -142,6 +149,7 @@ export const prepareTreeStructureAdvisorInputs = (
       treeOccurrenceClassificationShadowReport,
       treeOccurrenceClassificationReplacementReadiness,
       treeOccurrenceClassificationReplacementRecommendation,
+      treeOccurrenceClassificationRuntimeEvaluationPlan,
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,

--- a/calculogic-validator/tree/test/tree-occurrence-classification-runtime-evaluation-plan.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-runtime-evaluation-plan.logic.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { planTreeOccurrenceClassificationRuntimeEvaluation } from '../src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
+
+const baseInput = () => ({
+  treeOccurrenceClassificationReplacementRecommendation: {
+    source: 'tree-occurrence-classification-replacement-recommendation',
+    recommendation: 'review-before-replacement',
+    confidence: 'medium',
+  },
+  treeOccurrenceClassificationReplacementReadiness: {
+    source: 'tree-occurrence-classification-replacement-readiness',
+    replacementDecision: 'review-required',
+    summary: {
+      replacementReadinessStatus: 'needs-review',
+    },
+  },
+  treeOccurrenceClassificationShadowReport: {
+    source: 'tree-occurrence-classification-shadow-report',
+    summary: {
+      shadowComparisonStatus: 'needs-review',
+    },
+  },
+  treeOccurrenceClassificationParitySummary: {
+    source: 'tree-occurrence-classification-parity-summary',
+    comparableRecords: 3,
+    matchedRecords: 2,
+    differedRecords: 1,
+    insufficientEvidenceRecords: 0,
+    parityCoverageRatio: 1,
+    parityMatchRatio: 2 / 3,
+    replacementReadinessStatus: 'needs-review',
+  },
+});
+
+test('returns compatibility-only/blocked when recommendation is do-not-replace', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'do-not-replace';
+
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(input);
+
+  assert.equal(result.evaluationMode, 'compatibility-only');
+  assert.equal(result.evaluationStatus, 'blocked');
+});
+
+test('returns shadow-evaluation/review-required when recommendation is review-before-replacement', () => {
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(baseInput());
+
+  assert.equal(result.evaluationMode, 'shadow-evaluation');
+  assert.equal(result.evaluationStatus, 'review-required');
+});
+
+test('returns evaluation-candidate/ready-for-future-evaluation when candidate gates align and confidence is high', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'replacement-candidate';
+  input.treeOccurrenceClassificationReplacementRecommendation.confidence = 'high';
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'candidate-ready';
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'aligned';
+
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(input);
+
+  assert.equal(result.evaluationMode, 'evaluation-candidate');
+  assert.equal(result.evaluationStatus, 'ready-for-future-evaluation');
+});
+
+test('does not return ready-for-future-evaluation when recommendation confidence is not high', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'replacement-candidate';
+  input.treeOccurrenceClassificationReplacementRecommendation.confidence = 'medium';
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'candidate-ready';
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'aligned';
+
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(input);
+
+  assert.equal(result.evaluationMode, 'shadow-evaluation');
+  assert.equal(result.evaluationStatus, 'review-required');
+});
+
+test('does not return evaluation-candidate when replacementDecision is not candidate-ready', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'replacement-candidate';
+  input.treeOccurrenceClassificationReplacementRecommendation.confidence = 'high';
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'review-required';
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'aligned';
+
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(input);
+
+  assert.equal(result.evaluationMode, 'shadow-evaluation');
+});
+
+test('does not return evaluation-candidate when shadowComparisonStatus is not aligned', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'replacement-candidate';
+  input.treeOccurrenceClassificationReplacementRecommendation.confidence = 'high';
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'candidate-ready';
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'needs-review';
+
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(input);
+
+  assert.equal(result.evaluationMode, 'shadow-evaluation');
+});
+
+test('copies summary fields from prepared metadata and does not mutate input', () => {
+  const input = baseInput();
+  const before = structuredClone(input);
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(input);
+
+  assert.deepEqual(input, before);
+  assert.equal(result.summary.recommendation, input.treeOccurrenceClassificationReplacementRecommendation.recommendation);
+  assert.equal(result.summary.confidence, input.treeOccurrenceClassificationReplacementRecommendation.confidence);
+  assert.equal(result.summary.replacementDecision, input.treeOccurrenceClassificationReplacementReadiness.replacementDecision);
+  assert.equal(result.summary.replacementReadinessStatus, input.treeOccurrenceClassificationReplacementReadiness.summary.replacementReadinessStatus);
+  assert.equal(result.summary.shadowComparisonStatus, input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus);
+  assert.equal(result.summary.parityCoverageRatio, input.treeOccurrenceClassificationParitySummary.parityCoverageRatio);
+  assert.equal(result.summary.parityMatchRatio, input.treeOccurrenceClassificationParitySummary.parityMatchRatio);
+  assert.equal(result.summary.comparableRecords, input.treeOccurrenceClassificationParitySummary.comparableRecords);
+  assert.equal(result.summary.matchedRecords, input.treeOccurrenceClassificationParitySummary.matchedRecords);
+  assert.equal(result.summary.differedRecords, input.treeOccurrenceClassificationParitySummary.differedRecords);
+  assert.equal(result.summary.insufficientEvidenceRecords, input.treeOccurrenceClassificationParitySummary.insufficientEvidenceRecords);
+});
+
+test('does not emit finding/severity/verdict/advisor fields', () => {
+  const result = planTreeOccurrenceClassificationRuntimeEvaluation(baseInput());
+  const forbiddenKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+
+  for (const key of forbiddenKeys) {
+    assert.equal(Object.hasOwn(result, key), false);
+    assert.equal(Object.hasOwn(result.summary, key), false);
+  }
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(() => planTreeOccurrenceClassificationRuntimeEvaluation(), /input must be an object/u);
+  assert.throws(
+    () => planTreeOccurrenceClassificationRuntimeEvaluation({}),
+    /treeOccurrenceClassificationReplacementRecommendation must be an object/u,
+  );
+});

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -20,6 +20,7 @@ import { summarizeTreeOccurrenceClassificationParityEvidence } from '../src/tree
 import { prepareTreeOccurrenceClassificationShadowReport } from '../src/tree-occurrence-classification-shadow-report.logic.mjs';
 import { evaluateTreeOccurrenceClassificationReplacementReadiness } from '../src/tree-occurrence-classification-replacement-readiness.logic.mjs';
 import { recommendTreeOccurrenceClassificationReplacement } from '../src/tree-occurrence-classification-replacement-recommendation.logic.mjs';
+import { planTreeOccurrenceClassificationRuntimeEvaluation } from '../src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -176,6 +177,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -241,6 +243,15 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation,
       recommendTreeOccurrenceClassificationReplacement({
+        treeOccurrenceClassificationReplacementReadiness: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
+        treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
+        treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      }),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan,
+      planTreeOccurrenceClassificationRuntimeEvaluation({
+        treeOccurrenceClassificationReplacementRecommendation: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation,
         treeOccurrenceClassificationReplacementReadiness: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
         treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
         treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,


### PR DESCRIPTION
### Motivation
- Stage deterministic, tree-owned runtime evaluation planning metadata that describes how future occurrence-classification replacement evaluation could run while explicitly not enabling any runtime replacement behavior. 
- This slice consumes prepared evidence only and preserves the current runtime truth that known-roots classification remains authoritative. 
- Runtime authority for decisions in this PR was taken from `ValidatorSuite-Contracts-And-Modes.md`, `tree-structure-advisor-validator.spec.md`, `NamingValidatorSpec.md`, and `cfg-treeStructureAdvisor.md`, with `tree-owned/tree-documentation-map-and-reorg-inventory.md` treated as navigation-only. 

### Description
- Add `planTreeOccurrenceClassificationRuntimeEvaluation` in `calculogic-validator/tree/src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs` which consumes only `treeOccurrenceClassificationReplacementRecommendation`, `treeOccurrenceClassificationReplacementReadiness`, `treeOccurrenceClassificationShadowReport`, and `treeOccurrenceClassificationParitySummary` and returns `{ source, evaluationMode, evaluationStatus, summary, rationale }`. 
- Wire the prepared dependency `preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan` into the tree advisor inputs in `calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs` while preserving non-observable/evidence-only boundaries. 
- Add focused tests in `calculogic-validator/tree/test/tree-occurrence-classification-runtime-evaluation-plan.logic.test.mjs` that exercise mode/status gates, confidence handling, immutability, summary copying, evidence-only constraints, and invalid-input guards. 
- Extend existing `tree-structure-advisor` wiring tests to assert the prepared dependency exists and matches the standalone helper output without changing advisor findings or runtime behavior. 

### Testing
- Ran the helper unit tests with `node --test calculogic-validator/tree/test/tree-occurrence-classification-runtime-evaluation-plan.logic.test.mjs` and all tests passed. 
- Re-ran related unit tests with `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, and all tests passed. 
- Ran validators `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`, and both completed successfully (the tree validator output includes expected informational/advisory findings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fde42184883318f4a6e6ed6707c50)