### PR TITLE
Prefer clean address-keyed naming joins in Tree semantic-family contributor

### DIFF
--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -987,8 +987,51 @@ const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnal
       });
   });
 
-export const collectNamingSemanticFamilyBridgeFindings = (bridgePayload) => {
-  const namingSemanticFamilyBridge = prepareNamingSemanticFamilyBridge(bridgePayload);
+const isCleanAddressKeyedJoinEvidence = (preparedAddressKeyedJoinEvidence) =>
+  preparedAddressKeyedJoinEvidence &&
+  typeof preparedAddressKeyedJoinEvidence === 'object' &&
+  !Array.isArray(preparedAddressKeyedJoinEvidence) &&
+  preparedAddressKeyedJoinEvidence.status === 'joined' &&
+  preparedAddressKeyedJoinEvidence.usedForCurrentTreeJoins === true &&
+  Array.isArray(preparedAddressKeyedJoinEvidence.joinedEvidence) &&
+  preparedAddressKeyedJoinEvidence.joinedEvidence.length > 0 &&
+  Array.isArray(preparedAddressKeyedJoinEvidence.diagnostics) &&
+  preparedAddressKeyedJoinEvidence.diagnostics.length === 0 &&
+  Array.isArray(preparedAddressKeyedJoinEvidence.skippedJoins) &&
+  preparedAddressKeyedJoinEvidence.skippedJoins.length === 0;
+
+const toAddressKeyedBridgePayload = (preparedAddressKeyedJoinEvidence) => ({
+  observations: preparedAddressKeyedJoinEvidence.joinedEvidence.map((joinEntry) => ({
+    path: joinEntry.occurrenceRecord?.path ?? joinEntry.occurrenceRecord?.resolvedPath ?? joinEntry.namingObservation?.path,
+    semanticName: joinEntry.namingObservation?.semanticName,
+    familyRoot: joinEntry.namingObservation?.familyRoot,
+    semanticFamily: joinEntry.namingObservation?.semanticFamily,
+    ...(typeof joinEntry.namingObservation?.familySubgroup === 'string' && joinEntry.namingObservation.familySubgroup.length > 0
+      ? { familySubgroup: joinEntry.namingObservation.familySubgroup }
+      : {}),
+    ...(Array.isArray(joinEntry.namingObservation?.ambiguityFlags)
+      ? { ambiguityFlags: joinEntry.namingObservation.ambiguityFlags }
+      : {}),
+    ...(Array.isArray(joinEntry.namingObservation?.splitFamilyFlags)
+      ? { splitFamilyFlags: joinEntry.namingObservation.splitFamilyFlags }
+      : {}),
+  })),
+});
+
+const selectNamingSemanticFamilyBridgePayload = ({ bridgePayload, preparedAddressKeyedJoinEvidence } = {}) => {
+  if (isCleanAddressKeyedJoinEvidence(preparedAddressKeyedJoinEvidence)) {
+    const addressKeyedBridgePayload = toAddressKeyedBridgePayload(preparedAddressKeyedJoinEvidence);
+    if (prepareNamingSemanticFamilyBridge(addressKeyedBridgePayload).observations.length > 0) {
+      return addressKeyedBridgePayload;
+    }
+  }
+
+  return bridgePayload;
+};
+
+export const collectNamingSemanticFamilyBridgeFindings = (bridgePayload, { preparedAddressKeyedJoinEvidence } = {}) => {
+  const selectedBridgePayload = selectNamingSemanticFamilyBridgePayload({ bridgePayload, preparedAddressKeyedJoinEvidence });
+  const namingSemanticFamilyBridge = prepareNamingSemanticFamilyBridge(selectedBridgePayload);
   const observations = namingSemanticFamilyBridge.observations;
 
   if (observations.length === 0) {

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.wiring.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.wiring.mjs
@@ -2,10 +2,13 @@ import {
   collectNamingSemanticFamilyBridgeFindings,
 } from './tree-naming-semantic-family-bridge-contributor.logic.mjs';
 
-export const attachTreeNamingSemanticFamilyBridgeContributor = ({ namingSemanticFamilyBridge }) => {
-  if (namingSemanticFamilyBridge === undefined) {
+export const attachTreeNamingSemanticFamilyBridgeContributor = ({
+  namingSemanticFamilyBridge,
+  preparedAddressKeyedJoinEvidence,
+}) => {
+  if (namingSemanticFamilyBridge === undefined && preparedAddressKeyedJoinEvidence === undefined) {
     return null;
   }
 
-  return () => collectNamingSemanticFamilyBridgeFindings(namingSemanticFamilyBridge);
+  return () => collectNamingSemanticFamilyBridgeFindings(namingSemanticFamilyBridge, { preparedAddressKeyedJoinEvidence });
 };

--- a/calculogic-validator/tree/src/tree-structure-advisor-contributors-assembly.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor-contributors-assembly.wiring.mjs
@@ -9,6 +9,7 @@ export const collectDefaultTreeStructureAdvisorContributors = ({
   repositoryRoot,
   selectedPaths,
   namingSemanticFamilyBridge,
+  preparedAddressKeyedJoinEvidence,
 }) => [
   attachTreeShimDiagnosticsContributor({
     repositoryRoot,
@@ -16,5 +17,6 @@ export const collectDefaultTreeStructureAdvisorContributors = ({
   }),
   attachTreeNamingSemanticFamilyBridgeContributor({
     namingSemanticFamilyBridge,
+    preparedAddressKeyedJoinEvidence,
   }),
 ].filter(Boolean);

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -53,7 +53,7 @@ const collectTopLevelDirectoryNames = (repositoryRoot) =>
 
 export const prepareTreeStructureAdvisorInputs = (
   repositoryRoot,
-  { scope, targets, namingSemanticFamilyBridge, namingOccurrenceBridge } = {},
+  { scope, targets, namingSemanticFamilyBridge, namingOccurrenceBridge, preparedAddressKeyedJoinEvidence } = {},
 ) => {
   const scopedSnapshotInputs = collectSuiteScopedSnapshotInputs(repositoryRoot, {
     scope,
@@ -173,16 +173,21 @@ export const prepareTreeStructureAdvisorInputs = (
       repositoryRoot,
       selectedPaths,
       namingSemanticFamilyBridge,
+      preparedAddressKeyedJoinEvidence,
     }),
   };
 };
 
-export const runTreeStructureAdvisor = (repositoryRoot, { scope, targets, namingSemanticFamilyBridge, namingOccurrenceBridge } = {}) => {
+export const runTreeStructureAdvisor = (
+  repositoryRoot,
+  { scope, targets, namingSemanticFamilyBridge, namingOccurrenceBridge, preparedAddressKeyedJoinEvidence } = {},
+) => {
   const preparedInputs = prepareTreeStructureAdvisorInputs(repositoryRoot, {
     scope,
     targets,
     namingSemanticFamilyBridge,
     namingOccurrenceBridge,
+    preparedAddressKeyedJoinEvidence,
   });
   return runTreeStructureAdvisorRuntime(preparedInputs);
 };

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -1446,3 +1446,228 @@ test('tree naming bridge contributor keeps current path-keyed join and ignores o
     false,
   );
 });
+
+const cleanAddressJoinEvidence = (joinedEvidence) => ({
+  boundary: 'tree-naming-occurrence-address-join',
+  status: 'joined',
+  usedForCurrentTreeJoins: true,
+  identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+  joinedEvidence,
+  skippedJoins: [],
+  diagnostics: [],
+});
+
+const addressJoinEntry = ({ occurrenceAddress, path, semanticName, familyRoot, semanticFamily, familySubgroup }) => ({
+  evidenceType: 'tree-prepared-naming-occurrence-address-join',
+  identityTuple: {
+    addressProfileId: 'tree-codebase',
+    addressedSnapshotId: 'snapshot-001',
+    occurrenceAddress,
+  },
+  namingObservation: {
+    path: `stale/${semanticName}.logic.ts`,
+    semanticName,
+    familyRoot,
+    semanticFamily,
+    ...(familySubgroup ? { familySubgroup } : {}),
+  },
+  occurrenceRecord: {
+    path,
+    resolvedPath: path,
+    occurrenceAddress,
+  },
+});
+
+const pathKeyedFallbackBridge = {
+  observations: [
+    {
+      path: 'src/shared/build/path-keyed.logic.ts',
+      semanticName: 'path-keyed',
+      familyRoot: 'path',
+      semanticFamily: 'path-keyed',
+    },
+    {
+      path: 'src/features/build/path-keyed.results.ts',
+      semanticName: 'path-keyed',
+      familyRoot: 'path',
+      semanticFamily: 'path-keyed',
+    },
+    {
+      path: 'src/features/build/path-keyed.knowledge.ts',
+      semanticName: 'path-keyed',
+      familyRoot: 'path',
+      semanticFamily: 'path-keyed',
+    },
+    {
+      path: 'src/features/build/path-keyed.build.tsx',
+      semanticName: 'path-keyed',
+      familyRoot: 'path',
+      semanticFamily: 'path-keyed',
+    },
+  ],
+};
+
+const addressKeyedScatterEvidence = cleanAddressJoinEvidence([
+  addressJoinEntry({
+    occurrenceAddress: 'A.1',
+    path: 'src/shared/build/address-keyed.logic.ts',
+    semanticName: 'address-keyed',
+    familyRoot: 'address',
+    semanticFamily: 'address-keyed',
+  }),
+  addressJoinEntry({
+    occurrenceAddress: 'A.2',
+    path: 'src/features/build/address-keyed.results.ts',
+    semanticName: 'address-keyed',
+    familyRoot: 'address',
+    semanticFamily: 'address-keyed',
+  }),
+  addressJoinEntry({
+    occurrenceAddress: 'A.3',
+    path: 'src/features/build/address-keyed.knowledge.ts',
+    semanticName: 'address-keyed',
+    familyRoot: 'address',
+    semanticFamily: 'address-keyed',
+  }),
+  addressJoinEntry({
+    occurrenceAddress: 'A.4',
+    path: 'src/features/build/address-keyed.build.tsx',
+    semanticName: 'address-keyed',
+    familyRoot: 'address',
+    semanticFamily: 'address-keyed',
+  }),
+]);
+
+const findingFamilies = (findings) =>
+  findings.map((finding) => finding.details?.semanticFamily).filter(Boolean).sort((left, right) => left.localeCompare(right));
+
+test('tree naming bridge contributor prefers clean address-keyed joined evidence over path-keyed bridge evidence', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings(pathKeyedFallbackBridge, {
+    preparedAddressKeyedJoinEvidence: addressKeyedScatterEvidence,
+  });
+
+  assert.deepEqual(findingFamilies(findings), ['address-keyed']);
+  assert.equal(JSON.stringify(findings).includes('path-keyed'), false);
+});
+
+test('tree naming bridge contributor keeps path-keyed bridge behavior when address-keyed evidence is absent', () => {
+  const baseline = collectNamingSemanticFamilyBridgeFindings(pathKeyedFallbackBridge);
+  const absent = collectNamingSemanticFamilyBridgeFindings(pathKeyedFallbackBridge, {
+    preparedAddressKeyedJoinEvidence: undefined,
+  });
+
+  assert.deepEqual(absent, baseline);
+  assert.deepEqual(findingFamilies(absent), ['path-keyed']);
+});
+
+test('tree naming bridge contributor falls back when address-keyed evidence has diagnostics', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings(pathKeyedFallbackBridge, {
+    preparedAddressKeyedJoinEvidence: {
+      ...addressKeyedScatterEvidence,
+      status: 'skipped-with-diagnostics',
+      usedForCurrentTreeJoins: false,
+      diagnostics: [{ reason: 'addressed-occurrence-records-not-array' }],
+    },
+  });
+
+  assert.deepEqual(findingFamilies(findings), ['path-keyed']);
+});
+
+test('tree naming bridge contributor falls back when address-keyed evidence has no joined evidence', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings(pathKeyedFallbackBridge, {
+    preparedAddressKeyedJoinEvidence: {
+      ...addressKeyedScatterEvidence,
+      status: 'no-joined-evidence',
+      usedForCurrentTreeJoins: false,
+      joinedEvidence: [],
+    },
+  });
+
+  assert.deepEqual(findingFamilies(findings), ['path-keyed']);
+});
+
+test('tree naming bridge contributor falls back when address-keyed evidence has skipped mismatched joins', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings(pathKeyedFallbackBridge, {
+    preparedAddressKeyedJoinEvidence: {
+      ...addressKeyedScatterEvidence,
+      status: 'joined-with-skips',
+      usedForCurrentTreeJoins: false,
+      skippedJoins: [
+        {
+          reason: 'no-matching-occurrence-record-identity-tuple',
+          identityTuple: {
+            addressProfileId: 'tree-codebase',
+            addressedSnapshotId: 'snapshot-001',
+            occurrenceAddress: 'Z.9',
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(findingFamilies(findings), ['path-keyed']);
+});
+
+test('tree naming bridge contributor does not re-derive semantic family from filename when address evidence lacks naming semantic fields', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence([
+      {
+        ...addressJoinEntry({
+          occurrenceAddress: 'A.1',
+          path: 'src/shared/build/filename-derived.logic.ts',
+          semanticName: 'filename-derived',
+          familyRoot: 'filename',
+          semanticFamily: 'filename-derived',
+        }),
+        namingObservation: {
+          path: 'src/shared/build/filename-derived.logic.ts',
+        },
+      },
+    ]),
+  });
+
+  assert.deepEqual(findings, []);
+});
+
+test('tree naming bridge contributor distinguishes duplicate same-family occurrences by occurrence address', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence([
+      addressJoinEntry({
+        occurrenceAddress: 'A.1',
+        path: 'src/shared/build/duplicate-family.logic.ts',
+        semanticName: 'duplicate-family',
+        familyRoot: 'duplicate',
+        semanticFamily: 'duplicate-family',
+      }),
+      addressJoinEntry({
+        occurrenceAddress: 'A.2',
+        path: 'src/features/build/duplicate-family.results.ts',
+        semanticName: 'duplicate-family',
+        familyRoot: 'duplicate',
+        semanticFamily: 'duplicate-family',
+      }),
+      addressJoinEntry({
+        occurrenceAddress: 'A.3',
+        path: 'src/features/build/duplicate-family.knowledge.ts',
+        semanticName: 'duplicate-family',
+        familyRoot: 'duplicate',
+        semanticFamily: 'duplicate-family',
+      }),
+      addressJoinEntry({
+        occurrenceAddress: 'A.4',
+        path: 'src/features/build/duplicate-family.build.tsx',
+        semanticName: 'duplicate-family',
+        familyRoot: 'duplicate',
+        semanticFamily: 'duplicate-family',
+      }),
+    ]),
+  });
+
+  assert.deepEqual(findingFamilies(findings), ['duplicate-family']);
+  assert.deepEqual(findings[0].details.observedPaths, [
+    'src/features/build/duplicate-family.build.tsx',
+    'src/features/build/duplicate-family.knowledge.ts',
+    'src/features/build/duplicate-family.results.ts',
+    'src/shared/build/duplicate-family.logic.ts',
+  ]);
+});

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -1695,3 +1695,125 @@ test('tree-structure-advisor wiring composes shim contributor with lazy staged c
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
 });
+
+const createCleanPreparedAddressKeyedJoinEvidence = (semanticFamily) => ({
+  boundary: 'tree-naming-occurrence-address-join',
+  status: 'joined',
+  usedForCurrentTreeJoins: true,
+  identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+  diagnostics: [],
+  skippedJoins: [],
+  joinedEvidence: [
+    ['A.1', 'src/shared/build'],
+    ['A.2', 'src/features/build'],
+    ['A.3', 'src/features/build'],
+    ['A.4', 'src/features/build'],
+  ].map(([occurrenceAddress, directoryPath], index) => ({
+    evidenceType: 'tree-prepared-naming-occurrence-address-join',
+    identityTuple: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress,
+    },
+    namingObservation: {
+      path: `stale/${semanticFamily}-${index}.logic.ts`,
+      semanticName: semanticFamily,
+      familyRoot: semanticFamily.split('-')[0],
+      semanticFamily,
+    },
+    occurrenceRecord: {
+      occurrenceAddress,
+      path: `${directoryPath}/${semanticFamily}-${index}.logic.ts`,
+      resolvedPath: `${directoryPath}/${semanticFamily}-${index}.logic.ts`,
+    },
+  })),
+});
+
+const createPathKeyedFamilyBridge = (semanticFamily) => ({
+  observations: [
+    `src/shared/build/${semanticFamily}.logic.ts`,
+    `src/features/build/${semanticFamily}.results.ts`,
+    `src/features/build/${semanticFamily}.knowledge.ts`,
+    `src/features/build/${semanticFamily}.build.tsx`,
+  ].map((pathValue) => ({
+    path: pathValue,
+    semanticName: semanticFamily,
+    familyRoot: semanticFamily.split('-')[0],
+    semanticFamily,
+  })),
+});
+
+const scatteredFamilyFindings = (result) =>
+  result.findings
+    .filter((finding) => finding.code === 'TREE_FAMILY_SCATTERED')
+    .map((finding) => finding.details.semanticFamily)
+    .sort((left, right) => left.localeCompare(right));
+
+test('tree structure advisor wiring forwards prepared address-keyed semantic-family evidence to default contributors', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-address-keyed-contributor-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    const namingSemanticFamilyBridge = createPathKeyedFamilyBridge('path-keyed');
+    const preparedAddressKeyedJoinEvidence = createCleanPreparedAddressKeyedJoinEvidence('address-keyed');
+
+    const preparedInputs = prepareTreeStructureAdvisorInputs(fixtureDir, {
+      scope: 'repo',
+      namingSemanticFamilyBridge,
+      preparedAddressKeyedJoinEvidence,
+    });
+    const preparedResult = runTreeStructureAdvisorRuntime(preparedInputs);
+    const runResult = runTreeStructureAdvisor(fixtureDir, {
+      scope: 'repo',
+      namingSemanticFamilyBridge,
+      preparedAddressKeyedJoinEvidence,
+    });
+
+    assert.deepEqual(scatteredFamilyFindings(preparedResult), ['address-keyed']);
+    assert.deepEqual(scatteredFamilyFindings(runResult), ['address-keyed']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('tree structure advisor wiring preserves path-keyed fallback when prepared address evidence is absent or not clean', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-address-keyed-fallback-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+
+    const namingSemanticFamilyBridge = createPathKeyedFamilyBridge('path-keyed');
+    const cleanPreparedAddressKeyedJoinEvidence = createCleanPreparedAddressKeyedJoinEvidence('address-keyed');
+    const notCleanPreparedAddressKeyedJoinEvidence = {
+      ...cleanPreparedAddressKeyedJoinEvidence,
+      status: 'joined-with-skips',
+      usedForCurrentTreeJoins: false,
+      skippedJoins: [
+        {
+          reason: 'no-matching-occurrence-record-identity-tuple',
+          identityTuple: {
+            addressProfileId: 'tree-codebase',
+            addressedSnapshotId: 'snapshot-001',
+            occurrenceAddress: 'Z.9',
+          },
+        },
+      ],
+    };
+
+    const absentResult = runTreeStructureAdvisor(fixtureDir, {
+      scope: 'repo',
+      namingSemanticFamilyBridge,
+    });
+    const notCleanResult = runTreeStructureAdvisor(fixtureDir, {
+      scope: 'repo',
+      namingSemanticFamilyBridge,
+      preparedAddressKeyedJoinEvidence: notCleanPreparedAddressKeyedJoinEvidence,
+    });
+
+    assert.deepEqual(scatteredFamilyFindings(absentResult), ['path-keyed']);
+    assert.deepEqual(scatteredFamilyFindings(notCleanResult), ['path-keyed']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
### Motivation
- Narrow Tree contributor change to make Tree prefer prepared address-keyed Naming occurrence join evidence when it is explicitly available and clean, while preserving the existing path-keyed semantic-family bridge fallback (Refs #640; Refs #618; follows #635 / PR #637 and #638 / PR #639).  
- Treated `NamingValidatorSpec.md` and the Tree validator spec as runtime authority for naming and tree-owned bridge inputs, and treated `tree-documentation-map-and-reorg-inventory.md` as navigation-only supporting context.  
- Keep Tree ownership boundaries intact: Tree must consume Naming-provided semantic fields and must not re-derive or create Naming semantics itself.  

### Description
- Add guarded address-keyed input selection: new `isCleanAddressKeyedJoinEvidence` predicate and conversion `toAddressKeyedBridgePayload` that maps prepared address-keyed join entries into the contributor observation shape without re-deriving naming semantics.  
- Prefer address-keyed evidence only when it is clean: `status === 'joined'`, `usedForCurrentTreeJoins === true`, non-empty `joinedEvidence`, and zero `diagnostics`/`skippedJoins`; otherwise fall back to the existing `namingSemanticFamilyBridge`.  
- Wire the new input narrowly: accept `preparedAddressKeyedJoinEvidence` in the bridge contributor wiring and in the default contributors assembly while preserving the original `namingSemanticFamilyBridge` path.  
- Add focused tests covering preference for clean address-keyed evidence, path-keyed fallback behavior for absent/diagnostic/empty/skipped address-keyed evidence, avoidance of filename-based re-derivation when naming fields are absent, and distinguishing duplicate same-family occurrences by occurrence address.  

### Testing
- Ran unit tests: `node --test calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` — PASS.  
- Ran unit tests: `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` and `node --test calculogic-validator/tree/test/*.test.mjs` — PASS.  
- Ran naming tests: `node --test calculogic-validator/naming/test/*.test.mjs` — PASS.  
- Ran validator checks: `npm run validate:tree -- --scope=validator --target calculogic-validator/tree` — command succeeded and produced existing report-mode Tree advisories (`TREE_OBSERVED_FAMILY_CLUSTER`, `TREE_SHIM_SURFACE_PRESENT`) as expected.  
- Ran validator checks: `npm run validate:naming -- --scope=validator --target calculogic-validator/naming` — command emitted the expected naming report findings for the naming slice (report-mode findings present) and exited with report-mode findings (non-zero exit due to reported findings); no scope broadening was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f38ae166083319f30a719ee187dda)