### PR TITLE
Route Naming bridge occurrence contract and observation rules in validator docs index

### DIFF
--- a/calculogic-validator/doc/Indexes/validator-docs.index.md
+++ b/calculogic-validator/doc/Indexes/validator-docs.index.md
@@ -57,6 +57,12 @@ Authority labels used in this index:
 - `doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md`
   **Authority:** bounded normative supporting spec. **Intended use:** active documentation-first semantic-family modeling tranche for naming interpretation; runtime behavior remains governed by canonical authorities unless implemented.
 
+- `doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md`
+  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity contract for envelope shape, identity tuple, ownership boundaries, and migration/fallback rules; read before the Naming-owned bridge observation rules.
+
+- `doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md`
+  **Authority:** bounded normative supporting spec. **Intended use:** Naming-owned address-attached bridge observation rules for attaching semantic observations to occurrence identity without emitting Tree conclusions; not current runtime truth.
+
 - `doc/ValidatorSpecs/cross-cutting/registry-model-and-slice-interaction.spec.md`
   **Authority:** bounded normative supporting spec. **Intended use:** suite-level registry model/interaction constraints for implementation design and ownership boundaries; defer primary runtime authority to canonical contracts/slice specs.
 

--- a/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg.inventory.md
+++ b/calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg.inventory.md
@@ -43,12 +43,13 @@ Use this sequence for naming implementation tasks (runtime behavior, wiring/cont
 4. `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md`
 5. `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation.spec.md`
 6. `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md`
-7. `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md`
-8. `calculogic-validator/doc/ValidatorSpecs/cross-cutting/registry-model-and-slice-interaction.spec.md`
-9. `calculogic-validator/doc/ValidatorSpecs/validator-config.spec.md`
-10. `doc/nl-config/cfg-namingValidator.md` (supporting implementation context only)
-11. `calculogic-validator/doc/naming-compatibility.inventory.md` (transitional migration context)
-12. `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg.inventory.md` (this doc; routing/ownership metadata only)
+7. `calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md`
+8. `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md`
+9. `calculogic-validator/doc/ValidatorSpecs/cross-cutting/registry-model-and-slice-interaction.spec.md`
+10. `calculogic-validator/doc/ValidatorSpecs/validator-config.spec.md`
+11. `doc/nl-config/cfg-namingValidator.md` (supporting implementation context only)
+12. `calculogic-validator/doc/naming-compatibility.inventory.md` (transitional migration context)
+13. `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg.inventory.md` (this doc; routing/ownership metadata only)
 
 Interpretation notes:
 
@@ -68,6 +69,7 @@ Interpretation notes:
 | `calculogic-validator/doc/ValidatorSpecs/filename-case-and-interpretation-contract.md` | Shared filename interpretation and case-policy contract surface | **Bounded normative supporting spec** (shared contract lane; non-primary canonical authority in this map) | Cross-slice interpretation vocabulary, implementation alignment context | **Stay put** | **Reference and maintain as bounded supporting contract lane** |
 | `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-name-and-role-disambiguation.spec.md` | Naming interpretation spec for semantic-name vs role disambiguation | **Bounded normative supporting spec** | Naming interpretation implementation tasks and bounded design alignment | **Moved to `naming-owned/`** for clearer naming ownership while keeping canonical authorities stable elsewhere | **Keep in `naming-owned/`; split later only if scanability degrades materially** |
 | `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-semantic-family-and-interpretation.spec.md` | Naming interpretation spec for semantic-family semantics | **Bounded normative supporting spec** (active for documentation-first modeling) | Naming interpretation implementation tasks and bounded design alignment | **Moved to `naming-owned/`** for easier same-owner discovery | **Keep in `naming-owned/`; do not merge into master list authority** |
+| `calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md` | Cross-cutting occurrence identity contract for Naming bridge envelopes | **Bounded normative supporting spec** (cross-slice bridge contract; not current runtime truth) | Bridge contract implementation planning where readers need the envelope, identity tuple, ownership boundaries, and migration/fallback rules before Naming-owned observation rules | **Added under `cross-cutting/`** because occurrence identity is shared bridge contract context, not Naming-only behavior | **Read before the Naming-owned bridge observation rules; keep in `cross-cutting/`** |
 | `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md` | Naming-owned bridge observation rules for future address-attached observations | **Bounded normative supporting spec** (contract/specification slice; not current runtime truth) | Bridge contract implementation planning where Naming semantic observations attach to occurrence identity without emitting Tree conclusions | **Added under `naming-owned/`** because the rules are Naming-owned observation constraints that reference cross-slice occurrence identity | **Keep in `naming-owned/`; update alongside future Naming bridge contract slices** |
 | `calculogic-validator/doc/ValidatorSpecs/cross-cutting/registry-model-and-slice-interaction.spec.md` | Naming registry model and slice interaction reference | **Bounded normative supporting spec** (suite-level model constraints) | Wiring/modeling decisions and slice-boundary context | **Moved to `cross-cutting/`** because forcing it under naming would blur suite-level ownership | **Keep in `cross-cutting/`; consider later split by concern only if document growth harms scanability** |
 | `doc/nl-config/cfg-namingValidator.md` | Repo-local naming NL/config note | **Supporting implementation guidance** (repo-local/external to validator-owned canonical set) | Implementation sequencing/context for local repo tasks | **Stay put** | **Reference only** |


### PR DESCRIPTION
### Motivation
- The new Naming-owned bridge observation rules spec depends on a cross-cutting occurrence identity contract that should be read first to understand the bridge envelope, identity tuple, ownership boundaries, and migration/fallback rules. 
- Update the documentation routing so implementers following the Naming docs map encounter the cross-cutting occurrence contract immediately before the Naming-owned observation rules for correct reading order and discoverability.

### Description
- Inserted `calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md` immediately before `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md` in the canonical reading order in `calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg.inventory.md` and added a corresponding inventory table row describing the contract and read-order intent. 
- Added both the cross-cutting occurrence identity contract and the Naming-owned observation rules entries to `calculogic-validator/doc/Indexes/validator-docs.index.md` using the existing bounded normative supporting-spec authority wording so the new spec is discoverable from the validator index. 
- Did not modify the Naming-owned observation-rules spec content itself and avoided any runtime, registry, tree, payload, CLI, or broad docs cleanup changes. 
- PR references: Refs #623 and Refs #618.

### Testing
- Ran `git diff --check` which produced no index/whitespace errors and passed. 
- Ran focused validation with `node --experimental-strip-types calculogic-validator/scripts/validate-naming.host.mjs --scope=validator --target calculogic-validator/doc/ValidatorSpecs/naming-owned/naming-documentation-map-and-reorg.inventory.md --target calculogic-validator/doc/Indexes/validator-docs.index.md` which completed successfully and returned a focused report scanning 2 files with 2 canonical findings and 0 invalid/legacy findings. 
- Ran the broader docs naming scan with `npm run validate:naming:validator:doc` which executed but reported pre-existing repository findings outside the touched files (summary: 51 canonical, 25 legacy-exception, 2 invalid-ambiguous), indicating unrelated, pre-existing naming findings in the wider docs set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d8579f6b48331bd1305f85c35e9cf)