### PR TITLE
Migrate Naming candidate collection to suite-core helper

### DIFF
--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -1,14 +1,12 @@
 import path from 'node:path';
-import fs from 'node:fs';
 import {
   DEFAULT_VALIDATOR_SCOPE,
   listValidatorScopes,
   getValidatorScopeProfile,
 } from '../../src/core/validator-scopes.logic.mjs';
-import {
-  normalizePath,
-  filterScopedPathsByProfile,
-} from '../../src/core/scoped-target-paths.logic.mjs';
+import { normalizePath } from '../../src/core/scoped-target-paths.logic.mjs';
+import { collectValidatorCandidatePaths } from '../../src/core/validator-candidate-collection.logic.mjs';
+import { createValidatorCandidatePolicyFromValues } from '../../src/core/validator-candidate-policy.logic.mjs';
 import { parseCanonicalName } from './rules/naming-rule-parse-canonical.logic.mjs';
 import {
   getSpecialCaseType,
@@ -30,16 +28,6 @@ import {
 } from './rules/naming-rule-check-role.logic.mjs';
 
 export { parseCanonicalName, getSpecialCaseType, isAllowedSpecialCase };
-
-const isReportableFile = (relativePath, reportableExtensions, reportableRootFiles) => {
-  const extension = path.extname(relativePath);
-  if (reportableExtensions.has(extension)) {
-    return true;
-  }
-
-  const basename = path.basename(relativePath);
-  return reportableRootFiles.has(basename);
-};
 
 const assertPreparedReportableExtensions = (reportableExtensions) => {
   if (reportableExtensions instanceof Set) {
@@ -75,9 +63,6 @@ const assertPreparedNamingRolesRuntime = (namingRolesRuntime) => {
     'Naming runtime requires prepared namingRolesRuntime from wiring/runtime adapter.',
   );
 };
-
-
-
 
 const assertPreparedMissingRolePatternsRuntime = (missingRolePatternsRuntime) => {
   if (Array.isArray(missingRolePatternsRuntime)) {
@@ -193,57 +178,6 @@ const assertPreparedWalkExclusions = (walkExclusions) => {
   );
 };
 
-const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
-
-const collectPathsFromRoot = (rootDirectory, rootRelativePath = '.', options = {}) => {
-  const normalizedRoot = normalizePath(rootRelativePath);
-  const absoluteRoot = path.resolve(rootDirectory, normalizedRoot);
-  if (!fs.existsSync(absoluteRoot)) {
-    return [];
-  }
-
-  const stat = fs.statSync(absoluteRoot);
-  if (!stat.isDirectory()) {
-    return [];
-  }
-
-  const reportableExtensions = assertPreparedReportableExtensions(options.reportableExtensions);
-  const reportableRootFiles = assertPreparedReportableRootFiles(options.reportableRootFiles);
-  const walkExclusions = assertPreparedWalkExclusions(options.walkExclusions);
-  const collected = [];
-
-  const walk = (absoluteDirectoryPath) => {
-    const entries = fs.readdirSync(absoluteDirectoryPath, { withFileTypes: true });
-
-    for (const entry of entries) {
-      const isDotEntry = entry.name.startsWith('.');
-
-      if (entry.isDirectory()) {
-        if (walkExclusions.excludedDirectories.has(entry.name)) {
-          continue;
-        }
-
-        if (isDotEntry && walkExclusions.skipDotDirectories) {
-          continue;
-        }
-
-        walk(path.join(absoluteDirectoryPath, entry.name));
-        continue;
-      }
-
-      const absolutePath = path.join(absoluteDirectoryPath, entry.name);
-      const relativePath = path.relative(rootDirectory, absolutePath);
-      const normalizedPath = normalizePath(relativePath);
-      if (isReportableFile(normalizedPath, reportableExtensions, reportableRootFiles)) {
-        collected.push(normalizedPath);
-      }
-    }
-  };
-
-  walk(absoluteRoot);
-  return collected;
-};
-
 export const listNamingValidatorScopes = () => listValidatorScopes();
 
 export const getScopeProfile = (scope) => getValidatorScopeProfile(scope);
@@ -278,23 +212,20 @@ const detectMissingRoleCandidate = (basename, missingRolePatternsRuntime) => {
 };
 
 export const collectRepositoryPaths = (rootDirectory, options = {}) => {
-  const selectedScope = options.scope ?? DEFAULT_VALIDATOR_SCOPE;
-  const profile = getScopeProfile(selectedScope);
-  if (!profile) {
-    throw new Error(`Invalid scope profile: ${selectedScope}`);
-  }
-
-  const allReportablePaths = collectPathsFromRoot(rootDirectory, '.', {
-    reportableExtensions: options.reportableExtensions,
-    reportableRootFiles: options.reportableRootFiles,
-    walkExclusions: options.walkExclusions,
+  const reportableExtensions = assertPreparedReportableExtensions(options.reportableExtensions);
+  const reportableRootFiles = assertPreparedReportableRootFiles(options.reportableRootFiles);
+  const walkExclusions = assertPreparedWalkExclusions(options.walkExclusions);
+  const candidatePolicy = createValidatorCandidatePolicyFromValues({
+    candidateExtensions: reportableExtensions,
+    candidateRootFiles: reportableRootFiles,
+    walkExclusions,
   });
 
-  if (selectedScope === 'repo') {
-    return sortPaths(new Set(allReportablePaths));
-  }
-
-  return filterScopedPathsByProfile(allReportablePaths, profile);
+  return collectValidatorCandidatePaths(rootDirectory, {
+    scope: options.scope ?? DEFAULT_VALIDATOR_SCOPE,
+    targets: options.targets ?? [],
+    candidatePolicy,
+  }).selectedPaths;
 };
 
 export const classifyPath = (

--- a/calculogic-validator/naming/src/naming-validator.logic.mjs
+++ b/calculogic-validator/naming/src/naming-validator.logic.mjs
@@ -224,6 +224,7 @@ export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   return collectValidatorCandidatePaths(rootDirectory, {
     scope: options.scope ?? DEFAULT_VALIDATOR_SCOPE,
     targets: options.targets ?? [],
+    skipSymlinkedCandidateScopeRoots: true,
     candidatePolicy,
   }).selectedPaths;
 };

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -13,7 +13,6 @@ import {
   parseCanonicalName,
   getSpecialCaseType,
   isAllowedSpecialCase,
-  collectRepositoryPaths as collectRepositoryPathsRuntime,
   classifyPath as classifyPathRuntime,
   runNamingValidator as runNamingValidatorRuntime,
   listNamingValidatorScopes,
@@ -22,11 +21,9 @@ import {
 } from './naming-validator.logic.mjs';
 import { projectNamingSemanticFamilyBridge } from './naming-semantic-family-bridge-projection.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from './naming-semantic-evidence-bridge.logic.mjs';
-import {
-  normalizePath,
-  resolveScopedTargets,
-  filterScopedPathsByTargets,
-} from '../../src/core/scoped-target-paths.logic.mjs';
+import { normalizePath } from '../../src/core/scoped-target-paths.logic.mjs';
+import { collectValidatorCandidatePaths } from '../../src/core/validator-candidate-collection.logic.mjs';
+import { createValidatorCandidatePolicyFromValues } from '../../src/core/validator-candidate-policy.logic.mjs';
 import { DEFAULT_VALIDATOR_SCOPE } from '../../src/core/validator-scopes.logic.mjs';
 
 export const prepareNamingRuntimeInputs = (config) => {
@@ -49,25 +46,53 @@ export const prepareNamingRuntimeInputs = (config) => {
   };
 };
 
+const createNamingCandidatePolicy = ({
+  reportableExtensions,
+  reportableRootFiles,
+  walkExclusions,
+}) =>
+  createValidatorCandidatePolicyFromValues({
+    candidateExtensions: reportableExtensions,
+    candidateRootFiles: reportableRootFiles,
+    walkExclusions,
+  });
+
+const collectNamingCandidatePaths = (repositoryRoot, {
+  scope,
+  targets = [],
+  reportableExtensions,
+  reportableRootFiles,
+  walkExclusions,
+}) =>
+  collectValidatorCandidatePaths(repositoryRoot, {
+    scope,
+    targets,
+    candidatePolicy: createNamingCandidatePolicy({
+      reportableExtensions,
+      reportableRootFiles,
+      walkExclusions,
+    }),
+  });
+
 export const prepareNamingValidatorInputs = (
   repositoryRoot,
   { scope, config, targets } = {},
 ) => {
   const runtimeInputs = prepareNamingRuntimeInputs(config);
   const selectedScope = scope ?? DEFAULT_VALIDATOR_SCOPE;
-  const inScopePaths = collectRepositoryPathsRuntime(repositoryRoot, {
+  const candidatePaths = collectNamingCandidatePaths(repositoryRoot, {
     scope: selectedScope,
+    targets: targets ?? [],
     reportableExtensions: runtimeInputs.reportableExtensions,
     reportableRootFiles: runtimeInputs.reportableRootFiles,
     walkExclusions: runtimeInputs.walkExclusions,
   });
-  const resolvedTargets = resolveScopedTargets(repositoryRoot, targets ?? []);
 
   return {
     ...runtimeInputs,
-    scope: selectedScope,
-    selectedPaths: filterScopedPathsByTargets(repositoryRoot, inScopePaths, resolvedTargets),
-    targets: resolvedTargets.map((target) => target.relPath),
+    scope: candidatePaths.scope,
+    selectedPaths: candidatePaths.selectedPaths,
+    targets: candidatePaths.targets,
   };
 };
 
@@ -85,12 +110,13 @@ export const runNamingValidator = (repositoryRoot, { scope, config, targets } = 
 export const collectRepositoryPaths = (rootDirectory, options = {}) => {
   const runtimeInputs = prepareNamingRuntimeInputs(options.config);
 
-  return collectRepositoryPathsRuntime(rootDirectory, {
-    ...options,
+  return collectNamingCandidatePaths(rootDirectory, {
+    scope: options.scope,
+    targets: options.targets ?? [],
     reportableExtensions: options.reportableExtensions ?? runtimeInputs.reportableExtensions,
     reportableRootFiles: options.reportableRootFiles ?? runtimeInputs.reportableRootFiles,
     walkExclusions: options.walkExclusions ?? runtimeInputs.walkExclusions,
-  });
+  }).selectedPaths;
 };
 
 export const classifyPath = (relativePath, namingRolesRuntime, options = {}) => {

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -67,6 +67,7 @@ const collectNamingCandidatePaths = (repositoryRoot, {
   collectValidatorCandidatePaths(repositoryRoot, {
     scope,
     targets,
+    skipSymlinkedCandidateScopeRoots: true,
     candidatePolicy: createNamingCandidatePolicy({
       reportableExtensions,
       reportableRootFiles,

--- a/calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs
+++ b/calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs
@@ -23,7 +23,12 @@ const collectPathsFromScopeRoot = (
     return [];
   }
 
-  if (skipSymlinkedCandidateScopeRoots && fs.lstatSync(absoluteRoot).isSymbolicLink()) {
+  const isRepositoryRootScope = path.normalize(scopeRoot) === '.';
+  if (
+    skipSymlinkedCandidateScopeRoots &&
+    !isRepositoryRootScope &&
+    fs.lstatSync(absoluteRoot).isSymbolicLink()
+  ) {
     return [];
   }
 

--- a/calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs
+++ b/calculogic-validator/src/core/suite-scoped-snapshot-input.logic.mjs
@@ -12,10 +12,18 @@ const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.locale
 const collectPathsFromScopeRoot = (
   repositoryRoot,
   scopeRoot,
-  { walkExcludedDirectories = new Set(), skipDotDirectories = true } = {},
+  {
+    walkExcludedDirectories = new Set(),
+    skipDotDirectories = true,
+    skipSymlinkedCandidateScopeRoots = false,
+  } = {},
 ) => {
   const absoluteRoot = path.resolve(repositoryRoot, scopeRoot);
   if (!fs.existsSync(absoluteRoot)) {
+    return [];
+  }
+
+  if (skipSymlinkedCandidateScopeRoots && fs.lstatSync(absoluteRoot).isSymbolicLink()) {
     return [];
   }
 
@@ -81,6 +89,7 @@ export const collectSuiteScopedPaths = (
     scope,
     walkExcludedDirectories = new Set(),
     skipDotDirectories = true,
+    skipSymlinkedCandidateScopeRoots = false,
   } = {},
 ) => {
   const selectedScope = scope ?? DEFAULT_VALIDATOR_SCOPE;
@@ -94,6 +103,7 @@ export const collectSuiteScopedPaths = (
     collectPathsFromScopeRoot(repositoryRoot, scopeRoot, {
       walkExcludedDirectories,
       skipDotDirectories,
+      skipSymlinkedCandidateScopeRoots,
     }),
   );
   const rootFilePaths = collectPathsFromRootFiles(repositoryRoot, profile.includeRootFiles);
@@ -113,12 +123,14 @@ export const collectSuiteScopedSnapshotInputs = (
     targets = [],
     walkExcludedDirectories = new Set(),
     skipDotDirectories = true,
+    skipSymlinkedCandidateScopeRoots = false,
   } = {},
 ) => {
   const scopedCollection = collectSuiteScopedPaths(repositoryRoot, {
     scope,
     walkExcludedDirectories,
     skipDotDirectories,
+    skipSymlinkedCandidateScopeRoots,
   });
   const resolvedTargets = resolveScopedTargets(repositoryRoot, targets);
 

--- a/calculogic-validator/src/core/validator-candidate-collection.logic.mjs
+++ b/calculogic-validator/src/core/validator-candidate-collection.logic.mjs
@@ -22,6 +22,7 @@ export const collectValidatorCandidatePaths = (
     scope,
     targets = [],
     candidatePolicy,
+    skipSymlinkedCandidateScopeRoots = false,
   } = {},
 ) => {
   const normalizedPolicy = normalizeValidatorCandidatePolicy(candidatePolicy);
@@ -31,6 +32,7 @@ export const collectValidatorCandidatePaths = (
     targets,
     walkExcludedDirectories: policySets.walkExcludedDirectories,
     skipDotDirectories: policySets.skipDotDirectories,
+    skipSymlinkedCandidateScopeRoots,
   });
   const inScopeCandidatePaths = filterValidatorCandidatePaths(
     scopedSnapshot.inScopePaths,

--- a/calculogic-validator/src/core/validator-candidate-policy.contracts.mjs
+++ b/calculogic-validator/src/core/validator-candidate-policy.contracts.mjs
@@ -1,6 +1,6 @@
 const normalizeCandidateToken = (value) => String(value ?? '').trim();
 
-const normalizeUniqueSortedStrings = (values, fieldName) => {
+const normalizeUniqueSortedStrings = (values, fieldName, { allowEmpty = false } = {}) => {
   if (!values || typeof values[Symbol.iterator] !== 'function') {
     throw new Error(`Validator candidate policy requires iterable ${fieldName}.`);
   }
@@ -8,8 +8,10 @@ const normalizeUniqueSortedStrings = (values, fieldName) => {
   const normalizedValues = [];
   for (const value of values) {
     const normalizedValue = normalizeCandidateToken(value);
-    if (!normalizedValue) {
-      throw new Error(`Validator candidate policy ${fieldName} entries must be non-empty strings.`);
+    if (!normalizedValue && !allowEmpty) {
+      throw new Error(
+        `Validator candidate policy ${fieldName} entries must be non-empty strings.`,
+      );
     }
 
     normalizedValues.push(normalizedValue);
@@ -30,7 +32,9 @@ export const normalizeValidatorCandidatePolicy = ({
 
   return Object.freeze({
     candidateExtensions: Object.freeze(
-      normalizeUniqueSortedStrings(candidateExtensions ?? [], 'candidateExtensions'),
+      normalizeUniqueSortedStrings(candidateExtensions ?? [], 'candidateExtensions', {
+        allowEmpty: true,
+      }),
     ),
     candidateRootFiles: Object.freeze(
       normalizeUniqueSortedStrings(candidateRootFiles ?? [], 'candidateRootFiles'),

--- a/calculogic-validator/test/suite-scoped-snapshot-input.test.mjs
+++ b/calculogic-validator/test/suite-scoped-snapshot-input.test.mjs
@@ -53,3 +53,25 @@ test('suite scoped snapshot helper applies target filtering after scoped collect
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
 });
+
+test('suite scoped snapshot helper keeps existing symlinked scope-root traversal by default', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'suite-scoped-snapshot-symlink-'));
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'suite-scoped-snapshot-outside-'));
+
+  try {
+    await fs.writeFile(
+      path.join(outsideDir, 'outside.logic.ts'),
+      'export const outside = true;\n',
+      'utf8',
+    );
+    await fs.symlink(outsideDir, path.join(fixtureDir, 'src'), 'dir');
+
+    const snapshot = collectSuiteScopedSnapshotInputs(fixtureDir, { scope: 'app' });
+
+    assert.deepEqual(snapshot.inScopePaths, ['src/outside.logic.ts']);
+    assert.deepEqual(snapshot.selectedPaths, ['src/outside.logic.ts']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
+++ b/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
@@ -229,6 +229,40 @@ test('suite-core candidate helper reproduces current Naming scoped candidate col
   }
 });
 
+test('Naming candidate helper skips symlinked scoped roots to preserve legacy walk behavior', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'naming-symlink-scope-'));
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'naming-symlink-outside-'));
+
+  try {
+    await writeFixtureFile(outsideDir, 'outside.logic.ts', 'export const outside = true;\n');
+    await fs.symlink(outsideDir, path.join(fixtureDir, 'src'), 'dir');
+    await writeFixtureFile(fixtureDir, 'test/inside.test.js', 'export const inside = true;\n');
+
+    const runtimeInputs = prepareNamingRuntimeInputs();
+    const legacyAppPaths = collectLegacyNamingRepositoryPaths(fixtureDir, {
+      scope: 'app',
+      reportableExtensions: runtimeInputs.reportableExtensions,
+      reportableRootFiles: runtimeInputs.reportableRootFiles,
+      walkExclusions: runtimeInputs.walkExclusions,
+    });
+    const namingAppPaths = collectNamingRepositoryPaths(fixtureDir, { scope: 'app' });
+    const directCandidatePaths = collectValidatorCandidatePaths(fixtureDir, {
+      scope: 'app',
+      skipSymlinkedCandidateScopeRoots: true,
+      candidatePolicy: createNamingCandidatePolicy(),
+    });
+
+    assert.deepEqual(legacyAppPaths, ['test/inside.test.js']);
+    assert.deepEqual(namingAppPaths, legacyAppPaths);
+    assert.deepEqual(directCandidatePaths.selectedPaths, legacyAppPaths);
+    assert.equal(namingAppPaths.includes('src/outside.logic.ts'), false);
+    assert.equal(namingAppPaths.some((selectedPath) => selectedPath.startsWith('src/')), false);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
 test('suite-core candidate helper reproduces current Naming target filtering', async () => {
   const fixtureDir = await createCandidateFixture();
 

--- a/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
+++ b/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
@@ -263,6 +263,39 @@ test('Naming candidate helper skips symlinked scoped roots to preserve legacy wa
   }
 });
 
+test('Naming candidate helper follows symlinked repository root for repo scope', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'naming-symlink-repo-real-'));
+  const linkParentDir = await fs.mkdtemp(path.join(os.tmpdir(), 'naming-symlink-repo-link-parent-'));
+  const repositoryLink = path.join(linkParentDir, 'repository-link');
+
+  try {
+    await writeFixtureFile(fixtureDir, 'package.json', '{}\n');
+    await writeFixtureFile(fixtureDir, 'src/app.logic.mjs', 'export const app = true;\n');
+    await fs.symlink(fixtureDir, repositoryLink, 'dir');
+
+    const runtimeInputs = prepareNamingRuntimeInputs();
+    const legacyRepoPaths = collectLegacyNamingRepositoryPaths(repositoryLink, {
+      scope: 'repo',
+      reportableExtensions: runtimeInputs.reportableExtensions,
+      reportableRootFiles: runtimeInputs.reportableRootFiles,
+      walkExclusions: runtimeInputs.walkExclusions,
+    });
+    const namingRepoPaths = collectNamingRepositoryPaths(repositoryLink, { scope: 'repo' });
+    const directCandidatePaths = collectValidatorCandidatePaths(repositoryLink, {
+      scope: 'repo',
+      skipSymlinkedCandidateScopeRoots: true,
+      candidatePolicy: createNamingCandidatePolicy(),
+    });
+
+    assert.deepEqual(legacyRepoPaths, ['package.json', 'src/app.logic.mjs']);
+    assert.deepEqual(namingRepoPaths, legacyRepoPaths);
+    assert.deepEqual(directCandidatePaths.selectedPaths, legacyRepoPaths);
+  } finally {
+    await fs.rm(linkParentDir, { recursive: true, force: true });
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('suite-core candidate helper reproduces current Naming target filtering', async () => {
   const fixtureDir = await createCandidateFixture();
 

--- a/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
+++ b/calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,14 +8,94 @@ import {
   collectRepositoryPaths as collectNamingRepositoryPaths,
   prepareNamingRuntimeInputs,
   prepareNamingValidatorInputs,
+  runNamingValidator,
+  summarizeFindings,
 } from '../naming/src/naming-validator.wiring.mjs';
+import { runNamingValidator as runNamingValidatorRuntime } from '../naming/src/naming-validator.logic.mjs';
 import { createValidatorCandidatePolicyFromValues } from '../src/core/validator-candidate-policy.logic.mjs';
 import { collectValidatorCandidatePaths } from '../src/core/validator-candidate-collection.logic.mjs';
+import {
+  DEFAULT_VALIDATOR_SCOPE,
+  getValidatorScopeProfile,
+} from '../src/core/validator-scopes.logic.mjs';
+import {
+  filterScopedPathsByProfile,
+  filterScopedPathsByTargets,
+  normalizePath,
+  resolveScopedTargets,
+} from '../src/core/scoped-target-paths.logic.mjs';
 
 const writeFixtureFile = async (fixtureDir, relativePath, content = 'fixture\n') => {
   const absolutePath = path.join(fixtureDir, relativePath);
   await fs.mkdir(path.dirname(absolutePath), { recursive: true });
   await fs.writeFile(absolutePath, content, 'utf8');
+};
+
+const sortPaths = (paths) => Array.from(paths).sort((left, right) => left.localeCompare(right));
+
+const isLegacyNamingReportablePath = (relativePath, reportableExtensions, reportableRootFiles) =>
+  reportableExtensions.has(path.extname(relativePath)) ||
+  reportableRootFiles.has(path.basename(relativePath));
+
+const collectLegacyNamingWalkPaths = (repositoryRoot, options = {}) => {
+  const absoluteRoot = path.resolve(repositoryRoot);
+  if (!fsSync.existsSync(absoluteRoot) || !fsSync.statSync(absoluteRoot).isDirectory()) {
+    return [];
+  }
+
+  const collected = [];
+  const walk = (absoluteDirectoryPath) => {
+    for (const entry of fsSync.readdirSync(absoluteDirectoryPath, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (options.walkExclusions.excludedDirectories.has(entry.name)) {
+          continue;
+        }
+
+        if (entry.name.startsWith('.') && options.walkExclusions.skipDotDirectories) {
+          continue;
+        }
+
+        walk(path.join(absoluteDirectoryPath, entry.name));
+        continue;
+      }
+
+      const relativePath = normalizePath(
+        path.relative(repositoryRoot, path.join(absoluteDirectoryPath, entry.name)),
+      );
+      if (
+        isLegacyNamingReportablePath(
+          relativePath,
+          options.reportableExtensions,
+          options.reportableRootFiles,
+        )
+      ) {
+        collected.push(relativePath);
+      }
+    }
+  };
+
+  walk(absoluteRoot);
+  return collected;
+};
+
+const collectLegacyNamingRepositoryPaths = (repositoryRoot, options = {}) => {
+  const selectedScope = options.scope ?? DEFAULT_VALIDATOR_SCOPE;
+  const profile = getValidatorScopeProfile(selectedScope);
+  if (!profile) {
+    throw new Error(`Invalid scope profile: ${selectedScope}`);
+  }
+
+  const allReportablePaths = collectLegacyNamingWalkPaths(repositoryRoot, options);
+  if (selectedScope === 'repo') {
+    return sortPaths(new Set(allReportablePaths));
+  }
+
+  return filterScopedPathsByProfile(allReportablePaths, profile);
+};
+
+const filterLegacyNamingPathsByTargets = (repositoryRoot, relativePaths, targets = []) => {
+  const resolvedTargets = resolveScopedTargets(repositoryRoot, targets);
+  return filterScopedPathsByTargets(repositoryRoot, relativePaths, resolvedTargets);
 };
 
 const createCandidateFixture = async () => {
@@ -55,12 +136,31 @@ const createNamingCandidatePolicy = (overrides = {}) => {
 
 const assertNamingCandidateParity = (fixtureDir, options = {}) => {
   const candidatePolicy = createNamingCandidatePolicy(options);
-  const oldNamingPaths = collectNamingRepositoryPaths(fixtureDir, {
+  const oldNamingPaths = collectLegacyNamingRepositoryPaths(fixtureDir, {
     scope: options.scope,
-    reportableExtensions: options.reportableExtensions,
-    reportableRootFiles: options.reportableRootFiles,
-    walkExclusions: options.walkExclusions,
+    reportableExtensions:
+      options.reportableExtensions ?? new Set(candidatePolicy.candidateExtensions),
+    reportableRootFiles:
+      options.reportableRootFiles ?? new Set(candidatePolicy.candidateRootFiles),
+    walkExclusions:
+      options.walkExclusions ?? {
+        excludedDirectories: new Set(candidatePolicy.walkExcludedDirectories),
+        skipDotDirectories: candidatePolicy.skipDotDirectories,
+      },
   });
+
+  assert.deepEqual(
+    collectNamingRepositoryPaths(fixtureDir, {
+      scope: options.scope,
+      targets: options.targets,
+      reportableExtensions: options.reportableExtensions,
+      reportableRootFiles: options.reportableRootFiles,
+      walkExclusions: options.walkExclusions,
+    }),
+    options.targets?.length
+      ? filterLegacyNamingPathsByTargets(fixtureDir, oldNamingPaths, options.targets)
+      : oldNamingPaths,
+  );
   const newCandidatePaths = collectValidatorCandidatePaths(fixtureDir, {
     scope: options.scope,
     targets: options.targets,
@@ -68,12 +168,10 @@ const assertNamingCandidateParity = (fixtureDir, options = {}) => {
   });
 
   if (options.targets?.length) {
-    const oldPreparedInputs = prepareNamingValidatorInputs(fixtureDir, {
-      scope: options.scope,
-      targets: options.targets,
-    });
-
-    assert.deepEqual(newCandidatePaths.selectedPaths, oldPreparedInputs.selectedPaths);
+    assert.deepEqual(
+      newCandidatePaths.selectedPaths,
+      filterLegacyNamingPathsByTargets(fixtureDir, oldNamingPaths, options.targets),
+    );
   } else {
     assert.deepEqual(newCandidatePaths.selectedPaths, oldNamingPaths);
   }
@@ -173,6 +271,78 @@ test('suite-core candidate helper preserves current Naming root-file and sorting
       'package.json',
       'src/app.logic.ts',
     ]);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('Naming candidate helper migration preserves config overlay extension additions', async () => {
+  const fixtureDir = await createCandidateFixture();
+
+  try {
+    await writeFixtureFile(fixtureDir, 'src/overlay.customext', 'overlay\n');
+
+    const defaultPrepared = prepareNamingValidatorInputs(fixtureDir, { scope: 'app' });
+    const overlayPrepared = prepareNamingValidatorInputs(fixtureDir, {
+      scope: 'app',
+      config: { naming: { reportableExtensions: { add: ['.customext'] } } },
+    });
+
+    assert.equal(defaultPrepared.selectedPaths.includes('src/overlay.customext'), false);
+    assert.equal(overlayPrepared.selectedPaths.includes('src/overlay.customext'), true);
+    assert.deepEqual(
+      overlayPrepared.selectedPaths,
+      [
+        'src/app.logic.ts',
+        'src/App.tsx',
+        'src/data.json',
+        'src/overlay.customext',
+        'src/style.css',
+        'test/app.test.js',
+      ],
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('Naming report findings and summaries remain stable when selected paths come from suite-core helper', async () => {
+  const fixtureDir = await createCandidateFixture();
+
+  try {
+    const prepared = prepareNamingValidatorInputs(fixtureDir, {
+      scope: 'validator',
+      targets: ['calculogic-validator/src/core'],
+    });
+    const legacySelectedPaths = filterLegacyNamingPathsByTargets(
+      fixtureDir,
+      collectLegacyNamingRepositoryPaths(fixtureDir, {
+        scope: 'validator',
+        reportableExtensions: prepared.reportableExtensions,
+        reportableRootFiles: prepared.reportableRootFiles,
+        walkExclusions: prepared.walkExclusions,
+      }),
+      ['calculogic-validator/src/core'],
+    );
+
+    assert.deepEqual(prepared.selectedPaths, legacySelectedPaths);
+
+    const migratedReport = runNamingValidator(fixtureDir, {
+      scope: 'validator',
+      targets: ['calculogic-validator/src/core'],
+    });
+    const legacyReport = runNamingValidatorRuntime({
+      ...prepared,
+      selectedPaths: legacySelectedPaths,
+      targets: ['calculogic-validator/src/core'],
+    });
+    const migratedSummary = summarizeFindings(migratedReport.findings);
+    const legacySummary = summarizeFindings(legacyReport.findings);
+
+    assert.deepEqual(migratedReport.findings, legacyReport.findings);
+    assert.equal(migratedReport.totalFilesScanned, legacyReport.totalFilesScanned);
+    assert.deepEqual(migratedReport.filters, legacyReport.filters);
+    assert.deepEqual(migratedSummary, legacySummary);
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -1221,6 +1221,29 @@ test('tree-structure-advisor scope collection follows suite profiles uniformly, 
   }
 });
 
+test('tree-structure-advisor keeps current symlinked scope-root traversal behavior', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-scope-symlink-'));
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-scope-symlink-outside-'));
+
+  try {
+    await fs.mkdir(path.join(fixtureDir, 'test'), { recursive: true });
+    await fs.writeFile(path.join(fixtureDir, 'test', 'inside.test.js'), 'export const inside = true;\n', 'utf8');
+    await fs.writeFile(
+      path.join(outsideDir, 'outside.logic.ts'),
+      'export const outside = true;\n',
+      'utf8',
+    );
+    await fs.symlink(outsideDir, path.join(fixtureDir, 'src'), 'dir');
+
+    const prepared = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'app' });
+
+    assert.deepEqual(prepared.selectedPaths, ['src/outside.logic.ts', 'test/inside.test.js']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor rejects invalid scope deterministically', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-invalid-scope-'));
 


### PR DESCRIPTION
### Motivation
- Replace Naming’s local repository walk with the suite-core candidate-collection helper to remove duplicated traversal logic while preserving Naming as the source-of-truth for candidate policy values (extensions, root files, walk exclusions, dot-dir behavior, scope, and targets). 
- Keep a behavior-preserving migration so selected-paths, findings, summaries, exit behavior, and config overlay semantics remain unchanged.

### Description
- Wiring: Naming now builds a Naming-owned candidate policy from `reportableExtensions`, `reportableRootFiles`, and `walkExclusions` and passes it into the suite helper `collectValidatorCandidatePaths` to obtain `selectedPaths` and related descriptors; `prepareNamingValidatorInputs` and `collectRepositoryPaths` were updated to use that helper. (files: `calculogic-validator/naming/src/naming-validator.wiring.mjs`, `calculogic-validator/naming/src/naming-validator.logic.mjs`)
- Runtime: removed the runtime-local repository walk used for candidate collection and delegated deterministic candidate collection to suite-core. (file: `calculogic-validator/naming/src/naming-validator.logic.mjs`)
- Contract tweak: allowed an empty-string extension token in the suite candidate-policy normalizer to preserve reportable dot-file semantics (keeps dot-file behavior stable). (file: `calculogic-validator/src/core/validator-candidate-policy.contracts.mjs`)
- Tests: added/updated compatibility tests that preserve the legacy Naming walk as a test-only fixture and assert parity of selected paths, target filtering, root-file/extension handling, walk exclusion/dot-directory semantics, stable sorting/dedupe, config overlay extension additions, and report/findings/summary parity. (file: `calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs`)
- Ownership: Naming remains authoritative for candidate values and config overlay (`naming.reportableExtensions.add` etc.); no registry authority was moved to suite-core.
- Commit: change committed with message "Migrate Naming candidate collection to suite helper" (branch commit id: `89158a4`).

### Testing
- Commands run and outcomes (exact commands used):
  - `node --test calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs calculogic-validator/test/suite-scoped-snapshot-input.test.mjs` — PASS
  - `node --test calculogic-validator/naming/test/*.test.mjs` — PASS
  - `node --test calculogic-validator/test/*.test.mjs calculogic-validator/naming/test/*.test.mjs calculogic-validator/tree/test/*.test.mjs` — PASS
  - `node --test calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs calculogic-validator/naming/test/naming-walk-exclusions-registry.test.mjs` — PASS (final check)
  - `npm run validate:naming -- --scope=validator --target calculogic-validator/src/core` — PASS (naming run on core target)
  - `npm run validate:naming -- --scope=validator --target calculogic-validator/naming` — EXIT 2 (expected due to existing Naming findings/warnings in the naming slice itself; no scope broadening was performed in this PR)
  - `npm run validate:tree -- --scope=validator --target calculogic-validator/src/core` — PASS
- Automated test highlights proving parity and preservation:
  - Selected-path parity tests: `calculogic-validator/test/validator-candidate-collection.naming-compatibility.test.mjs` (repo/app/validator scopes, target filtering, root-file and extension combinations, sorting/dedupe, walk-exclusions, dot-dir behavior).
  - Report / findings / summary parity tests: added assertions in `validator-candidate-collection.naming-compatibility.test.mjs` that compare `runNamingValidator` results when selected paths are produced by the suite helper vs legacy walk, and `naming` slice unit tests remain green.
  - Config overlay behavior: compatibility test includes a case that verifies `naming.reportableExtensions.add` still causes the overlay extension to be included in selected paths.
- Result summary: all modified and related validator and naming test suites passed after the migration; the only non-zero exit observed was the expected `validate:naming` run against the naming slice itself (exit 2) caused by pre-existing naming warnings in that target, which is unrelated to the migration mechanics.

Refs #581
Refs #579
Refs #578

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23738f2bcc8331a2b242b8984c4817)