### PR TITLE
Align Naming direct report envelope mechanics

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSliceAndReportFormula.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSliceAndReportFormula.md
@@ -124,8 +124,8 @@ Report behavior requirements:
 | Summary | Slice owns summary meaning and summary buckets/counts. |
 | Counts | Slice should expose deterministic counts through `summary.counts` when available. |
 | Meta | Runtime normalized views and filter metadata may appear under `meta`; meta must not become competing policy truth. |
-| Report wrapping | Suite-core owns the runner report envelope and per-validator report-entry wrapping. |
-| Report id/description | Registry metadata should be the stable input for report identity. Existing wrappers may preserve current runtime truth until migrated. |
+| Report wrapping | Suite-core owns the runner report envelope, per-validator report-entry wrapping, and behavior-preserving direct-report envelope mechanics where exact parity tests prove current report shape remains stable. |
+| Report id/description | Registry metadata should be the stable input for report identity. Existing wrappers may preserve current runtime truth until migrated; migrated direct wrappers must preserve current report ids/descriptions unless a scoped behavior delta is explicitly accepted. |
 | Severity behavior | Slice-owned finding policy controls severity; this formula does not change severity behavior. |
 | Exit-code derivation | Suite-core derives exit code from findings and exit policy. Slices do not own suite exit-code mechanics. |
 | Stdout/stderr | CLI wrappers should keep deterministic JSON/report output behavior and route non-report diagnostics intentionally. |
@@ -138,7 +138,7 @@ Checklist:
 
 - [ ] Base runtime result shape is present.
 - [ ] Slice summary meaning remains slice-owned.
-- [ ] Suite-core wrapping remains the report envelope owner.
+- [ ] Suite-core wrapping remains the report envelope owner, including direct-report envelope mechanics where parity has been proven.
 - [ ] Exit-code derivation uses suite-core mechanics.
 - [ ] Metadata is deterministic and not competing policy truth.
 - [ ] Scope, target, and path fields are normalized and stable.

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
@@ -113,12 +113,15 @@ Only currently real, discoverable suite-owned surfaces are listed here.
 - **Path/area:**
   - `calculogic-validator/src/core/validator-report-meta.logic.mjs`
   - `calculogic-validator/src/core/source-snapshot.logic.mjs`
+  - `calculogic-validator/src/core/validator-direct-report.logic.mjs`
 - **Concern:** deterministic shared metadata helpers used in validator report envelopes.
 - **Reusable capability:**
   - tool version lookup and stable hashing/digest helpers for config/report metadata
   - git/filesystem source snapshot metadata capture for report reproducibility context
+  - direct validator report envelope mechanics for mode, validator identity, version, config digest, source snapshot, timestamps, and duration
 - **When to reuse:**
   - constructing validator or runner report envelopes that require suite-consistent metadata fields
+  - constructing direct validator reports that must preserve slice-owned findings and summaries while sharing suite-core envelope mechanics
   - computing deterministic config digest/fingerprint values used across validators
 - **When not to reuse:**
   - slice-specific finding logic or traversal mechanics
@@ -130,7 +133,7 @@ Only currently real, discoverable suite-owned surfaces are listed here.
 - **Owner:** suite-core
 - **Path/area:** `calculogic-validator/src/core/validator-registry.knowledge.mjs`
 - **Concern:** data-only slice registration metadata for current validator-suite registration surfaces.
-- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the behavior-driving fields. Metadata is inspectable registration data and does not drive runner dispatch, report construction, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
+- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the runner behavior-driving fields. Registry report metadata may drive behavior-preserving direct report identity fields where parity tests prove the emitted report stays stable. Other metadata remains inspectable registration data and does not drive runner dispatch, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
 - **Reusable capability:**
   - canonical slice identity metadata aligned to the registry id;
   - report identity metadata aligned to current report entry id/validator id/description;
@@ -141,9 +144,10 @@ Only currently real, discoverable suite-owned surfaces are listed here.
 - **When to reuse:**
   - inspecting current suite-core slice registration surfaces;
   - adding a future validator slice that needs the same bounded registration facts;
-  - writing shape tests that prove command/report/bin expectations are explicit without changing scripts or bins.
+  - writing shape tests that prove command/report/bin expectations are explicit without changing scripts or bins;
+  - sourcing direct report identity fields when exact parity coverage proves the current report shape is preserved.
 - **When not to reuse:**
-  - driving runtime runner selection, report shape, exit policy, or package command generation before a separate behavior-migration task explicitly scopes that change;
+  - driving runtime runner selection, broader report shape, exit policy, or package command generation before a separate behavior-migration task explicitly scopes that change;
   - storing slice-owned semantic interpretation policy, finding policy, Naming taxonomy, Tree placement policy, or candidate value authority in suite-core metadata;
   - creating a universal plugin architecture or generic shared bucket.
 - **Reuse boundary type:** data-only registration metadata boundary

--- a/calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-cli-runner.logic.mjs
@@ -6,6 +6,7 @@ import {
 } from '../../../src/core/validator-report-meta.logic.mjs';
 import { deriveExitCodeFromFindings } from '../../../src/core/validator-exit-code.logic.mjs';
 import { getSourceSnapshot } from '../../../src/core/source-snapshot.logic.mjs';
+import { getValidatorById } from '../../../src/core/validator-registry.knowledge.mjs';
 import {
   writeValidatorReportToStdout,
   setValidatorReportExitCode,
@@ -75,6 +76,7 @@ export const runNamingCli = ({ argv, usageLines, repositoryRoot, npmArgForwardin
     selectedScopeProfile,
     startedAtDate,
     endedAtDate,
+    registryEntry: getValidatorById('naming'),
   });
 
   const effectiveStrictExit = parsed.strict ? true : config?.strictExit === true;

--- a/calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs
@@ -1,3 +1,4 @@
+import { buildDirectValidatorReportEnvelope } from '../../../src/core/validator-direct-report.logic.mjs';
 import { summarizeFindings } from '../naming-validator.host.mjs';
 
 export const buildNamingValidatorReport = ({
@@ -12,16 +13,20 @@ export const buildNamingValidatorReport = ({
   selectedScopeProfile,
   startedAtDate,
   endedAtDate,
+  registryEntry,
 }) => {
   const summary = summarizeFindings(findings);
 
   return {
-    mode: 'report',
-    validatorId: 'naming',
-    toolVersion,
-    ...(toolVersion ? { validatorVersion: toolVersion } : {}),
-    ...(configDigest ? { configDigest } : {}),
-    sourceSnapshot,
+    ...buildDirectValidatorReportEnvelope({
+      registryEntry,
+      fallbackValidatorId: 'naming',
+      toolVersion,
+      configDigest,
+      sourceSnapshot,
+      startedAtDate,
+      endedAtDate,
+    }),
     ...(registry
       ? {
           registryState: registry.registryState,
@@ -29,9 +34,6 @@ export const buildNamingValidatorReport = ({
           registryDigests: registry.registryDigests,
         }
       : {}),
-    startedAt: startedAtDate.toISOString(),
-    endedAt: endedAtDate.toISOString(),
-    durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
     scope,
     totalFilesScanned,
     filters,

--- a/calculogic-validator/naming/test/naming-direct-report-parity.test.mjs
+++ b/calculogic-validator/naming/test/naming-direct-report-parity.test.mjs
@@ -1,0 +1,179 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { buildNamingValidatorReport } from '../src/cli/naming-report-builder.logic.mjs';
+import { summarizeFindings } from '../src/naming-validator.host.mjs';
+import { getValidatorById } from '../../src/core/validator-registry.knowledge.mjs';
+
+const fixedStartedAtDate = new Date('2026-01-02T03:04:05.000Z');
+const fixedEndedAtDate = new Date('2026-01-02T03:04:06.234Z');
+
+const stableSourceSnapshot = {
+  git: {
+    commit: 'test-commit',
+    branch: 'test-branch',
+    dirty: false,
+  },
+};
+
+const stableRegistry = {
+  registryState: 'builtin',
+  registrySource: 'builtin',
+  registryDigests: {
+    builtin: 'a'.repeat(64),
+    custom: 'b'.repeat(64),
+    resolved: 'c'.repeat(64),
+  },
+};
+
+const stableScopeProfile = {
+  description: 'Stable validator scope profile for direct report parity tests.',
+  includeRoots: ['calculogic-validator/src'],
+  includeRootFiles: ['package.json'],
+};
+
+const stableCanonicalFinding = {
+  code: 'NAMING_CANONICAL',
+  severity: 'info',
+  path: 'calculogic-validator/src/core/validator-direct-report.logic.mjs',
+  classification: 'canonical',
+  message: 'Filename is canonical.',
+  ruleRef: 'calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#core-filename-grammar',
+  details: {
+    semanticName: 'validator-direct-report',
+    role: 'logic',
+    extension: 'mjs',
+    roleStatus: 'active',
+    roleCategory: 'concern-core',
+    semanticTokens: ['validator', 'direct', 'report'],
+    semanticFamily: 'validator',
+    familyRoot: 'validator',
+    familySubgroup: 'direct-report',
+  },
+};
+
+const buildLegacyNamingDirectReportShape = ({ findings, configDigest }) => {
+  const summary = summarizeFindings(findings);
+
+  return {
+    mode: 'report',
+    validatorId: 'naming',
+    toolVersion: '0.1.0-test',
+    validatorVersion: '0.1.0-test',
+    ...(configDigest ? { configDigest } : {}),
+    sourceSnapshot: stableSourceSnapshot,
+    registryState: stableRegistry.registryState,
+    registrySource: stableRegistry.registrySource,
+    registryDigests: stableRegistry.registryDigests,
+    startedAt: fixedStartedAtDate.toISOString(),
+    endedAt: fixedEndedAtDate.toISOString(),
+    durationMs: fixedEndedAtDate.getTime() - fixedStartedAtDate.getTime(),
+    scope: 'validator',
+    totalFilesScanned: findings.length,
+    filters: { isFiltered: true, targets: ['calculogic-validator/src/core'] },
+    scopeSummary: {
+      scope: 'validator',
+      reportableFilesInScope: findings.length,
+      findingsGenerated: findings.length,
+    },
+    scopeContract: {
+      description: stableScopeProfile.description,
+      includeRoots: stableScopeProfile.includeRoots,
+      includeRootFiles: stableScopeProfile.includeRootFiles,
+    },
+    counts: summary.counts,
+    codeCounts: summary.codeCounts,
+    specialCaseTypeCounts: summary.specialCaseTypeCounts,
+    warningRoleStatusCounts: summary.warningRoleStatusCounts,
+    warningRoleCategoryCounts: summary.warningRoleCategoryCounts,
+    familyRootCounts: summary.familyRootCounts,
+    familySubgroupCounts: summary.familySubgroupCounts,
+    semanticFamilyCounts: summary.semanticFamilyCounts,
+    findings,
+  };
+};
+
+const buildCurrentNamingDirectReport = ({ findings, configDigest }) =>
+  buildNamingValidatorReport({
+    findings,
+    totalFilesScanned: findings.length,
+    scope: 'validator',
+    filters: { isFiltered: true, targets: ['calculogic-validator/src/core'] },
+    registry: stableRegistry,
+    toolVersion: '0.1.0-test',
+    ...(configDigest ? { configDigest } : {}),
+    sourceSnapshot: stableSourceSnapshot,
+    selectedScopeProfile: stableScopeProfile,
+    startedAtDate: fixedStartedAtDate,
+    endedAtDate: fixedEndedAtDate,
+    registryEntry: getValidatorById('naming'),
+  });
+
+test('Naming direct report builder preserves exact legacy shape when findings are present', () => {
+  assert.deepEqual(
+    buildCurrentNamingDirectReport({ findings: [stableCanonicalFinding] }),
+    buildLegacyNamingDirectReportShape({ findings: [stableCanonicalFinding] }),
+  );
+});
+
+test('Naming direct report builder preserves exact legacy shape when no findings are present', () => {
+  assert.deepEqual(
+    buildCurrentNamingDirectReport({ findings: [], configDigest: 'd'.repeat(64) }),
+    buildLegacyNamingDirectReportShape({ findings: [], configDigest: 'd'.repeat(64) }),
+  );
+});
+
+const runValidateNaming = (args) =>
+  spawnSync(
+    process.execPath,
+    [
+      '--experimental-strip-types',
+      'calculogic-validator/scripts/validate-naming.host.mjs',
+      ...args,
+    ],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+test('validate:naming direct stdout remains parseable JSON with findings present', () => {
+  const result = runValidateNaming([
+    '--scope=validator',
+    '--target=calculogic-validator/test/fixtures',
+  ]);
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stderr, '');
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.mode, 'report');
+  assert.equal(report.validatorId, 'naming');
+  assert.equal(report.scope, 'validator');
+  assert.equal(report.filters.isFiltered, true);
+  assert.deepEqual(report.filters.targets, ['calculogic-validator/test/fixtures']);
+  assert.equal(report.findings.length > 0, true);
+  assert.equal(report.scopeSummary.findingsGenerated, report.findings.length);
+  assert.equal(report.scopeSummary.reportableFilesInScope, report.totalFilesScanned);
+  assert.equal(typeof report.startedAt, 'string');
+  assert.equal(typeof report.endedAt, 'string');
+  assert.equal(typeof report.durationMs, 'number');
+  assert.equal(typeof report.sourceSnapshot, 'object');
+});
+
+test('validate:naming direct stdout remains parseable JSON with no findings present', () => {
+  const result = runValidateNaming([
+    '--scope=validator',
+    '--target=calculogic-validator/test/fixtures/no-reportable-files',
+  ]);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.mode, 'report');
+  assert.equal(report.validatorId, 'naming');
+  assert.equal(report.scope, 'validator');
+  assert.equal(report.totalFilesScanned, 0);
+  assert.deepEqual(report.findings, []);
+  assert.equal(report.scopeSummary.findingsGenerated, 0);
+  assert.equal(report.scopeSummary.reportableFilesInScope, 0);
+  assert.equal(report.counts.canonical, 0);
+});

--- a/calculogic-validator/src/core/validator-direct-report.logic.mjs
+++ b/calculogic-validator/src/core/validator-direct-report.logic.mjs
@@ -1,0 +1,25 @@
+export const buildDirectValidatorReportEnvelope = ({
+  registryEntry,
+  fallbackValidatorId,
+  toolVersion,
+  configDigest,
+  sourceSnapshot,
+  startedAtDate,
+  endedAtDate,
+}) => {
+  const reportMetadata = registryEntry?.metadata?.report ?? {};
+  const validatorId = reportMetadata.validatorId ?? registryEntry?.id ?? fallbackValidatorId;
+  const mode = reportMetadata.mode ?? 'report';
+
+  return {
+    mode,
+    validatorId,
+    toolVersion,
+    ...(toolVersion ? { validatorVersion: toolVersion } : {}),
+    ...(configDigest ? { configDigest } : {}),
+    sourceSnapshot,
+    startedAt: startedAtDate.toISOString(),
+    endedAt: endedAtDate.toISOString(),
+    durationMs: endedAtDate.getTime() - startedAtDate.getTime(),
+  };
+};


### PR DESCRIPTION
### Motivation
- Reduce suite-core vs slice-owned duplication by moving direct report envelope mechanics to a suite-core helper while preserving Naming semantics and exact report parity. 
- Prove behavior-preserving migration with focused parity tests before changing runtime wiring or registry-driven identity usage. 

### Description
- Add a suite-core helper `buildDirectValidatorReportEnvelope` at `calculogic-validator/src/core/validator-direct-report.logic.mjs` that centralizes mode/validator identity/toolVersion/configDigest/sourceSnapshot/timestamps/duration mechanics. 
- Wire the Naming direct report builder to use the suite-core envelope by updating `calculogic-validator/naming/src/cli/naming-report-builder.logic.mjs` and pass the registry entry via `naming-cli-runner.logic.mjs` to preserve registry-driven identity without changing Naming-owned findings/summaries. 
- Add exact-parity unit tests at `calculogic-validator/naming/test/naming-direct-report-parity.test.mjs` that assert byte-for-byte parity (normalized non-deterministic fields via fixed fixtures) for findings-present and no-findings cases and validate `validate:naming` stdout JSON parseability. 
- Update docs to record the envelope ownership boundary and reuse guidance in `ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md` and `ValidatorSliceAndReportFormula.md`. 

### Testing
- Ran `git diff --check` and `git diff --cached --check` with no errors (PASS). 
- Ran focused parity tests with `node --test calculogic-validator/naming/test/naming-direct-report-parity.test.mjs` and they passed (PASS). 
- Ran full validator test suites with `node --test calculogic-validator/test/*.test.mjs calculogic-validator/naming/test/*.test.mjs` and all tests passed (266 tests passed; PASS). 
- Verified CLI behavior with: `npm run validate:naming -- --scope=validator --target calculogic-validator/src/core` which exited `0` (PASS), `npm run validate:naming -- --scope=validator --target calculogic-validator/naming` which exited `2` as expected from existing Naming findings (PASS), and `npm run validate:all -- --scope=validator --target calculogic-validator/src/core` which exited `0` (PASS). 

Refs #601
Refs #598
Refs #599
Refs #600
Refs #590

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1a6676e08331b481af5e1a638e07)