### PR TITLE
Preserve tree repo-shape fallback behavior (avoid silent suppression of unexpected top-level folders)

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
+++ b/calculogic-validator/doc/ValidatorSpecs/nl-config/cfg-treeStructureAdvisor.md
@@ -100,6 +100,8 @@ V0.1.7 introduces a suite-core scoped snapshot/input helper boundary and migrate
 - Tree known-roots registry/runtime dependencies are retired in current runtime truth: `knownTopLevelDirectories` no longer controls unexpected top-level folder behavior, and `topRoots[].kind` no longer controls occurrence classification.
 - Tree runtime now uses prepared replacement evidence for occurrence classification from addressed occurrences, structural-home evidence, semantic-home evidence, and folder-kind evidence.
 - Unexpected top-level folder policy now uses an explicit Tree-owned repo-shape policy boundary; structural-home vocabulary does not automatically allow repo-top folders for `TREE_UNEXPECTED_TOP_LEVEL_FOLDER`.
+- Direct runtime callers that omit replacement-runtime composition still use the explicit Tree-owned repo-shape policy fallback instead of suppressing unexpected top-level folder findings.
+- Unexpected top-level folder details report the full Tree-owned allowed repo-shape policy in `details.knownRoots`, not only the observed allowed root subset.
 - The former guarded known-roots fallback route is historical context only and is not current runtime truth.
 
 Target behaviors in V0.1.2:

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -781,6 +781,8 @@ Deferred candidates above are a documentation menu only. They are not current ru
 - Tree known-roots registry/runtime dependencies are retired in current runtime truth: `topRoots[].kind` does not back occurrence classification and `knownTopLevelDirectories` does not back unexpected top-level folder policy.
 - Occurrence classification now uses prepared Tree replacement evidence from addressed occurrences, structural-home evidence, semantic-home evidence, and folder-kind evidence; the former guarded known-roots fallback route is not current runtime truth.
 - Unexpected top-level folder policy now uses an explicit Tree-owned repo-shape policy boundary; general structural-home evidence does not automatically make a top-level folder expected for `TREE_UNEXPECTED_TOP_LEVEL_FOLDER`.
+- Direct runtime callers that provide the required prepared tree-core inputs but omit the occurrence-classification replacement runtime still use the explicit Tree-owned repo-shape policy fallback for `TREE_UNEXPECTED_TOP_LEVEL_FOLDER`; missing replacement composition must not silently suppress unexpected top-level folder findings.
+- `TREE_UNEXPECTED_TOP_LEVEL_FOLDER` finding details report the full Tree-owned allowed repo-shape policy in `details.knownRoots`, not only the observed allowed top-level folder subset, so the payload explains the bounded policy used to classify a folder as unexpected.
 - If occurrence snapshot is missing or malformed, tree core deterministically falls back to prepared `selectedPaths` for file-path reasoning.
 - Required prepared tree-core fields:
   - `selectedPaths` (array)

--- a/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.logic.mjs
@@ -1,7 +1,11 @@
 import path from 'node:path';
 import { getBuiltinTreeSignalPolicy } from './registries/tree-signal-policy-registry.logic.mjs';
+import { getBuiltinTreeRepoShapePolicy } from './registries/tree-repo-shape-policy-registry.logic.mjs';
 
 const TREE_SIGNAL_POLICY = getBuiltinTreeSignalPolicy();
+const TREE_REPO_SHAPE_POLICY = getBuiltinTreeRepoShapePolicy();
+const ALLOWED_TOP_LEVEL_DIRECTORY_NAMES = TREE_REPO_SHAPE_POLICY.allowedTopLevelDirectories;
+const ALLOWED_TOP_LEVEL_DIRECTORY_NAME_SET = new Set(ALLOWED_TOP_LEVEL_DIRECTORY_NAMES);
 
 const VALIDATOR_SUITE_CORE_ROOT = 'calculogic-validator/src/';
 const SUITE_CORE_BOUNDARY_DRIFT_CARVEOUT_PREFIXES = [
@@ -32,7 +36,16 @@ const isValidatorOwnedBasenameSignal = (basename) =>
 
 const createNeutralReplacementRuntime = () => ({
   classifyOccurrenceRecords: (occurrenceRecords = []) => occurrenceRecords,
-  collectUnexpectedTopLevelDirectoryNames: () => [],
+  collectUnexpectedTopLevelDirectoryNames: (topLevelDirectoryNames = []) => {
+    if (!Array.isArray(topLevelDirectoryNames)) {
+      throw new Error('Tree unexpected top-level fallback runtime requires topLevelDirectoryNames array.');
+    }
+
+    return topLevelDirectoryNames
+      .filter((directoryName) => typeof directoryName === 'string' && directoryName.length > 0)
+      .filter((directoryName) => !ALLOWED_TOP_LEVEL_DIRECTORY_NAME_SET.has(directoryName))
+      .sort((left, right) => left.localeCompare(right));
+  },
 });
 
 const resolveReplacementRuntime = (replacementRuntime) => {
@@ -61,10 +74,7 @@ const collectTopLevelUnexpectedFolderFindings = (topLevelDirectoryNames, scope, 
     throw new Error('Tree replacement runtime collectUnexpectedTopLevelDirectoryNames() must return an array.');
   }
 
-  const unexpectedDirectoryNameSet = new Set(unexpectedDirectoryNames);
-  const knownRoots = topLevelDirectoryNames
-    .filter((directoryName) => !unexpectedDirectoryNameSet.has(directoryName))
-    .sort((left, right) => left.localeCompare(right));
+  const knownRoots = [...ALLOWED_TOP_LEVEL_DIRECTORY_NAMES];
 
   return unexpectedDirectoryNames
     .sort((left, right) => left.localeCompare(right))

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -33,7 +33,18 @@ const writeJson = async (filePath, value) => {
   await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
 };
 
-
+const EXPECTED_TREE_REPO_SHAPE_ALLOWED_TOP_LEVEL_DIRECTORIES = [
+  'bin',
+  'calculogic-doc-engine',
+  'calculogic-validator',
+  'doc',
+  'docs',
+  'public',
+  'scripts',
+  'src',
+  'test',
+  'tools',
+];
 
 const collectExpectedPathsFromScopeProfile = async (fixtureDir, scope) => {
   const profile = getValidatorScopeProfile(scope);
@@ -500,6 +511,24 @@ test('tree-structure-advisor structural-address handoff preserves file target ki
   }
 });
 
+test('tree-structure-advisor runtime fallback preserves unexpected top-level folder findings without replacement runtime', () => {
+  const result = runTreeStructureAdvisorRuntime({
+    selectedPaths: [],
+    topLevelDirectoryNames: ['src', 'experiments'],
+    targets: [],
+  });
+
+  const advisory = result.findings.find(
+    (finding) => finding.code === 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER' && finding.path === 'experiments',
+  );
+
+  assert.ok(advisory);
+  assert.deepEqual(advisory.details.knownRoots, EXPECTED_TREE_REPO_SHAPE_ALLOWED_TOP_LEVEL_DIRECTORIES);
+  assert.equal(advisory.details.knownRoots.includes('doc'), true);
+  assert.equal(advisory.details.knownRoots.includes('calculogic-validator'), true);
+  assert.equal(advisory.details.knownRoots.includes('src'), true);
+  assert.notDeepEqual(advisory.details.knownRoots, ['src']);
+});
 
 test('tree-structure-advisor replacement root policy comes from bounded structural-home evidence without behavior drift', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-root-policy-registry-'));
@@ -521,17 +550,11 @@ test('tree-structure-advisor replacement root policy comes from bounded structur
       false,
     );
     assert.ok(advisory);
-    assert.deepEqual(advisory.details.knownRoots, [
-      'calculogic-doc-engine',
-      'calculogic-validator',
-      'doc',
-      'src',
-    ]);
+    assert.deepEqual(advisory.details.knownRoots, EXPECTED_TREE_REPO_SHAPE_ALLOWED_TOP_LEVEL_DIRECTORIES);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
 });
-
 
 test('tree-structure-advisor keeps general structural-home top-level folders unexpected unless repo-shape policy allows them', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-repo-shape-policy-'));


### PR DESCRIPTION
### Motivation
- Fix two narrow runtime gaps left after known-roots retirement so direct runtime callers are not able to silently suppress `TREE_UNEXPECTED_TOP_LEVEL_FOLDER` when the replacement occurrence-classification runtime is not provided. 
- Ensure `details.knownRoots` reports the full Tree-owned allowed repo-shape policy (helpful explanatory payload) rather than only the observed allowed subset.

### Description
- Use the Tree-owned repo-shape policy at runtime by importing `getBuiltinTreeRepoShapePolicy()` and deriving the allowed top-level directory names as the deterministic fallback when replacement runtime is absent. 
- Change the neutral replacement runtime so `collectUnexpectedTopLevelDirectoryNames` filters against the repo-shape allow-list instead of returning an empty array, preventing silent suppression of unexpected-folder findings. 
- Report the full allowed repo-shape list in `details.knownRoots` for `TREE_UNEXPECTED_TOP_LEVEL_FOLDER` findings rather than the observed subset. 
- Add a focused test that calls `runTreeStructureAdvisorRuntime()` with `topLevelDirectoryNames: ['src','experiments']` and no `preparedDependencies.treeOccurrenceClassificationReplacementRuntime`, asserting an unexpected-folder finding for `experiments` and that `details.knownRoots` equals the full allowed repo-shape list; update an existing test to reuse the canonical expected list constant. 
- Update two validator docs (`cfg-treeStructureAdvisor.md` and `tree-structure-advisor-validator.spec.md`) to document the fallback semantics and the `details.knownRoots` behavior. 
- Preserve the known-roots retirement: no known-roots runtime/registry files were restored and no known-roots runtime truth was reintroduced.

### Testing
- Ran `node --test calculogic-validator/tree/test/*.test.mjs` and it passed: all tests succeeded (200 tests passed). 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and it exited `0` and emitted the validator report (scoped advisory findings were reported as expected). 
- Ran `rg "knownTopLevelDirectories|topRoots|tree-known-roots|TREE_KNOWN_ROOTS|getBuiltinTreeKnownRoots" calculogic-validator/tree calculogic-validator/doc/ValidatorSpecs -n` and the results show only historical/spec-documentation references without restoring the retired known-roots runtime surface. 

Refs #572
Refs #561
Follow-up to PR #573

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23368151648331b8508a11593916f2)