### PR TITLE
test(tree): assert runtime evaluation plan remains evidence-only in advisor wiring

### DIFF
--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -257,6 +257,25 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
       }),
     );
+    const runtimeEvaluationPlan = preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan;
+    assert.deepEqual(Object.keys(runtimeEvaluationPlan).sort(), ['evaluationMode', 'evaluationStatus', 'rationale', 'source', 'summary']);
+    assert.equal(
+      ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) => Object.hasOwn(runtimeEvaluationPlan, key)),
+      false,
+    );
+    assert.equal(
+      ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) => Object.hasOwn(runtimeEvaluationPlan.summary, key)),
+      false,
+    );
+    assert.deepEqual(
+      runtimeEvaluationPlan,
+      planTreeOccurrenceClassificationRuntimeEvaluation({
+        treeOccurrenceClassificationReplacementRecommendation: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation,
+        treeOccurrenceClassificationReplacementReadiness: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
+        treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
+        treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      }),
+    );
     const replacementRecommendation = preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation;
     assert.deepEqual(Object.keys(replacementRecommendation).sort(), ['confidence', 'rationale', 'recommendation', 'source', 'summary']);
     assert.equal(


### PR DESCRIPTION
### Motivation
- Refs #516 and Refs #557: stage prepared dependency wiring for occurrence classification runtime evaluation planning while ensuring no runtime replacement behavior is enabled.
- Ensure the prepared runtime evaluation planning metadata is deterministic and evidence-only and does not alter advisor output or occurrence classification behavior.
- Treated validator-owned tree specs and wiring guidance as runtime authority (`tree-structure-advisor` spec and related convention docs), and treated other listed convention docs as navigation/supporting context for this focused test-only slice.

### Description
- Strengthened `calculogic-validator/tree/test/tree-structure-advisor.test.mjs` to assert that `preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan` exists, matches the standalone helper output from `planTreeOccurrenceClassificationRuntimeEvaluation(...)`, and contains only evidence metadata keys (`source`, `evaluationMode`, `evaluationStatus`, `summary`, `rationale`).
- Added explicit assertions that forbid advisor/finding fields (`finding`, `findingCode`, `severity`, `verdict`, `placementVerdict`, `advisorDecision`) on both the runtime evaluation plan and its `summary` to keep the plan evidence-only.
- Changes are test-only and constrained to wiring assertions; no runtime logic, advisor behavior, findings, or occurrence classification code was modified.

### Testing
- Ran focused unit tests with `node --test calculogic-validator/tree/test/tree-occurrence-classification-runtime-evaluation-plan.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-readiness.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs`, and all tests passed.
- Ran validators `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test`, and both validations completed with expected report outputs and no failures.
- Verification confirms the prepared runtime evaluation plan is helper-aligned, deterministic, evidence-only, and that advisor runtime behavior and occurrence classification behavior remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1108af4fdc8331bf8327255883e321)