### PR TITLE
Guarded replacement for unexpected top-level folder policy (Tree known-roots route)

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -97,9 +97,9 @@ V0.1.7 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - tree-run default contributor selection is owned by a dedicated assembly/wiring module so tree wiring only prepares tree-core inputs
 - shim/content-backed diagnostics are attached from a shim-owned contributor helper that prepares lazy content access (cache + selected-path guard) so tree-core runtime does not require file-content access
 - naming stays on existing local collection/interpretation path in this increment (no naming behavior changes)
-- Tree known-roots runtime routing is now explicit and Tree-owned: default execution remains the legacy/current known-roots-backed path, `knownTopLevelDirectories` remains current runtime truth for unexpected top-level folder behavior, and `topRoots[].kind` remains current runtime truth for occurrence classification.
-- Prepared occurrence-classification replacement execution is only eligible when explicitly selected, available, guarded safe, structurally complete, and parity-aligned; unavailable, unsafe, incomplete, or divergent replacement execution falls back to the known-roots-backed occurrence classifier and must not become default behavior in this slice.
-- The guarded replacement slice is limited to occurrence classification (`topRoots[].kind` current runtime truth): `knownTopLevelDirectories` remains the current runtime truth for unexpected top-level folder behavior in both legacy and explicit replacement modes.
+- Tree known-roots runtime routing is explicit and Tree-owned: default execution remains the legacy/current known-roots-backed path, `knownTopLevelDirectories` remains current runtime truth for default unexpected top-level folder behavior, and `topRoots[].kind` remains current runtime truth for default occurrence classification.
+- Prepared replacement execution is only eligible when explicitly selected, available, guarded safe, structurally complete, and parity-aligned; unavailable, unsafe, incomplete, or divergent replacement execution falls back to the known-roots-backed runtime path and must not become default behavior in this slice.
+- The guarded replacement slice now covers occurrence classification and unexpected top-level folder policy: accepted replacement execution uses prepared Tree evidence instead of depending on `knownTopLevelDirectories` as runtime truth, while default legacy mode and all guarded fallback outcomes preserve known-roots-backed output.
 
 Target behaviors in V0.1.2:
 

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -778,6 +778,8 @@ Deferred candidates above are a documentation menu only. They are not current ru
 - Tree core consumes **prepared tree-core inputs only** and fails closed when that contract is bypassed.
 - Tree core consumes occurrence-derived file records from `occurrenceSnapshot.occurrenceRecords` when available for bounded structural helpers (`TREE_VALIDATOR_OWNED_FILE_OUTSIDE_TREE`, `TREE_OWNED_SLICE_BOUNDARY_DRIFT`) while keeping findings path output on resolved paths.
 - Occurrence-derived records are enriched with a bounded structural class interpretation layer (`structuralClass`, `structuralKind`, `isKnownTopRoot`, `isSemanticRoot`, `isStructuralRoot`, `isSubtreePartitionCandidate`, `isRepoTopOccurrence`, `isScopedRootOccurrence`) for tree-local reasoning substrate use; findings envelopes remain unchanged.
+- Tree known-roots runtime routing keeps default legacy behavior as current runtime truth: `topRoots[].kind` backs occurrence classification and `knownTopLevelDirectories` backs unexpected top-level folder policy.
+- Explicit guarded replacement mode may use prepared Tree evidence for occurrence classification and unexpected top-level folder policy only when replacement execution is available, guarded safe, structurally complete, and parity-aligned; unavailable, unsafe, incomplete, or divergent replacement execution deterministically falls back to the legacy known-roots-backed path with an inspectable fallback reason.
 - If occurrence snapshot is missing or malformed, tree core deterministically falls back to prepared `selectedPaths` for file-path reasoning.
 - Required prepared tree-core fields:
   - `selectedPaths` (array)

--- a/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
+++ b/calculogic-validator/tree/src/tree-known-roots-runtime-routing.logic.mjs
@@ -23,7 +23,7 @@ const REQUIRED_OCCURRENCE_CLASSIFICATION_FIELDS = Object.freeze([
   'isSubtreePartitionCandidate',
 ]);
 
-const REPLACEMENT_RUNTIME_FUNCTIONS = ['classifyOccurrenceRecords'];
+const REPLACEMENT_RUNTIME_FUNCTIONS = ['classifyOccurrenceRecords', 'collectUnexpectedTopLevelDirectoryNames'];
 
 const isObject = (value) => value && typeof value === 'object' && !Array.isArray(value);
 
@@ -157,6 +157,36 @@ const withFallback = (route, fallbackReason) => ({
   fallbackReason,
 });
 
+const toUnexpectedDirectoryComparable = (directoryNames) =>
+  directoryNames.map((directoryName) => String(directoryName)).sort((left, right) => left.localeCompare(right));
+
+const unexpectedDirectoryResultsDiverge = (leftDirectoryNames, rightDirectoryNames) =>
+  JSON.stringify(toUnexpectedDirectoryComparable(leftDirectoryNames)) !==
+  JSON.stringify(toUnexpectedDirectoryComparable(rightDirectoryNames));
+
+const replacementUnexpectedDirectoryNamesAreStructurallyComplete = (replacementDirectoryNames, topLevelDirectoryNames) => {
+  const topLevelDirectoryNameSet = new Set(topLevelDirectoryNames);
+  const seen = new Set();
+
+  for (const directoryName of replacementDirectoryNames) {
+    if (typeof directoryName !== 'string' || directoryName.length === 0) {
+      return false;
+    }
+
+    if (!topLevelDirectoryNameSet.has(directoryName)) {
+      return false;
+    }
+
+    if (seen.has(directoryName)) {
+      return false;
+    }
+
+    seen.add(directoryName);
+  }
+
+  return true;
+};
+
 export const resolveTreeOccurrenceClassificationRuntime = ({
   occurrenceRecords,
   legacyClassifyOccurrenceRecords,
@@ -231,8 +261,39 @@ export const resolveTreeUnexpectedTopLevelDirectoryRuntime = ({
     throw new Error('Tree known-roots runtime routing legacy unexpected top-level directory collector must return an array.');
   }
 
+  if (route?.activeExecutionMode !== TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT) {
+    return {
+      route,
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
+  const replacementDirectoryNames =
+    route.replacementRuntime?.collectUnexpectedTopLevelDirectoryNames?.(topLevelDirectoryNames);
+
+  if (!Array.isArray(replacementDirectoryNames)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-unavailable'),
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
+  if (!replacementUnexpectedDirectoryNamesAreStructurallyComplete(replacementDirectoryNames, topLevelDirectoryNames)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-incomplete'),
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
+  if (unexpectedDirectoryResultsDiverge(replacementDirectoryNames, legacyDirectoryNames)) {
+    return {
+      route: withFallback(route, 'replacement-runtime-divergent'),
+      unexpectedDirectoryNames: legacyDirectoryNames,
+    };
+  }
+
   return {
     route,
-    unexpectedDirectoryNames: legacyDirectoryNames,
+    unexpectedDirectoryNames: toUnexpectedDirectoryComparable(replacementDirectoryNames),
   };
 };

--- a/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
@@ -283,5 +283,30 @@ export const prepareTreeOccurrenceClassificationReplacementRuntime = (input) => 
         }),
       }));
     },
+    collectUnexpectedTopLevelDirectoryNames: (topLevelDirectoryNames = []) => {
+      if (!Array.isArray(topLevelDirectoryNames)) {
+        throw new Error('Tree unexpected top-level replacement runtime requires topLevelDirectoryNames array.');
+      }
+
+      return topLevelDirectoryNames
+        .filter((directoryName) => typeof directoryName === 'string' && directoryName.length > 0)
+        .filter((directoryName) => {
+          const classification = classifyWithPreparedEvidence({
+            occurrenceRecord: {
+              path: directoryName,
+              resolvedPath: directoryName,
+              actualName: directoryName,
+              name: directoryName,
+              occurrenceType: 'folder',
+            },
+            structuralHomeLookup,
+            semanticHomeLookup,
+            folderKindLookup,
+          });
+
+          return classification.isKnownTopRoot !== true;
+        })
+        .sort((left, right) => left.localeCompare(right));
+    },
   };
 };

--- a/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
+++ b/calculogic-validator/tree/test/tree-known-roots-runtime-routing.logic.test.mjs
@@ -36,6 +36,8 @@ const alignedReplacementRuntime = {
     isSemanticRoot: false,
     isSubtreePartitionCandidate: false,
   })),
+  collectUnexpectedTopLevelDirectoryNames: (topLevelDirectoryNames) =>
+    topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
 };
 
 const legacyClassifyOccurrenceRecords = (occurrenceRecords) => occurrenceRecords.map((record) => ({
@@ -234,7 +236,104 @@ test('tree known-roots runtime routing preserves legacy occurrence classificatio
   assert.deepEqual(resolved.records, legacyClassifyOccurrenceRecords(occurrenceRecords));
 });
 
-test('tree known-roots runtime routing preserves legacy unexpected top-level behavior when replacement route is selected', () => {
+test('tree known-roots runtime routing preserves legacy unexpected top-level behavior in default mode', () => {
+  const route = selectTreeKnownRootsRuntimeRoute({
+    replacementRuntime: alignedReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeUnexpectedTopLevelDirectoryRuntime({
+    topLevelDirectoryNames: ['experiments', 'src'],
+    legacyCollectUnexpectedDirectoryNames: (topLevelDirectoryNames) =>
+      topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.LEGACY);
+  assert.equal(resolved.route.fallbackReason, null);
+  assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
+});
+
+test('tree known-roots runtime routing selects replacement unexpected top-level policy when safe and parity-aligned', () => {
+  const selectedReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    collectUnexpectedTopLevelDirectoryNames: (topLevelDirectoryNames) =>
+      topLevelDirectoryNames
+        .filter((directoryName) => directoryName === 'experiments')
+        .map((directoryName) => directoryName),
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: selectedReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeUnexpectedTopLevelDirectoryRuntime({
+    topLevelDirectoryNames: ['experiments', 'src'],
+    legacyCollectUnexpectedDirectoryNames: (topLevelDirectoryNames) =>
+      topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT);
+  assert.equal(resolved.route.fallbackUsed, false);
+  assert.equal(resolved.route.fallbackReason, null);
+  assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
+});
+
+test('tree known-roots runtime routing falls back when replacement unexpected top-level policy is unavailable', () => {
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: {
+      classifyOccurrenceRecords: alignedReplacementRuntime.classifyOccurrenceRecords,
+    },
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeUnexpectedTopLevelDirectoryRuntime({
+    topLevelDirectoryNames: ['experiments', 'src'],
+    legacyCollectUnexpectedDirectoryNames: (topLevelDirectoryNames) =>
+      topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
+    route: {
+      ...route,
+      activeExecutionMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+      replacementRuntime: {
+        classifyOccurrenceRecords: alignedReplacementRuntime.classifyOccurrenceRecords,
+      },
+    },
+  });
+
+  assert.equal(route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(route.fallbackReason, 'replacement-runtime-unavailable');
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-unavailable');
+  assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
+});
+
+test('tree known-roots runtime routing falls back when replacement unexpected top-level policy is incomplete', () => {
+  const incompleteReplacementRuntime = {
+    ...alignedReplacementRuntime,
+    collectUnexpectedTopLevelDirectoryNames: () => ['experiments', 'missing-from-input'],
+  };
+  const route = selectTreeKnownRootsRuntimeRoute({
+    requestedMode: TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT,
+    replacementRuntime: incompleteReplacementRuntime,
+    runtimeExecutionContract: safeRuntimeExecutionContract,
+  });
+
+  const resolved = resolveTreeUnexpectedTopLevelDirectoryRuntime({
+    topLevelDirectoryNames: ['experiments', 'src'],
+    legacyCollectUnexpectedDirectoryNames: (topLevelDirectoryNames) =>
+      topLevelDirectoryNames.filter((directoryName) => directoryName === 'experiments'),
+    route,
+  });
+
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-incomplete');
+  assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
+});
+
+test('tree known-roots runtime routing falls back when replacement unexpected top-level policy diverges', () => {
   const divergentReplacementRuntime = {
     ...alignedReplacementRuntime,
     collectUnexpectedTopLevelDirectoryNames: () => [],
@@ -252,7 +351,7 @@ test('tree known-roots runtime routing preserves legacy unexpected top-level beh
     route,
   });
 
-  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.REPLACEMENT);
-  assert.equal(resolved.route.fallbackReason, null);
+  assert.equal(resolved.route.activeExecutionMode, TREE_KNOWN_ROOTS_RUNTIME_MODES.FALLBACK);
+  assert.equal(resolved.route.fallbackReason, 'replacement-runtime-divergent');
   assert.deepEqual(resolved.unexpectedDirectoryNames, ['experiments']);
 });

--- a/calculogic-validator/tree/test/tree-occurrence-classification.test.mjs
+++ b/calculogic-validator/tree/test/tree-occurrence-classification.test.mjs
@@ -149,3 +149,29 @@ test('tree occurrence classification replacement runtime classifies from prepare
   assert.equal(records['src/components'].structuralClass, 'subtree-structural-partition-candidate');
   assert.equal(records['src/components'].isSubtreePartitionCandidate, true);
 });
+
+test('tree occurrence classification replacement runtime collects unexpected top-level directories from prepared evidence', () => {
+  const replacementRuntime = prepareTreeOccurrenceClassificationReplacementRuntime({
+    treeStructuralHomeEvidence: {
+      source: 'test',
+      evidenceRecords: [{ path: 'src', occurrenceType: 'folder', structuralHome: 'src' }],
+    },
+    treeSemanticHomeEvidence: {
+      source: 'test',
+      evidenceRecords: [{ path: 'calculogic-validator', occurrenceType: 'folder', semanticHome: 'validator' }],
+    },
+    treeFolderKindEvidence: {
+      source: 'test',
+      evidenceRecords: [
+        { path: 'src', occurrenceType: 'folder', folderKind: 'structural' },
+        { path: 'calculogic-validator', occurrenceType: 'folder', folderKind: 'semantic' },
+        { path: 'experiments', occurrenceType: 'folder', folderKind: 'unspecified' },
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    replacementRuntime.collectUnexpectedTopLevelDirectoryNames(['src', 'experiments', 'calculogic-validator']),
+    ['experiments'],
+  );
+});


### PR DESCRIPTION
### Motivation
- Implement the minimal Tree slice in #567 to make unexpected top-level folder policy replaceable behind the guarded known-roots runtime route while preserving default legacy behavior. 
- Keep deterministic inspectability and a clear fallback reason when replacement execution is unavailable, unsafe, incomplete, or divergent. 
- Treat the suite contract and the Tree validator spec as runtime authority while using Tree-owned supporting docs for navigation and implementation guidance. 
- Refs #567
- Refs #561

### Description
- Extend the Tree known-roots runtime route so a prepared replacement runtime must expose both `classifyOccurrenceRecords` and `collectUnexpectedTopLevelDirectoryNames` before it is considered available, and use the replacement collector when explicitly requested and guarded safe. 
- Add replacement-path validation and safety checks: availability, structural completeness, and divergence detection, and preserve legacy `knownTopLevelDirectories` behavior when any guard fails (with an inspectable `fallbackReason`). 
- Add `collectUnexpectedTopLevelDirectoryNames` to the prepared replacement runtime produced by `prepareTreeOccurrenceClassificationReplacementRuntime(...)` and wire the route selection to call it when in replacement mode. 
- Update Tree wiring, tests, and docs to document the new guarded unexpected-folder replacement behavior and to keep default runtime behavior unchanged.

### Testing
- Ran unit tests: `node --test calculogic-validator/tree/test/*.test.mjs` and observed all Tree tests pass (224 tests passed). 
- Ran the targeted validator run: `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and observed the runner completed and emitted the structured report (the run reported existing advisory findings for the targeted tree scope and an `npm warn Unknown env config "http-proxy"` message). 
- Both automated verifications succeeded; replacement-mode and fallback behaviors are covered by new/updated unit tests which assert legacy default behavior, safe replacement selection, and fallback reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2316aa11948331a081c34cc546c563)