### PR TITLE
Add data-only validator registry metadata

### DIFF
--- a/calculogic-validator/doc/Audits/validator-repeatable-slice-infrastructure.audit.md
+++ b/calculogic-validator/doc/Audits/validator-repeatable-slice-infrastructure.audit.md
@@ -355,9 +355,13 @@ A follow-up child issue for validator registry metadata hardening should be acce
 7. No runtime behavior, report shape, exit behavior, package scripts, bins, Naming interpretation, or Tree interpretation changes.
 8. The PR body records exact verification commands and outcomes.
 
-## Later / not worth it yet
+## Implementation note for child issue #588
 
-Not worth doing before registry metadata hardening:
+Current implementation reality after #588: suite-core validator registry entries include bounded data-only metadata for Naming and Tree registration surfaces. This metadata makes current command/report/bin expectations, default `validate:all` inclusion, report-capture prefixes, and the Naming → Tree bridge relationship inspectable without changing runtime dispatch, report shape, exit-code behavior, package scripts, package bins, Naming behavior, Tree behavior, or candidate behavior.
+
+## Later / not worth in this metadata slice
+
+Not worth doing as part of the data-only registry metadata slice:
 
 - adding `calculogic-validate-tree` or changing package bins;
 - changing `calculogic-validate` to support `--target`;
@@ -380,14 +384,14 @@ Potential later slices after registry metadata hardening:
 
 ## Parent #585 recommendation
 
-Parent #585 should remain open after this audit long enough to create the next implementation child for **validator registry metadata hardening**. After that implementation child is accepted or explicitly queued, parent #585 can be summarized with:
+Parent #585 should remain open for human-owner review and manual closure. After child issue #588 is accepted, parent #585 can be summarized with:
 
 - current runtime truth: scope, target, candidate, report-output, report-meta, report-capture, and exit-code mechanics are already sufficiently repeatable for current slices;
-- current implementation reality: validator registry metadata and command/bin/report identity alignment remain under-hardened;
-- staged implementation path: harden registry metadata first, then use that metadata to decide whether command/bin/report-profile alignment is worth a separate child;
+- current implementation reality: validator registry metadata now exposes bounded data-only identity, command/report/bin, runner inclusion, report-capture, bridge, and compatibility expectations for current Naming and Tree registration surfaces;
+- staged implementation path: use the registry metadata to decide whether command/bin/report-profile alignment is worth a separate child;
 - not current runtime truth: no universal plugin architecture, no suite-core ownership of Naming/Tree interpretation policy, no package-consumer invocation model decision, and no report/exit behavior migration.
 
-Use `Refs #586`, `Refs #585`, and `Refs #579` in PR and parent notes. Do not use closing keywords; the human owner should close #586 and #585 manually after review.
+Use `Refs #588`, `Refs #586`, and `Refs #585` in PR and parent notes. Do not use closing keywords; the human owner should close #588, #586, and #585 manually after review.
 
 ## Evidence
 
@@ -436,7 +440,7 @@ Required inspection targets were reviewed across:
 - Root package scripts expose repo-local validator workflows and report capture commands in `package.json`.
 - Validator package exports and bins expose suite-core, registry, scopes, Naming, Tree, full-suite, Naming-only, and health surfaces in `calculogic-validator/package.json`.
 - `calculogic-validator/src/index.mjs` exports runner, registry, and report contract surfaces.
-- `calculogic-validator/src/core/validator-registry.knowledge.mjs` registers only `id`, `description`, and `run`, with id list/get helpers.
+- `calculogic-validator/src/core/validator-registry.knowledge.mjs` now registers behavior-driving `id`, `description`, and `run` fields plus bounded data-only metadata for slice identity, command/report/bin expectations, default runner inclusion, report capture prefixes, bridge relationships, and compatibility expectations; id list/get helpers remain unchanged.
 - `calculogic-validator/src/core/validator-runner.logic.mjs` owns selected-validator resolution, report-entry assembly, runner envelope, and current Naming → Tree staged bridge mechanics.
 - `calculogic-validator/src/core/validator-report.contracts.mjs` documents the current runner report contract and pass-through summary/meta areas.
 - `calculogic-validator/src/core/validator-report-meta.logic.mjs` owns tool-version lookup, stable stringify, sha256, and config digest helpers.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
@@ -125,6 +125,29 @@ Only currently real, discoverable suite-owned surfaces are listed here.
   - policy registry canonicalization that belongs in loader/converter layers
 - **Reuse boundary type:** composition boundary reuse
 
+### 3.6 Entry: suite-core validator registry metadata surface
+
+- **Owner:** suite-core
+- **Path/area:** `calculogic-validator/src/core/validator-registry.knowledge.mjs`
+- **Concern:** data-only slice registration metadata for current validator-suite registration surfaces.
+- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the behavior-driving fields. Metadata is inspectable registration data and does not drive runner dispatch, report construction, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
+- **Reusable capability:**
+  - canonical slice identity metadata aligned to the registry id;
+  - report identity metadata aligned to current report entry id/validator id/description;
+  - repo-local npm command, direct script, package-bin availability, and report-capture prefix expectations;
+  - default `validate:all` runner inclusion and direct-runnable/runner-only capability metadata;
+  - bounded bridge metadata for the current Naming semantic-family bridge contribution consumed by Tree;
+  - compatibility expectation metadata for current report-mode and behavior-preserving registration.
+- **When to reuse:**
+  - inspecting current suite-core slice registration surfaces;
+  - adding a future validator slice that needs the same bounded registration facts;
+  - writing shape tests that prove command/report/bin expectations are explicit without changing scripts or bins.
+- **When not to reuse:**
+  - driving runtime runner selection, report shape, exit policy, or package command generation before a separate behavior-migration task explicitly scopes that change;
+  - storing slice-owned semantic interpretation policy, finding policy, Naming taxonomy, Tree placement policy, or candidate value authority in suite-core metadata;
+  - creating a universal plugin architecture or generic shared bucket.
+- **Reuse boundary type:** data-only registration metadata boundary
+
 ## 4) Guardrails
 
 - Do **not** invent shared helpers in this inventory that do not currently exist.

--- a/calculogic-validator/src/core/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/core/validator-registry.knowledge.mjs
@@ -66,11 +66,103 @@ export const VALIDATOR_REGISTRY = [
   {
     id: 'naming',
     description: 'Filename naming validator (report-mode).',
+    metadata: {
+      sliceId: 'naming',
+      report: {
+        entryId: 'naming',
+        validatorId: 'naming',
+        description: 'Filename naming validator (report-mode).',
+        mode: 'report',
+        profileId: 'naming',
+      },
+      commands: {
+        repoLocalNpmScript: 'validate:naming',
+        repoLocalNpmInvocation: 'npm run validate:naming --',
+        directScriptPath: 'calculogic-validator/scripts/validate-naming.host.mjs',
+      },
+      packageBin: {
+        expectedName: 'calculogic-validate-naming',
+        available: true,
+      },
+      runner: {
+        defaultIncludedInValidateAll: true,
+        directRunnable: true,
+        runnerOnly: false,
+        selectionId: 'naming',
+      },
+      bridge: {
+        provides: [
+          {
+            id: 'naming-semantic-family-bridge',
+            consumerValidatorIds: ['tree-structure-advisor'],
+            stagedBy: 'validator-runner',
+          },
+        ],
+        consumes: [],
+      },
+      reportCapture: {
+        profileId: 'naming',
+        scriptPattern: 'report:naming:<scope>',
+        prefixPattern: 'naming-<scope>',
+        scopes: ['repo', 'app', 'docs', 'validator', 'system'],
+      },
+      compatibility: {
+        behaviorPreservingMetadataOnly: true,
+        selectedByRegistryId: true,
+        reportShapeDrivenByRunner: true,
+      },
+    },
     run: runNamingValidatorHook,
   },
   {
     id: 'tree-structure-advisor',
     description: 'Repository tree structure advisory validator (report-only).',
+    metadata: {
+      sliceId: 'tree-structure-advisor',
+      report: {
+        entryId: 'tree-structure-advisor',
+        validatorId: 'tree-structure-advisor',
+        description: 'Repository tree structure advisory validator (report-only).',
+        mode: 'report',
+        profileId: 'tree-structure-advisor',
+      },
+      commands: {
+        repoLocalNpmScript: 'validate:tree',
+        repoLocalNpmInvocation: 'npm run validate:tree --',
+        directScriptPath: 'calculogic-validator/scripts/validate-tree.host.mjs',
+      },
+      packageBin: {
+        expectedName: 'calculogic-validate-tree',
+        available: false,
+      },
+      runner: {
+        defaultIncludedInValidateAll: true,
+        directRunnable: true,
+        runnerOnly: false,
+        selectionId: 'tree-structure-advisor',
+      },
+      bridge: {
+        provides: [],
+        consumes: [
+          {
+            id: 'naming-semantic-family-bridge',
+            providerValidatorId: 'naming',
+            stagedBy: 'validator-runner',
+          },
+        ],
+      },
+      reportCapture: {
+        profileId: 'tree-structure-advisor',
+        scriptPattern: 'report:tree:<scope>',
+        prefixPattern: 'validate-tree-<scope>',
+        scopes: ['repo', 'app', 'docs', 'validator', 'system'],
+      },
+      compatibility: {
+        behaviorPreservingMetadataOnly: true,
+        selectedByRegistryId: true,
+        reportShapeDrivenByRunner: true,
+      },
+    },
     run: runTreeStructureAdvisorHook,
   },
 ];

--- a/calculogic-validator/test/validator-registry.test.mjs
+++ b/calculogic-validator/test/validator-registry.test.mjs
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { VALIDATOR_REGISTRY, getValidatorById, listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
+import { runValidatorRunner } from '../src/core/validator-runner.logic.mjs';
+
+const rootPackageJson = JSON.parse(fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+const validatorPackageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+
+const expectedMetadataShapeKeys = [
+  'sliceId',
+  'report',
+  'commands',
+  'packageBin',
+  'runner',
+  'bridge',
+  'reportCapture',
+  'compatibility',
+];
+
+const expectedReportScopes = ['repo', 'app', 'docs', 'validator', 'system'];
+
+const visitFunctionPaths = (value, pathSegments = []) => {
+  if (typeof value === 'function') {
+    return [pathSegments.join('.')];
+  }
+
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, childValue]) =>
+    visitFunctionPaths(childValue, [...pathSegments, key]),
+  );
+};
+
+test('registry ordering and list helper remain stable', () => {
+  assert.deepEqual(
+    VALIDATOR_REGISTRY.map((validator) => validator.id),
+    ['naming', 'tree-structure-advisor'],
+  );
+  assert.deepEqual(listRegisteredValidators(), ['naming', 'tree-structure-advisor']);
+});
+
+test('get helper still returns registered validators by id and null for unknown ids', () => {
+  assert.equal(getValidatorById('naming')?.id, 'naming');
+  assert.equal(getValidatorById('tree-structure-advisor')?.id, 'tree-structure-advisor');
+  assert.equal(getValidatorById('missing-validator'), null);
+});
+
+test('all registered validators expose required data-only metadata fields', () => {
+  for (const validator of VALIDATOR_REGISTRY) {
+    assert.equal(typeof validator.id, 'string');
+    assert.equal(typeof validator.description, 'string');
+    assert.equal(typeof validator.run, 'function');
+    assert.deepEqual(Object.keys(validator.metadata), expectedMetadataShapeKeys);
+
+    assert.equal(validator.metadata.sliceId, validator.id);
+    assert.equal(validator.metadata.report.entryId, validator.id);
+    assert.equal(validator.metadata.report.validatorId, validator.id);
+    assert.equal(validator.metadata.report.description, validator.description);
+    assert.equal(validator.metadata.report.mode, 'report');
+    assert.equal(validator.metadata.runner.selectionId, validator.id);
+    assert.equal(validator.metadata.runner.defaultIncludedInValidateAll, true);
+    assert.equal(validator.metadata.runner.directRunnable, true);
+    assert.equal(validator.metadata.runner.runnerOnly, false);
+    assert.deepEqual(validator.metadata.reportCapture.scopes, expectedReportScopes);
+    assert.equal(validator.metadata.compatibility.behaviorPreservingMetadataOnly, true);
+    assert.equal(validator.metadata.compatibility.selectedByRegistryId, true);
+    assert.equal(validator.metadata.compatibility.reportShapeDrivenByRunner, true);
+  }
+});
+
+test('registry metadata command, report, and bin fields match current naming patterns and package surfaces', () => {
+  for (const validator of VALIDATOR_REGISTRY) {
+    const { commands, packageBin, report, reportCapture } = validator.metadata;
+
+    assert.match(commands.repoLocalNpmScript, /^validate:(?:naming|tree)$/u);
+    assert.equal(rootPackageJson.scripts[commands.repoLocalNpmScript]?.startsWith('node '), true);
+    assert.equal(commands.repoLocalNpmInvocation, `npm run ${commands.repoLocalNpmScript} --`);
+    assert.match(commands.directScriptPath, /^calculogic-validator\/scripts\/validate-[a-z-]+\.host\.mjs$/u);
+    assert.equal(fs.existsSync(path.join(process.cwd(), commands.directScriptPath)), true);
+
+    assert.match(report.profileId, /^[a-z][a-z0-9-]*$/u);
+    assert.equal(report.profileId, report.entryId);
+    assert.match(reportCapture.profileId, /^[a-z][a-z0-9-]*$/u);
+    assert.equal(reportCapture.profileId, report.profileId);
+    assert.match(reportCapture.scriptPattern, /^report:[a-z]+:<scope>$/u);
+    assert.match(reportCapture.prefixPattern, /^[a-z]+(?:-[a-z]+)*-<scope>$/u);
+
+    for (const scope of reportCapture.scopes) {
+      const scriptName = reportCapture.scriptPattern.replace('<scope>', scope);
+      const expectedPrefix = reportCapture.prefixPattern.replace('<scope>', scope);
+      assert.ok(rootPackageJson.scripts[scriptName], `${scriptName} should exist`);
+      assert.match(rootPackageJson.scripts[scriptName], new RegExp(`--prefix ${expectedPrefix}\\b`, 'u'));
+    }
+
+    assert.match(packageBin.expectedName, /^calculogic-validate(?:-[a-z]+)?$/u);
+    assert.equal(Boolean(validatorPackageJson.bin?.[packageBin.expectedName]), packageBin.available);
+  }
+});
+
+test('validate:all/default inclusion metadata matches current runner behavior', async () => {
+  const fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'validator-registry-default-'));
+
+  try {
+    const report = runValidatorRunner(fixtureRoot, { scope: 'repo' });
+    const defaultIncludedIds = VALIDATOR_REGISTRY.filter(
+      (validator) => validator.metadata.runner.defaultIncludedInValidateAll,
+    ).map((validator) => validator.id);
+
+    assert.deepEqual(
+      report.validators.map((validator) => validator.id),
+      defaultIncludedIds,
+    );
+  } finally {
+    await fsPromises.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('bridge metadata documents current Naming to Tree relationship without driving runner behavior', () => {
+  const namingMetadata = getValidatorById('naming').metadata;
+  const treeMetadata = getValidatorById('tree-structure-advisor').metadata;
+
+  assert.deepEqual(namingMetadata.bridge.provides, [
+    {
+      id: 'naming-semantic-family-bridge',
+      consumerValidatorIds: ['tree-structure-advisor'],
+      stagedBy: 'validator-runner',
+    },
+  ]);
+  assert.deepEqual(namingMetadata.bridge.consumes, []);
+  assert.deepEqual(treeMetadata.bridge.provides, []);
+  assert.deepEqual(treeMetadata.bridge.consumes, [
+    {
+      id: 'naming-semantic-family-bridge',
+      providerValidatorId: 'naming',
+      stagedBy: 'validator-runner',
+    },
+  ]);
+});
+
+test('registry metadata is serializable and only run hooks remain executable functions', () => {
+  for (const validator of VALIDATOR_REGISTRY) {
+    assert.doesNotThrow(() => JSON.stringify(validator.metadata));
+    assert.deepEqual(visitFunctionPaths(validator.metadata), []);
+    assert.deepEqual(visitFunctionPaths(validator), ['run']);
+    assert.equal(typeof validator.run, 'function');
+  }
+});


### PR DESCRIPTION
### Motivation
- Make the suite-core validator registry inspectable and future-slice-ready by adding bounded, data-only metadata to existing registry entries without changing runtime behavior.
- Provide a single, suite-owned place to record slice identity, command/report/bin expectations, default runner inclusion, and bridge relationships so future slices can register deterministically.

### Description
- Added a `metadata` object to each `VALIDATOR_REGISTRY` entry in `calculogic-validator/src/core/validator-registry.knowledge.mjs` with fields for `sliceId`, `report`, `commands`, `packageBin`, `runner`, `bridge`, `reportCapture`, and `compatibility` for the `naming` and `tree-structure-advisor` entries.
- Added focused tests in `calculogic-validator/test/validator-registry.test.mjs` that validate registry ordering, `list/get` helpers, metadata shape, id alignment, command/report/bin patterns against package surfaces, default `validate:all` inclusion, bridge metadata, and metadata serialization (ensuring only `run` remains executable).
- Documented the new registry metadata seam as a suite-core reusable surface in `calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md` and added a short implementation note to the audit `calculogic-validator/doc/Audits/validator-repeatable-slice-infrastructure.audit.md` describing the post-change reality.
- Preserved all existing runtime behavior and registry helper APIs (`listRegisteredValidators()` and `getValidatorById()` remain unchanged).

### Testing
- Ran focused registry tests: `node --test calculogic-validator/test/validator-registry.test.mjs` — PASS.
- Ran nearby compatibility tests: `node --test calculogic-validator/test/validator-runner.test.mjs calculogic-validator/test/validator-report-meta.test.mjs calculogic-validator/test/validator-exit-codes.test.mjs` — PASS.
- Ran the full validator and slice test suites: `node --test calculogic-validator/test/*.test.mjs calculogic-validator/naming/test/*.test.mjs calculogic-validator/tree/test/*.test.mjs` — PASS.
- Verified runtime CLI behavior: `npm run validate:naming -- --scope=validator --target calculogic-validator/src/core` — PASS (npm emitted a non-failing env warning); `npm run validate:tree -- --scope=validator --target calculogic-validator/src/core` — PASS (npm emitted a non-failing env warning).

Refs #588
Refs #585
Refs #586

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2475a2790c8331b4de14170ef37eba)