### PR TITLE
Define Naming bridge enrichment eligibility contract

### DIFF
--- a/calculogic-validator/doc/Indexes/validator-docs.index.md
+++ b/calculogic-validator/doc/Indexes/validator-docs.index.md
@@ -58,7 +58,7 @@ Authority labels used in this index:
   **Authority:** bounded normative supporting spec. **Intended use:** active documentation-first semantic-family modeling tranche for naming interpretation; runtime behavior remains governed by canonical authorities unless implemented.
 
 - `doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md`
-  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity contract for envelope shape, identity tuple, ownership boundaries, and migration/fallback rules; read before the Naming-owned bridge observation rules.
+  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity and enrichment eligibility contract for envelope shape, identity tuple, approved/deferred/rejected future fields, ownership boundaries, versioning, and migration/fallback rules; read before the Naming-owned bridge observation rules.
 
 - `doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md`
   **Authority:** bounded normative supporting spec. **Intended use:** Naming-owned address-attached bridge observation rules for attaching semantic observations to occurrence identity without emitting Tree conclusions; not current runtime truth.

--- a/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
@@ -30,7 +30,8 @@ Current runtime truth from the issue #648 / PR #649 audit:
 - `path` and `repoRelativePath` remain compatibility/source-trace fields, not the preferred durable join identity.
 - `addressPath` remains a compatibility/debug mirror unless it is explicitly equal to `occurrenceAddress`; it must not become a second competing occurrence identity.
 - Current Naming bridge semantic evidence includes existing Naming-owned semantic fields such as `semanticName`, `familyRoot`, `semanticFamily`, optional `familySubgroup`, optional sorted `ambiguityFlags`, and optional sorted `splitFamilyFlags`.
-- The bridge does not currently emit enriched context partition fields such as `parentAddressPath`, `depth`, `orderIndex`, `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, `role-like fields`, `disambiguationNotes`, `evidenceStrength`, or `evidenceLimitNotes` merely because they may be useful.
+- `occurrenceType` is an existing optional `naming-occurrence-bridge.v1` occurrence-context / compatibility field when the addressed occurrence record supplies it. It is Addressing-owned occurrence type data that Naming may echo when available; it is not part of the durable identity tuple and is not Tree folder-kind interpretation.
+- The bridge does not currently emit genuinely new enriched context partition fields such as `parentAddressPath`, `depth`, `orderIndex`, `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, `role-like fields`, `disambiguationNotes`, `evidenceStrength`, or `evidenceLimitNotes` merely because they may be useful.
 - Tree staged intake and address-keyed join preparation may inspect the v1 bridge, but current Tree contributor behavior preserves fallback to path-keyed semantic-family evidence unless address-keyed evidence is clean and usable under Tree-owned policy.
 
 ## 3. Canonical occurrence identity contract
@@ -67,9 +68,11 @@ Normative identity rules:
 
 ### 4.2 Future enriched version decision
 
-Approved enrichment fields in this spec require a future explicit version named `naming-occurrence-bridge.v2` unless a later contract slice intentionally chooses a separately named additive sidecar. The default path is an additive v2 bridge payload, not mutation of v1 semantics.
+Genuinely new approved enrichment fields in this spec require a future explicit version named `naming-occurrence-bridge.v2` unless a later contract slice intentionally chooses a separately named additive sidecar. The default path is an additive v2 bridge payload, not mutation of v1 semantics.
 
-The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, approved fields below are contract-approved but **not current runtime truth**.
+Existing valid v1 fields do not require a version bump merely to retain or document them. In particular, valid v1 observations may retain optional `occurrenceType` when supplied by the addressed occurrence record; retaining `occurrenceType` does not require `naming-occurrence-bridge.v2`.
+
+The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields for genuinely new enrichment. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, approved new fields below are contract-approved but **not current runtime truth**.
 
 ### 4.3 Version handling and unknown fields
 
@@ -95,7 +98,17 @@ Version handling rules:
 
 Suite-core owns only runner orchestration, staging, target/scope transport, source metadata, report-envelope mechanics, and neutral opaque payload transport.
 
-## 6. Field eligibility table for future enriched bridge versions
+## 6. Existing v1 occurrence-context and compatibility fields
+
+The field-eligibility table below applies only to genuinely new future enrichment candidates. It does not re-decide existing valid v1 fields.
+
+Existing v1 occurrence-context / compatibility fields include:
+
+| Field | v1 status | Owner | Source of truth | Value shape | Required / optional | Identity status | Tree-consumption limitation | Versioning effect |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `occurrenceType` | Existing optional v1 occurrence-context / compatibility field | Addressing | Addressed occurrence record occurrence-type vocabulary | Non-empty string from the Addressing-owned vocabulary, currently expected to include values such as `file` or `folder` | Optional in v1 because current production includes it only when the addressed occurrence record supplies it | Not part of `addressProfileId + addressedSnapshotId + occurrenceAddress`; must not be used as a replacement identity | Tree may consume only as occurrence type evidence; it is not Tree folder-kind interpretation and must not encode folder kind, structural home, semantic home, placement, confidence, severity, or findings | Retaining or documenting existing `occurrenceType` in valid v1 observations does not require a v2 bridge version |
+
+## 7. Field eligibility table for future enriched bridge versions
 
 Decision standard: approve only fields with a clear current source, a narrow semantic purpose, a deterministic representation, and a concrete need for the first enriched Naming bridge version. Defer fields that require a new vocabulary, an opaque grouping strategy, a separate role/token model, unclear source authority, or likely Tree-policy leakage. Reject fields that would encode Tree placement, folder/home interpretation, severity, confidence policy, or findings.
 
@@ -104,7 +117,6 @@ Decision standard: approve only fields with a clear current source, a narrow sem
 | `parentAddressPath` | approved for a future enriched bridge version | Addressing | Addressed occurrence record from the active `addressProfileId` / `addressedSnapshotId` namespace | `parentOccurrenceAddress` | string occurrence address in the same namespace as `occurrenceAddress`, or `null` for namespace roots | Optional | Omit when the source record does not provide parent identity; use `null` only for an addressed root whose source explicitly has no parent | Must equal the Addressing-owned parent occurrence identity; no Naming inference; stable string; no sorting role | neutral context | Tree may consume only as parent identity evidence and must not infer folder kind, structural home, semantic home, or placement from Naming emission alone | n/a | n/a |
 | `depth` | approved for a future enriched bridge version | Addressing | Addressed occurrence record | `occurrenceDepth` | non-negative integer rooted at `0` in the addressed snapshot namespace | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; producer must not bucket, band, or semantically label depth | neutral context | Tree may consume only as neutral nesting evidence; Tree owns any placement or scatter/cluster interpretation | n/a | n/a |
 | `orderIndex` | approved for a future enriched bridge version | Addressing | Addressed occurrence record deterministic traversal output | `occurrenceOrderIndex` | non-negative integer stable for the addressed snapshot traversal | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; represents Addressing traversal order only; consumers must not treat it as identity | neutral context / diagnostic metadata | Tree may use only for deterministic ordering or evidence review, not placement quality, severity, or confidence | n/a | n/a |
-| `occurrenceType` | approved for a future enriched bridge version | Addressing | Addressed occurrence record occurrence-type vocabulary | `occurrenceType` | non-empty string from the Addressing-owned vocabulary, currently expected to include values such as `file` or `folder` | Optional when available | Omit when unavailable; do not invent `unknown`; invalid values are unsupported enrichment unless they break identity validation elsewhere | Preserve source spelling from the approved Addressing vocabulary; no Mapping to Tree `folderKind` | neutral context / compatibility | Tree may consume only as occurrence kind evidence; it must not be treated as Tree folder-kind policy | n/a | n/a |
 | `lineageKey` | deferred | Addressing, with Naming allowed to reference only after source is defined | No approved current source for bridge payload use | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not consume a Naming-computed lineage key as structural-home or semantic-home evidence | Addressing must define an opaque, deterministic lineage/grouping key source and collision semantics, or the bridge must choose `parentOccurrenceAddress` instead | n/a |
 | `contextPartitionKey` | deferred | Naming if semantic-evidence partitioning; Addressing if opaque occurrence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | semantic evidence partition candidate | Tree must not treat it as folder/home/placement policy | A later Naming-owned contract must define the partition purpose, stable algorithm, collision behavior, and proof it is folder-agnostic and not Tree policy | n/a |
 | `siblingContextKey` | deferred | Addressing preferred; Naming only if it can prove neutral evidence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not treat it as sibling placement quality or folder-kind evidence | Addressing must define sibling identity/group semantics, or a later Naming contract must define an opaque source-backed key without Tree-policy leakage | n/a |
@@ -116,19 +128,19 @@ Decision standard: approve only fields with a clear current source, a narrow sem
 | `evidenceStrength` | rejected for bridge payload use | Tree, if strength/confidence is ever interpreted; Naming may own only source facts | Tree confidence/severity policy, not a Naming bridge field | n/a | n/a | n/a | n/a | n/a | rejected Tree-policy/confidence candidate | Tree must not receive Naming-authored strength as bridge policy | n/a | It would encode confidence/strength policy and blur Tree-owned clean/usable evidence assessment, confidence, severity, and findings. |
 | `evidenceLimitNotes` | approved for a future enriched bridge version | Naming | Naming-owned bridge production and source limitation diagnostics | `evidenceLimitNotes` | array of objects, each `{ "code": "<non-empty-kebab-case-string>", "message": "<short deterministic string>", "source": "naming" }`; no severity/confidence/verdict fields | Optional | Omit when there are no limits; empty array is allowed only when a producer intentionally serializes empty containers; `null` is not allowed | Sort by `code`, then `message`, then `source`; remove exact duplicates; messages must be deterministic and not environment-specific | diagnostic metadata | Tree may consume only as source-limit evidence or diagnostics; Tree owns fallback and finding policy | n/a | n/a |
 
-Approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
+Approved genuinely new first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
-Deferred set: `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, and `role-like fields`.
+Deferred genuinely new candidate set: `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, and `role-like fields`.
 
-Rejected set: `evidenceStrength`.
+Rejected genuinely new candidate set: `evidenceStrength`.
 
-## 7. Guardrails for approved future enrichment fields
+## 8. Guardrails for approved future enrichment fields
 
 Every approved future enrichment field is governed by these rules:
 
 1. Naming remains folder-agnostic.
 2. The field is evidence, not Tree policy.
-3. The field must not encode folder kind, structural home, semantic home, placement judgment, scatter/cluster judgment, confidence, severity, or findings.
+3. The field must not encode occurrence identity, folder kind, structural home, semantic home, placement judgment, scatter/cluster judgment, confidence, severity, or findings.
 4. Tree may consume the field only as evidence and retains all clean/usable evidence assessment, fallback selection, join diagnostics, placement reasoning, confidence, severity, and findings policy.
 5. The field does not move tuple matching or join preparation into Addressing.
 6. The field does not require shared join-helper extraction.
@@ -137,7 +149,7 @@ Every approved future enrichment field is governed by these rules:
 9. A future implementation must not remove `path`, `repoRelativePath`, or path-keyed compatibility fallback solely because approved enrichment fields exist.
 10. A future implementation must validate enriched fields separately from the required identity tuple so unsupported enrichment can be reported without mislabeling valid identity as invalid.
 
-## 8. Fallback and migration rule
+## 9. Fallback and migration rule
 
 Future implementation slices must follow this migration rule:
 
@@ -147,10 +159,11 @@ Future implementation slices must follow this migration rule:
 4. Fallback diagnostics should make it clear when Tree used path compatibility instead of address identity.
 5. Tree must not silently re-derive Naming semantic-family interpretation when Naming evidence is missing. Missing Naming evidence should remain missing, bounded, or diagnostic according to Tree-owned consumer policy.
 6. Future v2 enrichment does not by itself authorize provider swaps, Tree consumption changes, fallback removal, helper extraction, CLI changes, report-envelope changes, or runtime bridge production.
+7. Retaining existing optional v1 `occurrenceType` does not require v2 and does not authorize any Tree folder-kind interpretation.
 
 Path fallback is current implementation reality and must not be removed in this contract slice.
 
-## 9. Relationship to current audited runtime fields
+## 10. Relationship to current audited runtime fields
 
 | Current audited field/surface | Relationship to this contract |
 | --- | --- |
@@ -160,32 +173,32 @@ Path fallback is current implementation reality and must not be removed in this 
 | Structural-addressing `addressPath` | Candidate compatibility/debug alias and possible initial source for `occurrenceAddress`; must be interpreted inside profile/snapshot namespace. |
 | Structural-addressing `profileId` | Candidate source for contract field `addressProfileId`; this spec uses the bridge field name `addressProfileId` for clarity. |
 | Structural-addressing `snapshotOutputId` | Related to `addressedSnapshotId`, but not identical by contract until a later slice decides whether output id is sufficient or an instance/source id is required. |
-| Structural-addressing `occurrenceType` | Approved future bridge enrichment field when available; it remains neutral occurrence kind evidence, not Tree folder-kind policy. |
+| Structural-addressing `occurrenceType` | Existing optional v1 occurrence-context / compatibility field when available; it remains Addressing-owned occurrence type data that Naming may echo, not durable identity and not Tree folder-kind policy. |
 | Structural-addressing `depth` | Approved future bridge enrichment source for `occurrenceDepth`; it remains neutral context evidence. |
 | Structural-addressing `orderIndex` | Approved future bridge enrichment source for `occurrenceOrderIndex`; it remains deterministic ordering/diagnostic evidence, not identity. |
 | Current Naming bridge `path` observations | Current runtime truth and temporary compatibility alias. Future bridge observations should preserve `repoRelativePath` / `path` compatibility during migration. |
 | Current Tree semantic-home evidence join by `path` | Current runtime truth and temporary fallback path. Future Tree consumption should prefer address-keyed joins only when contract fields are present and Tree-owned qualification accepts them. |
 
-## 10. Unresolved naming and migration follow-up notes
+## 11. Unresolved naming and migration follow-up notes
 
 The following questions remain explicit follow-up work and are not resolved by runtime changes in this slice:
 
 1. Whether `addressedSnapshotId` should be a run/snapshot instance id, a content digest, a source snapshot id, or a constrained alias of current `snapshotOutputId`.
-2. Whether the future v2 bridge should emit approved enrichment fields directly on each observation, inside a nested `occurrenceContext` / `diagnostics` object, or in a separately named additive sidecar.
+2. Whether the future v2 bridge should emit genuinely new approved enrichment fields directly on each observation, inside a nested `occurrenceContext` / `diagnostics` object, or in a separately named additive sidecar.
 3. Whether structural-addressing `address` or `addressPath` should populate the first `occurrenceAddress` field in every producer path, and which compatibility alias must be retained in reports.
 4. Which focused repeated-same-family fixtures should prove that address-keyed joins beat path/family bucket assumptions before fallback removal.
 5. Which producer is the authoritative addressed snapshot provider for the cross-slice bridge: Tree-local addressed occurrences, structural-addressing addressed snapshots, or a later compatibility bridge between them.
 6. Whether deferred partition keys should ever be emitted, and if so whether Addressing or Naming owns the exact grouping algorithm.
 7. Whether deferred Naming token and role evidence should be modeled as bridge fields, a Naming-owned sidecar, or remain outside the occurrence bridge.
 
-## 11. Non-goals
+## 12. Non-goals
 
 This spec does not:
 
 - change runtime behavior;
 - change Naming bridge payloads;
 - change Tree join behavior;
-- add enriched fields to runtime outputs;
+- add genuinely new enriched fields to runtime outputs;
 - rename `addressPath` in runtime code;
 - wire Tree runtime to a different structural-addressing provider;
 - remove path fallback;
@@ -201,8 +214,8 @@ This spec does not:
 - fix unrelated validator findings;
 - perform broad docs cleanup outside this contract slice.
 
-## 12. Recommended next implementation child
+## 13. Recommended next implementation child
 
-Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity and path/source-trace compatibility while carrying only the approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
+Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity, optional v1 `occurrenceType`, and path/source-trace compatibility while carrying only the approved genuinely new first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
 That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape, version handling, unsupported-enrichment diagnostics, and explicit fallback behavior without removing the current path-based consumer path.

--- a/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
@@ -1,231 +1,141 @@
 # Naming Bridge Occurrence Identity Contract
 
-- **Classification:** Normative for the target contract direction; descriptive where explicitly labeled as current runtime truth.
+- **Classification:** Normative for the Naming occurrence bridge identity, field-eligibility, enrichment, versioning, and migration contract; descriptive only where explicitly labeled as **current runtime truth**.
 - **Applies to:** Cross-slice occurrence identity used by Addressing, Naming bridge observations, Tree evidence joins, and suite-core neutral transport.
-- **Status:** Contract/specification slice only for issue #621; no runtime behavior is changed by this artifact.
-- **Issue context:** Refs #621 and Refs #618.
-- **Repo-reality input:** `calculogic-validator/doc/Audits/occurrence-identity-and-naming-tree-bridge.audit.md` from issue #619 / PR #620.
+- **Status:** Contract/specification decision slice only for issue #651; no runtime behavior is changed by this artifact.
+- **Issue context:** Refs #651 and Refs #647. Earlier identity baseline: Refs #621, Refs #618, and Slice 1 audit #648 / PR #649.
+- **Repo-reality input:** `calculogic-validator/doc/Audits/occurrence-identity-and-naming-tree-bridge.audit.md` and `calculogic-validator/doc/Audits/addressing-backed-naming-tree-bridge-enrichment-surfaces.audit.md`.
 
 ## 1. Purpose and authority boundary
 
-This spec defines the neutral occurrence identity contract and the versioned Naming bridge envelope needed for future address-keyed Naming bridge evidence.
+This spec defines the neutral occurrence identity contract, the versioned Naming bridge envelope, and the normative decision gate for future enriched Naming occurrence bridge fields.
 
-This artifact is intentionally narrow. It defines contract names, ownership boundaries, migration expectations, and non-goals only. It does not implement the Naming bridge, does not change Tree joins, does not add runtime payload fields, does not wire Tree to the structural-addressing provider, and does not change CLI or report envelope behavior.
+This artifact is intentionally narrow. It defines contract names, ownership boundaries, approved future field shapes, deferred/rejected candidate status, migration expectations, and non-goals only. It does not implement Naming bridge enrichment, does not change Tree joins or consumption policy, does not add runtime payload fields, does not wire Tree to a different provider, does not extract shared join helpers, and does not change CLI or report envelope behavior.
 
 Authority posture:
 
-1. Current source files, tests, and the issue #619 audit remain the source for **current runtime truth**.
+1. Current source files, tests, and the issue #648 audit remain the source for **current runtime truth**.
 2. This spec defines the **target contract direction** for future implementation slices.
-3. Any field marked deferred is **deferred implementation work**, not current runtime truth.
+3. A field marked `approved for a future enriched bridge version` is approved for an additive future contract shape only; it is **not current runtime truth** until a later implementation slice emits and tests it.
+4. A field marked `deferred` is **deferred implementation work** that needs the named prerequisite before runtime payload use.
+5. A field marked `rejected for bridge payload use` must not be emitted by the Naming bridge payload as a contract field.
 
 ## 2. Current runtime truth
 
-Current runtime truth from the issue #619 / PR #620 audit:
+Current runtime truth from the issue #648 / PR #649 audit:
 
-- Naming bridge observations are path-keyed today. The current bridge projection emits `observations[]` records with `path`, `semanticName`, `familyRoot`, `semanticFamily`, and optional `familySubgroup`, `ambiguityFlags`, and `splitFamilyFlags`.
-- Naming bridge observations do not currently carry `addressProfileId`, `addressedSnapshotId`, `occurrenceAddress`, `addressPath`, `parentOccurrenceAddress`, `parentAddressPath`, `depth`, or root-lane fields.
-- Tree-local addressed occurrence records expose `addressPath` and `parentAddressPath`; they do not expose `occurrenceAddress`.
-- Structural-addressing currently has its own addressed snapshot shape with `profileId`, `snapshotOutputId`, `domainPrefix`, and occurrence records containing `address`, `addressPath`, `occurrenceType`, `path`, `parentAddressPath`, `depth`, and `orderIndex`.
-- Tree semantic-home evidence currently joins Naming semantic evidence by `path`; `occurrenceType` is only available as a tie-breaker when Naming evidence supplies it, and the current Naming bridge projection does not.
-- Tree runtime is not currently wired to `calculogic-validator/structural-addressing/**` as its canonical addressed snapshot provider.
+- Naming bridge observations can be emitted in a versioned occurrence bridge payload with `bridgeContractVersion: naming-occurrence-bridge.v1`.
+- The only resolved durable occurrence identity tuple for addressed Naming occurrence observations is `addressProfileId + addressedSnapshotId + occurrenceAddress`.
+- Naming occurrence bridge observations currently preserve path/source trace fields: `repoRelativePath`, `path`, and optional `addressPath`.
+- `path` and `repoRelativePath` remain compatibility/source-trace fields, not the preferred durable join identity.
+- `addressPath` remains a compatibility/debug mirror unless it is explicitly equal to `occurrenceAddress`; it must not become a second competing occurrence identity.
+- Current Naming bridge semantic evidence includes existing Naming-owned semantic fields such as `semanticName`, `familyRoot`, `semanticFamily`, optional `familySubgroup`, optional sorted `ambiguityFlags`, and optional sorted `splitFamilyFlags`.
+- The bridge does not currently emit enriched context partition fields such as `parentAddressPath`, `depth`, `orderIndex`, `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, `role-like fields`, `disambiguationNotes`, `evidenceStrength`, or `evidenceLimitNotes` merely because they may be useful.
+- Tree staged intake and address-keyed join preparation may inspect the v1 bridge, but current Tree contributor behavior preserves fallback to path-keyed semantic-family evidence unless address-keyed evidence is clean and usable under Tree-owned policy.
 
-## 3. Target contract direction
+## 3. Canonical occurrence identity contract
 
-Target contract direction:
-
-- Cross-slice joins should use address-backed occurrence identity in an explicit profile/snapshot namespace.
-- The minimum join identity is:
-
-```text
-addressProfileId + addressedSnapshotId + occurrenceAddress
-```
-
-- `repoRelativePath` remains a compatibility and diagnostic reference during migration; it is not the durable semantic identity.
-- Naming semantic payloads should be preserved where practical and identity fields should be added additively in later implementation slices.
-- Tree should prefer address-keyed joins when required identity fields are present and compatible, while retaining an explicit temporary path-based fallback during migration.
-
-## 4. Occurrence identity contract
-
-### 4.1 Namespace rule
+### 3.1 Namespace rule
 
 `occurrenceAddress` is interpreted only inside the namespace identified by `addressProfileId` and `addressedSnapshotId`.
 
-The tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` is a deterministic join identity for one addressed snapshot namespace. It is not a timeless global id, not a repo-wide immutable id across every profile, and not a semantic identity by itself.
+The tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` is the preferred durable join identity for one addressed snapshot namespace. It is not a timeless global id, not a repo-wide immutable id across every profile, and not a semantic identity by itself.
 
-### 4.2 Required first-slice identity fields
+### 3.2 Required durable identity tuple
 
-| Field | Requirement for first implementation slice | Owner | Contract meaning | Current runtime relationship |
+For an addressed Naming occurrence observation, all three fields are required either directly on the observation or by an explicitly validated envelope inheritance rule:
+
+| Field | Requirement | Owner | Contract meaning | Current runtime relationship |
 | --- | --- | --- | --- | --- |
-| `addressProfileId` | Required | Addressing | Identifier for the address profile whose grammar/provider semantics make `occurrenceAddress` meaningful. | Structural-addressing currently uses `profileId`; Tree-local snapshots do not carry this field. |
-| `addressedSnapshotId` | Required | Addressing | Identifier for the specific addressed snapshot namespace shared by the producer and consumers during a run or staged payload exchange. | Structural-addressing currently has `snapshotOutputId`; the audit records an unresolved question about whether that is an output-type id or a snapshot instance/source id. |
-| `occurrenceAddress` | Required | Addressing | Neutral occurrence address used for cross-slice joins inside the profile/snapshot namespace. | Current runtime fields are `addressPath` and structural-addressing `address`/`addressPath`; `occurrenceAddress` is not current runtime truth. |
-| `repoRelativePath` | Required compatibility/debug field | Suite-core transports; originating occurrence/address snapshot producer supplies | Repository-relative path for diagnostics, compatibility fallback, and human traceability. | Current Naming bridge uses `path`; Tree occurrence and structural-addressing records also expose path-like fields. |
-| `occurrenceType` | Required when available from the addressed occurrence record | Addressing supplies; Naming may echo only as identity/debug context | Bounded occurrence kind/type such as `file` or `folder`. | Current runtime uses `occurrenceType`; preserve this name rather than introducing `occurrenceKind` in the first implementation slice. |
+| `addressProfileId` | Required | Addressing | Identifier for the address profile whose grammar/provider semantics make `occurrenceAddress` meaningful. | Structural-addressing currently uses `profileId`; Naming bridge payloads normalize the contract field as `addressProfileId`. |
+| `addressedSnapshotId` | Required | Addressing | Identifier for the specific addressed snapshot namespace shared by the producer and consumers during a run or staged payload exchange. | Structural-addressing has `snapshotOutputId`; whether that is sufficient as the durable snapshot namespace remains a later provider decision. |
+| `occurrenceAddress` | Required | Addressing | Neutral occurrence address used for cross-slice joins inside the profile/snapshot namespace. | Current bridge payload construction can normalize an addressed occurrence `occurrenceAddress`, `address`, or `addressPath` into this field. |
 
-### 4.3 `occurrenceAddress` and current `addressPath`
+Normative identity rules:
 
-Target contract direction: use `occurrenceAddress` as the neutral bridge identity field.
+- The tuple remains the preferred durable join identity for addressed Naming occurrence observations.
+- `path` and `repoRelativePath` remain compatibility/source-trace fields.
+- `addressPath` remains a compatibility/debug mirror unless explicitly equal to `occurrenceAddress`.
+- No second competing occurrence identity is introduced by this spec.
+- Consumers must not treat observation array index, path, semantic family, context partition key, diagnostic metadata, or Tree placement evidence as a replacement identity.
 
-Migration rule: current `addressPath` should be preserved and aliased first rather than renamed in runtime code. A later implementation slice may populate `occurrenceAddress` from the current Addressing-owned address field while preserving `addressPath` as a compatibility/debug alias until consumers are migrated.
+## 4. Versioned Naming bridge envelope contract
 
-`addressPath` remains current runtime truth. `occurrenceAddress` is deferred implementation work and must not be added to runtime outputs in this docs-only slice.
+### 4.1 Current valid version
 
-### 4.4 Deferred identity fields
+`naming-occurrence-bridge.v1` remains valid. Existing v1 producers and consumers must continue to preserve the canonical identity tuple and path-keyed compatibility/source-trace fields during migration.
 
-The following fields are not required on every first-slice Naming bridge observation unless a later implementation slice documents a specific need:
+### 4.2 Future enriched version decision
 
-- `parentOccurrenceAddress` or `parentAddressPath`
-- `depth`
-- `orderIndex`
-- `displayMarker`
-- `domainPrefix`
-- `scopeRootPath`
-- root-lane or repo-top/scope-top markers
-- lineage arrays or ancestor address paths
+Approved enrichment fields in this spec require a future explicit version named `naming-occurrence-bridge.v2` unless a later contract slice intentionally chooses a separately named additive sidecar. The default path is an additive v2 bridge payload, not mutation of v1 semantics.
 
-These fields may belong on addressed occurrence records or addressed snapshot envelopes. They should not be copied into Naming bridge observations merely for convenience.
+The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, approved fields below are contract-approved but **not current runtime truth**.
 
-## 5. Naming bridge envelope contract
+### 4.3 Version handling and unknown fields
 
-### 5.1 Envelope shape
+Version handling rules:
 
-Target contract direction for a versioned Naming bridge payload:
+- v1 consumers may ignore unknown enrichment fields only if those fields are not needed to validate identity and do not change v1 semantics.
+- Consumers that interpret v2 enrichment need an explicit v2-aware intake path or an explicitly documented sidecar intake path.
+- Unsupported bridge versions must be handled as unsupported future evidence, not as invalid identity by default.
+- Diagnostics must distinguish invalid identity from unsupported enrichment:
+  - **invalid identity:** missing, non-string, empty, mismatched, duplicate, or namespace-incompatible `addressProfileId`, `addressedSnapshotId`, or `occurrenceAddress`.
+  - **unsupported enrichment:** recognized identity with a bridge version, field, or sidecar that the consumer does not interpret.
+  - **unsupported version:** a bridge contract version outside the consumer's supported set.
+- Unsupported enrichment must not force fallback removal, shared-helper extraction, provider swaps, or Tree policy changes.
 
-```json
-{
-  "bridgeContractVersion": "naming-occurrence-bridge.v1",
-  "bridgeSource": "calculogic-validator/naming",
-  "bridgeProducerId": "naming-semantic-family-bridge",
-  "addressProfileId": "tree-codebase",
-  "addressedSnapshotId": "<addressed snapshot namespace id>",
-  "sourceReportRef": "<optional source/report reference>",
-  "sourceSnapshotRef": "<optional source snapshot reference>",
-  "observations": []
-}
-```
-
-### 5.2 Envelope fields
-
-| Field | Requirement for first implementation slice | Owner | Semantics |
-| --- | --- | --- | --- |
-| `bridgeContractVersion` | Required | Naming owns the bridge contract; suite-core may transport | Version field for the Naming bridge payload shape. Use this exact field name for the first versioned bridge. |
-| `bridgeSource` | Required | Naming | Stable source identity for the slice producing the bridge payload. |
-| `bridgeProducerId` | Required | Naming | Stable producer identity for the specific bridge projection routine or payload family. |
-| `addressProfileId` | Required | Addressing semantics; Naming references | Address profile namespace used by all observations in the envelope unless an observation explicitly overrides it in a future version. |
-| `addressedSnapshotId` | Required | Addressing semantics; Naming references | Addressed snapshot namespace shared by the envelope and observations. |
-| `sourceReportRef` | Deferred | Suite-core transport/report mechanics | Optional pointer to report metadata when needed for traceability. It must not become a semantic owner. |
-| `sourceSnapshotRef` | Deferred | Suite-core transport/source snapshot mechanics | Optional pointer to source snapshot metadata when needed for traceability. It must not replace `addressedSnapshotId`. |
-| `observations` | Required | Naming | Ordered container of Naming-owned semantic observations attached to occurrence identity and compatibility/debug context. |
-
-### 5.3 Observations container semantics
-
-`observations[]` contains Naming observations for occurrences in the addressed snapshot namespace declared by the envelope. The first implementation slice should require envelope-level `addressProfileId` and `addressedSnapshotId` and should not require per-observation overrides.
-
-Observation order should be deterministic for repeatable reports, but consumers must not treat array index as occurrence identity.
-
-## 6. Naming bridge observation contract
-
-### 6.1 Observation shape
-
-Target contract direction for one observation:
-
-```json
-{
-  "addressProfileId": "tree-codebase",
-  "addressedSnapshotId": "<addressed snapshot namespace id>",
-  "occurrenceAddress": "<address in the addressed snapshot namespace>",
-  "repoRelativePath": "calculogic-validator/example/path.md",
-  "path": "calculogic-validator/example/path.md",
-  "addressPath": "<compatibility/debug alias when populated>",
-  "occurrenceType": "file",
-  "semanticName": "example-path",
-  "familyRoot": "example",
-  "semanticFamily": "example-path",
-  "familySubgroup": "example",
-  "ambiguityFlags": [],
-  "splitFamilyFlags": [],
-  "disambiguation": {},
-  "findingRefs": []
-}
-```
-
-This illustrative object is not current runtime truth. It shows target field groupings and additive migration direction.
-
-### 6.2 Addressing / occurrence identity fields
-
-| Field | Requirement for first implementation slice | Notes |
-| --- | --- | --- |
-| `addressProfileId` | Required, or inherited from required envelope field | Per-observation field may be omitted only if inherited from the envelope by contract. |
-| `addressedSnapshotId` | Required, or inherited from required envelope field | Per-observation field may be omitted only if inherited from the envelope by contract. |
-| `occurrenceAddress` | Required | Neutral join field. It may initially be populated from an Addressing-owned `addressPath` alias, but runtime renaming is not part of this slice. |
-| `repoRelativePath` | Required compatibility/debug | Human-readable and fallback path reference. |
-| `occurrenceType` | Required when available | Use current runtime term `occurrenceType` for `file`/`folder`; do not introduce `occurrenceKind` unless a future contract intentionally renames it. |
-
-### 6.3 Compatibility/debug path fields
-
-| Field | Requirement | Notes |
-| --- | --- | --- |
-| `path` | Temporary compatibility alias | Current Naming bridge consumers expect `path`; preserve it during migration. |
-| `addressPath` | Temporary compatibility/debug alias when producer has it | Current Tree-local and structural-addressing surfaces expose `addressPath`; do not rename runtime code in this slice. |
-| `parentAddressPath` | Deferred; generally not on Naming observations | If needed, prefer addressed occurrence records as the source. |
-
-### 6.4 Naming-owned semantic fields
-
-Preserve current Naming semantic payloads where practical:
-
-- `semanticName`
-- `semanticFamily`
-- `familyRoot`
-- `familySubgroup`
-- `ambiguityFlags`
-- `splitFamilyFlags`
-
-Additional Naming-owned fields may include role parse and disambiguation metadata when a later Naming-owned implementation slice documents the exact shape:
-
-- `role`
-- `extension`
-- `roleStatus`
-- `roleCategory`
-- `disambiguation.roleLikeSemanticTokens`
-- `disambiguation.roleLikeFolderTokens`
-
-Naming owns these fields because they are filename-derived semantic interpretation, ambiguity, and disambiguation evidence. They are observations, not Tree placement conclusions.
-
-### 6.5 Finding/source references
-
-`findingRefs[]` or equivalent source references are deferred for the first implementation slice unless needed to preserve traceability from bridge observations to Naming findings.
-
-If added later, finding/source references may identify Naming findings or source report metadata. They must not be required for Tree to infer semantic-family meaning, and suite-core must only transport them neutrally.
-
-### 6.6 Fields not allowed on Naming bridge observations
-
-Naming bridge observations must not include Tree conclusions, including:
-
-- `structuralHome`
-- `semanticHome`
-- `folderKind`
-- `repoShape`
-- `placement`
-- `placementConfidence`
-- `scatterStatus`
-- `clusterStatus`
-- `driftStatus`
-- `expectedTopLevelFolder`
-- `allowedTopLevelFolder`
-- Tree advisory finding severity or verdict fields
-
-Tree may derive or attach those fields after joining Naming evidence to addressed occurrence records. Naming must not emit them as bridge semantics.
-
-## 7. Ownership matrix
+## 5. Ownership boundaries
 
 | Surface | Addressing | Naming | Tree | Suite-core |
 | --- | --- | --- | --- | --- |
-| Occurrence identity | Owns `occurrenceAddress`, address profile semantics, addressed snapshot semantics, and address grammar/provider semantics. | References identity to attach observations; does not define address grammar. | Consumes identity for joins; does not define Naming semantics. | Transports identity neutrally; does not own semantics. |
-| Bridge envelope | Owns profile/snapshot meaning referenced by the envelope. | Owns bridge version, producer identity, semantic payload, and observation production. | Owns supported consumer behavior and fallback policy after receiving payloads. | Owns orchestration, staging, target/scope transport, report envelope mechanics, and neutral payload guardrails. |
-| Semantic interpretation | Does not own Naming semantics. | Owns semantic-name, semantic-family, family root, family subgroup, role parse, ambiguity, and disambiguation. | Consumes Naming evidence for Tree-owned interpretation after joining. | May report metadata without semantic ownership. |
-| Tree conclusions | Does not own Tree placement conclusions. | Must not emit Tree conclusions. | Owns structural-home, semantic-home, folder kind, repo-shape, placement, scatter/cluster, and interpretation after joining. | May transport/report metadata without owning Tree conclusions. |
+| Occurrence identity | Owns `occurrenceAddress`, address profile semantics, address grammar, addressed snapshot/provider output rules, and parent/child/sibling identity facts. | References identity to attach observations; does not define address grammar. | Consumes identity for tuple matching and join preparation; does not define Naming semantics. | Transports identity neutrally; does not own semantics. |
+| Neutral occurrence context | Owns neutral lineage/depth/containment facts, parent/child/sibling identity facts, and deterministic occurrence ordering. | May copy approved neutral context as evidence when sourced from Addressing and shaped by this spec. | May consume neutral context only as evidence under Tree-owned qualification policy. | May stage opaque payloads without semantic ownership. |
+| Semantic interpretation | Does not own Naming semantics. | Owns semantic-name, family-root, semantic-family, family-subgroup, token interpretation, role interpretation, ambiguity flags, split-family flags, disambiguation interpretation, bridge observation production, and approved semantic-evidence partitioning representation. | Consumes Naming evidence for Tree-owned interpretation after joining. | May report metadata without semantic ownership. |
+| Tree conclusions | Does not own Tree placement conclusions. | Must not emit Tree conclusions. | Owns folder-kind interpretation, structural-home interpretation, semantic-home interpretation, placement reasoning, scatter/cluster reasoning, confidence, severity, findings, fallback selection, join diagnostics, and clean/usable evidence assessment. | May transport/report metadata without owning Tree conclusions. |
 
-Suite-core may stage, transport, validate envelope mechanics, or report bridge metadata, but suite-core must not become the owner of Naming, Tree, or Addressing semantics.
+Suite-core owns only runner orchestration, staging, target/scope transport, source metadata, report-envelope mechanics, and neutral opaque payload transport.
+
+## 6. Field eligibility table for future enriched bridge versions
+
+Decision standard: approve only fields with a clear current source, a narrow semantic purpose, a deterministic representation, and a concrete need for the first enriched Naming bridge version. Defer fields that require a new vocabulary, an opaque grouping strategy, a separate role/token model, unclear source authority, or likely Tree-policy leakage. Reject fields that would encode Tree placement, folder/home interpretation, severity, confidence policy, or findings.
+
+| Candidate | Decision status | Owner | Source of truth | Exact field name when approved | Value shape when approved | Required / optional when approved | Null / absence behavior when approved | Normalization and deterministic-order requirements when approved | Classification | Tree-consumption limitation | Explicit prerequisite when deferred | Reason when rejected |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `parentAddressPath` | approved for a future enriched bridge version | Addressing | Addressed occurrence record from the active `addressProfileId` / `addressedSnapshotId` namespace | `parentOccurrenceAddress` | string occurrence address in the same namespace as `occurrenceAddress`, or `null` for namespace roots | Optional | Omit when the source record does not provide parent identity; use `null` only for an addressed root whose source explicitly has no parent | Must equal the Addressing-owned parent occurrence identity; no Naming inference; stable string; no sorting role | neutral context | Tree may consume only as parent identity evidence and must not infer folder kind, structural home, semantic home, or placement from Naming emission alone | n/a | n/a |
+| `depth` | approved for a future enriched bridge version | Addressing | Addressed occurrence record | `occurrenceDepth` | non-negative integer rooted at `0` in the addressed snapshot namespace | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; producer must not bucket, band, or semantically label depth | neutral context | Tree may consume only as neutral nesting evidence; Tree owns any placement or scatter/cluster interpretation | n/a | n/a |
+| `orderIndex` | approved for a future enriched bridge version | Addressing | Addressed occurrence record deterministic traversal output | `occurrenceOrderIndex` | non-negative integer stable for the addressed snapshot traversal | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; represents Addressing traversal order only; consumers must not treat it as identity | neutral context / diagnostic metadata | Tree may use only for deterministic ordering or evidence review, not placement quality, severity, or confidence | n/a | n/a |
+| `occurrenceType` | approved for a future enriched bridge version | Addressing | Addressed occurrence record occurrence-type vocabulary | `occurrenceType` | non-empty string from the Addressing-owned vocabulary, currently expected to include values such as `file` or `folder` | Optional when available | Omit when unavailable; do not invent `unknown`; invalid values are unsupported enrichment unless they break identity validation elsewhere | Preserve source spelling from the approved Addressing vocabulary; no Mapping to Tree `folderKind` | neutral context / compatibility | Tree may consume only as occurrence kind evidence; it must not be treated as Tree folder-kind policy | n/a | n/a |
+| `lineageKey` | deferred | Addressing, with Naming allowed to reference only after source is defined | No approved current source for bridge payload use | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not consume a Naming-computed lineage key as structural-home or semantic-home evidence | Addressing must define an opaque, deterministic lineage/grouping key source and collision semantics, or the bridge must choose `parentOccurrenceAddress` instead | n/a |
+| `contextPartitionKey` | deferred | Naming if semantic-evidence partitioning; Addressing if opaque occurrence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | semantic evidence partition candidate | Tree must not treat it as folder/home/placement policy | A later Naming-owned contract must define the partition purpose, stable algorithm, collision behavior, and proof it is folder-agnostic and not Tree policy | n/a |
+| `siblingContextKey` | deferred | Addressing preferred; Naming only if it can prove neutral evidence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not treat it as sibling placement quality or folder-kind evidence | Addressing must define sibling identity/group semantics, or a later Naming contract must define an opaque source-backed key without Tree-policy leakage | n/a |
+| `subtreeContextKey` | deferred | Addressing preferred; Naming only if it can prove neutral evidence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not treat it as subtree ownership, structural home, semantic home, or placement evidence by itself | Addressing must define subtree grouping semantics and stability/collision rules, or a later sidecar must carry it as opaque evidence | n/a |
+| `semanticTokens` | deferred | Naming | Naming token interpretation model | n/a | n/a | n/a | n/a | n/a | semantic evidence candidate | Tree must not derive role/category/home policy from tokens without Tree-owned rules | Naming must define a token vocabulary, token source, normalization, ordering, duplicate handling, and relationship to `semanticName`, `familyRoot`, and `semanticFamily` | n/a |
+| `role` | deferred | Naming | Naming role parser / role registry | n/a | n/a | n/a | n/a | n/a | semantic evidence candidate | Tree must not derive folder/home/placement policy solely from role | Naming must define whether the bridge emits raw parsed role, normalized role, registry category/status, or all of these, and how provisional/deprecated roles serialize | n/a |
+| `role-like fields` | deferred | Naming | Naming disambiguation / role-like token interpretation | n/a | n/a | n/a | n/a | n/a | semantic evidence candidate | Tree must not treat role-like evidence as a role verdict or placement policy | Naming must define bounded field names and distinguish role verdicts from role-like hints, ambiguity flags, and disambiguation evidence | n/a |
+| `disambiguationNotes` | approved for a future enriched bridge version | Naming | Naming-owned disambiguation interpretation | `disambiguationNotes` | array of objects, each `{ "code": "<non-empty-kebab-case-string>", "message": "<short deterministic string>", "source": "naming" }`; no severity/confidence/verdict fields | Optional | Omit when there are no notes; empty array is allowed only when a producer intentionally serializes empty containers; `null` is not allowed | Sort by `code`, then `message`, then `source`; remove exact duplicates; messages must be deterministic and not environment-specific | diagnostic metadata / semantic evidence | Tree may consume only as Naming disambiguation evidence; Tree owns whether it is usable, diagnostic-only, or ignored | n/a | n/a |
+| `evidenceStrength` | rejected for bridge payload use | Tree, if strength/confidence is ever interpreted; Naming may own only source facts | Tree confidence/severity policy, not a Naming bridge field | n/a | n/a | n/a | n/a | n/a | rejected Tree-policy/confidence candidate | Tree must not receive Naming-authored strength as bridge policy | n/a | It would encode confidence/strength policy and blur Tree-owned clean/usable evidence assessment, confidence, severity, and findings. |
+| `evidenceLimitNotes` | approved for a future enriched bridge version | Naming | Naming-owned bridge production and source limitation diagnostics | `evidenceLimitNotes` | array of objects, each `{ "code": "<non-empty-kebab-case-string>", "message": "<short deterministic string>", "source": "naming" }`; no severity/confidence/verdict fields | Optional | Omit when there are no limits; empty array is allowed only when a producer intentionally serializes empty containers; `null` is not allowed | Sort by `code`, then `message`, then `source`; remove exact duplicates; messages must be deterministic and not environment-specific | diagnostic metadata | Tree may consume only as source-limit evidence or diagnostics; Tree owns fallback and finding policy | n/a | n/a |
+
+Approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
+
+Deferred set: `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, and `role-like fields`.
+
+Rejected set: `evidenceStrength`.
+
+## 7. Guardrails for approved future enrichment fields
+
+Every approved future enrichment field is governed by these rules:
+
+1. Naming remains folder-agnostic.
+2. The field is evidence, not Tree policy.
+3. The field must not encode folder kind, structural home, semantic home, placement judgment, scatter/cluster judgment, confidence, severity, or findings.
+4. Tree may consume the field only as evidence and retains all clean/usable evidence assessment, fallback selection, join diagnostics, placement reasoning, confidence, severity, and findings policy.
+5. The field does not move tuple matching or join preparation into Addressing.
+6. The field does not require shared join-helper extraction.
+7. The field must remain additive and versioned.
+8. The field must preserve current path-keyed compatibility during migration.
+9. A future implementation must not remove `path`, `repoRelativePath`, or path-keyed compatibility fallback solely because approved enrichment fields exist.
+10. A future implementation must validate enriched fields separately from the required identity tuple so unsupported enrichment can be reported without mislabeling valid identity as invalid.
 
 ## 8. Fallback and migration rule
 
@@ -233,9 +143,10 @@ Future implementation slices must follow this migration rule:
 
 1. Tree should prefer address-keyed joins when `addressProfileId`, `addressedSnapshotId`, and `occurrenceAddress` are present and match the addressed occurrence namespace being consumed.
 2. Path-based joins may remain as an explicit temporary compatibility fallback during migration.
-3. Fallback behavior must be documented, test-covered, and removable later.
+3. Fallback behavior must be documented, test-covered, and removable later by an explicit implementation slice.
 4. Fallback diagnostics should make it clear when Tree used path compatibility instead of address identity.
 5. Tree must not silently re-derive Naming semantic-family interpretation when Naming evidence is missing. Missing Naming evidence should remain missing, bounded, or diagnostic according to Tree-owned consumer policy.
+6. Future v2 enrichment does not by itself authorize provider swaps, Tree consumption changes, fallback removal, helper extraction, CLI changes, report-envelope changes, or runtime bridge production.
 
 Path fallback is current implementation reality and must not be removed in this contract slice.
 
@@ -244,25 +155,28 @@ Path fallback is current implementation reality and must not be removed in this 
 | Current audited field/surface | Relationship to this contract |
 | --- | --- |
 | Tree-local `addressPath` | Current runtime truth. Preserve as compatibility/debug alias during migration. Do not rename in runtime code as part of this contract. |
-| Tree-local `parentAddressPath` | Current runtime truth. Keep on addressed occurrence records; do not require on Naming observations in the first bridge shape. |
-| Structural-addressing `address` | Candidate source for neutral `occurrenceAddress`; exact aliasing requires a later implementation slice. |
+| Tree-local `parentAddressPath` | Current runtime truth on addressed occurrence records. Future enriched bridge payloads may emit `parentOccurrenceAddress` sourced from this parent identity, but the old source field name is not approved as the bridge field name. |
+| Structural-addressing `address` | Candidate source for neutral `occurrenceAddress`; exact aliasing remains an implementation-slice decision. |
 | Structural-addressing `addressPath` | Candidate compatibility/debug alias and possible initial source for `occurrenceAddress`; must be interpreted inside profile/snapshot namespace. |
-| Structural-addressing `profileId` | Candidate source for contract field `addressProfileId`; this spec chooses the bridge field name `addressProfileId` for clarity. |
+| Structural-addressing `profileId` | Candidate source for contract field `addressProfileId`; this spec uses the bridge field name `addressProfileId` for clarity. |
 | Structural-addressing `snapshotOutputId` | Related to `addressedSnapshotId`, but not identical by contract until a later slice decides whether output id is sufficient or an instance/source id is required. |
-| Structural-addressing `domainPrefix` | Address grammar/provider metadata. It is not required in every Naming observation. |
-| Current Naming bridge `path` observations | Current runtime truth and temporary compatibility alias. Future bridge observations should add `repoRelativePath` rather than remove `path` immediately. |
-| Current Tree semantic-home evidence join by `path` | Current runtime truth and temporary fallback path. Future Tree consumption should prefer address-keyed joins only when contract fields are present. |
+| Structural-addressing `occurrenceType` | Approved future bridge enrichment field when available; it remains neutral occurrence kind evidence, not Tree folder-kind policy. |
+| Structural-addressing `depth` | Approved future bridge enrichment source for `occurrenceDepth`; it remains neutral context evidence. |
+| Structural-addressing `orderIndex` | Approved future bridge enrichment source for `occurrenceOrderIndex`; it remains deterministic ordering/diagnostic evidence, not identity. |
+| Current Naming bridge `path` observations | Current runtime truth and temporary compatibility alias. Future bridge observations should preserve `repoRelativePath` / `path` compatibility during migration. |
+| Current Tree semantic-home evidence join by `path` | Current runtime truth and temporary fallback path. Future Tree consumption should prefer address-keyed joins only when contract fields are present and Tree-owned qualification accepts them. |
 
 ## 10. Unresolved naming and migration follow-up notes
 
 The following questions remain explicit follow-up work and are not resolved by runtime changes in this slice:
 
 1. Whether `addressedSnapshotId` should be a run/snapshot instance id, a content digest, a source snapshot id, or a constrained alias of current `snapshotOutputId`.
-2. Whether the first bridge implementation should emit per-observation `addressProfileId` and `addressedSnapshotId` redundantly, or rely on envelope-level inheritance plus validation.
-3. Whether structural-addressing `address` or `addressPath` should populate the first `occurrenceAddress` field, and which compatibility alias must be retained in reports.
-4. Whether `findingRefs[]`, `sourceReportRef`, or `sourceSnapshotRef` are needed in the first implementation slice for traceability.
-5. Which focused repeated-same-family fixtures should prove that address-keyed joins beat path/family bucket assumptions before fallback removal.
-6. Which producer is the authoritative addressed snapshot provider for the cross-slice bridge: Tree-local addressed occurrences, structural-addressing addressed snapshots, or a later compatibility bridge between them.
+2. Whether the future v2 bridge should emit approved enrichment fields directly on each observation, inside a nested `occurrenceContext` / `diagnostics` object, or in a separately named additive sidecar.
+3. Whether structural-addressing `address` or `addressPath` should populate the first `occurrenceAddress` field in every producer path, and which compatibility alias must be retained in reports.
+4. Which focused repeated-same-family fixtures should prove that address-keyed joins beat path/family bucket assumptions before fallback removal.
+5. Which producer is the authoritative addressed snapshot provider for the cross-slice bridge: Tree-local addressed occurrences, structural-addressing addressed snapshots, or a later compatibility bridge between them.
+6. Whether deferred partition keys should ever be emitted, and if so whether Addressing or Naming owns the exact grouping algorithm.
+7. Whether deferred Naming token and role evidence should be modeled as bridge fields, a Naming-owned sidecar, or remain outside the occurrence bridge.
 
 ## 11. Non-goals
 
@@ -271,14 +185,17 @@ This spec does not:
 - change runtime behavior;
 - change Naming bridge payloads;
 - change Tree join behavior;
-- add `occurrenceAddress` fields to runtime outputs;
+- add enriched fields to runtime outputs;
 - rename `addressPath` in runtime code;
-- wire Tree runtime to the structural-addressing provider;
+- wire Tree runtime to a different structural-addressing provider;
 - remove path fallback;
 - remove known-roots or revive known-roots;
 - promote Addressing to a standalone runnable validator slice;
 - move Addressing semantics into suite-core;
+- move tuple matching or join preparation into Addressing;
+- require shared join-helper extraction;
 - broaden Tree semantic-home, structural-home, scatter, cluster, or drift reasoning;
+- add Tree confidence, severity, findings, or report-envelope policy to Naming bridge payloads;
 - rework validator report envelopes;
 - change CLI behavior;
 - fix unrelated validator findings;
@@ -286,6 +203,6 @@ This spec does not:
 
 ## 12. Recommended next implementation child
 
-Recommended next implementation child: define and test a data-only, versioned Naming bridge payload shape that preserves the current semantic payload and `path` compatibility field while additively carrying `bridgeContractVersion`, `bridgeSource`, `bridgeProducerId`, `addressProfileId`, `addressedSnapshotId`, `occurrenceAddress`, `repoRelativePath`, and `occurrenceType` when an addressed occurrence namespace is available.
+Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity and path/source-trace compatibility while carrying only the approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
-That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape and explicit fallback behavior without removing the current path-based consumer path.
+That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape, version handling, unsupported-enrichment diagnostics, and explicit fallback behavior without removing the current path-based consumer path.


### PR DESCRIPTION
### Motivation
- Provide a narrow, docs-only decision slice (Refs #651, Refs #647) that preserves the canonical addressed occurrence identity while creating a deterministic gate for future Naming bridge enrichment fields. 
- Prevent premature runtime changes by explicitly approving, deferring, or rejecting each candidate enrichment field and preserving ownership boundaries between Addressing, Naming, Tree, and suite-core. 
- Ensure future enrichment remains evidence-only, folder-agnostic, additive, and versioned so Tree retains all placement/confidence policy. 

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md` to add a normative field-eligibility table, approve a minimal first enriched set, defer higher-risk candidates, reject Tree-policy fields, and add versioning/migration guardrails (preferred route: `naming-occurrence-bridge.v2` or an additive sidecar). 
- Approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`; deferred: `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, and `role-like fields`; rejected: `evidenceStrength`. 
- Clarified canonical identity rules to preserve the durable tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` and to treat `path`, `repoRelativePath`, and `addressPath` as compatibility/debug fields only. 
- Updated `calculogic-validator/doc/Indexes/validator-docs.index.md` to reflect expanded contract scope and intended usage as pre-read for Naming-owned observation rules. 

### Testing
- `git diff --check` — passed with no whitespace errors. 
- `npm run validate:naming -- --scope=validator --target calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md --target calculogic-validator/doc/Indexes/validator-docs.index.md` — ran validator in report mode and completed successfully with only canonical filename findings reported. 
- `npm run validate:tree -- --scope=validator --target calculogic-validator/doc` — ran tree validator in report mode and completed successfully with zero advisory findings. 
- Scope and intent: this is a docs-only change and no runtime code, payloads, tests, CLI, or report-envelope behavior were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b48ab3f48331abf4bdb5167138ad)