### PR TITLE
Implement guarded Tree occurrence-classification replacement route

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -98,7 +98,8 @@ V0.1.7 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
 - Tree known-roots runtime routing is now explicit and Tree-owned: default execution remains the legacy/current known-roots-backed path, `knownTopLevelDirectories` remains current runtime truth for unexpected top-level folder behavior, and `topRoots[].kind` remains current runtime truth for occurrence classification.
-- Prepared replacement execution is only eligible when explicitly selected, available, and guarded safe; unavailable, unsafe, or divergent replacement execution falls back to the known-roots-backed path and must not become default behavior in this slice.
+- Prepared occurrence-classification replacement execution is only eligible when explicitly selected, available, guarded safe, structurally complete, and parity-aligned; unavailable, unsafe, incomplete, or divergent replacement execution falls back to the known-roots-backed occurrence classifier and must not become default behavior in this slice.
+- The guarded replacement slice is limited to occurrence classification (`topRoots[].kind` current runtime truth): `knownTopLevelDirectories` remains the current runtime truth for unexpected top-level folder behavior in both legacy and explicit replacement modes.
 
 Target behaviors in V0.1.2:
 

--- a/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
@@ -11,7 +11,19 @@ const LEGACY_RUNTIME_TRUTH = Object.freeze({
   occurrenceClassification: 'topRoots[].kind',
 });
 
-const REPLACEMENT_RUNTIME_FUNCTIONS = ['classifyOccurrenceRecords', 'collectUnexpectedTopLevelDirectoryNames'];
+const REQUIRED_OCCURRENCE_CLASSIFICATION_FIELDS = Object.freeze([
+  'path',
+  'resolvedPath',
+  'occurrenceType',
+  'structuralClass',
+  'structuralKind',
+  'isKnownTopRoot',
+  'isStructuralRoot',
+  'isSemanticRoot',
+  'isSubtreePartitionCandidate',
+]);
+
+const REPLACEMENT_RUNTIME_FUNCTIONS = ['classifyOccurrenceRecords'];
 
 const isObject = (value) => value && typeof value === 'object' && !Array.isArray(value);
 
@@ -116,6 +128,28 @@ const classificationResultsDiverge = (leftRecords, rightRecords) =>
   JSON.stringify(leftRecords.map(toClassificationComparable)) !==
   JSON.stringify(rightRecords.map(toClassificationComparable));
 
+const replacementRecordsAreStructurallyComplete = (replacementRecords, legacyRecords) => {
+  if (replacementRecords.length !== legacyRecords.length) {
+    return false;
+  }
+
+  return legacyRecords.every((legacyRecord, index) => {
+    const replacementRecord = replacementRecords[index];
+
+    if (!replacementRecord || typeof replacementRecord !== 'object' || Array.isArray(replacementRecord)) {
+      return false;
+    }
+
+    return REQUIRED_OCCURRENCE_CLASSIFICATION_FIELDS.every((fieldName) => {
+      if (!Object.hasOwn(legacyRecord ?? {}, fieldName)) {
+        return true;
+      }
+
+      return Object.hasOwn(replacementRecord, fieldName);
+    });
+  });
+};
+
 const withFallback = (route, fallbackReason) => ({
   ...route,
   activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK,
@@ -158,6 +192,13 @@ export const resolveTreeOccurrenceClassificationRuntime = ({
     };
   }
 
+  if (!replacementRecordsAreStructurallyComplete(replacementRecords, legacyRecords)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-incomplete'),
+      records: legacyRecords,
+    };
+  }
+
   if (classificationResultsDiverge(replacementRecords, legacyRecords)) {
     return {
       route: withFallback(route, 'replacement-runtime-divergent'),
@@ -190,34 +231,8 @@ export const resolveTreeUnexpectedTopLevelDirectoryRuntime = ({
     throw new Error('Tree known-roots runtime routing legacy unexpected top-level directory collector must return an array.');
   }
 
-  if (route?.activeExecutionMode !== TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT) {
-    return {
-      route,
-      unexpectedDirectoryNames: legacyDirectoryNames,
-    };
-  }
-
-  const replacementDirectoryNames = route.replacementRuntime?.collectUnexpectedTopLevelDirectoryNames?.(topLevelDirectoryNames);
-
-  if (!Array.isArray(replacementDirectoryNames)) {
-    return {
-      route: withFallback(route, 'replacement-runtime-unavailable'),
-      unexpectedDirectoryNames: legacyDirectoryNames,
-    };
-  }
-
-  const sortedReplacementDirectoryNames = [...replacementDirectoryNames].sort((left, right) => left.localeCompare(right));
-  const sortedLegacyDirectoryNames = [...legacyDirectoryNames].sort((left, right) => left.localeCompare(right));
-
-  if (JSON.stringify(sortedReplacementDirectoryNames) !== JSON.stringify(sortedLegacyDirectoryNames)) {
-    return {
-      route: withFallback(route, 'replacement-runtime-divergent'),
-      unexpectedDirectoryNames: legacyDirectoryNames,
-    };
-  }
-
   return {
     route,
-    unexpectedDirectoryNames: sortedReplacementDirectoryNames,
+    unexpectedDirectoryNames: legacyDirectoryNames,
   };
 };

--- a/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
@@ -1,5 +1,7 @@
 const SUBTREE_PARTITION_CANDIDATE_NAMES = new Set(['assets', 'components', 'content', 'shared']);
 
+const SOURCE_ID = 'tree-occurrence-classification-replacement-runtime';
+
 const buildTopRootKindByName = (treeKnownRoots) => {
   const topRoots = Array.isArray(treeKnownRoots?.topRoots) ? treeKnownRoots.topRoots : [];
 
@@ -79,4 +81,207 @@ export const classifyTreeOccurrenceRecords = ({ occurrenceRecords = [], treeKnow
     ...occurrenceRecord,
     ...classifyWithTopRootMap(occurrenceRecord, topRootKindByName),
   }));
+};
+
+
+const toIdentityKeys = (record) => {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return [];
+  }
+
+  const keys = [];
+
+  if (typeof record.addressPath === 'string' && record.addressPath.length > 0) {
+    keys.push(`address:${record.addressPath}`);
+  }
+
+  if (
+    typeof record.path === 'string' &&
+    record.path.length > 0 &&
+    typeof record.occurrenceType === 'string' &&
+    record.occurrenceType.length > 0
+  ) {
+    keys.push(`path-type:${record.path}::${record.occurrenceType}`);
+  }
+
+  if (typeof record.path === 'string' && record.path.length > 0) {
+    keys.push(`path:${record.path}`);
+  }
+
+  return keys;
+};
+
+const toEvidenceLookup = (evidenceRecords, evidenceKey) => {
+  const lookup = new Map();
+
+  for (const evidenceRecord of evidenceRecords) {
+    for (const key of toIdentityKeys(evidenceRecord)) {
+      if (lookup.has(key)) {
+        continue;
+      }
+
+      lookup.set(key, evidenceRecord[evidenceKey] ?? null);
+    }
+  }
+
+  return lookup;
+};
+
+const lookupFirstAvailable = (lookup, record, fallback = null) => {
+  for (const key of toIdentityKeys(record)) {
+    if (lookup.has(key)) {
+      return lookup.get(key);
+    }
+  }
+
+  return fallback;
+};
+
+const assertReplacementRuntimeInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Tree occurrence classification replacement runtime input must be an object.');
+  }
+
+  if (!input.treeStructuralHomeEvidence || typeof input.treeStructuralHomeEvidence !== 'object' || Array.isArray(input.treeStructuralHomeEvidence)) {
+    throw new Error('Tree occurrence classification replacement runtime input must include treeStructuralHomeEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeStructuralHomeEvidence.evidenceRecords)) {
+    throw new Error('Tree occurrence classification replacement runtime treeStructuralHomeEvidence.evidenceRecords must be an array.');
+  }
+
+  if (!input.treeSemanticHomeEvidence || typeof input.treeSemanticHomeEvidence !== 'object' || Array.isArray(input.treeSemanticHomeEvidence)) {
+    throw new Error('Tree occurrence classification replacement runtime input must include treeSemanticHomeEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeSemanticHomeEvidence.evidenceRecords)) {
+    throw new Error('Tree occurrence classification replacement runtime treeSemanticHomeEvidence.evidenceRecords must be an array.');
+  }
+
+  if (!input.treeFolderKindEvidence || typeof input.treeFolderKindEvidence !== 'object' || Array.isArray(input.treeFolderKindEvidence)) {
+    throw new Error('Tree occurrence classification replacement runtime input must include treeFolderKindEvidence object.');
+  }
+
+  if (!Array.isArray(input.treeFolderKindEvidence.evidenceRecords)) {
+    throw new Error('Tree occurrence classification replacement runtime treeFolderKindEvidence.evidenceRecords must be an array.');
+  }
+};
+
+const toReplacementRootClassification = ({ folderKind, structuralHome, semanticHome }) => {
+  if (folderKind === 'structural' || structuralHome) {
+    return {
+      structuralClass: 'repo-top-structural-root',
+      structuralKind: 'top-root-structural',
+      isKnownTopRoot: true,
+      isStructuralRoot: true,
+      isSemanticRoot: false,
+    };
+  }
+
+  if (folderKind === 'semantic' || semanticHome) {
+    return {
+      structuralClass: 'repo-top-semantic-root',
+      structuralKind: 'semantic-root',
+      isKnownTopRoot: true,
+      isStructuralRoot: false,
+      isSemanticRoot: true,
+    };
+  }
+
+  return {
+    structuralClass: 'unclassified',
+    structuralKind: 'unknown',
+    isKnownTopRoot: false,
+    isStructuralRoot: false,
+    isSemanticRoot: false,
+  };
+};
+
+const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, semanticHomeLookup, folderKindLookup }) => {
+  if (!occurrenceRecord || typeof occurrenceRecord !== 'object') {
+    return {
+      structuralClass: 'unclassified',
+      structuralKind: 'unknown',
+      isRepoTopOccurrence: false,
+      isScopedRootOccurrence: false,
+      isKnownTopRoot: false,
+      isStructuralRoot: false,
+      isSemanticRoot: false,
+      isSubtreePartitionCandidate: false,
+    };
+  }
+
+  const resolvedPath = String(occurrenceRecord.resolvedPath ?? '');
+  const actualName = String(occurrenceRecord.actualName ?? '');
+  const occurrenceType = String(occurrenceRecord.occurrenceType ?? '');
+  const isRepoTopOccurrence = isRepoTopOccurrencePath(resolvedPath);
+  const isScopedRootOccurrence = occurrenceRecord.isScopedRoot === true;
+  const isSubtreePartitionCandidate =
+    occurrenceType === 'folder' &&
+    !isRepoTopOccurrence &&
+    SUBTREE_PARTITION_CANDIDATE_NAMES.has(actualName);
+
+  if (occurrenceType === 'folder' && isRepoTopOccurrence) {
+    return {
+      ...toReplacementRootClassification({
+        folderKind: lookupFirstAvailable(folderKindLookup, occurrenceRecord),
+        structuralHome: lookupFirstAvailable(structuralHomeLookup, occurrenceRecord),
+        semanticHome: lookupFirstAvailable(semanticHomeLookup, occurrenceRecord),
+      }),
+      isRepoTopOccurrence,
+      isScopedRootOccurrence,
+      isSubtreePartitionCandidate,
+    };
+  }
+
+  if (isSubtreePartitionCandidate) {
+    return {
+      structuralClass: 'subtree-structural-partition-candidate',
+      structuralKind: 'subtree-partition',
+      isRepoTopOccurrence,
+      isScopedRootOccurrence,
+      isKnownTopRoot: false,
+      isStructuralRoot: false,
+      isSemanticRoot: false,
+      isSubtreePartitionCandidate,
+    };
+  }
+
+  return {
+    structuralClass: 'unclassified',
+    structuralKind: 'unknown',
+    isRepoTopOccurrence,
+    isScopedRootOccurrence,
+    isKnownTopRoot: false,
+    isStructuralRoot: false,
+    isSemanticRoot: false,
+    isSubtreePartitionCandidate,
+  };
+};
+
+export const prepareTreeOccurrenceClassificationReplacementRuntime = (input) => {
+  assertReplacementRuntimeInput(input);
+
+  const structuralHomeLookup = toEvidenceLookup(input.treeStructuralHomeEvidence.evidenceRecords, 'structuralHome');
+  const semanticHomeLookup = toEvidenceLookup(input.treeSemanticHomeEvidence.evidenceRecords, 'semanticHome');
+  const folderKindLookup = toEvidenceLookup(input.treeFolderKindEvidence.evidenceRecords, 'folderKind');
+
+  return {
+    source: SOURCE_ID,
+    classifyOccurrenceRecords: (occurrenceRecords = []) => {
+      if (!Array.isArray(occurrenceRecords)) {
+        throw new Error('Tree occurrence classification replacement runtime requires occurrenceRecords array.');
+      }
+
+      return occurrenceRecords.map((occurrenceRecord) => ({
+        ...occurrenceRecord,
+        ...classifyWithPreparedEvidence({
+          occurrenceRecord,
+          structuralHomeLookup,
+          semanticHomeLookup,
+          folderKindLookup,
+        }),
+      }));
+    },
+  };
 };

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -153,7 +153,7 @@ const collectOwnedSliceBoundaryDriftFindings = (paths) => {
 
 
 const collectFileReasoningInput = (preparedInputs, runtimeRoute) => {
-  const occurrenceSnapshot = preparedInputs?.occurrenceSnapshot;
+  const occurrenceSnapshot = preparedInputs?.structuralAddressSnapshot ?? preparedInputs?.occurrenceSnapshot;
 
   const occurrenceRecords = occurrenceSnapshot?.occurrenceRecords;
 

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -15,7 +15,10 @@ import { prepareTreeKnownRootsCompatibilityEvidence } from './tree-known-roots-c
 import { prepareTreeStructuralHomeEvidence } from './tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from './tree-semantic-home-evidence.logic.mjs';
 import { prepareTreeFolderKindEvidence } from './tree-folder-kind-evidence.logic.mjs';
-import { classifyTreeOccurrenceRecords } from './tree-occurrence-classification.logic.mjs';
+import {
+  classifyTreeOccurrenceRecords,
+  prepareTreeOccurrenceClassificationReplacementRuntime,
+} from './tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-evidence.logic.mjs';
 import { summarizeTreeOccurrenceClassificationParityEvidence } from './tree-occurrence-classification-parity-summary.logic.mjs';
 import { prepareTreeOccurrenceClassificationShadowReport } from './tree-occurrence-classification-shadow-report.logic.mjs';
@@ -137,9 +140,14 @@ export const prepareTreeStructureAdvisorInputs = (
     treeOccurrenceClassificationShadowReport,
     treeOccurrenceClassificationParitySummary,
   });
+  const treeOccurrenceClassificationReplacementRuntime = prepareTreeOccurrenceClassificationReplacementRuntime({
+    treeStructuralHomeEvidence,
+    treeSemanticHomeEvidence,
+    treeFolderKindEvidence,
+  });
   const treeKnownRootsRuntimeRoute = selectTreeKnownRootsRuntimeRoute({
     requestedMode: treeKnownRootsRuntimeSelection?.requestedMode,
-    replacementRuntime: treeKnownRootsRuntimeSelection?.replacementRuntime,
+    replacementRuntime: treeKnownRootsRuntimeSelection?.replacementRuntime ?? treeOccurrenceClassificationReplacementRuntime,
     runtimeExecutionContract: treeOccurrenceClassificationRuntimeExecutionContract,
   });
 
@@ -165,6 +173,7 @@ export const prepareTreeStructureAdvisorInputs = (
       treeOccurrenceClassificationReplacementRecommendation,
       treeOccurrenceClassificationRuntimeEvaluationPlan,
       treeOccurrenceClassificationRuntimeExecutionContract,
+      treeOccurrenceClassificationReplacementRuntime,
       treeKnownRootsRuntimeRoute,
     },
     findingContributors: collectDefaultTreeStructureAdvisorContributors({

--- a/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
@@ -36,8 +36,6 @@ const alignedReplacementRuntime = {
     isSemanticRoot: false,
     isSubtreePartitionCandidate: false,
   })),
-  collectUnexpectedTopLevelDirectoryNames: (topLevelDirectoryNames) =>
-    topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
 };
 
 const legacyClassifyOccurrenceRecords = (occurrenceRecords) => occurrenceRecords.map((record) => ({
@@ -118,6 +116,38 @@ test('tree known-roots runtime routing selects replacement only when explicit, a
   assert.equal(route.replacementRuntime, alignedReplacementRuntime);
 });
 
+
+test('tree known-roots runtime routing returns replacement occurrence records when explicit selection is safe and parity-aligned', () => {
+  const selectedReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    classifyOccurrenceRecords: (records) => records.map((record) => ({
+      ...record,
+      structuralClass: 'repo-top-structural-root',
+      structuralKind: 'top-root-structural',
+      isKnownTopRoot: true,
+      isStructuralRoot: true,
+      isSemanticRoot: false,
+      isSubtreePartitionCandidate: false,
+      replacementTrace: 'selected',
+    })),
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: selectedReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeOccurrenceClassificationRuntime({
+    occurrenceRecords,
+    legacyClassifyOccurrenceRecords,
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT);
+  assert.equal(resolved.route.fallbackUsed, false);
+  assert.equal(resolved.records[0].replacementTrace, 'selected');
+});
+
 test('tree known-roots runtime routing preserves legacy occurrence classification on divergent replacement output', () => {
   const divergentReplacementRuntime = {
     ...alignedReplacementRuntime,
@@ -178,11 +208,33 @@ test('tree known-roots runtime routing preserves legacy occurrence classificatio
   });
 
   assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
-  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-divergent');
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-incomplete');
   assert.deepEqual(resolved.records, legacyClassifyOccurrenceRecords(occurrenceRecords));
 });
 
-test('tree known-roots runtime routing preserves legacy unexpected top-level behavior on divergent replacement output', () => {
+test('tree known-roots runtime routing preserves legacy occurrence classification on replacement length mismatch', () => {
+  const incompleteReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    classifyOccurrenceRecords: () => [],
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: incompleteReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeOccurrenceClassificationRuntime({
+    occurrenceRecords,
+    legacyClassifyOccurrenceRecords,
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-incomplete');
+  assert.deepEqual(resolved.records, legacyClassifyOccurrenceRecords(occurrenceRecords));
+});
+
+test('tree known-roots runtime routing preserves legacy unexpected top-level behavior when replacement route is selected', () => {
   const divergentReplacementRuntime = {
     ...alignedReplacementRuntime,
     collectUnexpectedTopLevelDirectoryNames: () => [],
@@ -200,7 +252,7 @@ test('tree known-roots runtime routing preserves legacy unexpected top-level beh
     route,
   });
 
-  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
-  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-divergent');
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT);
+  assert.equal(resolved.route.fallbackReason, null);
   assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
 });

--- a/calculogic-validator/tree/test/tree-occurrence-classification.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classification.logic.mjs';
+import {
+  classifyTreeOccurrenceRecords,
+  prepareTreeOccurrenceClassificationReplacementRuntime,
+} from '../src/tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceSnapshot } from '../src/tree-occurrence-snapshot.logic.mjs';
+import { prepareTreeStructuralAddressSnapshot } from '../src/tree-structural-address-snapshot.logic.mjs';
 import { getBuiltinTreeKnownRoots } from '../src/registries/tree-known-roots-registry.logic.mjs';
 
 const TREE_KNOWN_ROOTS = getBuiltinTreeKnownRoots();
@@ -95,4 +99,53 @@ test('tree occurrence classification keeps unknown cases deterministic and bound
   assert.equal(records.experiments.structuralKind, 'unknown');
   assert.equal(records.experiments.isKnownTopRoot, false);
   assert.equal(records.experiments.isSubtreePartitionCandidate, false);
+});
+
+
+test('tree occurrence classification replacement runtime classifies from prepared Tree evidence', () => {
+  const snapshot = prepareTreeOccurrenceSnapshot({
+    selectedPaths: ['src/components/button.js', 'calculogic-validator/tree/index.mjs'],
+    includeRoots: [],
+    targets: [],
+  });
+  const addressedSnapshot = prepareTreeStructuralAddressSnapshot({
+    occurrenceSnapshot: snapshot,
+    selectedPaths: ['src/components/button.js', 'calculogic-validator/tree/index.mjs'],
+    targets: [],
+    includeRoots: [],
+    scope: { source: 'test' },
+  });
+  const replacementRuntime = prepareTreeOccurrenceClassificationReplacementRuntime({
+    treeStructuralHomeEvidence: {
+      source: 'test',
+      evidenceRecords: [{ path: 'src', occurrenceType: 'folder', structuralHome: 'src' }],
+    },
+    treeSemanticHomeEvidence: {
+      source: 'test',
+      evidenceRecords: [{ path: 'calculogic-validator', occurrenceType: 'folder', semanticHome: 'validator' }],
+    },
+    treeFolderKindEvidence: {
+      source: 'test',
+      evidenceRecords: [
+        { path: 'src', occurrenceType: 'folder', folderKind: 'structural' },
+        { path: 'calculogic-validator', occurrenceType: 'folder', folderKind: 'semantic' },
+      ],
+    },
+  });
+
+  const records = byResolvedPath(replacementRuntime.classifyOccurrenceRecords(addressedSnapshot.occurrenceRecords));
+
+  assert.equal(replacementRuntime.source, 'tree-occurrence-classification-replacement-runtime');
+  assert.equal(records.src.structuralClass, 'repo-top-structural-root');
+  assert.equal(records.src.structuralKind, 'top-root-structural');
+  assert.equal(records.src.isKnownTopRoot, true);
+  assert.equal(records.src.isStructuralRoot, true);
+  assert.equal(records.src.isSemanticRoot, false);
+  assert.equal(records['calculogic-validator'].structuralClass, 'repo-top-semantic-root');
+  assert.equal(records['calculogic-validator'].structuralKind, 'semantic-root');
+  assert.equal(records['calculogic-validator'].isKnownTopRoot, true);
+  assert.equal(records['calculogic-validator'].isStructuralRoot, false);
+  assert.equal(records['calculogic-validator'].isSemanticRoot, true);
+  assert.equal(records['src/components'].structuralClass, 'subtree-structural-partition-candidate');
+  assert.equal(records['src/components'].isSubtreePartitionCandidate, true);
 });

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -14,7 +14,10 @@ import { prepareTreeKnownRootsCompatibilityEvidence } from '../src/tree-known-ro
 import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evidence.logic.mjs';
 import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.logic.mjs';
-import { classifyTreeOccurrenceRecords } from '../src/tree-occurrence-classification.logic.mjs';
+import {
+  classifyTreeOccurrenceRecords,
+  prepareTreeOccurrenceClassificationReplacementRuntime,
+} from '../src/tree-occurrence-classification.logic.mjs';
 import { prepareTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-evidence.logic.mjs';
 import { summarizeTreeOccurrenceClassificationParityEvidence } from '../src/tree-occurrence-classification-parity-summary.logic.mjs';
 import { prepareTreeOccurrenceClassificationShadowReport } from '../src/tree-occurrence-classification-shadow-report.logic.mjs';
@@ -181,6 +184,7 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRecommendation);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeEvaluationPlan);
     assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract);
+    assert.ok(preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime);
     assert.ok(preparedInputs.preparedDependencies.treeKnownRootsRuntimeRoute);
     assert.deepEqual(
       preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
@@ -270,6 +274,19 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
         treeOccurrenceClassificationShadowReport: preparedInputs.preparedDependencies.treeOccurrenceClassificationShadowReport,
         treeOccurrenceClassificationParitySummary: preparedInputs.preparedDependencies.treeOccurrenceClassificationParitySummary,
       }),
+    );
+    const expectedOccurrenceClassificationReplacementRuntime = prepareTreeOccurrenceClassificationReplacementRuntime({
+      treeStructuralHomeEvidence: preparedInputs.preparedDependencies.treeStructuralHomeEvidence,
+      treeSemanticHomeEvidence: preparedInputs.preparedDependencies.treeSemanticHomeEvidence,
+      treeFolderKindEvidence: preparedInputs.preparedDependencies.treeFolderKindEvidence,
+    });
+    assert.equal(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime.source,
+      expectedOccurrenceClassificationReplacementRuntime.source,
+    );
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime.classifyOccurrenceRecords(snapshot.occurrenceRecords),
+      expectedOccurrenceClassificationReplacementRuntime.classifyOccurrenceRecords(snapshot.occurrenceRecords),
     );
     const knownRootsRuntimeRoute = preparedInputs.preparedDependencies.treeKnownRootsRuntimeRoute;
     assert.equal(knownRootsRuntimeRoute.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY);


### PR DESCRIPTION
### Motivation
- Provide a guarded replacement execution path for Tree occurrence classification (`topRoots[].kind`) while keeping the legacy known-roots behavior as the default runtime truth.
- Ensure replacement is only used when explicitly requested, available, safe, structurally complete, and parity-aligned, with deterministic fallback and inspectable fallback reasons.

### Description
- Added a Tree-owned prepared replacement runtime that classifies occurrence records using Tree-prepared evidence (`treeStructuralHomeEvidence`, `treeSemanticHomeEvidence`, `treeFolderKindEvidence`) and exposes `classifyOccurrenceRecords` behind `prepareTreeOccurrenceClassificationReplacementRuntime` in `tree/src/tree-occurrence-classification.logic.mjs`.
- Extended the known-roots runtime router in `tree/src/tree-known-roots-runtime-routing.logic.mjs` to: require only occurrence-classification replacement functions, validate structural completeness of replacement records (preserving required legacy fields), detect divergence, and return inspectable fallback reasons (`replacement-runtime-unavailable`, `replacement-runtime-unsafe`, `replacement-runtime-incomplete`, `replacement-runtime-divergent`).
- Wired the prepared replacement runtime into the Tree wiring in `tree/src/tree-structure-advisor.wiring.mjs` so the replacement runtime is prepared and passed into the guarded route when not otherwise provided, while leaving default behavior unchanged.
- Adjusted Tree runtime reasoning in `tree/src/tree-structure-advisor.logic.mjs` to prefer addressed occurrence records (`structuralAddressSnapshot`) when present so replacement/runtime classification can rely on path-bearing addressed inputs and downstream Tree logic keeps required fields.
- Kept unexpected top-level folder behavior on the legacy `knownTopLevelDirectories` path by always returning legacy results for unexpected top-level folders; documented the narrowed scope and contract in `calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md`.
- Updated and added tests to cover: default legacy behavior preserved, explicit replacement selection when safe and aligned, fallback on unavailable/unsafe/incomplete/divergent replacement, replacement runtime classification from prepared evidence, and wiring/prepared-dependencies inspection.

### Testing
- Ran unit tests: `node --test calculogic-validator/tree/test/*.test.mjs` — all tests passed.
- Ran targeted validator run: `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` — passed and produced expected informational Tree advisory findings for the targeted validator tree paths.

Refs #565
Refs #561

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fc9a33888331b099b74a40ab21a9)