### PR TITLE
Add guarded Tree known-roots runtime routing seam

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -97,6 +97,8 @@ V0.1.7 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - tree-run default contributor selection is owned by a dedicated assembly/wiring module so tree wiring only prepares tree-core inputs
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
+- Tree known-roots runtime routing is now explicit and Tree-owned: default execution remains the legacy/current known-roots-backed path, `knownTopLevelDirectories` remains current runtime truth for unexpected top-level folder behavior, and `topRoots[].kind` remains current runtime truth for occurrence classification.
+- Prepared replacement execution is only eligible when explicitly selected, available, and guarded safe; unavailable, unsafe, or divergent replacement execution falls back to the known-roots-backed path and must not become default behavior in this slice.
 
 Target behaviors in V0.1.2:
 

--- a/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
@@ -1,0 +1,223 @@
+const SOURCE_ID = 'tree-known-roots-runtime-routing';
+
+export const TREE_KNOWN_ROOTS_RUNTIME_MODES = Object.freeze({
+  LEGACY: 'legacy-known-roots',
+  REPLACEMENT: 'replacement-prepared',
+  FALLBACK: 'fallback-known-roots',
+});
+
+const LEGACY_RUNTIME_TRUTH = Object.freeze({
+  unexpectedTopLevelFolders: 'knownTopLevelDirectories',
+  occurrenceClassification: 'topRoots[].kind',
+});
+
+const REPLACEMENT_RUNTIME_FUNCTIONS = ['classifyOccurrenceRecords', 'collectUnexpectedTopLevelDirectoryNames'];
+
+const isObject = (value) => value && typeof value === 'object' && !Array.isArray(value);
+
+const normalizeRequestedMode = (requestedMode) => {
+  if (requestedMode === TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT) {
+    return TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT;
+  }
+
+  return TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY;
+};
+
+const hasPreparedReplacementRuntime = (replacementRuntime) =>
+  Boolean(
+    isObject(replacementRuntime) &&
+      REPLACEMENT_RUNTIME_FUNCTIONS.every((functionName) => typeof replacementRuntime[functionName] === 'function'),
+  );
+
+const hasSatisfiedRuntimeExecutionContract = (runtimeExecutionContract) =>
+  Boolean(
+    isObject(runtimeExecutionContract) &&
+      runtimeExecutionContract.executionMode === 'execution-candidate' &&
+      Array.isArray(runtimeExecutionContract.requiredGuards) &&
+      runtimeExecutionContract.requiredGuards.length > 0 &&
+      runtimeExecutionContract.requiredGuards.every((guard) => guard?.satisfied === true),
+  );
+
+export const selectTreeKnownRootsRuntimeRoute = ({
+  requestedMode,
+  replacementRuntime,
+  runtimeExecutionContract,
+} = {}) => {
+  const normalizedRequestedMode = normalizeRequestedMode(requestedMode);
+
+  if (normalizedRequestedMode !== TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT) {
+    return {
+      source: SOURCE_ID,
+      requestedMode: normalizedRequestedMode,
+      activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY,
+      fallbackUsed: false,
+      fallbackReason: null,
+      replacementAvailable: hasPreparedReplacementRuntime(replacementRuntime),
+      replacementSafe: hasSatisfiedRuntimeExecutionContract(runtimeExecutionContract),
+      legacyRuntimeTruth: LEGACY_RUNTIME_TRUTH,
+    };
+  }
+
+  const replacementAvailable = hasPreparedReplacementRuntime(replacementRuntime);
+  const replacementSafe = hasSatisfiedRuntimeExecutionContract(runtimeExecutionContract);
+
+  if (!replacementAvailable) {
+    return {
+      source: SOURCE_ID,
+      requestedMode: normalizedRequestedMode,
+      activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK,
+      fallbackUsed: true,
+      fallbackReason: 'replacement-runtime-unavailable',
+      replacementAvailable,
+      replacementSafe,
+      legacyRuntimeTruth: LEGACY_RUNTIME_TRUTH,
+    };
+  }
+
+  if (!replacementSafe) {
+    return {
+      source: SOURCE_ID,
+      requestedMode: normalizedRequestedMode,
+      activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK,
+      fallbackUsed: true,
+      fallbackReason: 'replacement-runtime-unsafe',
+      replacementAvailable,
+      replacementSafe,
+      legacyRuntimeTruth: LEGACY_RUNTIME_TRUTH,
+    };
+  }
+
+  return {
+    source: SOURCE_ID,
+    requestedMode: normalizedRequestedMode,
+    activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    fallbackUsed: false,
+    fallbackReason: null,
+    replacementAvailable,
+    replacementSafe,
+    legacyRuntimeTruth: LEGACY_RUNTIME_TRUTH,
+    replacementRuntime,
+  };
+};
+
+const toClassificationComparable = (record) => ({
+  path: record?.path ?? record?.resolvedPath ?? null,
+  resolvedPath: record?.resolvedPath ?? record?.path ?? null,
+  occurrenceType: record?.occurrenceType ?? null,
+  structuralClass: record?.structuralClass ?? null,
+  structuralKind: record?.structuralKind ?? null,
+  isKnownTopRoot: record?.isKnownTopRoot === true,
+  isStructuralRoot: record?.isStructuralRoot === true,
+  isSemanticRoot: record?.isSemanticRoot === true,
+  isSubtreePartitionCandidate: record?.isSubtreePartitionCandidate === true,
+});
+
+const classificationResultsDiverge = (leftRecords, rightRecords) =>
+  JSON.stringify(leftRecords.map(toClassificationComparable)) !==
+  JSON.stringify(rightRecords.map(toClassificationComparable));
+
+const withFallback = (route, fallbackReason) => ({
+  ...route,
+  activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK,
+  fallbackUsed: true,
+  fallbackReason,
+});
+
+export const resolveTreeOccurrenceClassificationRuntime = ({
+  occurrenceRecords,
+  legacyClassifyOccurrenceRecords,
+  route,
+} = {}) => {
+  if (!Array.isArray(occurrenceRecords)) {
+    throw new Error('Tree known-roots runtime routing requires occurrenceRecords array.');
+  }
+
+  if (typeof legacyClassifyOccurrenceRecords !== 'function') {
+    throw new Error('Tree known-roots runtime routing requires a legacy occurrence classifier.');
+  }
+
+  const legacyRecords = legacyClassifyOccurrenceRecords(occurrenceRecords);
+
+  if (!Array.isArray(legacyRecords)) {
+    throw new Error('Tree known-roots runtime routing legacy occurrence classifier must return an array.');
+  }
+
+  if (route?.activeExecutionMode !== TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT) {
+    return {
+      route,
+      records: legacyRecords,
+    };
+  }
+
+  const replacementRecords = route.replacementRuntime?.classifyOccurrenceRecords?.(occurrenceRecords);
+
+  if (!Array.isArray(replacementRecords)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-unavailable'),
+      records: legacyRecords,
+    };
+  }
+
+  if (classificationResultsDiverge(replacementRecords, legacyRecords)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-divergent'),
+      records: legacyRecords,
+    };
+  }
+
+  return {
+    route,
+    records: replacementRecords,
+  };
+};
+
+export const resolveTreeUnexpectedTopLevelDirectoryRuntime = ({
+  topLevelDirectoryNames,
+  legacyCollectUnexpectedDirectoryNames,
+  route,
+} = {}) => {
+  if (!Array.isArray(topLevelDirectoryNames)) {
+    throw new Error('Tree known-roots runtime routing requires topLevelDirectoryNames array.');
+  }
+
+  if (typeof legacyCollectUnexpectedDirectoryNames !== 'function') {
+    throw new Error('Tree known-roots runtime routing requires a legacy unexpected top-level directory collector.');
+  }
+
+  const legacyDirectoryNames = legacyCollectUnexpectedDirectoryNames(topLevelDirectoryNames);
+
+  if (!Array.isArray(legacyDirectoryNames)) {
+    throw new Error('Tree known-roots runtime routing legacy unexpected top-level directory collector must return an array.');
+  }
+
+  if (route?.activeExecutionMode !== TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT) {
+    return {
+      route,
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
+  const replacementDirectoryNames = route.replacementRuntime?.collectUnexpectedTopLevelDirectoryNames?.(topLevelDirectoryNames);
+
+  if (!Array.isArray(replacementDirectoryNames)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-unavailable'),
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
+  const sortedReplacementDirectoryNames = [...replacementDirectoryNames].sort((left, right) => left.localeCompare(right));
+  const sortedLegacyDirectoryNames = [...legacyDirectoryNames].sort((left, right) => left.localeCompare(right));
+
+  if (JSON.stringify(sortedReplacementDirectoryNames) !== JSON.stringify(sortedLegacyDirectoryNames)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-divergent'),
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
+  return {
+    route,
+    unexpectedDirectoryNames: sortedReplacementDirectoryNames,
+  };
+};

--- a/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
@@ -101,8 +101,8 @@ export const selectTreeKnownRootsRuntimeRoute = ({
 };
 
 const toClassificationComparable = (record) => ({
-  path: record?.path ?? record?.resolvedPath ?? null,
-  resolvedPath: record?.resolvedPath ?? record?.path ?? null,
+  path: record?.path ?? null,
+  resolvedPath: record?.resolvedPath ?? null,
   occurrenceType: record?.occurrenceType ?? null,
   structuralClass: record?.structuralClass ?? null,
   structuralKind: record?.structuralKind ?? null,

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -2,6 +2,11 @@ import path from 'node:path';
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy-registry.logic.mjs';
 import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.logic.mjs';
+import {
+  resolveTreeOccurrenceClassificationRuntime,
+  resolveTreeUnexpectedTopLevelDirectoryRuntime,
+  selectTreeKnownRootsRuntimeRoute,
+} from './tree-known-roots-runtime-routing.logic.mjs';
 
 const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
 const TREE_SIGNAL_POLICY = getBuiltinTreeSignalPolicy();
@@ -33,14 +38,23 @@ const sortByPathThenCode = (left, right) => {
 const isValidatorOwnedBasenameSignal = (basename) =>
   TREE_SIGNAL_POLICY.validatorOwnedBasenameSignalMatchers.some(({ matcher }) => matcher.test(basename));
 
-const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope) => {
+const collectKnownRootsUnexpectedDirectoryNames = (topLevelDirectoryNames) =>
+  topLevelDirectoryNames
+    .filter((directoryName) => !TREE_KNOWN_ROOTS.knownTopLevelDirectories.has(directoryName))
+    .sort((left, right) => left.localeCompare(right));
+
+const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope, runtimeRoute) => {
   if ((scope ?? 'repo') !== 'repo') {
     return [];
   }
 
-  return topLevelDirectoryNames
-    .filter((directoryName) => !TREE_KNOWN_ROOTS.knownTopLevelDirectories.has(directoryName))
-    .sort((left, right) => left.localeCompare(right))
+  const { unexpectedDirectoryNames } = resolveTreeUnexpectedTopLevelDirectoryRuntime({
+    topLevelDirectoryNames,
+    legacyCollectUnexpectedDirectoryNames: collectKnownRootsUnexpectedDirectoryNames,
+    route: runtimeRoute,
+  });
+
+  return unexpectedDirectoryNames
     .map((directoryName) => ({
       code: 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER',
       severity: 'info',
@@ -138,15 +152,19 @@ const collectOwnedSliceBoundaryDriftFindings = (paths) => {
 };
 
 
-const collectFileReasoningInput = (preparedInputs) => {
+const collectFileReasoningInput = (preparedInputs, runtimeRoute) => {
   const occurrenceSnapshot = preparedInputs?.occurrenceSnapshot;
 
   const occurrenceRecords = occurrenceSnapshot?.occurrenceRecords;
 
   if (Array.isArray(occurrenceRecords)) {
-    const classifiedOccurrenceRecords = classifyTreeOccurrenceRecords({
+    const { records: classifiedOccurrenceRecords } = resolveTreeOccurrenceClassificationRuntime({
       occurrenceRecords,
-      treeKnownRoots: TREE_KNOWN_ROOTS,
+      legacyClassifyOccurrenceRecords: (records) => classifyTreeOccurrenceRecords({
+        occurrenceRecords: records,
+        treeKnownRoots: TREE_KNOWN_ROOTS,
+      }),
+      route: runtimeRoute,
     });
     const fileRecords = classifiedOccurrenceRecords.filter(
       (record) =>
@@ -237,11 +255,12 @@ const collectContributorFindings = (preparedInputs) => {
 
 export const runTreeStructureAdvisor = (preparedInputs = {}) => {
   const prepared = assertPreparedTreeInputs(preparedInputs);
-  const fileReasoningInput = collectFileReasoningInput(prepared);
+  const knownRootsRuntimeRoute = prepared.preparedDependencies?.treeKnownRootsRuntimeRoute ?? selectTreeKnownRootsRuntimeRoute();
+  const fileReasoningInput = collectFileReasoningInput(prepared, knownRootsRuntimeRoute);
   const selectedPathsForReasoning = fileReasoningInput.resolvedFilePaths;
 
   const findings = [
-    ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope),
+    ...collectTopLevelUnexpectedFolderFindings(prepared.topLevelDirectoryNames, prepared.scope, knownRootsRuntimeRoute),
     ...collectValidatorOwnedOutsideTreeFindings(selectedPathsForReasoning),
     ...collectOwnedSliceBoundaryDriftFindings(selectedPathsForReasoning),
     ...collectContributorFindings(prepared),

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -27,6 +27,7 @@ import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-sem
 import { getBuiltinTreeKnownRoots } from './registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from './registries/tree-folder-kinds-registry.logic.mjs';
+import { selectTreeKnownRootsRuntimeRoute } from './tree-known-roots-runtime-routing.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
 const WALK_EXCLUDED_DIRECTORIES = new Set([
@@ -51,7 +52,7 @@ const collectTopLevelDirectoryNames = (repositoryRoot) =>
 
 export const prepareTreeStructureAdvisorInputs = (
   repositoryRoot,
-  { scope, targets, namingSemanticFamilyBridge } = {},
+  { scope, targets, namingSemanticFamilyBridge, treeKnownRootsRuntimeSelection } = {},
 ) => {
   const scopedSnapshotInputs = collectSuiteScopedSnapshotInputs(repositoryRoot, {
     scope,
@@ -136,6 +137,11 @@ export const prepareTreeStructureAdvisorInputs = (
     treeOccurrenceClassificationShadowReport,
     treeOccurrenceClassificationParitySummary,
   });
+  const treeKnownRootsRuntimeRoute = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: treeKnownRootsRuntimeSelection?.requestedMode,
+    replacementRuntime: treeKnownRootsRuntimeSelection?.replacementRuntime,
+    runtimeExecutionContract: treeOccurrenceClassificationRuntimeExecutionContract,
+  });
 
   return {
     scope: scopedSnapshotInputs.scope,
@@ -159,6 +165,7 @@ export const prepareTreeStructureAdvisorInputs = (
       treeOccurrenceClassificationReplacementRecommendation,
       treeOccurrenceClassificationRuntimeEvaluationPlan,
       treeOccurrenceClassificationRuntimeExecutionContract,
+      treeKnownRootsRuntimeRoute,
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({
       repositoryRoot,
@@ -168,11 +175,12 @@ export const prepareTreeStructureAdvisorInputs = (
   };
 };
 
-export const runTreeStructureAdvisor = (repositoryRoot, { scope, targets, namingSemanticFamilyBridge } = {}) => {
+export const runTreeStructureAdvisor = (repositoryRoot, { scope, targets, namingSemanticFamilyBridge, treeKnownRootsRuntimeSelection } = {}) => {
   const preparedInputs = prepareTreeStructureAdvisorInputs(repositoryRoot, {
     scope,
     targets,
     namingSemanticFamilyBridge,
+    treeKnownRootsRuntimeSelection,
   });
   return runTreeStructureAdvisorRuntime(preparedInputs);
 };

--- a/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  resolveTreeOccurrenceClassificationRuntime,
+  resolveTreeUnexpectedTopLevelDirectoryRuntime,
+  selectTreeKnownRootsRuntimeRoute,
+  TREE_KNOWN_ROOTS_RUNTIME_MODES,
+} from '../src/tree-known-roots-runtime-routing.logic.mjs';
+
+const safeRuntimeExecutionContract = {
+  executionMode: 'execution-candidate',
+  requiredGuards: [
+    { id: 'parity-alignment', satisfied: true },
+    { id: 'shadow-alignment', satisfied: true },
+    { id: 'high-confidence', satisfied: true },
+    { id: 'runtime-observability', satisfied: true },
+    { id: 'rollback-available', satisfied: true },
+  ],
+};
+
+const unsafeRuntimeExecutionContract = {
+  executionMode: 'execution-candidate',
+  requiredGuards: [
+    { id: 'parity-alignment', satisfied: true },
+    { id: 'rollback-available', satisfied: false },
+  ],
+};
+
+const alignedReplacementRuntime = {
+  classifyOccurrenceRecords: (occurrenceRecords) => occurrenceRecords.map((record) => ({
+    ...record,
+    structuralClass: 'repo-top-structural-root',
+    structuralKind: 'top-root-structural',
+    isKnownTopRoot: true,
+    isStructuralRoot: true,
+    isSemanticRoot: false,
+    isSubtreePartitionCandidate: false,
+  })),
+  collectUnexpectedTopLevelDirectoryNames: (topLevelDirectoryNames) =>
+    topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
+};
+
+const legacyClassifyOccurrenceRecords = (occurrenceRecords) => occurrenceRecords.map((record) => ({
+  ...record,
+  structuralClass: 'repo-top-structural-root',
+  structuralKind: 'top-root-structural',
+  isKnownTopRoot: true,
+  isStructuralRoot: true,
+  isSemanticRoot: false,
+  isSubtreePartitionCandidate: false,
+}));
+
+const occurrenceRecords = [
+  {
+    path: 'src',
+    resolvedPath: 'src',
+    actualName: 'src',
+    occurrenceType: 'folder',
+  },
+];
+
+test('tree known-roots runtime routing defaults to the legacy known-roots-backed path', () => {
+  const route = selectTreeKnownRootsRuntimeRoute();
+
+  assert.deepEqual(route, {
+    source: 'tree-known-roots-runtime-routing',
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY,
+    activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY,
+    fallbackUsed: false,
+    fallbackReason: null,
+    replacementAvailable: false,
+    replacementSafe: false,
+    legacyRuntimeTruth: {
+      unexpectedTopLevelFolders: 'knownTopLevelDirectories',
+      occurrenceClassification: 'topRoots[].kind',
+    },
+  });
+});
+
+test('tree known-roots runtime routing falls back when replacement is explicitly requested but unavailable', () => {
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  assert.equal(route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(route.fallbackUsed, true);
+  assert.equal(route.fallbackReason, 'replacement-runtime-unavailable');
+  assert.equal(route.replacementAvailable, false);
+  assert.equal(route.replacementSafe, true);
+});
+
+test('tree known-roots runtime routing falls back when replacement is explicitly requested but unsafe', () => {
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: alignedReplacementRuntime,
+    runtimeExecutionContract: unsafeRuntimeExecutionContract,
+  });
+
+  assert.equal(route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(route.fallbackUsed, true);
+  assert.equal(route.fallbackReason, 'replacement-runtime-unsafe');
+  assert.equal(route.replacementAvailable, true);
+  assert.equal(route.replacementSafe, false);
+});
+
+test('tree known-roots runtime routing selects replacement only when explicit, available, and safe', () => {
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: alignedReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  assert.equal(route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT);
+  assert.equal(route.fallbackUsed, false);
+  assert.equal(route.replacementAvailable, true);
+  assert.equal(route.replacementSafe, true);
+  assert.equal(route.replacementRuntime, alignedReplacementRuntime);
+});
+
+test('tree known-roots runtime routing preserves legacy occurrence classification on divergent replacement output', () => {
+  const divergentReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    classifyOccurrenceRecords: (records) => records.map((record) => ({
+      ...record,
+      structuralClass: 'repo-top-semantic-root',
+      structuralKind: 'semantic-root',
+      isKnownTopRoot: true,
+      isStructuralRoot: false,
+      isSemanticRoot: true,
+      isSubtreePartitionCandidate: false,
+    })),
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: divergentReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeOccurrenceClassificationRuntime({
+    occurrenceRecords,
+    legacyClassifyOccurrenceRecords,
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-divergent');
+  assert.deepEqual(resolved.records, legacyClassifyOccurrenceRecords(occurrenceRecords));
+});
+
+test('tree known-roots runtime routing preserves legacy unexpected top-level behavior on divergent replacement output', () => {
+  const divergentReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    collectUnexpectedTopLevelDirectoryNames: () => [],
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: divergentReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeUnexpectedTopLevelDirectoryRuntime({
+    topLevelDirectoryNames: ['experiments', 'src'],
+    legacyCollectUnexpectedDirectoryNames: (topLevelDirectoryNames) =>
+      topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-divergent');
+  assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
+});

--- a/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
@@ -148,6 +148,40 @@ test('tree known-roots runtime routing preserves legacy occurrence classificatio
   assert.deepEqual(resolved.records, legacyClassifyOccurrenceRecords(occurrenceRecords));
 });
 
+test('tree known-roots runtime routing preserves legacy occurrence classification when replacement omits resolvedPath', () => {
+  const missingResolvedPathReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    classifyOccurrenceRecords: (records) => records.map((record) => {
+      const { resolvedPath: _omittedResolvedPath, ...recordWithoutResolvedPath } = record;
+
+      return {
+        ...recordWithoutResolvedPath,
+        structuralClass: 'repo-top-structural-root',
+        structuralKind: 'top-root-structural',
+        isKnownTopRoot: true,
+        isStructuralRoot: true,
+        isSemanticRoot: false,
+        isSubtreePartitionCandidate: false,
+      };
+    }),
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: missingResolvedPathReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeOccurrenceClassificationRuntime({
+    occurrenceRecords,
+    legacyClassifyOccurrenceRecords,
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-divergent');
+  assert.deepEqual(resolved.records, legacyClassifyOccurrenceRecords(occurrenceRecords));
+});
+
 test('tree known-roots runtime routing preserves legacy unexpected top-level behavior on divergent replacement output', () => {
   const divergentReplacementRuntime = {
     ...alignedReplacementRuntime,

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -22,6 +22,7 @@ import { evaluateTreeOccurrenceClassificationReplacementReadiness } from '../src
 import { recommendTreeOccurrenceClassificationReplacement } from '../src/tree-occurrence-classification-replacement-recommendation.logic.mjs';
 import { planTreeOccurrenceClassificationRuntimeEvaluation } from '../src/tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
 import { planTreeOccurrenceClassificationRuntimeExecutionContract } from '../src/tree-occurrence-classification-runtime-execution-contract.logic.mjs';
+import { TREE_KNOWN_ROOTS_RUNTIME_MODES } from '../src/tree-known-roots-runtime-routing.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
@@ -180,6 +181,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract);
+    assert.ok(preparedInputs.preparedDependencies.treeKnownRootsRuntimeRoute);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
       prepareTreeStructuralHomeEvidence({
@@ -269,6 +271,13 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
       }),
     );
+    const knownRootsRuntimeRoute = preparedInputs.preparedDependencies.treeKnownRootsRuntimeRoute;
+    assert.equal(knownRootsRuntimeRoute.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY);
+    assert.equal(knownRootsRuntimeRoute.fallbackUsed, false);
+    assert.deepEqual(knownRootsRuntimeRoute.legacyRuntimeTruth, {
+      unexpectedTopLevelFolders: 'knownTopLevelDirectories',
+      occurrenceClassification: 'topRoots[].kind',
+    });
     const runtimeExecutionContract = preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract;
     assert.deepEqual(Object.keys(runtimeExecutionContract).sort(), ['executionMode', 'executionStatus', 'rationale', 'requiredGuards', 'source', 'summary']);
     assert.equal(


### PR DESCRIPTION
### Motivation
- Provide a minimal Tree-owned runtime routing seam that makes the active known-roots execution mode explicit while preserving the current known-roots-backed behavior by default. 
- Enable a guarded replacement path that is only selected when explicitly requested, prepared (functions present), and guarded safe, with deterministic fallback to legacy behavior in all other cases. 

### Description
- Add `calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs` implementing explicit `LEGACY`, `REPLACEMENT`, and `FALLBACK` runtime modes plus helpers `selectTreeKnownRootsRuntimeRoute`, `resolveTreeOccurrenceClassificationRuntime`, and `resolveTreeUnexpectedTopLevelDirectoryRuntime`. 
- Wire the route into Tree preparation and runtime by threading an optional `treeKnownRootsRuntimeSelection` through `prepareTreeStructureAdvisorInputs` and `runTreeStructureAdvisor` and exposing `preparedDependencies.treeKnownRootsRuntimeRoute` for inspection. 
- Replace in-process occurrence classification and top-level-folder collection calls with guarded runtime resolution that chooses replacement only when explicitly requested, available, and safe, and otherwise preserves legacy `knownTopLevelDirectories` and `topRoots[].kind` behavior. 
- Add focused tests `calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs` and extend Tree tests to assert the default legacy route is inspectable; update wiring/logic tests accordingly and update `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md` with the documented runtime contract. 
- Refs #563
- Refs #561

### Testing
- Ran `node --test calculogic-validator/tree/test/*.test.mjs` and the Tree test suite passed (215 tests) as reported in the run output. 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and the validator run completed successfully; the validator report included existing advisory findings (for example `TREE_SHIM_SURFACE_PRESENT` and `TREE_OBSERVED_FAMILY_CLUSTER`) and no broadening of scope or behavior was performed. 
- All new and modified Tree tests exercising default legacy selection, explicit replacement selection, unavailable/unsafe fallback, and divergent-fallback preservation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221e5f52fc8331a33167f317650811)