### PR TITLE
Harden validator report-capture metadata

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSliceAndReportFormula.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSliceAndReportFormula.md
@@ -40,7 +40,7 @@ Every slice/layer MUST declare or intentionally omit each item below.
 | Runner inclusion | Declare whether the slice is included by default in `validate:all`, selected by registry id, runner-only, or omitted from runner dispatch. |
 | Runnable status | Classify as `direct runnable`, `runner-only`, `bridge provider`, or a hybrid status. Do not imply package-bin availability unless it exists. |
 | Package-bin expectation | Record expected bin name and availability. This formula does not recommend package/bin changes by itself. |
-| Report-capture profile | Declare capture profile id, script pattern, prefix pattern, and supported scopes when report capture is expected. |
+| Report-capture profile | Declare capture profile id, script pattern, prefix pattern, and supported scopes when report capture is expected. Suite-core may also keep data-only package-script preset metadata for current capture commands; that metadata records command mechanics and must not become semantic policy. |
 | Compatibility metadata | Record behavior-preserving metadata, registry-selection compatibility, and report-shape ownership expectations. |
 
 Checklist for a new slice:
@@ -129,7 +129,7 @@ Report behavior requirements:
 | Severity behavior | Slice-owned finding policy controls severity; this formula does not change severity behavior. |
 | Exit-code derivation | Suite-core derives exit code from findings and exit policy. Slices do not own suite exit-code mechanics. |
 | Stdout/stderr | CLI wrappers should keep deterministic JSON/report output behavior and route non-report diagnostics intentionally. |
-| Report capture | Capture commands should use the slice's report-capture profile and supported scopes. |
+| Report capture | Capture commands should use the slice's report-capture profile and supported scopes. Report-capture preset metadata may guard package-script alignment and captured-output parity, but it must preserve current report output shape, ids/descriptions, summaries, severities, and exit-code behavior. |
 | Ordering | Slices should sort findings, paths, targets, evidence records, and summary buckets deterministically. |
 | Path normalization | Use suite-core path normalization where applicable; slice output should use stable repo-relative paths. |
 | Scope/target metadata | Scope and target metadata should reflect suite-core scoped input and filters. |

--- a/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
+++ b/calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md
@@ -133,13 +133,16 @@ Only currently real, discoverable suite-owned surfaces are listed here.
 ### 3.6 Entry: suite-core validator registry metadata surface
 
 - **Owner:** suite-core
-- **Path/area:** `calculogic-validator/src/core/validator-registry.knowledge.mjs`
+- **Path/area:**
+  - `calculogic-validator/src/core/validator-registry.knowledge.mjs`
+  - `calculogic-validator/src/core/validator-report-capture-metadata.logic.mjs`
 - **Concern:** data-only slice registration metadata for current validator-suite registration surfaces.
-- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the runner behavior-driving fields. Registry report metadata may drive behavior-preserving runner/direct report identity fields where parity tests prove the emitted report stays stable. Registry command metadata may drive bounded direct usage text where parity tests prove the command surface stays stable. Other metadata remains inspectable registration data and does not drive runner dispatch, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
+- **Current runtime truth:** registry entries keep `id`, `description`, and `run` as the runner behavior-driving fields. Registry report metadata may drive behavior-preserving runner/direct report identity fields where parity tests prove the emitted report stays stable. Registry command metadata may drive bounded direct usage text where parity tests prove the command surface stays stable. Report-capture preset metadata records current package-script capture mechanics and may be read by tests or inspection helpers, but package scripts remain literal current runtime truth until a separately scoped behavior migration changes that. Other metadata remains inspectable registration data and does not drive runner dispatch, package scripts, package bins, exit-code behavior, Naming behavior, Tree behavior, or candidate behavior.
 - **Reusable capability:**
   - canonical slice identity metadata aligned to the registry id;
   - report identity metadata aligned to current report entry id/validator id/description;
   - repo-local npm command, direct script, package-bin availability, and report-capture prefix expectations;
+  - report-capture package-script presets for current Naming, Tree, validate-all, and explicitly deferred Addressing capture surfaces;
   - default `validate:all` runner inclusion and direct-runnable/runner-only capability metadata;
   - bounded bridge metadata for the current Naming semantic-family bridge contribution consumed by Tree;
   - compatibility expectation metadata for current report-mode and behavior-preserving registration.
@@ -147,11 +150,13 @@ Only currently real, discoverable suite-owned surfaces are listed here.
   - inspecting current suite-core slice registration surfaces;
   - adding a future validator slice that needs the same bounded registration facts;
   - writing shape tests that prove command/report/bin expectations are explicit without changing scripts or bins;
+  - writing report-capture preset tests that compare registry-backed metadata to literal package scripts and representative emitted reports;
   - sourcing runner/direct report identity fields when exact parity coverage proves the current report shape is preserved;
   - sourcing direct command usage text when exact parity coverage proves the command surface is preserved.
 - **When not to reuse:**
   - driving runtime runner selection, broader report shape, exit policy, or package command generation before a separate behavior-migration task explicitly scopes that change;
   - treating command metadata as authority for Naming or Tree semantic interpretation;
+  - treating report-capture metadata as semantic policy or as authority for finding ids, summaries, severities, Naming interpretation, Tree reasoning, Addressing behavior, or report output shape;
   - storing slice-owned semantic interpretation policy, finding policy, Naming taxonomy, Tree placement policy, or candidate value authority in suite-core metadata;
   - creating a universal plugin architecture or generic shared bucket.
 - **Reuse boundary type:** data-only registration metadata boundary

--- a/calculogic-validator/src/core/validator-registry.knowledge.mjs
+++ b/calculogic-validator/src/core/validator-registry.knowledge.mjs
@@ -62,6 +62,159 @@ const runTreeStructureAdvisorHook = (repositoryRoot, options = {}) => {
   };
 };
 
+const REPORT_CAPTURE_DEFAULT_OPTIONS = {
+  captureCommand: 'calculogic-report-capture',
+  json: true,
+  dir: './.reports',
+  keep: 20,
+};
+
+const buildValidatorReportCapturePresets = ({
+  scriptNamespace,
+  profileId,
+  directScriptPath,
+  prefixBase,
+  semanticPolicyOwner,
+  scopes,
+}) =>
+  scopes.map((scope) => ({
+    scriptName: `report:${scriptNamespace}:${scope}`,
+    profileId,
+    commandSurface: 'validator-report-capture',
+    semanticPolicyOwner,
+    capture: {
+      ...REPORT_CAPTURE_DEFAULT_OPTIONS,
+      prefix: `${prefixBase}-${scope}`,
+    },
+    wrappedCommand: {
+      executable: 'node',
+      args: ['--experimental-strip-types', directScriptPath, `--scope=${scope}`],
+    },
+  }));
+
+const namingValidatorSliceReportCapturePresets = [
+  ...buildValidatorReportCapturePresets({
+    scriptNamespace: 'naming',
+    profileId: 'naming',
+    directScriptPath: 'calculogic-validator/scripts/validate-naming.host.mjs',
+    prefixBase: 'naming',
+    semanticPolicyOwner: 'naming',
+    scopes: ['repo', 'app', 'docs'],
+  }),
+  {
+    scriptName: 'report:naming:validator',
+    profileId: 'naming',
+    commandSurface: 'validator-report-capture',
+    semanticPolicyOwner: 'naming',
+    capture: {
+      ...REPORT_CAPTURE_DEFAULT_OPTIONS,
+      prefix: 'naming-validator',
+    },
+    wrappedCommand: {
+      executable: 'node',
+      args: [
+        '--experimental-strip-types',
+        'calculogic-validator/scripts/validate-naming.host.mjs',
+        '--scope=validator',
+      ],
+    },
+  },
+  {
+    scriptName: 'report:naming:validator:entry',
+    profileId: 'naming',
+    commandSurface: 'validator-report-capture',
+    semanticPolicyOwner: 'naming',
+    capture: {
+      ...REPORT_CAPTURE_DEFAULT_OPTIONS,
+      prefix: 'naming-validator-entry',
+    },
+    wrappedCommand: {
+      executable: 'node',
+      args: [
+        '--experimental-strip-types',
+        'calculogic-validator/scripts/validate-naming.host.mjs',
+        '--scope=validator',
+        '--target',
+        'calculogic-validator/bin',
+        '--target',
+        'calculogic-validator/scripts',
+      ],
+    },
+  },
+  ...['naming', 'tree', 'doc'].map((targetName) => ({
+    scriptName: `report:naming:validator:${targetName}`,
+    profileId: 'naming',
+    commandSurface: 'validator-report-capture',
+    semanticPolicyOwner: 'naming',
+    capture: {
+      ...REPORT_CAPTURE_DEFAULT_OPTIONS,
+      prefix: `naming-validator-${targetName}`,
+    },
+    wrappedCommand: {
+      executable: 'node',
+      args: [
+        '--experimental-strip-types',
+        'calculogic-validator/scripts/validate-naming.host.mjs',
+        '--scope=validator',
+        '--target',
+        `calculogic-validator/${targetName}`,
+      ],
+    },
+  })),
+  {
+    scriptName: 'report:naming:system',
+    profileId: 'naming',
+    commandSurface: 'validator-report-capture',
+    semanticPolicyOwner: 'naming',
+    capture: {
+      ...REPORT_CAPTURE_DEFAULT_OPTIONS,
+      prefix: 'naming-system',
+    },
+    wrappedCommand: {
+      executable: 'node',
+      args: [
+        '--experimental-strip-types',
+        'calculogic-validator/scripts/validate-naming.host.mjs',
+        '--scope=system',
+      ],
+    },
+  },
+];
+
+export const VALIDATOR_REPORT_CAPTURE_PRESETS = [
+  ...namingValidatorSliceReportCapturePresets,
+  ...buildValidatorReportCapturePresets({
+    scriptNamespace: 'all',
+    profileId: 'validate-all',
+    directScriptPath: 'calculogic-validator/scripts/validate-all.host.mjs',
+    prefixBase: 'validate-all',
+    semanticPolicyOwner: 'suite-core-runner',
+    scopes: ['repo', 'app', 'docs', 'validator', 'system'],
+  }),
+  ...buildValidatorReportCapturePresets({
+    scriptNamespace: 'tree',
+    profileId: 'tree-structure-advisor',
+    directScriptPath: 'calculogic-validator/scripts/validate-tree.host.mjs',
+    prefixBase: 'validate-tree',
+    semanticPolicyOwner: 'tree',
+    scopes: ['repo', 'app', 'docs', 'validator', 'system'],
+  }),
+  {
+    scriptName: 'report:addressing:get-tree:validator',
+    profileId: 'addressing-get-tree',
+    commandSurface: 'validator-report-capture',
+    semanticPolicyOwner: 'addressing-deferred',
+    capture: {
+      ...REPORT_CAPTURE_DEFAULT_OPTIONS,
+      prefix: 'addressing-get-tree-validator',
+    },
+    wrappedCommand: {
+      executable: 'npm',
+      args: ['run', 'addressing:get-tree', '--', '--scope=validator', '--format=both'],
+    },
+  },
+];
+
 export const VALIDATOR_REGISTRY = [
   {
     id: 'naming',

--- a/calculogic-validator/src/core/validator-report-capture-metadata.logic.mjs
+++ b/calculogic-validator/src/core/validator-report-capture-metadata.logic.mjs
@@ -1,0 +1,23 @@
+import { VALIDATOR_REPORT_CAPTURE_PRESETS } from './validator-registry.knowledge.mjs';
+
+export const listValidatorReportCapturePresets = () =>
+  VALIDATOR_REPORT_CAPTURE_PRESETS.map((preset) => ({
+    ...preset,
+    capture: { ...preset.capture },
+    wrappedCommand: {
+      ...preset.wrappedCommand,
+      args: [...preset.wrappedCommand.args],
+    },
+  }));
+
+export const getValidatorReportCapturePresetByScriptName = (scriptName) =>
+  listValidatorReportCapturePresets().find((preset) => preset.scriptName === scriptName) ?? null;
+
+export const buildReportCapturePackageScript = (preset) => {
+  const jsonFlag = preset.capture.json ? ' --json' : '';
+  const wrappedCommand = [preset.wrappedCommand.executable, ...preset.wrappedCommand.args].join(
+    ' ',
+  );
+
+  return `${preset.capture.captureCommand}${jsonFlag} --dir ${preset.capture.dir} --keep ${preset.capture.keep} --prefix ${preset.capture.prefix} -- ${wrappedCommand}`;
+};

--- a/calculogic-validator/test/report-capture.registry-metadata.test.mjs
+++ b/calculogic-validator/test/report-capture.registry-metadata.test.mjs
@@ -1,0 +1,176 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import {
+  buildReportCapturePackageScript,
+  getValidatorReportCapturePresetByScriptName,
+  listValidatorReportCapturePresets,
+} from '../src/core/validator-report-capture-metadata.logic.mjs';
+
+const rootPackageJson = JSON.parse(
+  fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+);
+
+const directScriptByPreset = {
+  'report:naming:system': 'calculogic-validator/scripts/validate-naming.host.mjs',
+  'report:tree:system': 'calculogic-validator/scripts/validate-tree.host.mjs',
+  'report:all:system': 'calculogic-validator/scripts/validate-all.host.mjs',
+};
+
+const reportCapturePackageScripts = Object.entries(rootPackageJson.scripts)
+  .filter(([, command]) => command.includes('calculogic-report-capture'))
+  .map(([scriptName]) => scriptName)
+  .sort((left, right) => left.localeCompare(right));
+
+const normalizeReport = (report) => {
+  const normalized = structuredClone(report);
+  delete normalized.startedAt;
+  delete normalized.endedAt;
+  delete normalized.durationMs;
+  return normalized;
+};
+
+const runDirectReport = ({ scriptPath, scope }) => {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', scriptPath, `--scope=${scope}`],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.ok([0, 1, 2].includes(result.status));
+  assert.equal(result.stderr, '');
+  return JSON.parse(result.stdout);
+};
+
+const runCapturedReport = ({ preset, outputDir }) => {
+  const hostPath = path.resolve(
+    'calculogic-validator/tools/report-capture/src/report-capture.host.mjs',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      hostPath,
+      '--dir',
+      outputDir,
+      '--keep',
+      '20',
+      '--prefix',
+      preset.capture.prefix,
+      '--json',
+      '--',
+      preset.wrappedCommand.executable,
+      ...preset.wrappedCommand.args,
+    ],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.ok([0, 1, 2].includes(result.status));
+  const metadataLine = result.stderr
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('{') && line.includes('"path"'));
+  assert.ok(metadataLine, `missing report-capture metadata line in stderr: ${result.stderr}`);
+
+  const metadata = JSON.parse(metadataLine);
+  const capturedContent = fs.readFileSync(metadata.path, 'utf8');
+  assert.equal(capturedContent, result.stdout);
+  return JSON.parse(capturedContent);
+};
+
+test('report-capture preset metadata matches current package script surfaces exactly', () => {
+  const presets = listValidatorReportCapturePresets();
+  const presetScriptNames = presets
+    .map((preset) => preset.scriptName)
+    .sort((a, b) => a.localeCompare(b));
+
+  assert.deepEqual(presetScriptNames, reportCapturePackageScripts);
+
+  for (const preset of presets) {
+    assert.equal(
+      rootPackageJson.scripts[preset.scriptName],
+      buildReportCapturePackageScript(preset),
+    );
+    assert.deepEqual(getValidatorReportCapturePresetByScriptName(preset.scriptName), preset);
+    assert.equal(preset.commandSurface, 'validator-report-capture');
+    assert.equal(preset.capture.captureCommand, 'calculogic-report-capture');
+    assert.equal(preset.capture.json, true);
+    assert.equal(preset.capture.dir, './.reports');
+    assert.equal(preset.capture.keep, 20);
+  }
+
+  assert.equal(getValidatorReportCapturePresetByScriptName('report:missing'), null);
+});
+
+test('report-capture preset metadata records command mechanics but not semantic policy', () => {
+  const presets = listValidatorReportCapturePresets();
+  const forbiddenSemanticPolicyKeys = new Set([
+    'findings',
+    'summaries',
+    'severities',
+    'severity',
+    'rules',
+    'filenameParsing',
+    'semanticName',
+    'semanticFamily',
+    'placement',
+    'folderKind',
+    'structuralHome',
+    'semanticHome',
+  ]);
+
+  const visitKeys = (value, seenKeys = []) => {
+    if (!value || typeof value !== 'object') return seenKeys;
+    for (const [key, child] of Object.entries(value)) {
+      seenKeys.push(key);
+      visitKeys(child, seenKeys);
+    }
+    return seenKeys;
+  };
+
+  for (const preset of presets) {
+    for (const key of visitKeys(preset)) {
+      assert.equal(
+        forbiddenSemanticPolicyKeys.has(key),
+        false,
+        `${preset.scriptName} stores ${key}`,
+      );
+    }
+  }
+
+  assert.equal(
+    getValidatorReportCapturePresetByScriptName('report:naming:system').semanticPolicyOwner,
+    'naming',
+  );
+  assert.equal(
+    getValidatorReportCapturePresetByScriptName('report:tree:system').semanticPolicyOwner,
+    'tree',
+  );
+  assert.equal(
+    getValidatorReportCapturePresetByScriptName('report:all:system').semanticPolicyOwner,
+    'suite-core-runner',
+  );
+  assert.equal(
+    getValidatorReportCapturePresetByScriptName('report:addressing:get-tree:validator')
+      .semanticPolicyOwner,
+    'addressing-deferred',
+  );
+});
+
+for (const [scriptName, scriptPath] of Object.entries(directScriptByPreset)) {
+  test(`${scriptName} capture metadata preserves emitted report JSON`, () => {
+    const preset = getValidatorReportCapturePresetByScriptName(scriptName);
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-capture-registry-parity-'));
+
+    try {
+      const directReport = runDirectReport({ scriptPath, scope: 'system' });
+      const capturedReport = runCapturedReport({ preset, outputDir: tempDir });
+
+      assert.deepEqual(normalizeReport(capturedReport), normalizeReport(directReport));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
### Motivation
- Make report-capture command/preset expectations explicit and registry-backed where safe while preserving current behavior and ownership boundaries. 
- Provide deterministic, inspectable presets so package-script/report-capture parity can be tested before any runtime consumption changes. 
- Add tests to guard that metadata is command-mechanics-only and does not become semantic policy or alter emitted reports.

### Description
- Add data-only report-capture preset metadata (`VALIDATOR_REPORT_CAPTURE_PRESETS`) in `calculogic-validator/src/core/validator-registry.knowledge.mjs` for Naming, `validate:all`, Tree, and the deferred Addressing capture surface. 
- Add suite-core inspection helpers in `calculogic-validator/src/core/validator-report-capture-metadata.logic.mjs` exposing `listValidatorReportCapturePresets`, `getValidatorReportCapturePresetByScriptName`, and `buildReportCapturePackageScript`. 
- Add tests in `calculogic-validator/test/report-capture.registry-metadata.test.mjs` that assert package-script exact-match coverage, forbid semantic-policy keys inside presets, and verify parity between direct vs captured emitted reports for representative presets. 
- Update docs in `calculogic-validator/doc/ConventionRoutines/ValidatorSuiteOwnedSharedHelpers-And-Capabilities.md` and `calculogic-validator/doc/ConventionRoutines/ValidatorSliceAndReportFormula.md` to clarify that report-capture preset metadata records command mechanics only and must not be treated as semantic policy.

### Testing
- Ran `git diff --check` and it passed with no issues. 
- Ran focused report-capture metadata tests with `node --test calculogic-validator/test/report-capture.registry-metadata.test.mjs` and they passed. 
- Ran the full validator test set with `node --test calculogic-validator/test/*.test.mjs calculogic-validator/naming/test/*.test.mjs calculogic-validator/tree/test/*.test.mjs` and all tests passed (479 tests). 
- Verified runtime validator commands: `npm run validate:naming -- --scope=validator --target calculogic-validator/src/core`, `npm run validate:tree -- --scope=validator --target calculogic-validator/src/core`, and `npm run validate:all -- --scope=validator --target calculogic-validator/src/core` all succeeded and preserved report outputs; targeted report-capture parity checks for `report:naming:system`, `report:tree:system`, and `report:all:system` passed. 
- Observed an existing repo-doc naming run `npm run validate:naming -- --scope=validator --target calculogic-validator/doc` exited `2` due to pre-existing doc naming warnings/legacy exceptions (this is expected and unrelated to the metadata changes); running naming validation limited to the two changed docs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b5434a0ac833199b6880d8111ce1a)