### PR TITLE
Harden Naming and Tree metadata identity consumption

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
@@ -114,11 +114,13 @@ Only currently real, discoverable suite-owned surfaces are listed here.
   - `calculogic-validator/src/core/validator-report-meta.logic.mjs`
   - `calculogic-validator/src/core/source-snapshot.logic.mjs`
   - `calculogic-validator/src/core/validator-direct-report.logic.mjs`
+  - `calculogic-validator/src/core/validator-report-identity.logic.mjs`
 - **Concern:** deterministic shared metadata helpers used in validator report envelopes.
 - **Reusable capability:**
   - tool version lookup and stable hashing/digest helpers for config/report metadata
   - git/filesystem source snapshot metadata capture for report reproducibility context
   - direct validator report envelope mechanics for mode, validator identity, version, config digest, source snapshot, timestamps, and duration
+  - bounded report identity lookup from registry report metadata when parity tests prove current emitted identity fields stay unchanged
 - **When to reuse:**
   - constructing validator or runner report envelopes that require suite-consistent metadata fields
   - constructing direct validator reports that must preserve slice-owned findings and summaries while sharing suite-core envelope mechanics
@@ -133,7 +135,7 @@ Only currently real, discoverable suite-owned surfaces are listed here.
 - **Owner:** suite-core
 - **Path/area:** `calculogic-validator/src/core/validator-registry.knowledge.mjs`
 - **Concern:** data-only slice registration metadata for current validator-suite registration surfaces.
-- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the runner behavior-driving fields. Registry report metadata may drive behavior-preserving direct report identity fields where parity tests prove the emitted report stays stable. Other metadata remains inspectable registration data and does not drive runner dispatch, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
+- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the runner behavior-driving fields. Registry report metadata may drive behavior-preserving runner/direct report identity fields where parity tests prove the emitted report stays stable. Registry command metadata may drive bounded direct usage text where parity tests prove the command surface stays stable. Other metadata remains inspectable registration data and does not drive runner dispatch, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
 - **Reusable capability:**
   - canonical slice identity metadata aligned to the registry id;
   - report identity metadata aligned to current report entry id/validator id/description;
@@ -145,9 +147,11 @@ Only currently real, discoverable suite-owned surfaces are listed here.
   - inspecting current suite-core slice registration surfaces;
   - adding a future validator slice that needs the same bounded registration facts;
   - writing shape tests that prove command/report/bin expectations are explicit without changing scripts or bins;
-  - sourcing direct report identity fields when exact parity coverage proves the current report shape is preserved.
+  - sourcing runner/direct report identity fields when exact parity coverage proves the current report shape is preserved;
+  - sourcing direct command usage text when exact parity coverage proves the command surface is preserved.
 - **When not to reuse:**
   - driving runtime runner selection, broader report shape, exit policy, or package command generation before a separate behavior-migration task explicitly scopes that change;
+  - treating command metadata as authority for Naming or Tree semantic interpretation;
   - storing slice-owned semantic interpretation policy, finding policy, Naming taxonomy, Tree placement policy, or candidate value authority in suite-core metadata;
   - creating a universal plugin architecture or generic shared bucket.
 - **Reuse boundary type:** data-only registration metadata boundary

--- a/calculogic-validator/naming/src/cli/naming-cli-usage.logic.mjs
+++ b/calculogic-validator/naming/src/cli/naming-cli-usage.logic.mjs
@@ -1,3 +1,4 @@
+import { getValidatorById } from '../../../src/core/validator-registry.knowledge.mjs';
 import { listNamingValidatorScopes, getScopeProfile } from '../naming-validator.host.mjs';
 
 const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
@@ -5,12 +6,29 @@ const preferredScopeOrder = ['repo', 'app', 'docs', 'validator', 'system'];
 const buildScopeToken = (supportedScopes) =>
   preferredScopeOrder.filter((scope) => supportedScopes.includes(scope)).join('|');
 
-export const buildNamingCliUsageLines = ({ commandPrefix, strictExampleCommand }) => {
+export const buildNamingCliUsageLines = ({
+  validatorId = 'naming',
+  commandPrefix,
+  strictExampleCommand,
+} = {}) => {
   const supportedScopes = listNamingValidatorScopes();
   const supportedScopesToken = buildScopeToken(supportedScopes);
+  const validator = getValidatorById(validatorId);
+  if (!validator) {
+    throw new Error(`Unknown validator: ${validatorId}`);
+  }
+
+  const repoLocalNpmInvocation = validator.metadata?.commands?.repoLocalNpmInvocation;
+  if (!repoLocalNpmInvocation) {
+    throw new Error(`Missing repo-local npm invocation metadata for validator: ${validatorId}`);
+  }
+
+  const effectiveCommandPrefix = commandPrefix ?? repoLocalNpmInvocation;
+  const effectiveStrictExampleCommand =
+    strictExampleCommand ?? `${repoLocalNpmInvocation} --scope=repo --strict`;
 
   return [
-    `Usage: ${commandPrefix} [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
+    `Usage: ${effectiveCommandPrefix} [--scope=<${supportedScopesToken}>] [--target=<path>]... [--config=<path>] [--strict]`,
     'Scopes:',
     ...supportedScopes.map((scope) => {
       const profile = getScopeProfile(scope);
@@ -18,12 +36,12 @@ export const buildNamingCliUsageLines = ({ commandPrefix, strictExampleCommand }
     }),
     'Default scope: repo',
     'Examples:',
-    '  ✅ npm run validate:naming -- --scope=app',
-    '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
-    '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
+    `  ✅ ${repoLocalNpmInvocation} --scope=app`,
+    `  ✅ ${repoLocalNpmInvocation} --scope=app --target src/buildsurface`,
+    `  ✅ ${repoLocalNpmInvocation} --scope=app --target src/buildsurface --target src/shared`,
     '  ✅ npm run validate:all -- --validators=naming --scope=docs',
     '  ✅ node calculogic-validator/bin/calculogic-validate-naming.host.mjs --scope=app',
     '  ✅ node calculogic-validator/bin/calculogic-validate.host.mjs --scope=docs',
-    `  ✅ ${strictExampleCommand}`,
+    `  ✅ ${effectiveStrictExampleCommand}`,
   ];
 };

--- a/calculogic-validator/naming/test/naming-direct-report-parity.test.mjs
+++ b/calculogic-validator/naming/test/naming-direct-report-parity.test.mjs
@@ -38,7 +38,8 @@ const stableCanonicalFinding = {
   path: 'calculogic-validator/src/core/validator-direct-report.logic.mjs',
   classification: 'canonical',
   message: 'Filename is canonical.',
-  ruleRef: 'calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#core-filename-grammar',
+  ruleRef:
+    'calculogic-validator/doc/ConventionRoutines/FileNamingMasterList-V1_1.md#core-filename-grammar',
   details: {
     semanticName: 'validator-direct-report',
     role: 'logic',
@@ -176,4 +177,33 @@ test('validate:naming direct stdout remains parseable JSON with no findings pres
   assert.equal(report.scopeSummary.findingsGenerated, 0);
   assert.equal(report.scopeSummary.reportableFilesInScope, 0);
   assert.equal(report.counts.canonical, 0);
+});
+
+test('validate:naming help keeps current command usage surface from registry command metadata', () => {
+  const result = runValidateNaming(['--help']);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+  assert.equal(
+    result.stdout,
+    [
+      'Usage: npm run validate:naming -- [--scope=<repo|app|docs|validator|system>] [--target=<path>]... [--config=<path>] [--strict]',
+      'Scopes:',
+      '  - app: Application-only scan (src/** and test/**).',
+      '  - docs: Documentation-focused scan (doc/docs and root conventional docs: README.md).',
+      '  - repo: Repository-wide scan of all reportable files.',
+      '  - system: System/tooling files scan (root package/tsconfig/eslint/vite files).',
+      '  - validator: Validator-only scan (calculogic-validator/**).',
+      'Default scope: repo',
+      'Examples:',
+      '  ✅ npm run validate:naming -- --scope=app',
+      '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface',
+      '  ✅ npm run validate:naming -- --scope=app --target src/buildsurface --target src/shared',
+      '  ✅ npm run validate:all -- --validators=naming --scope=docs',
+      '  ✅ node calculogic-validator/bin/calculogic-validate-naming.host.mjs --scope=app',
+      '  ✅ node calculogic-validator/bin/calculogic-validate.host.mjs --scope=docs',
+      '  ✅ npm run validate:naming -- --scope=repo --strict',
+      '',
+    ].join('\n'),
+  );
 });

--- a/calculogic-validator/scripts/validate-naming.host.mjs
+++ b/calculogic-validator/scripts/validate-naming.host.mjs
@@ -4,10 +4,7 @@ import { buildNamingCliUsageLines } from '../naming/src/cli/naming-cli-usage.log
 import { runNamingCli } from '../naming/src/cli/naming-cli-runner.logic.mjs';
 
 const repositoryRoot = resolveRepositoryRoot();
-const usageLines = buildNamingCliUsageLines({
-  commandPrefix: 'npm run validate:naming --',
-  strictExampleCommand: 'npm run validate:naming -- --scope=repo --strict',
-});
+const usageLines = buildNamingCliUsageLines({ validatorId: 'naming' });
 
 const npmArgForwardingMessage = detectNpmArgForwardingFootgun({
   argv: process.argv.slice(2),

--- a/calculogic-validator/src/core/validator-direct-report.logic.mjs
+++ b/calculogic-validator/src/core/validator-direct-report.logic.mjs
@@ -1,3 +1,4 @@
+import { getValidatorReportIdentity } from './validator-report-identity.logic.mjs';
 export const buildDirectValidatorReportEnvelope = ({
   registryEntry,
   fallbackValidatorId,
@@ -7,13 +8,13 @@ export const buildDirectValidatorReportEnvelope = ({
   startedAtDate,
   endedAtDate,
 }) => {
-  const reportMetadata = registryEntry?.metadata?.report ?? {};
-  const validatorId = reportMetadata.validatorId ?? registryEntry?.id ?? fallbackValidatorId;
-  const mode = reportMetadata.mode ?? 'report';
+  const reportIdentity = getValidatorReportIdentity(registryEntry, {
+    validatorId: fallbackValidatorId,
+  });
 
   return {
-    mode,
-    validatorId,
+    mode: reportIdentity.mode,
+    validatorId: reportIdentity.validatorId,
     toolVersion,
     ...(toolVersion ? { validatorVersion: toolVersion } : {}),
     ...(configDigest ? { configDigest } : {}),

--- a/calculogic-validator/src/core/validator-report-identity.logic.mjs
+++ b/calculogic-validator/src/core/validator-report-identity.logic.mjs
@@ -1,0 +1,12 @@
+export const getValidatorReportIdentity = (registryEntry, fallback = {}) => {
+  const reportMetadata = registryEntry?.metadata?.report ?? {};
+  const fallbackId = fallback.id ?? registryEntry?.id;
+
+  return {
+    id: reportMetadata.entryId ?? fallbackId,
+    validatorId:
+      reportMetadata.validatorId ?? fallback.validatorId ?? registryEntry?.id ?? fallbackId,
+    description: reportMetadata.description ?? fallback.description ?? registryEntry?.description,
+    mode: reportMetadata.mode ?? fallback.mode ?? 'report',
+  };
+};

--- a/calculogic-validator/src/core/validator-runner.logic.mjs
+++ b/calculogic-validator/src/core/validator-runner.logic.mjs
@@ -1,6 +1,7 @@
 import { CALCULOGIC_VALIDATOR_REPORT_VERSION } from './validator-report.contracts.mjs';
 import { VALIDATOR_REGISTRY, getValidatorById } from './validator-registry.knowledge.mjs';
 import { getSourceSnapshot } from './source-snapshot.logic.mjs';
+import { getValidatorReportIdentity } from './validator-report-identity.logic.mjs';
 import { projectNamingSemanticFamilyBridge } from '../../naming/src/naming-validator.host.mjs';
 
 const toValidatorReportEntry = (registryEntry, validatorResult) => {
@@ -10,10 +11,12 @@ const toValidatorReportEntry = (registryEntry, validatorResult) => {
     ? Object.fromEntries(Object.entries(summary).filter(([key]) => key !== 'counts'))
     : {};
 
+  const reportIdentity = getValidatorReportIdentity(registryEntry);
+
   return {
-    id: registryEntry.id,
-    validatorId: registryEntry.id,
-    description: registryEntry.description,
+    id: reportIdentity.id,
+    validatorId: reportIdentity.validatorId,
+    description: reportIdentity.description,
     scope: validatorResult.scope,
     totalFilesScanned: validatorResult.totalFilesScanned,
     ...(counts ? { counts } : {}),
@@ -48,7 +51,9 @@ export const runValidatorRunner = (repositoryRoot, options = {}) => {
   const shouldRunTreeStructureAdvisor = validatorsToRun.some(
     (registryEntry) => registryEntry.id === 'tree-structure-advisor',
   );
-  const shouldIncludeNamingReport = validatorsToRun.some((registryEntry) => registryEntry.id === 'naming');
+  const shouldIncludeNamingReport = validatorsToRun.some(
+    (registryEntry) => registryEntry.id === 'naming',
+  );
   const namingRegistryEntry = getValidatorById('naming');
 
   let stagedNamingResult = null;

--- a/calculogic-validator/test/validator-registry.test.mjs
+++ b/calculogic-validator/test/validator-registry.test.mjs
@@ -4,11 +4,20 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { VALIDATOR_REGISTRY, getValidatorById, listRegisteredValidators } from '../src/core/validator-registry.knowledge.mjs';
+import {
+  VALIDATOR_REGISTRY,
+  getValidatorById,
+  listRegisteredValidators,
+} from '../src/core/validator-registry.knowledge.mjs';
 import { runValidatorRunner } from '../src/core/validator-runner.logic.mjs';
+import { getValidatorReportIdentity } from '../src/core/validator-report-identity.logic.mjs';
 
-const rootPackageJson = JSON.parse(fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
-const validatorPackageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const rootPackageJson = JSON.parse(
+  fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+);
+const validatorPackageJson = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
 
 const expectedMetadataShapeKeys = [
   'sliceId',
@@ -81,7 +90,10 @@ test('registry metadata command, report, and bin fields match current naming pat
     assert.match(commands.repoLocalNpmScript, /^validate:(?:naming|tree)$/u);
     assert.equal(rootPackageJson.scripts[commands.repoLocalNpmScript]?.startsWith('node '), true);
     assert.equal(commands.repoLocalNpmInvocation, `npm run ${commands.repoLocalNpmScript} --`);
-    assert.match(commands.directScriptPath, /^calculogic-validator\/scripts\/validate-[a-z-]+\.host\.mjs$/u);
+    assert.match(
+      commands.directScriptPath,
+      /^calculogic-validator\/scripts\/validate-[a-z-]+\.host\.mjs$/u,
+    );
     assert.equal(fs.existsSync(path.join(process.cwd(), commands.directScriptPath)), true);
 
     assert.match(report.profileId, /^[a-z][a-z0-9-]*$/u);
@@ -95,16 +107,35 @@ test('registry metadata command, report, and bin fields match current naming pat
       const scriptName = reportCapture.scriptPattern.replace('<scope>', scope);
       const expectedPrefix = reportCapture.prefixPattern.replace('<scope>', scope);
       assert.ok(rootPackageJson.scripts[scriptName], `${scriptName} should exist`);
-      assert.match(rootPackageJson.scripts[scriptName], new RegExp(`--prefix ${expectedPrefix}\\b`, 'u'));
+      assert.match(
+        rootPackageJson.scripts[scriptName],
+        new RegExp(`--prefix ${expectedPrefix}\\b`, 'u'),
+      );
     }
 
     assert.match(packageBin.expectedName, /^calculogic-validate(?:-[a-z]+)?$/u);
-    assert.equal(Boolean(validatorPackageJson.bin?.[packageBin.expectedName]), packageBin.available);
+    assert.equal(
+      Boolean(validatorPackageJson.bin?.[packageBin.expectedName]),
+      packageBin.available,
+    );
+  }
+});
+
+test('report identity helper consumes registry report metadata without changing current identity values', () => {
+  for (const validator of VALIDATOR_REGISTRY) {
+    assert.deepEqual(getValidatorReportIdentity(validator), {
+      id: validator.id,
+      validatorId: validator.id,
+      description: validator.description,
+      mode: 'report',
+    });
   }
 });
 
 test('validate:all/default inclusion metadata matches current runner behavior', async () => {
-  const fixtureRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'validator-registry-default-'));
+  const fixtureRoot = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'validator-registry-default-'),
+  );
 
   try {
     const report = runValidatorRunner(fixtureRoot, { scope: 'repo' });
@@ -116,6 +147,27 @@ test('validate:all/default inclusion metadata matches current runner behavior', 
       report.validators.map((validator) => validator.id),
       defaultIncludedIds,
     );
+  } finally {
+    await fsPromises.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('validate:all report entries preserve registry report identity metadata values', async () => {
+  const fixtureRoot = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'validator-registry-identity-'),
+  );
+
+  try {
+    const report = runValidatorRunner(fixtureRoot, { scope: 'repo' });
+
+    for (const reportEntry of report.validators) {
+      const registryEntry = getValidatorById(reportEntry.id);
+      const identity = getValidatorReportIdentity(registryEntry);
+
+      assert.equal(reportEntry.id, identity.id);
+      assert.equal(reportEntry.validatorId, identity.validatorId);
+      assert.equal(reportEntry.description, identity.description);
+    }
   } finally {
     await fsPromises.rm(fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
### Motivation
- Reduce duplicated literal command/report identity strings by consuming existing suite-core validator registry metadata in bounded, behavior-preserving places. 
- Preserve current runtime semantics and slice ownership while using registry-sourced identity/command text where parity can be proven. 
- Add parity coverage before widening runtime consumption of registry metadata to avoid any report/CLI regressions. 

### Description
- Add a suite-core helper `getValidatorReportIdentity` (`calculogic-validator/src/core/validator-report-identity.logic.mjs`) that returns report `id`, `validatorId`, `description`, and `mode` using registry metadata with fallbacks. 
- Route runner report entries and direct report envelopes through the new helper by updating `validator-runner.logic.mjs` and `validator-direct-report.logic.mjs` so emitted report identity uses registry metadata when present. 
- Make Naming CLI usage construction consume registry command metadata by updating `naming-cli-usage.logic.mjs` and `validate-naming.host.mjs` to generate help/usage text from `commands.repoLocalNpmInvocation` while preserving the exact prior help surface. 
- Add focused parity and metadata tests and update docs: extend `validator-registry.test.mjs` with tests asserting the identity helper and that `validate:all` entries preserve registry identity, add a Naming help parity test in `naming-direct-report-parity.test.mjs`, and update `ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md` to document the bounded metadata-consumption behavior. 

### Testing
- Ran `git diff --check` and it passed. 
- Ran unit/integration suites with `node --test calculogic-validator/test/*.test.mjs calculogic-validator/naming/test/*.test.mjs calculogic-validator/tree/test/*.test.mjs` and all tests passed (total run reported: 474 tests; 0 failures). 
- Verified CLI/runtime parity via: `npm run validate:naming -- --scope=validator --target calculogic-validator/src/core` (passed), `npm run validate:tree -- --scope=validator --target calculogic-validator/src/core` (passed), and `npm run validate:all -- --scope=validator --target calculogic-validator/src/core` (passed). 
- Note: `npm run validate:naming -- --scope=validator --target calculogic-validator/doc` exited 2 due to pre-existing naming findings in validator docs; no changed code introduced the doc failures (warning noted, not a regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3f7cacd48331ac67da4edfea71ef)