### PR TITLE
Stage tree occurrence runtime execution contract planning

### DIFF
--- a/calculogic-validator/tree/src/tree-occurrence-classification-runtime-execution-contract.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification-runtime-execution-contract.logic.mjs
@@ -1,0 +1,183 @@
+const SOURCE_ID = 'tree-occurrence-classification-runtime-execution-contract';
+
+const assertObject = (value, label) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+};
+
+const toNumber = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+const toSummary = ({
+  treeOccurrenceClassificationRuntimeEvaluationPlan,
+  treeOccurrenceClassificationReplacementRecommendation,
+  treeOccurrenceClassificationReplacementReadiness,
+  treeOccurrenceClassificationShadowReport,
+  treeOccurrenceClassificationParitySummary,
+}) => ({
+  evaluationMode: treeOccurrenceClassificationRuntimeEvaluationPlan?.evaluationMode ?? null,
+  evaluationStatus: treeOccurrenceClassificationRuntimeEvaluationPlan?.evaluationStatus ?? null,
+  recommendation: treeOccurrenceClassificationReplacementRecommendation?.recommendation ?? null,
+  confidence: treeOccurrenceClassificationReplacementRecommendation?.confidence ?? null,
+  replacementDecision: treeOccurrenceClassificationReplacementReadiness?.replacementDecision ?? null,
+  replacementReadinessStatus:
+    treeOccurrenceClassificationReplacementReadiness?.summary?.replacementReadinessStatus
+    ?? treeOccurrenceClassificationParitySummary?.replacementReadinessStatus
+    ?? null,
+  shadowComparisonStatus:
+    treeOccurrenceClassificationShadowReport?.summary?.shadowComparisonStatus ?? null,
+  parityCoverageRatio: toNumber(treeOccurrenceClassificationParitySummary?.parityCoverageRatio),
+  parityMatchRatio: toNumber(treeOccurrenceClassificationParitySummary?.parityMatchRatio),
+  comparableRecords: toNumber(treeOccurrenceClassificationParitySummary?.comparableRecords),
+  matchedRecords: toNumber(treeOccurrenceClassificationParitySummary?.matchedRecords),
+  differedRecords: toNumber(treeOccurrenceClassificationParitySummary?.differedRecords),
+  insufficientEvidenceRecords: toNumber(treeOccurrenceClassificationParitySummary?.insufficientEvidenceRecords),
+});
+
+const hasExecutionCandidateEvidence = (summary) => (
+  summary.evaluationMode === 'evaluation-candidate'
+  && summary.evaluationStatus === 'ready-for-future-evaluation'
+  && summary.recommendation === 'replacement-candidate'
+  && summary.confidence === 'high'
+  && summary.replacementDecision === 'candidate-ready'
+  && summary.shadowComparisonStatus === 'aligned'
+  && summary.parityMatchRatio === 1
+);
+
+const toExecutionMode = (summary) => {
+  if (
+    summary.evaluationMode === 'compatibility-only'
+    || summary.evaluationStatus === 'blocked'
+    || summary.recommendation === 'do-not-replace'
+  ) {
+    return 'compatibility-preserved';
+  }
+
+  if (hasExecutionCandidateEvidence(summary)) {
+    return 'execution-candidate';
+  }
+
+  return 'evaluation-only';
+};
+
+const toExecutionStatus = (executionMode) => {
+  if (executionMode === 'compatibility-preserved') {
+    return 'blocked';
+  }
+
+  if (executionMode === 'execution-candidate') {
+    return 'ready-for-future-execution-contract';
+  }
+
+  return 'guarded-review-required';
+};
+
+const toGuardRationale = ({ id, satisfied }) => {
+  if (id === 'parity-alignment') {
+    return satisfied
+      ? 'Parity alignment guard is satisfied because parityMatchRatio is 1.'
+      : 'Parity alignment guard remains required because parityMatchRatio is not 1.';
+  }
+
+  if (id === 'shadow-alignment') {
+    return satisfied
+      ? 'Shadow alignment guard is satisfied because shadowComparisonStatus is aligned.'
+      : 'Shadow alignment guard remains required because shadowComparisonStatus is not aligned.';
+  }
+
+  if (id === 'high-confidence') {
+    return satisfied
+      ? 'High confidence guard is satisfied because recommendation confidence is high.'
+      : 'High confidence guard remains required because recommendation confidence is not high.';
+  }
+
+  if (id === 'runtime-observability') {
+    return satisfied
+      ? 'Runtime observability guard is satisfied because evaluationStatus is ready-for-future-evaluation.'
+      : 'Runtime observability guard remains required because evaluationStatus is not ready-for-future-evaluation.';
+  }
+
+  return 'Rollback availability guard remains required because no current prepared metadata provides rollback availability evidence.';
+};
+
+const toRequiredGuards = (summary) => ([
+  {
+    id: 'parity-alignment',
+    satisfied: summary.parityMatchRatio === 1,
+  },
+  {
+    id: 'shadow-alignment',
+    satisfied: summary.shadowComparisonStatus === 'aligned',
+  },
+  {
+    id: 'high-confidence',
+    satisfied: summary.confidence === 'high',
+  },
+  {
+    id: 'runtime-observability',
+    satisfied: summary.evaluationStatus === 'ready-for-future-evaluation',
+  },
+  {
+    id: 'rollback-available',
+    satisfied: false,
+  },
+]).map((guard) => ({
+  ...guard,
+  rationale: toGuardRationale(guard),
+}));
+
+const toRationale = ({ executionMode, summary }) => {
+  if (executionMode === 'compatibility-preserved') {
+    return 'Runtime execution-contract planning preserves compatibility because evaluation evidence is blocked, compatibility-only, or recommends do-not-replace.';
+  }
+
+  if (executionMode === 'execution-candidate') {
+    return 'Runtime execution-contract planning is an execution-candidate because evaluation, recommendation, readiness, shadow, confidence, and parity evidence are aligned; this remains evidence metadata only.';
+  }
+
+  if (summary.evaluationMode === 'shadow-evaluation' || summary.evaluationStatus === 'review-required') {
+    return 'Runtime execution-contract planning remains evaluation-only because runtime evaluation evidence still requires guarded review before any future execution contract.';
+  }
+
+  if (summary.recommendation === 'review-before-replacement') {
+    return 'Runtime execution-contract planning remains evaluation-only because replacement recommendation requires review before replacement.';
+  }
+
+  return 'Runtime execution-contract planning remains evaluation-only because candidate execution-contract evidence is incomplete.';
+};
+
+export const planTreeOccurrenceClassificationRuntimeExecutionContract = (input) => {
+  assertObject(input, 'Tree occurrence classification runtime execution contract input');
+  assertObject(
+    input.treeOccurrenceClassificationRuntimeEvaluationPlan,
+    'Tree occurrence classification runtime execution contract input treeOccurrenceClassificationRuntimeEvaluationPlan',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationReplacementRecommendation,
+    'Tree occurrence classification runtime execution contract input treeOccurrenceClassificationReplacementRecommendation',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationReplacementReadiness,
+    'Tree occurrence classification runtime execution contract input treeOccurrenceClassificationReplacementReadiness',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationShadowReport,
+    'Tree occurrence classification runtime execution contract input treeOccurrenceClassificationShadowReport',
+  );
+  assertObject(
+    input.treeOccurrenceClassificationParitySummary,
+    'Tree occurrence classification runtime execution contract input treeOccurrenceClassificationParitySummary',
+  );
+
+  const summary = toSummary(input);
+  const executionMode = toExecutionMode(summary);
+
+  return {
+    source: SOURCE_ID,
+    executionMode,
+    executionStatus: toExecutionStatus(executionMode),
+    requiredGuards: toRequiredGuards(summary),
+    summary,
+    rationale: toRationale({ executionMode, summary }),
+  };
+};

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -22,6 +22,7 @@ import { prepareTreeOccurrenceClassificationShadowReport } from './tree-occurren
 import { evaluateTreeOccurrenceClassificationReplacementReadiness } from './tree-occurrence-classification-replacement-readiness.logic.mjs';
 import { recommendTreeOccurrenceClassificationReplacement } from './tree-occurrence-classification-replacement-recommendation.logic.mjs';
 import { planTreeOccurrenceClassificationRuntimeEvaluation } from './tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
+import { planTreeOccurrenceClassificationRuntimeExecutionContract } from './tree-occurrence-classification-runtime-execution-contract.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
@@ -128,6 +129,13 @@ export const prepareTreeStructureAdvisorInputs = (
     treeOccurrenceClassificationShadowReport,
     treeOccurrenceClassificationParitySummary,
   });
+  const treeOccurrenceClassificationRuntimeExecutionContract = planTreeOccurrenceClassificationRuntimeExecutionContract({
+    treeOccurrenceClassificationRuntimeEvaluationPlan,
+    treeOccurrenceClassificationReplacementRecommendation,
+    treeOccurrenceClassificationReplacementReadiness,
+    treeOccurrenceClassificationShadowReport,
+    treeOccurrenceClassificationParitySummary,
+  });
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -150,6 +158,7 @@ export const prepareTreeStructureAdvisorInputs = (
       treeOccurrenceClassificationReplacementReadiness,
       treeOccurrenceClassificationReplacementRecommendation,
       treeOccurrenceClassificationRuntimeEvaluationPlan,
+      treeOccurrenceClassificationRuntimeExecutionContract,
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,

--- a/calculogic-validator/tree/test/tree-occurrence-classification-runtime-execution-contract.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification-runtime-execution-contract.logic.test.mjs
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { planTreeOccurrenceClassificationRuntimeExecutionContract } from '../src/tree-occurrence-classification-runtime-execution-contract.logic.mjs';
+
+const forbiddenEvidenceKeys = ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'];
+
+const baseInput = () => ({
+  treeOccurrenceClassificationRuntimeEvaluationPlan: {
+    source: 'tree-occurrence-classification-runtime-evaluation-plan',
+    evaluationMode: 'shadow-evaluation',
+    evaluationStatus: 'review-required',
+  },
+  treeOccurrenceClassificationReplacementRecommendation: {
+    source: 'tree-occurrence-classification-replacement-recommendation',
+    recommendation: 'review-before-replacement',
+    confidence: 'medium',
+  },
+  treeOccurrenceClassificationReplacementReadiness: {
+    source: 'tree-occurrence-classification-replacement-readiness',
+    replacementDecision: 'review-required',
+    summary: {
+      replacementReadinessStatus: 'needs-review',
+    },
+  },
+  treeOccurrenceClassificationShadowReport: {
+    source: 'tree-occurrence-classification-shadow-report',
+    summary: {
+      shadowComparisonStatus: 'needs-review',
+    },
+  },
+  treeOccurrenceClassificationParitySummary: {
+    source: 'tree-occurrence-classification-parity-summary',
+    comparableRecords: 3,
+    matchedRecords: 2,
+    differedRecords: 1,
+    insufficientEvidenceRecords: 0,
+    parityCoverageRatio: 1,
+    parityMatchRatio: 2 / 3,
+    replacementReadinessStatus: 'needs-review',
+  },
+});
+
+const candidateInput = () => {
+  const input = baseInput();
+
+  input.treeOccurrenceClassificationRuntimeEvaluationPlan.evaluationMode = 'evaluation-candidate';
+  input.treeOccurrenceClassificationRuntimeEvaluationPlan.evaluationStatus = 'ready-for-future-evaluation';
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'replacement-candidate';
+  input.treeOccurrenceClassificationReplacementRecommendation.confidence = 'high';
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'candidate-ready';
+  input.treeOccurrenceClassificationReplacementReadiness.summary.replacementReadinessStatus = 'candidate-ready';
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'aligned';
+  input.treeOccurrenceClassificationParitySummary.comparableRecords = 3;
+  input.treeOccurrenceClassificationParitySummary.matchedRecords = 3;
+  input.treeOccurrenceClassificationParitySummary.differedRecords = 0;
+  input.treeOccurrenceClassificationParitySummary.insufficientEvidenceRecords = 0;
+  input.treeOccurrenceClassificationParitySummary.parityCoverageRatio = 1;
+  input.treeOccurrenceClassificationParitySummary.parityMatchRatio = 1;
+  input.treeOccurrenceClassificationParitySummary.replacementReadinessStatus = 'candidate-ready';
+
+  return input;
+};
+
+test('returns compatibility-preserved/blocked when evaluationMode is compatibility-only', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationRuntimeEvaluationPlan.evaluationMode = 'compatibility-only';
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'compatibility-preserved');
+  assert.equal(result.executionStatus, 'blocked');
+});
+
+test('returns compatibility-preserved/blocked when recommendation is do-not-replace', () => {
+  const input = baseInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'do-not-replace';
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'compatibility-preserved');
+  assert.equal(result.executionStatus, 'blocked');
+});
+
+test('returns evaluation-only/guarded-review-required when evaluationMode is shadow-evaluation', () => {
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(baseInput());
+
+  assert.equal(result.executionMode, 'evaluation-only');
+  assert.equal(result.executionStatus, 'guarded-review-required');
+});
+
+test('returns evaluation-only/guarded-review-required when recommendation is review-before-replacement', () => {
+  const input = candidateInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.recommendation = 'review-before-replacement';
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'evaluation-only');
+  assert.equal(result.executionStatus, 'guarded-review-required');
+});
+
+test('returns execution-candidate/ready-for-future-execution-contract only when all candidate conditions pass', () => {
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(candidateInput());
+
+  assert.equal(result.executionMode, 'execution-candidate');
+  assert.equal(result.executionStatus, 'ready-for-future-execution-contract');
+});
+
+test('does not return execution-candidate when confidence is not high', () => {
+  const input = candidateInput();
+  input.treeOccurrenceClassificationReplacementRecommendation.confidence = 'medium';
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'evaluation-only');
+  assert.equal(result.executionStatus, 'guarded-review-required');
+});
+
+test('does not return execution-candidate when replacementDecision is not candidate-ready', () => {
+  const input = candidateInput();
+  input.treeOccurrenceClassificationReplacementReadiness.replacementDecision = 'review-required';
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'evaluation-only');
+});
+
+test('does not return execution-candidate when shadowComparisonStatus is not aligned', () => {
+  const input = candidateInput();
+  input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus = 'needs-review';
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'evaluation-only');
+});
+
+test('does not return execution-candidate when parityMatchRatio is not 1', () => {
+  const input = candidateInput();
+  input.treeOccurrenceClassificationParitySummary.parityMatchRatio = 2 / 3;
+
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.equal(result.executionMode, 'evaluation-only');
+});
+
+test('does not mark rollback-available satisfied without current prepared metadata support', () => {
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(candidateInput());
+  const rollbackGuard = result.requiredGuards.find((guard) => guard.id === 'rollback-available');
+
+  assert.deepEqual(rollbackGuard, {
+    id: 'rollback-available',
+    satisfied: false,
+    rationale: 'Rollback availability guard remains required because no current prepared metadata provides rollback availability evidence.',
+  });
+});
+
+test('emits deterministic required guard records', () => {
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(candidateInput());
+
+  assert.deepEqual(result.requiredGuards, [
+    {
+      id: 'parity-alignment',
+      satisfied: true,
+      rationale: 'Parity alignment guard is satisfied because parityMatchRatio is 1.',
+    },
+    {
+      id: 'shadow-alignment',
+      satisfied: true,
+      rationale: 'Shadow alignment guard is satisfied because shadowComparisonStatus is aligned.',
+    },
+    {
+      id: 'high-confidence',
+      satisfied: true,
+      rationale: 'High confidence guard is satisfied because recommendation confidence is high.',
+    },
+    {
+      id: 'runtime-observability',
+      satisfied: true,
+      rationale: 'Runtime observability guard is satisfied because evaluationStatus is ready-for-future-evaluation.',
+    },
+    {
+      id: 'rollback-available',
+      satisfied: false,
+      rationale: 'Rollback availability guard remains required because no current prepared metadata provides rollback availability evidence.',
+    },
+  ]);
+});
+
+test('copies summary fields from prepared metadata and does not mutate input', () => {
+  const input = baseInput();
+  const before = structuredClone(input);
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(input);
+
+  assert.deepEqual(input, before);
+  assert.equal(result.summary.evaluationMode, input.treeOccurrenceClassificationRuntimeEvaluationPlan.evaluationMode);
+  assert.equal(result.summary.evaluationStatus, input.treeOccurrenceClassificationRuntimeEvaluationPlan.evaluationStatus);
+  assert.equal(result.summary.recommendation, input.treeOccurrenceClassificationReplacementRecommendation.recommendation);
+  assert.equal(result.summary.confidence, input.treeOccurrenceClassificationReplacementRecommendation.confidence);
+  assert.equal(result.summary.replacementDecision, input.treeOccurrenceClassificationReplacementReadiness.replacementDecision);
+  assert.equal(result.summary.replacementReadinessStatus, input.treeOccurrenceClassificationReplacementReadiness.summary.replacementReadinessStatus);
+  assert.equal(result.summary.shadowComparisonStatus, input.treeOccurrenceClassificationShadowReport.summary.shadowComparisonStatus);
+  assert.equal(result.summary.parityCoverageRatio, input.treeOccurrenceClassificationParitySummary.parityCoverageRatio);
+  assert.equal(result.summary.parityMatchRatio, input.treeOccurrenceClassificationParitySummary.parityMatchRatio);
+  assert.equal(result.summary.comparableRecords, input.treeOccurrenceClassificationParitySummary.comparableRecords);
+  assert.equal(result.summary.matchedRecords, input.treeOccurrenceClassificationParitySummary.matchedRecords);
+  assert.equal(result.summary.differedRecords, input.treeOccurrenceClassificationParitySummary.differedRecords);
+  assert.equal(result.summary.insufficientEvidenceRecords, input.treeOccurrenceClassificationParitySummary.insufficientEvidenceRecords);
+});
+
+test('does not emit findings/severity/verdict/advisor fields', () => {
+  const result = planTreeOccurrenceClassificationRuntimeExecutionContract(candidateInput());
+
+  assert.deepEqual(Object.keys(result).sort(), ['executionMode', 'executionStatus', 'rationale', 'requiredGuards', 'source', 'summary']);
+  assert.equal(forbiddenEvidenceKeys.some((key) => Object.hasOwn(result, key)), false);
+  assert.equal(forbiddenEvidenceKeys.some((key) => Object.hasOwn(result.summary, key)), false);
+  assert.equal(
+    result.requiredGuards.some((guard) => forbiddenEvidenceKeys.some((key) => Object.hasOwn(guard, key))),
+    false,
+  );
+});
+
+test('rejects invalid input deterministically', () => {
+  assert.throws(
+    () => planTreeOccurrenceClassificationRuntimeExecutionContract({}),
+    /treeOccurrenceClassificationRuntimeEvaluationPlan must be an object/u,
+  );
+});

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -21,6 +21,7 @@ import { prepareTreeOccurrenceClassificationShadowReport } from '../src/tree-occ
 import { evaluateTreeOccurrenceClassificationReplacementReadiness } from '../src/tree-occurrence-classification-replacement-readiness.logic.mjs';
 import { recommendTreeOccurrenceClassificationReplacement } from '../src/tree-occurrence-classification-replacement-recommendation.logic.mjs';
 import { planTreeOccurrenceClassificationRuntimeEvaluation } from '../src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
+import { planTreeOccurrenceClassificationRuntimeExecutionContract } from '../src/tree-occurrence-classification-runtime-execution-contract.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -178,6 +179,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -255,6 +257,42 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         treeOccurrenceClassificationReplacementReadiness: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
         treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
         treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      }),
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract,
+      planTreeOccurrenceClassificationRuntimeExecutionContract({
+        treeOccurrenceClassificationRuntimeEvaluationPlan: preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan,
+        treeOccurrenceClassificationReplacementRecommendation: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation,
+        treeOccurrenceClassificationReplacementReadiness: preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementReadiness,
+        treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
+        treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
+      }),
+    );
+    const runtimeExecutionContract = preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract;
+    assert.deepEqual(Object.keys(runtimeExecutionContract).sort(), ['executionMode', 'executionStatus', 'rationale', 'requiredGuards', 'source', 'summary']);
+    assert.equal(
+      ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) => Object.hasOwn(runtimeExecutionContract, key)),
+      false,
+    );
+    assert.equal(
+      ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) => Object.hasOwn(runtimeExecutionContract.summary, key)),
+      false,
+    );
+    assert.equal(
+      runtimeExecutionContract.requiredGuards.some((guard) =>
+        ['finding', 'findingCode', 'severity', 'verdict', 'placementVerdict', 'advisorDecision'].some((key) => Object.hasOwn(guard, key))),
+      false,
+    );
+    const {
+      treeOccurrenceClassificationRuntimeExecutionContract: _omittedRuntimeExecutionContract,
+      ...preparedDependenciesWithoutRuntimeExecutionContract
+    } = preparedInputs.preparedDependencies;
+    assert.deepEqual(
+      runTreeStructureAdvisorRuntime(preparedInputs),
+      runTreeStructureAdvisorRuntime({
+        ...preparedInputs,
+        preparedDependencies: preparedDependenciesWithoutRuntimeExecutionContract,
       }),
     );
     const runtimeEvaluationPlan = preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan;


### PR DESCRIPTION
### Motivation
- Stage deterministic, evidence-only runtime execution-contract planning metadata for tree occurrence-classification replacement without enabling replacement behavior. 
- Capture what future runtime replacement would require (guards, modes, status) while preserving current occurrence classification as the current runtime truth.

### Description
- Added helper `planTreeOccurrenceClassificationRuntimeExecutionContract` (`calculogic-validator/tree/src/tree-occurrence-classification-runtime-execution-contract.logic.mjs`) that consumes prepared metadata and emits an evidence-only execution contract with `executionMode`, `executionStatus`, `requiredGuards`, `summary`, and `rationale` fields. 
- Implemented deterministic mode/status rules and guard records (`parity-alignment`, `shadow-alignment`, `high-confidence`, `runtime-observability`, `rollback-available`) and ensured `rollback-available` remains unsatisfied unless input evidence supports it. 
- Wired the prepared execution contract into advisor inputs as a non-observable prepared dependency at `prepareTreeStructureAdvisorInputs` (`calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs`) while preserving advisor runtime behavior. 
- Added focused unit tests: `calculogic-validator/tree/test/tree-occurrence-classification-runtime-execution-contract.logic.test.mjs` and extended wiring tests in `calculogic-validator/tree/test/tree-structure-advisor.test.mjs` to prove deterministic rules, evidence-only output, immutability, and non-observability.

### Testing
- Ran unit tests: `node --test calculogic-validator/tree/test/tree-occurrence-classification-runtime-execution-contract.logic.test.mjs` — passed. 
- Ran related unit suites: `node --test calculogic-validator/tree/test/tree-occurrence-classification-runtime-evaluation-plan.logic.test.mjs`, `node --test calculogic-validator/tree/test/tree-occurrence-classification-replacement-recommendation.logic.test.mjs`, and `node --test calculogic-validator/tree/test/tree-structure-advisor.test.mjs` — all passed. 
- Ran validator checks: `npm run validate:naming -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` — passed, and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree/src --target calculogic-validator/tree/test` — passed with existing report-mode advisory findings (and an npm http-proxy warning). 

Refs #516
Refs #559

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c1164bec83319c326629f7243efb)