### PR TITLE
Wire Naming occurrence bridge staging

### DIFF
--- a/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
+++ b/calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md
@@ -383,6 +383,14 @@ Prepared bridge projection (small explicit surface):
 
 This bridge is an intentionally narrow projection for advisory consumption. It is not a generic "pass the full naming report to tree" contract.
 
+Additive occurrence bridge staging path (current implementation reality):
+
+- naming can produce a versioned `naming-occurrence-bridge.v1` payload when a caller supplies an addressed occurrence namespace
+- the occurrence bridge is produced from the existing path-keyed semantic-family projection and address-attaches observations only when namespace identifiers and matching occurrence identity are present
+- missing or invalid namespace state remains visible through occurrence bridge diagnostics and produces empty address-attached observations for invalid namespace input
+- the occurrence bridge preserves the current path-keyed compatibility field and does not carry tree-owned conclusion fields such as semantic-home, structural-home, folder-kind, placement, scatter, cluster, or drift conclusions
+- tree consumption remains on the current path-keyed semantic-family bridge until a separate tree consumption slice changes that behavior
+
 Current runner production path (shipped behavior):
 
 - the shared suite runner stages naming before tree whenever tree is selected in the run

--- a/calculogic-validator/naming/src/naming-validator.wiring.mjs
+++ b/calculogic-validator/naming/src/naming-validator.wiring.mjs
@@ -20,6 +20,7 @@ import {
   summarizeFindings as summarizeFindingsRuntime,
 } from './naming-validator.logic.mjs';
 import { projectNamingSemanticFamilyBridge } from './naming-semantic-family-bridge-projection.logic.mjs';
+import { createNamingOccurrenceBridgePayload } from './naming-occurrence-bridge-payload.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from './naming-semantic-evidence-bridge.logic.mjs';
 import { normalizePath } from '../../src/core/scoped-target-paths.logic.mjs';
 import { collectValidatorCandidatePaths } from '../../src/core/validator-candidate-collection.logic.mjs';
@@ -97,14 +98,27 @@ export const prepareNamingValidatorInputs = (
   };
 };
 
-export const runNamingValidator = (repositoryRoot, { scope, config, targets } = {}) => {
+export const projectNamingOccurrenceBridge = (namingRuntimeOrReportOutput = {}, options = {}) =>
+  createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: options.namingSemanticFamilyBridge ??
+      projectNamingSemanticFamilyBridge(namingRuntimeOrReportOutput),
+    addressedOccurrenceNamespace: options.addressedOccurrenceNamespace,
+    sourceReportRef: options.sourceReportRef,
+    sourceSnapshotRef: options.sourceSnapshotRef,
+  });
+
+export const runNamingValidator = (repositoryRoot, { scope, config, targets, addressedOccurrenceNamespace } = {}) => {
   const preparedInputs = prepareNamingValidatorInputs(repositoryRoot, { scope, config, targets });
 
   const result = runNamingValidatorRuntime(preparedInputs);
+  const namingOccurrenceBridge = addressedOccurrenceNamespace !== undefined
+    ? projectNamingOccurrenceBridge(result, { addressedOccurrenceNamespace })
+    : undefined;
 
   return {
     ...result,
     registry: preparedInputs.registry,
+    ...(namingOccurrenceBridge ? { namingOccurrenceBridge } : {}),
   };
 };
 
@@ -145,5 +159,6 @@ export {
   listNamingValidatorScopes,
   getScopeProfile,
   projectNamingSemanticFamilyBridge,
+  createNamingOccurrenceBridgePayload,
   prepareNamingSemanticEvidenceBridge,
 };

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  projectNamingOccurrenceBridge,
+  projectNamingSemanticFamilyBridge,
+  runNamingValidator,
+} from '../src/naming-validator.host.mjs';
+
+const createRuntimeOutput = () => ({
+  findings: [
+    {
+      path: 'src/build-surface.logic.mjs',
+      classification: 'canonical',
+      details: {
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+        familySubgroup: 'surface',
+      },
+    },
+  ],
+});
+
+const validNamespace = {
+  addressProfileId: 'tree-codebase',
+  addressedSnapshotId: 'snapshot-001',
+  occurrenceRecords: [
+    {
+      repoRelativePath: 'src/build-surface.logic.mjs',
+      path: 'src/build-surface.logic.mjs',
+      occurrenceAddress: 'A.1',
+      addressPath: 'A.1',
+      occurrenceType: 'file',
+    },
+  ],
+};
+
+test('projectNamingOccurrenceBridge produces versioned payload without changing path-keyed semantic-family bridge', () => {
+  const runtimeOutput = createRuntimeOutput();
+  const pathKeyedBridgeBefore = projectNamingSemanticFamilyBridge(runtimeOutput);
+
+  const occurrenceBridge = projectNamingOccurrenceBridge(runtimeOutput, {
+    addressedOccurrenceNamespace: validNamespace,
+  });
+
+  assert.equal(occurrenceBridge.bridgeContractVersion, 'naming-occurrence-bridge.v1');
+  assert.equal(occurrenceBridge.compatibility.pathKeyedSemanticPayloadPreserved, true);
+  assert.deepEqual(projectNamingSemanticFamilyBridge(runtimeOutput), pathKeyedBridgeBefore);
+  assert.deepEqual(pathKeyedBridgeBefore, {
+    observations: [
+      {
+        path: 'src/build-surface.logic.mjs',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+        familySubgroup: 'surface',
+      },
+    ],
+  });
+});
+
+test('projectNamingOccurrenceBridge attaches addresses for a valid namespace and omits Tree conclusions', () => {
+  const occurrenceBridge = projectNamingOccurrenceBridge(createRuntimeOutput(), {
+    addressedOccurrenceNamespace: validNamespace,
+  });
+
+  assert.deepEqual(occurrenceBridge.observations, [
+    {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A.1',
+      repoRelativePath: 'src/build-surface.logic.mjs',
+      path: 'src/build-surface.logic.mjs',
+      addressPath: 'A.1',
+      occurrenceType: 'file',
+      semanticName: 'build-surface',
+      semanticFamily: 'build-surface',
+      familyRoot: 'build',
+      familySubgroup: 'surface',
+    },
+  ]);
+
+  const forbiddenTreeConclusionFields = [
+    'semanticHome',
+    'structuralHome',
+    'folderKind',
+    'placementConfidence',
+    'scatter',
+    'cluster',
+    'drift',
+  ];
+  for (const field of forbiddenTreeConclusionFields) {
+    assert.equal(Object.hasOwn(occurrenceBridge.observations[0], field), false);
+  }
+});
+
+test('projectNamingOccurrenceBridge keeps missing namespace diagnostics visible with empty address-attached observations', () => {
+  const occurrenceBridge = projectNamingOccurrenceBridge(createRuntimeOutput());
+
+  assert.equal(occurrenceBridge.addressProfileId, null);
+  assert.equal(occurrenceBridge.addressedSnapshotId, null);
+  assert.deepEqual(occurrenceBridge.observations, []);
+  assert.equal(occurrenceBridge.compatibility.addressedNamespaceValid, false);
+  assert.deepEqual(
+    occurrenceBridge.diagnostics.map((diagnostic) => diagnostic.reason),
+    ['missing-address-profile-id', 'missing-addressed-snapshot-id'],
+  );
+});
+
+test('runNamingValidator stages occurrence bridge only when an addressed namespace is supplied', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-occurrence-bridge-wiring-'));
+  try {
+    fs.mkdirSync(path.join(tempRoot, 'src'));
+    fs.writeFileSync(path.join(tempRoot, 'src', 'build-surface.logic.mjs'), 'export const value = true;\n');
+
+    const withoutNamespace = runNamingValidator(tempRoot, { scope: 'repo' });
+    assert.equal(Object.hasOwn(withoutNamespace, 'namingOccurrenceBridge'), false);
+
+    const withNamespace = runNamingValidator(tempRoot, {
+      scope: 'repo',
+      addressedOccurrenceNamespace: validNamespace,
+    });
+
+    assert.equal(withNamespace.namingOccurrenceBridge.bridgeContractVersion, 'naming-occurrence-bridge.v1');
+    assert.equal(withNamespace.namingOccurrenceBridge.observations.length, 1);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -1389,3 +1389,60 @@ test('tree naming bridge contributor keeps local-first routing deterministic whe
   assert.deepEqual(firstScatter, secondScatter);
   assert.equal(firstScatter.length, 1);
 });
+
+test('tree naming bridge contributor keeps current path-keyed join and ignores occurrence bridge sibling payload', () => {
+  const stagedBridgeTransport = {
+    observations: [
+      {
+        path: 'src/shared/build/build-surface.logic.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/features/build/build-surface.results.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/features/build/build-surface.knowledge.ts',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+      {
+        path: 'src/features/build/build-surface.build.tsx',
+        semanticName: 'build-surface',
+        familyRoot: 'build',
+        semanticFamily: 'build-surface',
+      },
+    ],
+    namingOccurrenceBridge: {
+      bridgeContractVersion: 'naming-occurrence-bridge.v1',
+      observations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'Z.9',
+          repoRelativePath: 'different/address-keyed-only.logic.ts',
+          path: 'different/address-keyed-only.logic.ts',
+          semanticName: 'address-keyed-only',
+          familyRoot: 'address',
+          semanticFamily: 'address-keyed-only',
+        },
+      ],
+    },
+  };
+
+  const findings = collectNamingSemanticFamilyBridgeFindings(stagedBridgeTransport);
+
+  assert.deepEqual(
+    findings.map((finding) => finding.code).sort((left, right) => left.localeCompare(right)),
+    ['TREE_FAMILY_SCATTERED'],
+  );
+  assert.equal(
+    findings.some((finding) => JSON.stringify(finding).includes('address-keyed-only')),
+    false,
+  );
+});


### PR DESCRIPTION
### Motivation
- Provide an additive, Naming-owned occurrence bridge payload (`naming-occurrence-bridge.v1`) so addressed occurrence namespaces can produce address-attached naming observations without changing existing Tree join behavior. 
- Preserve the current path-keyed Naming semantic-family bridge used by Tree while enabling a versioned occurrence payload for future address-keyed joins. 
- Runtime authority treated: `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` and the runner wiring; navigation-only: Tree specification docs; supporting context: suite runner contracts (`ValidatorSuite-Contracts-And-Modes.md`).

### Description
- Added `projectNamingOccurrenceBridge(...)` in `calculogic-validator/naming/src/naming-validator.wiring.mjs` which reuses `createNamingOccurrenceBridgePayload(...)` and preserves `projectNamingSemanticFamilyBridge(...)`. 
- `runNamingValidator(...)` now stages `namingOccurrenceBridge` in its return envelope only when an explicit `addressedOccurrenceNamespace` is supplied, keeping previous outputs unchanged. 
- Added focused tests `calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs` and a regression test appended to `calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` that assert additive staging, namespace diagnostics, address-attached observations, omission of Tree conclusion fields, and unchanged Tree path-keyed consumption. 
- Documented the additive occurrence bridge staging path in `calculogic-validator/doc/ConventionRoutines/NamingValidatorSpec.md` and exported the helper `createNamingOccurrenceBridgePayload` without changing Tree joins or runtime behavior. 

### Testing
- `node --test calculogic-validator/naming/test/*.test.mjs` — all naming tests passed (including new wiring tests). 
- `node --test calculogic-validator/tree/test/*.test.mjs` — all tree tests passed (including new regression test). 
- `node --test calculogic-validator/src/test/*.test.mjs` — ran but `calculogic-validator/src/test` does not exist (0 tests). 
- `npm run validate:naming -- --scope=validator --target calculogic-validator/naming` — command executed and exited with code 2 producing validator report output for the targeted Naming slice (report findings observed; not a test harness failure). 
- `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` — completed and returned the expected advisory report output (successful run).

Refs #630
Refs #618

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2efc201ea883318aa42fde3fd3642e)