### PR TITLE
Add suite-core validator candidate-policy contract and collection helper

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
@@ -69,7 +69,28 @@ Only currently real, discoverable suite-owned surfaces are listed here.
   - slice heuristics that should remain slice-owned interpretation behavior
 - **Reuse boundary type:** runtime boundary reuse (and composition boundary reuse for cross-slice composition)
 
-### 3.3 Entry: suite-core exit policy derivation helper
+### 3.3 Entry: suite-core validator candidate policy and collection helper
+
+- **Owner:** suite-core
+- **Path/area:**
+  - `calculogic-validator/src/core/validator-candidate-policy.contracts.mjs`
+  - `calculogic-validator/src/core/validator-candidate-policy.logic.mjs`
+  - `calculogic-validator/src/core/validator-candidate-collection.logic.mjs`
+- **Concern:** broad validator candidate policy contract and deterministic candidate collection mechanics before slice-owned interpretation.
+- **Reusable capability:**
+  - normalized candidate extension and candidate root-file policy inputs
+  - walk-exclusion and skip-dot-directory inputs
+  - suite scope/profile and target filtering reuse through existing suite-core scoped snapshot helpers
+  - deterministic candidate path sorting and dedupe
+- **When to reuse:**
+  - proving or adopting shared broad candidate collection before a validator slice interprets candidate paths
+  - adapting slice-owned candidate values into a suite-owned candidate collection contract without moving registry authority
+- **When not to reuse:**
+  - deciding what a filename, folder, semantic family, structural home, or candidate path means for a specific slice
+  - moving slice-owned initial policy value authority into suite-core
+- **Reuse boundary type:** contract/helper boundary reuse
+
+### 3.4 Entry: suite-core exit policy derivation helper
 
 - **Owner:** suite-core
 - **Path/area:** `calculogic-validator/src/core/validator-exit-code.logic.mjs`
@@ -86,7 +107,7 @@ Only currently real, discoverable suite-owned surfaces are listed here.
   - experimental policy behavior not yet part of suite exit policy contract
 - **Reuse boundary type:** runtime boundary reuse
 
-### 3.4 Entry: suite-core report meta + source snapshot helpers
+### 3.5 Entry: suite-core report meta + source snapshot helpers
 
 - **Owner:** suite-core
 - **Path/area:**

--- a/calculogic-validator/src/core/validator-candidate-collection.logic.mjs
+++ b/calculogic-validator/src/core/validator-candidate-collection.logic.mjs
@@ -1,0 +1,50 @@
+import { collectSuiteScopedSnapshotInputs } from './suite-scoped-snapshot-input.logic.mjs';
+import {
+  normalizeValidatorCandidatePolicy,
+  toValidatorCandidatePolicyInputSets,
+} from './validator-candidate-policy.contracts.mjs';
+import { isValidatorCandidatePath } from './validator-candidate-policy.logic.mjs';
+
+const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
+
+export const filterValidatorCandidatePaths = (relativePaths, candidatePolicy) => {
+  const normalizedPolicy = normalizeValidatorCandidatePolicy(candidatePolicy);
+  const candidatePaths = relativePaths.filter((relativePath) =>
+    isValidatorCandidatePath(relativePath, normalizedPolicy),
+  );
+
+  return sortPaths(new Set(candidatePaths));
+};
+
+export const collectValidatorCandidatePaths = (
+  repositoryRoot,
+  {
+    scope,
+    targets = [],
+    candidatePolicy,
+  } = {},
+) => {
+  const normalizedPolicy = normalizeValidatorCandidatePolicy(candidatePolicy);
+  const policySets = toValidatorCandidatePolicyInputSets(normalizedPolicy);
+  const scopedSnapshot = collectSuiteScopedSnapshotInputs(repositoryRoot, {
+    scope,
+    targets,
+    walkExcludedDirectories: policySets.walkExcludedDirectories,
+    skipDotDirectories: policySets.skipDotDirectories,
+  });
+  const inScopeCandidatePaths = filterValidatorCandidatePaths(
+    scopedSnapshot.inScopePaths,
+    normalizedPolicy,
+  );
+
+  return {
+    candidatePolicy: normalizedPolicy,
+    scope: scopedSnapshot.scope,
+    includeRoots: scopedSnapshot.includeRoots,
+    includeRootFiles: scopedSnapshot.includeRootFiles,
+    inScopePaths: inScopeCandidatePaths,
+    selectedPaths: filterValidatorCandidatePaths(scopedSnapshot.selectedPaths, normalizedPolicy),
+    targetDescriptors: scopedSnapshot.targetDescriptors,
+    targets: scopedSnapshot.targets,
+  };
+};

--- a/calculogic-validator/src/core/validator-candidate-policy.contracts.mjs
+++ b/calculogic-validator/src/core/validator-candidate-policy.contracts.mjs
@@ -1,0 +1,54 @@
+const normalizeCandidateToken = (value) => String(value ?? '').trim();
+
+const normalizeUniqueSortedStrings = (values, fieldName) => {
+  if (!values || typeof values[Symbol.iterator] !== 'function') {
+    throw new Error(`Validator candidate policy requires iterable ${fieldName}.`);
+  }
+
+  const normalizedValues = [];
+  for (const value of values) {
+    const normalizedValue = normalizeCandidateToken(value);
+    if (!normalizedValue) {
+      throw new Error(`Validator candidate policy ${fieldName} entries must be non-empty strings.`);
+    }
+
+    normalizedValues.push(normalizedValue);
+  }
+
+  return Array.from(new Set(normalizedValues)).sort((left, right) => left.localeCompare(right));
+};
+
+export const normalizeValidatorCandidatePolicy = ({
+  candidateExtensions,
+  candidateRootFiles,
+  walkExcludedDirectories = [],
+  skipDotDirectories = true,
+} = {}) => {
+  if (typeof skipDotDirectories !== 'boolean') {
+    throw new Error('Validator candidate policy skipDotDirectories must be a boolean.');
+  }
+
+  return Object.freeze({
+    candidateExtensions: Object.freeze(
+      normalizeUniqueSortedStrings(candidateExtensions ?? [], 'candidateExtensions'),
+    ),
+    candidateRootFiles: Object.freeze(
+      normalizeUniqueSortedStrings(candidateRootFiles ?? [], 'candidateRootFiles'),
+    ),
+    walkExcludedDirectories: Object.freeze(
+      normalizeUniqueSortedStrings(walkExcludedDirectories ?? [], 'walkExcludedDirectories'),
+    ),
+    skipDotDirectories,
+  });
+};
+
+export const toValidatorCandidatePolicyInputSets = (candidatePolicy) => {
+  const normalizedPolicy = normalizeValidatorCandidatePolicy(candidatePolicy);
+
+  return Object.freeze({
+    candidateExtensions: new Set(normalizedPolicy.candidateExtensions),
+    candidateRootFiles: new Set(normalizedPolicy.candidateRootFiles),
+    walkExcludedDirectories: new Set(normalizedPolicy.walkExcludedDirectories),
+    skipDotDirectories: normalizedPolicy.skipDotDirectories,
+  });
+};

--- a/calculogic-validator/src/core/validator-candidate-policy.logic.mjs
+++ b/calculogic-validator/src/core/validator-candidate-policy.logic.mjs
@@ -1,0 +1,30 @@
+import path from 'node:path';
+import {
+  normalizeValidatorCandidatePolicy,
+  toValidatorCandidatePolicyInputSets,
+} from './validator-candidate-policy.contracts.mjs';
+import { normalizePath } from './scoped-target-paths.logic.mjs';
+
+export const isValidatorCandidatePath = (relativePath, candidatePolicy) => {
+  const normalizedPath = normalizePath(relativePath);
+  const policySets = toValidatorCandidatePolicyInputSets(candidatePolicy);
+  const extension = path.extname(normalizedPath);
+
+  if (policySets.candidateExtensions.has(extension)) {
+    return true;
+  }
+
+  return policySets.candidateRootFiles.has(path.basename(normalizedPath));
+};
+
+export const createValidatorCandidatePolicyFromValues = ({
+  candidateExtensions,
+  candidateRootFiles,
+  walkExclusions,
+} = {}) =>
+  normalizeValidatorCandidatePolicy({
+    candidateExtensions,
+    candidateRootFiles,
+    walkExcludedDirectories: walkExclusions?.excludedDirectories ?? [],
+    skipDotDirectories: walkExclusions?.skipDotDirectories ?? true,
+  });

--- a/calculogic-validator/test/suite-scoped-snapshot-input.test.mjs
+++ b/calculogic-validator/test/suite-scoped-snapshot-input.test.mjs
@@ -16,7 +16,11 @@ test('suite scoped snapshot helper collects scope roots and root files determini
     const snapshot = collectSuiteScopedSnapshotInputs(fixtureDir, { scope: 'docs' });
 
     assert.equal(snapshot.scope, 'docs');
+    assert.deepEqual(snapshot.includeRoots, ['doc', 'docs']);
+    assert.deepEqual(snapshot.includeRootFiles, ['README.md']);
+    assert.deepEqual(snapshot.inScopePaths, ['doc/README.md', 'README.md']);
     assert.deepEqual(snapshot.selectedPaths, ['doc/README.md', 'README.md']);
+    assert.deepEqual(snapshot.targetDescriptors, []);
     assert.equal(snapshot.targets.length, 0);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
@@ -36,7 +40,14 @@ test('suite scoped snapshot helper applies target filtering after scoped collect
       targets: ['src/a.logic.ts'],
     });
 
+    assert.equal(snapshot.scope, 'app');
     assert.deepEqual(snapshot.selectedPaths, ['src/a.logic.ts']);
+    assert.deepEqual(snapshot.targetDescriptors, [
+      {
+        kind: 'file',
+        relPath: 'src/a.logic.ts',
+      },
+    ]);
     assert.deepEqual(snapshot.targets, ['src/a.logic.ts']);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });

--- a/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
+++ b/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
@@ -1,0 +1,179 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  collectRepositoryPaths as collectNamingRepositoryPaths,
+  prepareNamingRuntimeInputs,
+  prepareNamingValidatorInputs,
+} from '../naming/src/naming-validator.wiring.mjs';
+import { createValidatorCandidatePolicyFromValues } from '../src/core/validator-candidate-policy.logic.mjs';
+import { collectValidatorCandidatePaths } from '../src/core/validator-candidate-collection.logic.mjs';
+
+const writeFixtureFile = async (fixtureDir, relativePath, content = 'fixture\n') => {
+  const absolutePath = path.join(fixtureDir, relativePath);
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.writeFile(absolutePath, content, 'utf8');
+};
+
+const createCandidateFixture = async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validator-candidates-'));
+
+  await Promise.all([
+    writeFixtureFile(fixtureDir, 'package.json', '{}\n'),
+    writeFixtureFile(fixtureDir, 'package-lock.json', '{}\n'),
+    writeFixtureFile(fixtureDir, 'README.md', '# repo\n'),
+    writeFixtureFile(fixtureDir, 'src/app.logic.ts'),
+    writeFixtureFile(fixtureDir, 'src/App.tsx'),
+    writeFixtureFile(fixtureDir, 'src/style.css'),
+    writeFixtureFile(fixtureDir, 'src/data.json', '{}\n'),
+    writeFixtureFile(fixtureDir, 'test/app.test.js'),
+    writeFixtureFile(fixtureDir, 'doc/guide.md', '# guide\n'),
+    writeFixtureFile(fixtureDir, 'calculogic-validator/src/core/example.logic.mjs'),
+    writeFixtureFile(fixtureDir, 'calculogic-validator/src/core/example.logic.js'),
+    writeFixtureFile(fixtureDir, 'calculogic-validator/test/example.test.mjs'),
+    writeFixtureFile(fixtureDir, 'node_modules/pkg/ignored.logic.ts'),
+    writeFixtureFile(fixtureDir, 'dist/ignored.logic.ts'),
+    writeFixtureFile(fixtureDir, '.hidden/ignored.logic.ts'),
+  ]);
+
+  return fixtureDir;
+};
+
+const createNamingCandidatePolicy = (overrides = {}) => {
+  const namingRuntimeInputs = prepareNamingRuntimeInputs();
+
+  return createValidatorCandidatePolicyFromValues({
+    candidateExtensions:
+      overrides.reportableExtensions ?? namingRuntimeInputs.reportableExtensions,
+    candidateRootFiles:
+      overrides.reportableRootFiles ?? namingRuntimeInputs.reportableRootFiles,
+    walkExclusions: overrides.walkExclusions ?? namingRuntimeInputs.walkExclusions,
+  });
+};
+
+const assertNamingCandidateParity = (fixtureDir, options = {}) => {
+  const candidatePolicy = createNamingCandidatePolicy(options);
+  const oldNamingPaths = collectNamingRepositoryPaths(fixtureDir, {
+    scope: options.scope,
+    reportableExtensions: options.reportableExtensions,
+    reportableRootFiles: options.reportableRootFiles,
+    walkExclusions: options.walkExclusions,
+  });
+  const newCandidatePaths = collectValidatorCandidatePaths(fixtureDir, {
+    scope: options.scope,
+    targets: options.targets,
+    candidatePolicy,
+  });
+
+  if (options.targets?.length) {
+    const oldPreparedInputs = prepareNamingValidatorInputs(fixtureDir, {
+      scope: options.scope,
+      targets: options.targets,
+    });
+
+    assert.deepEqual(newCandidatePaths.selectedPaths, oldPreparedInputs.selectedPaths);
+  } else {
+    assert.deepEqual(newCandidatePaths.selectedPaths, oldNamingPaths);
+  }
+
+  assert.deepEqual(newCandidatePaths.inScopePaths, oldNamingPaths);
+  return newCandidatePaths;
+};
+
+test('suite-core candidate helper reproduces current Naming repo candidate collection', async () => {
+  const fixtureDir = await createCandidateFixture();
+
+  try {
+    const newCandidatePaths = assertNamingCandidateParity(fixtureDir, { scope: 'repo' });
+
+    assert.deepEqual(newCandidatePaths.selectedPaths, [
+      'calculogic-validator/src/core/example.logic.js',
+      'calculogic-validator/src/core/example.logic.mjs',
+      'calculogic-validator/test/example.test.mjs',
+      'doc/guide.md',
+      'package-lock.json',
+      'package.json',
+      'README.md',
+      'src/app.logic.ts',
+      'src/App.tsx',
+      'src/data.json',
+      'src/style.css',
+      'test/app.test.js',
+    ]);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('suite-core candidate helper reproduces current Naming scoped candidate collection', async () => {
+  const fixtureDir = await createCandidateFixture();
+
+  try {
+    const appCandidates = assertNamingCandidateParity(fixtureDir, { scope: 'app' });
+    const validatorCandidates = assertNamingCandidateParity(fixtureDir, { scope: 'validator' });
+
+    assert.deepEqual(appCandidates.selectedPaths, [
+      'src/app.logic.ts',
+      'src/App.tsx',
+      'src/data.json',
+      'src/style.css',
+      'test/app.test.js',
+    ]);
+    assert.deepEqual(validatorCandidates.selectedPaths, [
+      'calculogic-validator/src/core/example.logic.js',
+      'calculogic-validator/src/core/example.logic.mjs',
+      'calculogic-validator/test/example.test.mjs',
+    ]);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('suite-core candidate helper reproduces current Naming target filtering', async () => {
+  const fixtureDir = await createCandidateFixture();
+
+  try {
+    const targetCandidates = assertNamingCandidateParity(fixtureDir, {
+      scope: 'validator',
+      targets: ['calculogic-validator/src/core'],
+    });
+
+    assert.deepEqual(targetCandidates.selectedPaths, [
+      'calculogic-validator/src/core/example.logic.js',
+      'calculogic-validator/src/core/example.logic.mjs',
+    ]);
+    assert.deepEqual(targetCandidates.targetDescriptors, [
+      {
+        kind: 'dir',
+        relPath: 'calculogic-validator/src/core',
+      },
+    ]);
+    assert.deepEqual(targetCandidates.targets, ['calculogic-validator/src/core']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('suite-core candidate helper preserves current Naming root-file and sorting behavior', async () => {
+  const fixtureDir = await createCandidateFixture();
+
+  try {
+    const rootFileCandidates = assertNamingCandidateParity(fixtureDir, {
+      scope: 'repo',
+      reportableExtensions: new Set(['.mjs', '.ts']),
+      reportableRootFiles: new Set(['package.json', 'package-lock.json']),
+    });
+
+    assert.deepEqual(rootFileCandidates.selectedPaths, [
+      'calculogic-validator/src/core/example.logic.mjs',
+      'calculogic-validator/test/example.test.mjs',
+      'package-lock.json',
+      'package.json',
+      'src/app.logic.ts',
+    ]);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide a narrow suite-core contract/helper to represent broad validator candidate policy and deterministic candidate collection mechanics without pulling Naming registry authority into suite-core. 
- Prove old-vs-new compatibility so suite-core can be adopted contract-first while preserving current Naming and Tree runtime behavior. 

### Description
- Added a candidate-policy contract that normalizes candidate extensions, candidate root files, walk exclusions, and `skipDotDirectories` with stable sort/dedupe semantics in `calculogic-validator/src/core/validator-candidate-policy.contracts.mjs`. 
- Added candidate-policy logic and an adapter-style helper that can be fed by current Naming runtime values without moving Naming registry authority in `calculogic-validator/src/core/validator-candidate-policy.logic.mjs`. 
- Added a candidate-collection helper that reuses existing suite scoped snapshot and scoped-target helpers for scope/profile selection, target filtering, selected path packaging, and deterministic candidate filtering in `calculogic-validator/src/core/validator-candidate-collection.logic.mjs`. 
- Added compatibility tests comparing the new suite-core helper against current Naming candidate collection behavior in `calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs` and expanded suite snapshot assertions in `calculogic-validator/test/suite-scoped-snapshot-input.test.mjs`. 
- Documented the new helper in the suite-owned helpers inventory at `calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md` and preserved explicit non-ownership of slice interpretation and initial policy values. 
- No runtime migration or registry ownership change was performed; Naming wiring remains unchanged and continues to be the initial value source (adapter-only). 

### Testing
- Ran the focused compatibility test `node --test calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs` and it passed. 
- Ran the combined snapshot+compat test `node --test calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs calculogic-validator/test/suite-scoped-snapshot-input.test.mjs` and it passed. 
- Ran the broader validator suites `node --test calculogic-validator/test/*.test.mjs calculogic-validator/naming/test/*.test.mjs calculogic-validator/tree/test/*.test.mjs` and all tests passed. 
- Verified CLI validator runs: `npm run validate:naming -- --scope=validator --target calculogic-validator/src/core` completed successfully and produced unchanged Naming report outputs for the target, and `npm run validate:tree -- --scope=validator --target calculogic-validator/src/core` completed successfully and preserved Tree scoped snapshot behavior. 
- Note: `npm run validate:naming -- --scope=validator --target calculogic-validator/test` exited with code 2 due to existing, pre‑existing Naming warnings in checked-in validator test fixtures/report examples; this is an unrelated pre-existing condition and was not broadened for this PR. 

Refs #578
Refs #579
Refs #575

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2369b277c88331bc5be5a6cac0434e)