### PR TITLE
Reuse suite-core CLI helpers for Tree direct host surface

### DIFF
--- a/calculogic-validator/scripts/validate-tree.host.mjs
+++ b/calculogic-validator/scripts/validate-tree.host.mjs
@@ -1,70 +1,22 @@
-import {
-  listValidatorScopes,
-} from '../src/core/validator-scopes.logic.mjs';
 import { resolveRepositoryRoot } from '../src/core/repository-root.logic.mjs';
-import { parseRepeatableTargetArgument } from '../src/core/cli/validator-cli-targets.logic.mjs';
 import {
-  buildSupportedScopeToken,
-  buildValidatorScopeUsageLinesFromRuntimeProfiles,
-} from '../src/core/cli/validator-cli-scopes.logic.mjs';
+  buildDirectValidatorRunnerUsageLines,
+  parseDirectValidatorRunnerCliArgs,
+} from '../src/core/cli/validator-cli-direct.logic.mjs';
 import { runValidatorRunnerCli } from '../src/core/cli/validator-cli-runner.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
 
-const supportedScopes = listValidatorScopes();
-const supportedScopesToken = buildSupportedScopeToken(supportedScopes);
-
-const usageLines = [
-  `Usage: npm run validate:tree -- [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>]`,
-  'Scopes:',
-  ...buildValidatorScopeUsageLinesFromRuntimeProfiles(supportedScopes),
-  'Default scope: validator default (repo for tree-structure-advisor)',
-  'Validator: tree-structure-advisor',
-  'Examples:',
-  '  ✅ npm run validate:tree -- --scope=repo',
-  '  ✅ npm run validate:tree -- --scope=app --target src/tree',
-  '  ✅ npm run validate:tree -- --target calculogic-validator/tree/src',
-  '  ✅ npm run validate:all -- --validators=tree-structure-advisor --scope=repo',
-];
-
-const parseCliArgs = (argv) => {
-  let selectedScope;
-  let configPath;
-  const targets = [];
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index];
-
-    if (argument === '--help' || argument === '-h') {
-      return { helpRequested: true, selectedScope, configPath, targets };
-    }
-
-    if (argument.startsWith('--scope=')) {
-      selectedScope = argument.slice('--scope='.length);
-      continue;
-    }
-
-    const targetArgumentResult = parseRepeatableTargetArgument({
-      argv,
-      index,
-      argument,
-      targets,
-    });
-    if (targetArgumentResult.handled) {
-      index = targetArgumentResult.nextIndex;
-      continue;
-    }
-
-    if (argument.startsWith('--config=')) {
-      configPath = argument.slice('--config='.length);
-      continue;
-    }
-
-    throw new Error(`Invalid argument: ${argument}`);
-  }
-
-  return { helpRequested: false, selectedScope, configPath, targets };
-};
+const usageLines = buildDirectValidatorRunnerUsageLines({
+  validatorId: 'tree-structure-advisor',
+  defaultScopeLine: 'Default scope: validator default (repo for tree-structure-advisor)',
+  examples: [
+    '  ✅ npm run validate:tree -- --scope=repo',
+    '  ✅ npm run validate:tree -- --scope=app --target src/tree',
+    '  ✅ npm run validate:tree -- --target calculogic-validator/tree/src',
+    '  ✅ npm run validate:all -- --validators=tree-structure-advisor --scope=repo',
+  ],
+});
 
 const result = runValidatorRunnerCli({
   argv: process.argv.slice(2),
@@ -72,7 +24,7 @@ const result = runValidatorRunnerCli({
   repositoryRoot,
   expectedLifecycleEvent: 'validate:tree',
   supportedFlagNames: ['scope', 'target', 'config'],
-  parseCliArgs,
+  parseCliArgs: parseDirectValidatorRunnerCliArgs,
   buildRunnerOptions: ({ parsed, config, toolVersion, configDigest }) => ({
     scope: parsed.selectedScope,
     validators: ['tree-structure-advisor'],

--- a/calculogic-validator/src/core/cli/validator-cli-direct.logic.mjs
+++ b/calculogic-validator/src/core/cli/validator-cli-direct.logic.mjs
@@ -1,0 +1,75 @@
+import { listValidatorScopes } from '../validator-scopes.logic.mjs';
+import { getValidatorById } from '../validator-registry.knowledge.mjs';
+import { parseRepeatableTargetArgument } from './validator-cli-targets.logic.mjs';
+import {
+  buildSupportedScopeToken,
+  buildValidatorScopeUsageLinesFromRuntimeProfiles,
+} from './validator-cli-scopes.logic.mjs';
+
+export const parseDirectValidatorRunnerCliArgs = (argv) => {
+  let selectedScope;
+  let configPath;
+  const targets = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--help' || argument === '-h') {
+      return { helpRequested: true, selectedScope, configPath, targets };
+    }
+
+    if (argument.startsWith('--scope=')) {
+      selectedScope = argument.slice('--scope='.length);
+      continue;
+    }
+
+    const targetArgumentResult = parseRepeatableTargetArgument({
+      argv,
+      index,
+      argument,
+      targets,
+    });
+    if (targetArgumentResult.handled) {
+      index = targetArgumentResult.nextIndex;
+      continue;
+    }
+
+    if (argument.startsWith('--config=')) {
+      configPath = argument.slice('--config='.length);
+      continue;
+    }
+
+    throw new Error(`Invalid argument: ${argument}`);
+  }
+
+  return { helpRequested: false, selectedScope, configPath, targets };
+};
+
+export const buildDirectValidatorRunnerUsageLines = ({
+  validatorId,
+  defaultScopeLine,
+  examples,
+  supportedScopes = listValidatorScopes(),
+}) => {
+  const validator = getValidatorById(validatorId);
+  if (!validator) {
+    throw new Error(`Unknown validator: ${validatorId}`);
+  }
+
+  const repoLocalNpmInvocation = validator.metadata?.commands?.repoLocalNpmInvocation;
+  if (!repoLocalNpmInvocation) {
+    throw new Error(`Missing repo-local npm invocation metadata for validator: ${validatorId}`);
+  }
+
+  const supportedScopesToken = buildSupportedScopeToken(supportedScopes);
+
+  return [
+    `Usage: ${repoLocalNpmInvocation} [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>]`,
+    'Scopes:',
+    ...buildValidatorScopeUsageLinesFromRuntimeProfiles(supportedScopes),
+    defaultScopeLine,
+    `Validator: ${validator.id}`,
+    'Examples:',
+    ...examples,
+  ];
+};

--- a/calculogic-validator/test/validate-tree.script.integration.test.mjs
+++ b/calculogic-validator/test/validate-tree.script.integration.test.mjs
@@ -111,6 +111,102 @@ test('validate-tree prints usage when npm args are not forwarded', () => {
   assert.match(result.stderr, /Usage: npm run validate:tree --/);
 });
 
+
+test('validate-tree help keeps current command usage surface', () => {
+  const result = runValidateTree(repositoryRoot, ['--help']);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+  assert.equal(
+    result.stdout,
+    [
+      'Usage: npm run validate:tree -- [--scope=<repo|app|docs|validator|system>] [--target=<path>]... [--config=<path>]',
+      'Scopes:',
+      '  - app: Application-only scan (src/** and test/**).',
+      '  - docs: Documentation-focused scan (doc/docs and root conventional docs: README.md).',
+      '  - repo: Repository-wide scan of all reportable files.',
+      '  - system: System/tooling files scan (root package/tsconfig/eslint/vite files).',
+      '  - validator: Validator-only scan (calculogic-validator/**).',
+      'Default scope: validator default (repo for tree-structure-advisor)',
+      'Validator: tree-structure-advisor',
+      'Examples:',
+      '  ✅ npm run validate:tree -- --scope=repo',
+      '  ✅ npm run validate:tree -- --scope=app --target src/tree',
+      '  ✅ npm run validate:tree -- --target calculogic-validator/tree/src',
+      '  ✅ npm run validate:all -- --validators=tree-structure-advisor --scope=repo',
+      '',
+    ].join('\n'),
+  );
+});
+
+test('validate-tree direct report entry preserves no-finding shape against runner tree selection', () => {
+  const directResult = runValidateTree(repositoryRoot, [
+    '--scope=validator',
+    '--target=calculogic-validator/src/core',
+  ]);
+  const runnerResult = spawnSync(
+    process.execPath,
+    [
+      '--experimental-strip-types',
+      path.resolve(repositoryRoot, 'calculogic-validator/scripts/validate-all.host.mjs'),
+      '--scope=validator',
+      '--validators=tree-structure-advisor',
+      '--target=calculogic-validator/src/core',
+    ],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  );
+
+  assert.equal(directResult.status, 0);
+  assert.equal(runnerResult.status, 0);
+
+  const directReport = JSON.parse(directResult.stdout);
+  const runnerReport = JSON.parse(runnerResult.stdout);
+
+  assert.equal(directReport.mode, 'report');
+  assert.equal(directReport.validatorId, 'runner');
+  assert.equal(directReport.validators.length, 1);
+  assert.deepEqual(directReport.validators[0], runnerReport.validators[0]);
+  assert.deepEqual(directReport.validators[0].findings, []);
+  assert.deepEqual(directReport.validators[0].counts, { 'advisory-structure': 0 });
+  assert.deepEqual(directReport.validators[0].codeCounts, {});
+});
+
+test('validate-tree direct report entry preserves finding codes severities and summaries against runner tree selection', () => {
+  const args = ['--scope=validator', '--target=calculogic-validator/tree'];
+  const directResult = runValidateTree(repositoryRoot, args);
+  const runnerResult = spawnSync(
+    process.execPath,
+    [
+      '--experimental-strip-types',
+      path.resolve(repositoryRoot, 'calculogic-validator/scripts/validate-all.host.mjs'),
+      '--scope=validator',
+      '--validators=tree-structure-advisor',
+      '--target=calculogic-validator/tree',
+    ],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  );
+
+  assert.equal(directResult.status, 0);
+  assert.equal(runnerResult.status, 0);
+
+  const directEntry = JSON.parse(directResult.stdout).validators[0];
+  const runnerEntry = JSON.parse(runnerResult.stdout).validators[0];
+  const findingSignature = (finding) => ({
+    code: finding.code,
+    severity: finding.severity,
+    path: finding.path,
+    classification: finding.classification,
+  });
+
+  assert.deepEqual(directEntry.counts, runnerEntry.counts);
+  assert.deepEqual(directEntry.codeCounts, runnerEntry.codeCounts);
+  assert.deepEqual(
+    directEntry.findings.map(findingSignature),
+    runnerEntry.findings.map(findingSignature),
+  );
+  assert.ok(directEntry.findings.length > 0);
+});
+
 test('validate-tree does not expose strict-mode toggling', () => {
   const result = runValidateTree(repositoryRoot, ['--strict']);
 


### PR DESCRIPTION
### Motivation
- Reduce duplication by moving Tree host command-surface mechanics (usage-line text and argument parsing) to a suite-core CLI helper while preserving current runtime truth and Tree-owned reasoning. 
- Follow the validator slice formula and the naming/tree suite-core usage audit to consume existing suite-core CLI surfaces where safe. 
- This change is strictly behavior-preserving for Tree reports, findings, summaries, severities, and exit-code behavior.

### Description
- Add a suite-core direct-runner helper `calculogic-validator/src/core/cli/validator-cli-direct.logic.mjs` that builds usage lines from registry metadata and parses `--scope`, repeatable `--target`, and `--config` for direct-validator hosts. 
- Update `calculogic-validator/scripts/validate-tree.host.mjs` to reuse the new helper (`buildDirectValidatorRunnerUsageLines` / `parseDirectValidatorRunnerCliArgs`) and keep `runValidatorRunnerCli`-based runner dispatch and report wrapping intact. 
- Add focused integration tests in `calculogic-validator/test/validate-tree.script.integration.test.mjs` to prove help/usage parity and runner-vs-direct report parity for no-finding and finding-bearing targets. 
- No changes to Tree reasoning, Tree registries, package scripts/bins, report shape, or Naming behavior were made; runtime authority relied on `ValidatorSuite-Contracts-And-Modes.md` and the Tree slice spec for behavior decisions and `tree-documentation-map-and-reorg-inventory.md` as navigation-only context.

### Testing
- Ran `git diff --check` and observed no issues. (passed)
- Ran `node --test calculogic-validator/test/validate-tree.script.integration.test.mjs` and the new Tree host parity tests passed (10 tests passed). (passed)
- Ran `node --test calculogic-validator/test/*.test.mjs calculogic-validator/tree/test/*.test.mjs` to exercise suite and tree tests and all tests passed (332 tests passed). (passed)
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/src/core` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and confirmed JSON report stdout and existing Tree findings/summary behavior were preserved (exit 0 for targeted runs; informational findings preserved for `calculogic-validator/tree`). (passed)
- Ran `npm run validate:all -- --scope=validator --target calculogic-validator/src/core` and confirmed runner-wrapped report output remained unchanged. (passed)

Refs #603
Refs #598
Refs #599
Refs #600
Refs #601
Refs #602
Refs #590

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b2aeac76c8331aa14fa8f02d61e17)