### PR TITLE
Add versioned Naming occurrence bridge payload shape

### DIFF
--- a/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
+++ b/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
@@ -102,6 +102,30 @@ const toMissingIdentityDiagnostic = ({ semanticObservation, reason }) => ({
   semanticName: toOptionalNonEmptyString(semanticObservation.semanticName) ?? null,
 });
 
+const toInvalidAddressedNamespaceDiagnostics = ({ addressProfileId, addressedSnapshotId }) => {
+  const diagnostics = [];
+
+  if (!addressProfileId) {
+    diagnostics.push({
+      diagnosticType: 'invalid-addressed-namespace',
+      reason: 'missing-address-profile-id',
+      addressProfileId: null,
+      addressedSnapshotId: addressedSnapshotId ?? null,
+    });
+  }
+
+  if (!addressedSnapshotId) {
+    diagnostics.push({
+      diagnosticType: 'invalid-addressed-namespace',
+      reason: 'missing-addressed-snapshot-id',
+      addressProfileId: addressProfileId ?? null,
+      addressedSnapshotId: null,
+    });
+  }
+
+  return diagnostics;
+};
+
 export const createNamingOccurrenceBridgePayload = ({
   namingSemanticFamilyBridge = {},
   addressedOccurrenceNamespace = {},
@@ -116,46 +140,49 @@ export const createNamingOccurrenceBridgePayload = ({
   const occurrenceByPath = buildOccurrenceByPath(addressedOccurrenceNamespace.occurrenceRecords);
 
   const observations = [];
-  const diagnostics = [];
+  const diagnostics = toInvalidAddressedNamespaceDiagnostics({ addressProfileId, addressedSnapshotId });
+  const hasValidAddressedNamespace = diagnostics.length === 0;
 
-  for (const semanticObservation of sourceObservations) {
-    if (!semanticObservation || typeof semanticObservation !== 'object' || Array.isArray(semanticObservation)) {
-      continue;
+  if (hasValidAddressedNamespace) {
+    for (const semanticObservation of sourceObservations) {
+      if (!semanticObservation || typeof semanticObservation !== 'object' || Array.isArray(semanticObservation)) {
+        continue;
+      }
+
+      const pathKey = toPathKey(semanticObservation.repoRelativePath) ?? toPathKey(semanticObservation.path);
+      if (!pathKey) {
+        diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'missing-path-key' }));
+        continue;
+      }
+
+      const occurrenceRecord = occurrenceByPath.get(pathKey);
+      if (!occurrenceRecord) {
+        diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'unmatched-occurrence-record' }));
+        continue;
+      }
+
+      const observation = toAddressAttachedObservation({
+        semanticObservation,
+        occurrenceRecord,
+        addressProfileId,
+        addressedSnapshotId,
+      });
+
+      if (!observation) {
+        diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'incomplete-occurrence-identity' }));
+        continue;
+      }
+
+      observations.push(observation);
     }
-
-    const pathKey = toPathKey(semanticObservation.repoRelativePath) ?? toPathKey(semanticObservation.path);
-    if (!pathKey) {
-      diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'missing-path-key' }));
-      continue;
-    }
-
-    const occurrenceRecord = occurrenceByPath.get(pathKey);
-    if (!occurrenceRecord) {
-      diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'unmatched-occurrence-record' }));
-      continue;
-    }
-
-    const observation = toAddressAttachedObservation({
-      semanticObservation,
-      occurrenceRecord,
-      addressProfileId,
-      addressedSnapshotId,
-    });
-
-    if (!observation) {
-      diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'incomplete-occurrence-identity' }));
-      continue;
-    }
-
-    observations.push(observation);
   }
 
   return {
     bridgeContractVersion: BRIDGE_CONTRACT_VERSION,
     bridgeSource: BRIDGE_SOURCE,
     bridgeProducerId: BRIDGE_PRODUCER_ID,
-    ...(addressProfileId ? { addressProfileId } : {}),
-    ...(addressedSnapshotId ? { addressedSnapshotId } : {}),
+    addressProfileId: addressProfileId ?? null,
+    addressedSnapshotId: addressedSnapshotId ?? null,
     ...(sourceReportRef !== undefined ? { sourceReportRef } : {}),
     ...(sourceSnapshotRef !== undefined ? { sourceSnapshotRef } : {}),
     compatibility: {
@@ -163,9 +190,16 @@ export const createNamingOccurrenceBridgePayload = ({
       temporaryCompatibilityPathField: 'path',
       temporaryDebugAddressPathField: 'addressPath',
       addressAttachedObservationsOmitMissingIdentity: true,
+      addressedNamespaceValid: hasValidAddressedNamespace,
+      invalidAddressedNamespaceDiagnosticCount: diagnostics.filter(
+        (diagnostic) => diagnostic.diagnosticType === 'invalid-addressed-namespace',
+      ).length,
       sourceObservationCount: sourceObservations.length,
       addressAttachedObservationCount: observations.length,
-      missingIdentityDiagnosticCount: diagnostics.length,
+      missingIdentityDiagnosticCount: diagnostics.filter(
+        (diagnostic) => diagnostic.diagnosticType === 'missing-occurrence-identity',
+      ).length,
+      totalDiagnosticCount: diagnostics.length,
     },
     observations: observations.sort((left, right) =>
       left.addressProfileId.localeCompare(right.addressProfileId) ||

--- a/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
+++ b/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
@@ -1,0 +1,178 @@
+const BRIDGE_CONTRACT_VERSION = 'naming-occurrence-bridge.v1';
+const BRIDGE_SOURCE = 'calculogic-validator/naming';
+const BRIDGE_PRODUCER_ID = 'naming-semantic-family-occurrence-bridge';
+
+const NAMING_SEMANTIC_FIELDS = [
+  'semanticName',
+  'semanticFamily',
+  'familyRoot',
+  'familySubgroup',
+  'ambiguityFlags',
+  'splitFamilyFlags',
+];
+
+const toOptionalNonEmptyString = (value) => (typeof value === 'string' && value.length > 0 ? value : null);
+
+const cloneStringArray = (value) =>
+  Array.isArray(value) ? value.filter((item) => typeof item === 'string' && item.length > 0) : null;
+
+const toPathKey = (value) => toOptionalNonEmptyString(value);
+
+const buildOccurrenceByPath = (occurrenceRecords) => {
+  const occurrenceByPath = new Map();
+
+  for (const occurrenceRecord of Array.isArray(occurrenceRecords) ? occurrenceRecords : []) {
+    if (!occurrenceRecord || typeof occurrenceRecord !== 'object' || Array.isArray(occurrenceRecord)) {
+      continue;
+    }
+
+    const repoRelativePath = toPathKey(occurrenceRecord.repoRelativePath) ?? toPathKey(occurrenceRecord.path);
+    if (!repoRelativePath || occurrenceByPath.has(repoRelativePath)) {
+      continue;
+    }
+
+    occurrenceByPath.set(repoRelativePath, occurrenceRecord);
+  }
+
+  return occurrenceByPath;
+};
+
+const copyNamingSemanticPayload = (observation) => {
+  const payload = {};
+
+  for (const field of NAMING_SEMANTIC_FIELDS) {
+    if (field === 'ambiguityFlags' || field === 'splitFamilyFlags') {
+      const clonedFlags = cloneStringArray(observation[field]);
+      if (clonedFlags) {
+        payload[field] = clonedFlags;
+      }
+      continue;
+    }
+
+    const fieldValue = toOptionalNonEmptyString(observation[field]);
+    if (fieldValue) {
+      payload[field] = fieldValue;
+    }
+  }
+
+  return payload;
+};
+
+const toAddressAttachedObservation = ({
+  semanticObservation,
+  occurrenceRecord,
+  addressProfileId,
+  addressedSnapshotId,
+}) => {
+  const repoRelativePath =
+    toPathKey(semanticObservation.repoRelativePath) ??
+    toPathKey(occurrenceRecord.repoRelativePath) ??
+    toPathKey(semanticObservation.path) ??
+    toPathKey(occurrenceRecord.path);
+  const occurrenceAddress =
+    toOptionalNonEmptyString(occurrenceRecord.occurrenceAddress) ??
+    toOptionalNonEmptyString(occurrenceRecord.address) ??
+    toOptionalNonEmptyString(occurrenceRecord.addressPath);
+
+  if (!addressProfileId || !addressedSnapshotId || !occurrenceAddress || !repoRelativePath) {
+    return null;
+  }
+
+  return {
+    addressProfileId,
+    addressedSnapshotId,
+    occurrenceAddress,
+    repoRelativePath,
+    path: toPathKey(semanticObservation.path) ?? repoRelativePath,
+    ...(toOptionalNonEmptyString(occurrenceRecord.addressPath)
+      ? { addressPath: occurrenceRecord.addressPath }
+      : {}),
+    ...(toOptionalNonEmptyString(occurrenceRecord.occurrenceType)
+      ? { occurrenceType: occurrenceRecord.occurrenceType }
+      : {}),
+    ...copyNamingSemanticPayload(semanticObservation),
+  };
+};
+
+const toMissingIdentityDiagnostic = ({ semanticObservation, reason }) => ({
+  diagnosticType: 'missing-occurrence-identity',
+  reason,
+  repoRelativePath: toPathKey(semanticObservation.repoRelativePath) ?? toPathKey(semanticObservation.path) ?? null,
+  path: toPathKey(semanticObservation.path) ?? null,
+  semanticName: toOptionalNonEmptyString(semanticObservation.semanticName) ?? null,
+});
+
+export const createNamingOccurrenceBridgePayload = ({
+  namingSemanticFamilyBridge = {},
+  addressedOccurrenceNamespace = {},
+  sourceReportRef,
+  sourceSnapshotRef,
+} = {}) => {
+  const sourceObservations = Array.isArray(namingSemanticFamilyBridge.observations)
+    ? namingSemanticFamilyBridge.observations
+    : [];
+  const addressProfileId = toOptionalNonEmptyString(addressedOccurrenceNamespace.addressProfileId);
+  const addressedSnapshotId = toOptionalNonEmptyString(addressedOccurrenceNamespace.addressedSnapshotId);
+  const occurrenceByPath = buildOccurrenceByPath(addressedOccurrenceNamespace.occurrenceRecords);
+
+  const observations = [];
+  const diagnostics = [];
+
+  for (const semanticObservation of sourceObservations) {
+    if (!semanticObservation || typeof semanticObservation !== 'object' || Array.isArray(semanticObservation)) {
+      continue;
+    }
+
+    const pathKey = toPathKey(semanticObservation.repoRelativePath) ?? toPathKey(semanticObservation.path);
+    if (!pathKey) {
+      diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'missing-path-key' }));
+      continue;
+    }
+
+    const occurrenceRecord = occurrenceByPath.get(pathKey);
+    if (!occurrenceRecord) {
+      diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'unmatched-occurrence-record' }));
+      continue;
+    }
+
+    const observation = toAddressAttachedObservation({
+      semanticObservation,
+      occurrenceRecord,
+      addressProfileId,
+      addressedSnapshotId,
+    });
+
+    if (!observation) {
+      diagnostics.push(toMissingIdentityDiagnostic({ semanticObservation, reason: 'incomplete-occurrence-identity' }));
+      continue;
+    }
+
+    observations.push(observation);
+  }
+
+  return {
+    bridgeContractVersion: BRIDGE_CONTRACT_VERSION,
+    bridgeSource: BRIDGE_SOURCE,
+    bridgeProducerId: BRIDGE_PRODUCER_ID,
+    ...(addressProfileId ? { addressProfileId } : {}),
+    ...(addressedSnapshotId ? { addressedSnapshotId } : {}),
+    ...(sourceReportRef !== undefined ? { sourceReportRef } : {}),
+    ...(sourceSnapshotRef !== undefined ? { sourceSnapshotRef } : {}),
+    compatibility: {
+      pathKeyedSemanticPayloadPreserved: true,
+      temporaryCompatibilityPathField: 'path',
+      temporaryDebugAddressPathField: 'addressPath',
+      addressAttachedObservationsOmitMissingIdentity: true,
+      sourceObservationCount: sourceObservations.length,
+      addressAttachedObservationCount: observations.length,
+      missingIdentityDiagnosticCount: diagnostics.length,
+    },
+    observations: observations.sort((left, right) =>
+      left.addressProfileId.localeCompare(right.addressProfileId) ||
+      left.addressedSnapshotId.localeCompare(right.addressedSnapshotId) ||
+      left.occurrenceAddress.localeCompare(right.occurrenceAddress) ||
+      left.repoRelativePath.localeCompare(right.repoRelativePath),
+    ),
+    ...(diagnostics.length > 0 ? { diagnostics } : {}),
+  };
+};

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createNamingOccurrenceBridgePayload } from '../src/naming-occurrence-bridge-payload.logic.mjs';
+
+const treeOwnedFields = [
+  'structuralHome',
+  'semanticHome',
+  'folderKind',
+  'repoShape',
+  'placement',
+  'placementConfidence',
+  'scatterStatus',
+  'clusterStatus',
+  'driftStatus',
+  'severity',
+  'verdict',
+  'parentStructuralHome',
+  'childStructuralHome',
+  'rootLanePlacement',
+];
+
+test('createNamingOccurrenceBridgePayload creates a versioned Naming bridge envelope', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: { observations: [] },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [],
+    },
+    sourceReportRef: { reportId: 'naming-report-001' },
+    sourceSnapshotRef: { snapshotId: 'source-snapshot-001' },
+  });
+
+  assert.equal(result.bridgeContractVersion, 'naming-occurrence-bridge.v1');
+  assert.equal(result.bridgeSource, 'calculogic-validator/naming');
+  assert.equal(result.bridgeProducerId, 'naming-semantic-family-occurrence-bridge');
+  assert.equal(result.addressProfileId, 'tree-codebase');
+  assert.equal(result.addressedSnapshotId, 'snapshot-001');
+  assert.deepEqual(result.sourceReportRef, { reportId: 'naming-report-001' });
+  assert.deepEqual(result.sourceSnapshotRef, { snapshotId: 'source-snapshot-001' });
+  assert.deepEqual(result.observations, []);
+  assert.equal(result.compatibility.pathKeyedSemanticPayloadPreserved, true);
+});
+
+test('createNamingOccurrenceBridgePayload attaches full occurrence identity and preserves Naming semantic payloads', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [
+        {
+          path: 'calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs',
+          semanticName: 'naming-semantic-family-bridge-projection',
+          semanticFamily: 'naming-semantic-family',
+          familyRoot: 'naming',
+          familySubgroup: 'semantic-family',
+          ambiguityFlags: ['family-boundary-heuristic'],
+          splitFamilyFlags: ['family-root-observed-multiple-families'],
+        },
+      ],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [
+        {
+          occurrenceAddress: 'A.B.1',
+          addressPath: 'A.B.1',
+          path: 'calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs',
+          occurrenceType: 'file',
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(result.observations, [
+    {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A.B.1',
+      repoRelativePath: 'calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs',
+      path: 'calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs',
+      addressPath: 'A.B.1',
+      occurrenceType: 'file',
+      semanticName: 'naming-semantic-family-bridge-projection',
+      semanticFamily: 'naming-semantic-family',
+      familyRoot: 'naming',
+      familySubgroup: 'semantic-family',
+      ambiguityFlags: ['family-boundary-heuristic'],
+      splitFamilyFlags: ['family-root-observed-multiple-families'],
+    },
+  ]);
+});
+
+test('createNamingOccurrenceBridgePayload makes missing or unmatched occurrence identity visible', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [
+        { path: 'src/missing.logic.mjs', semanticName: 'missing', semanticFamily: 'missing', familyRoot: 'missing' },
+        { path: 'src/incomplete.logic.mjs', semanticName: 'incomplete', semanticFamily: 'incomplete', familyRoot: 'incomplete' },
+      ],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [{ path: 'src/incomplete.logic.mjs', occurrenceType: 'file' }],
+    },
+  });
+
+  assert.deepEqual(result.observations, []);
+  assert.equal(result.compatibility.addressAttachedObservationsOmitMissingIdentity, true);
+  assert.equal(result.compatibility.missingIdentityDiagnosticCount, 2);
+  assert.deepEqual(result.diagnostics.map((diagnostic) => diagnostic.reason), [
+    'unmatched-occurrence-record',
+    'incomplete-occurrence-identity',
+  ]);
+});
+
+test('createNamingOccurrenceBridgePayload does not emit Tree-owned conclusion fields', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [
+        {
+          path: 'src/app.logic.mjs',
+          semanticName: 'app',
+          semanticFamily: 'app',
+          familyRoot: 'app',
+          structuralHome: 'src',
+          semanticHome: 'app',
+          folderKind: 'semantic',
+          placementConfidence: 'high',
+          severity: 'warning',
+          verdict: 'drift',
+        },
+      ],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [{ occurrenceAddress: 'A.1', addressPath: 'A.1', path: 'src/app.logic.mjs', occurrenceType: 'file' }],
+    },
+  });
+
+  for (const observation of result.observations) {
+    for (const field of treeOwnedFields) {
+      assert.equal(Object.hasOwn(observation, field), false, `${field} must not be emitted`);
+    }
+  }
+});

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
@@ -40,6 +40,89 @@ test('createNamingOccurrenceBridgePayload creates a versioned Naming bridge enve
   assert.deepEqual(result.sourceSnapshotRef, { snapshotId: 'source-snapshot-001' });
   assert.deepEqual(result.observations, []);
   assert.equal(result.compatibility.pathKeyedSemanticPayloadPreserved, true);
+  assert.equal(result.compatibility.addressedNamespaceValid, true);
+  assert.equal(result.compatibility.invalidAddressedNamespaceDiagnosticCount, 0);
+  assert.equal(result.addressProfileId, 'tree-codebase');
+  assert.equal(result.addressedSnapshotId, 'snapshot-001');
+});
+
+
+test('createNamingOccurrenceBridgePayload reports missing addressProfileId as an invalid namespace', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [{ path: 'src/app.logic.mjs', semanticName: 'app', semanticFamily: 'app', familyRoot: 'app' }],
+    },
+    addressedOccurrenceNamespace: {
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [{ occurrenceAddress: 'A.1', addressPath: 'A.1', path: 'src/app.logic.mjs', occurrenceType: 'file' }],
+    },
+  });
+
+  assert.equal(result.addressProfileId, null);
+  assert.equal(result.addressedSnapshotId, 'snapshot-001');
+  assert.deepEqual(result.observations, []);
+  assert.equal(result.compatibility.addressedNamespaceValid, false);
+  assert.equal(result.compatibility.invalidAddressedNamespaceDiagnosticCount, 1);
+  assert.equal(result.compatibility.missingIdentityDiagnosticCount, 0);
+  assert.equal(result.compatibility.totalDiagnosticCount, 1);
+  assert.deepEqual(result.diagnostics, [
+    {
+      diagnosticType: 'invalid-addressed-namespace',
+      reason: 'missing-address-profile-id',
+      addressProfileId: null,
+      addressedSnapshotId: 'snapshot-001',
+    },
+  ]);
+});
+
+test('createNamingOccurrenceBridgePayload reports missing addressedSnapshotId as an invalid namespace', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [{ path: 'src/app.logic.mjs', semanticName: 'app', semanticFamily: 'app', familyRoot: 'app' }],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      occurrenceRecords: [{ occurrenceAddress: 'A.1', addressPath: 'A.1', path: 'src/app.logic.mjs', occurrenceType: 'file' }],
+    },
+  });
+
+  assert.equal(result.addressProfileId, 'tree-codebase');
+  assert.equal(result.addressedSnapshotId, null);
+  assert.deepEqual(result.observations, []);
+  assert.equal(result.compatibility.addressedNamespaceValid, false);
+  assert.equal(result.compatibility.invalidAddressedNamespaceDiagnosticCount, 1);
+  assert.equal(result.compatibility.totalDiagnosticCount, 1);
+  assert.deepEqual(result.diagnostics, [
+    {
+      diagnosticType: 'invalid-addressed-namespace',
+      reason: 'missing-addressed-snapshot-id',
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: null,
+    },
+  ]);
+});
+
+test('createNamingOccurrenceBridgePayload reports both missing namespace IDs and keeps observations empty', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [{ path: 'src/app.logic.mjs', semanticName: 'app', semanticFamily: 'app', familyRoot: 'app' }],
+    },
+    addressedOccurrenceNamespace: {
+      occurrenceRecords: [{ occurrenceAddress: 'A.1', addressPath: 'A.1', path: 'src/app.logic.mjs', occurrenceType: 'file' }],
+    },
+  });
+
+  assert.equal(result.addressProfileId, null);
+  assert.equal(result.addressedSnapshotId, null);
+  assert.deepEqual(result.observations, []);
+  assert.equal(result.compatibility.addressedNamespaceValid, false);
+  assert.equal(result.compatibility.invalidAddressedNamespaceDiagnosticCount, 2);
+  assert.equal(result.compatibility.missingIdentityDiagnosticCount, 0);
+  assert.equal(result.compatibility.totalDiagnosticCount, 2);
+  assert.deepEqual(result.diagnostics.map((diagnostic) => diagnostic.reason), [
+    'missing-address-profile-id',
+    'missing-addressed-snapshot-id',
+  ]);
 });
 
 test('createNamingOccurrenceBridgePayload attaches full occurrence identity and preserves Naming semantic payloads', () => {
@@ -108,6 +191,7 @@ test('createNamingOccurrenceBridgePayload makes missing or unmatched occurrence 
   assert.deepEqual(result.observations, []);
   assert.equal(result.compatibility.addressAttachedObservationsOmitMissingIdentity, true);
   assert.equal(result.compatibility.missingIdentityDiagnosticCount, 2);
+  assert.equal(result.compatibility.totalDiagnosticCount, 2);
   assert.deepEqual(result.diagnostics.map((diagnostic) => diagnostic.reason), [
     'unmatched-occurrence-record',
     'incomplete-occurrence-identity',


### PR DESCRIPTION
### Motivation
- Implement the first data-only, versioned Naming bridge payload shape to support address-attached Naming observations for the canonical identity tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` while preserving current path-keyed compatibility.
- Preserve existing Naming semantic payloads and temporary compatibility/debug fields during migration and make missing or unmatched occurrence identity explicit instead of hiding it behind path fallback.
- Follow the issue and contract inputs (`#621`, `#623`, PR #626) and maintain the restriction that Tree/runtime behavior and report/CLI envelopes are not changed in this slice. 

### Description
- Add a helper `createNamingOccurrenceBridgePayload` in `calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs` that emits a versioned envelope (`bridgeContractVersion: "naming-occurrence-bridge.v1"`) including `bridgeSource`, `bridgeProducerId`, optional `addressProfileId`/`addressedSnapshotId`, `compatibility` metadata, deterministic `observations[]`, and `diagnostics[]` for missing identity.
- Define address-attached observation shaping that preserves Naming semantic fields (`semanticName`, `semanticFamily`, `familyRoot`, `familySubgroup`, `ambiguityFlags`, `splitFamilyFlags`), includes `repoRelativePath`/temporary `path`, optional debug `addressPath`, supplied `occurrenceType`, and the canonical identity tuple when available, and explicitly omits Tree-owned conclusion fields.
- Make missing/unmatched/incomplete occurrence identity visible via `diagnostics` and omit such records from address-attached `observations[]` per the migration/fallback rules.
- Add focused tests in `calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs` that validate envelope creation, full identity attachment and semantic-payload preservation, temporary compatibility fields, missing/unmatched identity behavior, and proof that Tree-owned conclusion fields are not emitted; do not wire this helper into runtime Tree consumers. 

### Testing
- Ran naming unit tests with: `node --test calculogic-validator/naming/test/*.test.mjs` and observed all tests pass (including the new focused tests).
- Ran tree unit tests with: `node --test calculogic-validator/tree/test/*.test.mjs` and observed all tests pass.
- Ran slice validations with: `npm run validate:naming -- --scope=validator --target calculogic-validator/naming` and `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` and observed both validations complete successfully (report-only advisory/findings are pre-existing and expected).

Refs #627
Refs #618

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2da58d0e308331bb86b5fb0fd3f8de)