### PR TITLE
Clarify parentOccurrenceAddress guardrails in Naming occurrence bridge spec

### DIFF
--- a/calculogic-validator/doc/Indexes/validator-docs.index.md
+++ b/calculogic-validator/doc/Indexes/validator-docs.index.md
@@ -58,7 +58,7 @@ Authority labels used in this index:
   **Authority:** bounded normative supporting spec. **Intended use:** active documentation-first semantic-family modeling tranche for naming interpretation; runtime behavior remains governed by canonical authorities unless implemented.
 
 - `doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md`
-  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity and enrichment eligibility contract for envelope shape, identity tuple, approved/deferred/rejected future fields, ownership boundaries, versioning, and migration/fallback rules; read before the Naming-owned bridge observation rules.
+  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity and enrichment eligibility contract for envelope shape, identity tuple, existing optional v1 context/compatibility fields, approved/deferred/rejected future fields, ownership boundaries, versioning, and migration/fallback rules; read before the Naming-owned bridge observation rules.
 
 - `doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md`
   **Authority:** bounded normative supporting spec. **Intended use:** Naming-owned address-attached bridge observation rules for attaching semantic observations to occurrence identity without emitting Tree conclusions; not current runtime truth.

--- a/calculogic-validator/doc/Indexes/validator-docs.index.md
+++ b/calculogic-validator/doc/Indexes/validator-docs.index.md
@@ -58,7 +58,7 @@ Authority labels used in this index:
   **Authority:** bounded normative supporting spec. **Intended use:** active documentation-first semantic-family modeling tranche for naming interpretation; runtime behavior remains governed by canonical authorities unless implemented.
 
 - `doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md`
-  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity contract for envelope shape, identity tuple, ownership boundaries, and migration/fallback rules; read before the Naming-owned bridge observation rules.
+  **Authority:** bounded normative supporting spec. **Intended use:** cross-cutting bridge occurrence identity and enrichment eligibility contract for envelope shape, identity tuple, approved/deferred/rejected future fields, ownership boundaries, versioning, and migration/fallback rules; read before the Naming-owned bridge observation rules.
 
 - `doc/ValidatorSpecs/naming-owned/naming-address-attached-bridge-observation-rules.spec.md`
   **Authority:** bounded normative supporting spec. **Intended use:** Naming-owned address-attached bridge observation rules for attaching semantic observations to occurrence identity without emitting Tree conclusions; not current runtime truth.

--- a/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
@@ -1,6 +1,6 @@
 # Naming Bridge Occurrence Identity Contract
 
-- **Classification:** Normative for the Naming occurrence bridge identity, field-eligibility, enrichment, versioning, and migration contract; descriptive only where explicitly labeled as **current runtime truth**.
+- **Classification:** Normative for the Naming occurrence bridge identity, field-eligibility, existing v1 context/compatibility, enrichment, versioning, and migration contract; descriptive only where explicitly labeled as **current runtime truth**.
 - **Applies to:** Cross-slice occurrence identity used by Addressing, Naming bridge observations, Tree evidence joins, and suite-core neutral transport.
 - **Status:** Contract/specification decision slice only for issue #651; no runtime behavior is changed by this artifact.
 - **Issue context:** Refs #651 and Refs #647. Earlier identity baseline: Refs #621, Refs #618, and Slice 1 audit #648 / PR #649.
@@ -30,7 +30,8 @@ Current runtime truth from the issue #648 / PR #649 audit:
 - `path` and `repoRelativePath` remain compatibility/source-trace fields, not the preferred durable join identity.
 - `addressPath` remains a compatibility/debug mirror unless it is explicitly equal to `occurrenceAddress`; it must not become a second competing occurrence identity.
 - Current Naming bridge semantic evidence includes existing Naming-owned semantic fields such as `semanticName`, `familyRoot`, `semanticFamily`, optional `familySubgroup`, optional sorted `ambiguityFlags`, and optional sorted `splitFamilyFlags`.
-- The bridge does not currently emit enriched context partition fields such as `parentAddressPath`, `depth`, `orderIndex`, `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, `role-like fields`, `disambiguationNotes`, `evidenceStrength`, or `evidenceLimitNotes` merely because they may be useful.
+- `occurrenceType` is existing optional v1 neutral occurrence-context / compatibility evidence when the addressed occurrence record supplies it. It remains Addressing-owned occurrence-type data; Naming may echo it, and valid v1 observations containing it remain valid.
+- The bridge does not currently emit new enriched context partition fields such as `parentAddressPath`, `depth`, `orderIndex`, `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, `role-like fields`, `disambiguationNotes`, `evidenceStrength`, or `evidenceLimitNotes` merely because they may be useful.
 - Tree staged intake and address-keyed join preparation may inspect the v1 bridge, but current Tree contributor behavior preserves fallback to path-keyed semantic-family evidence unless address-keyed evidence is clean and usable under Tree-owned policy.
 
 ## 3. Canonical occurrence identity contract
@@ -73,14 +74,17 @@ Explicit identity distinction:
 
 ### 4.2 Future enriched version decision
 
-Approved enrichment fields in this spec require a future explicit version named `naming-occurrence-bridge.v2` unless a later contract slice intentionally chooses a separately named additive sidecar. The default path is an additive v2 bridge payload, not mutation of v1 semantics.
+`occurrenceType` does not require a bridge version bump because it is existing optional v1 neutral occurrence-context / compatibility evidence when supplied by the addressed occurrence record. Valid v1 observations containing optional `occurrenceType` must not be stripped, rejected, or treated as unsupported enrichment.
 
-The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, approved fields below are contract-approved but **not current runtime truth**.
+New approved enrichment fields in this spec require a future explicit version named `naming-occurrence-bridge.v2` unless a later contract slice intentionally chooses a separately named additive sidecar. The default path is an additive v2 bridge payload, not mutation of v1 semantics.
+
+The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields for genuinely new approved fields that valid v1 observations do not already emit. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, new approved fields below are contract-approved but **not current runtime truth**.
 
 ### 4.3 Version handling and unknown fields
 
 Version handling rules:
 
+- v1 consumers must continue accepting optional `occurrenceType` as existing v1 context/compatibility evidence when present; it is not unknown enrichment and not unsupported enrichment.
 - v1 consumers may ignore unknown enrichment fields only if those fields are not needed to validate identity and do not change v1 semantics.
 - Consumers that interpret v2 enrichment need an explicit v2-aware intake path or an explicitly documented sidecar intake path.
 - Unsupported bridge versions must be handled as unsupported future evidence, not as invalid identity by default.
@@ -101,7 +105,15 @@ Version handling rules:
 
 Suite-core owns only runner orchestration, staging, target/scope transport, source metadata, report-envelope mechanics, and neutral opaque payload transport.
 
-## 6. Field eligibility table for future enriched bridge versions
+## 6. Field eligibility table for existing v1 fields and future enriched bridge versions
+
+### 6.1 Existing optional v1 context/compatibility field
+
+| Field | Classification | Owner | Source of truth | Value shape | Required / optional | Null / absence behavior | Normalization and deterministic-order requirements | Identity status | Tree-consumption limitation | Versioning rule |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `occurrenceType` | existing optional v1 neutral occurrence-context / compatibility evidence | Addressing | Addressed occurrence record occurrence-type data supplied in current v1 observation production | non-empty string from the Addressing-owned vocabulary when supplied | Optional in v1 because existing production includes it only when available | Omit when unavailable; do not invent `unknown`; invalid values affect only this optional context field unless they break identity validation elsewhere | Preserve source spelling from the approved Addressing vocabulary; no mapping to Tree `folderKind`; no sorting role | Not part of the canonical durable observation identity tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` | Tree may consume only as occurrence kind evidence; it is not Tree folderKind, structural-home policy, semantic-home policy, placement policy, confidence, severity, diagnostics, or findings | Retaining or documenting `occurrenceType` does not require `naming-occurrence-bridge.v2`; valid v1 observations containing it remain valid and must not be stripped, rejected, or treated as unsupported enrichment |
+
+### 6.2 Candidate table for genuinely new future enrichment fields
 
 Decision standard: approve only fields with a clear current source, a narrow semantic purpose, a deterministic representation, and a concrete need for the first enriched Naming bridge version. Defer fields that require a new vocabulary, an opaque grouping strategy, a separate role/token model, unclear source authority, or likely Tree-policy leakage. Reject fields that would encode Tree placement, folder/home interpretation, severity, confidence policy, or findings.
 
@@ -110,7 +122,6 @@ Decision standard: approve only fields with a clear current source, a narrow sem
 | `parentAddressPath` | approved for a future enriched bridge version | Addressing | Addressed occurrence record from the active `addressProfileId` / `addressedSnapshotId` namespace | `parentOccurrenceAddress` | string occurrence address in the same namespace as `occurrenceAddress`, or `null` for namespace roots | Optional | Omit when the source record does not provide parent identity; use `null` only for an addressed root whose source explicitly has no parent | Must equal the Addressing-owned parent occurrence identity in the same validated `addressProfileId` / `addressedSnapshotId` namespace; no Naming inference; stable string; no sorting role | neutral context / parent-reference identity evidence | Tree may later consume only as neutral evidence after Tree validates the canonical observation tuple and applies Tree-owned join policy; Tree must not infer folder kind, structural home, semantic home, placement, confidence, severity, diagnostics, or findings from Naming emission alone | n/a | n/a |
 | `depth` | approved for a future enriched bridge version | Addressing | Addressed occurrence record | `occurrenceDepth` | non-negative integer rooted at `0` in the addressed snapshot namespace | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; producer must not bucket, band, or semantically label depth | neutral context | Tree may consume only as neutral nesting evidence; Tree owns any placement or scatter/cluster interpretation | n/a | n/a |
 | `orderIndex` | approved for a future enriched bridge version | Addressing | Addressed occurrence record deterministic traversal output | `occurrenceOrderIndex` | non-negative integer stable for the addressed snapshot traversal | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; represents Addressing traversal order only; consumers must not treat it as identity | neutral context / diagnostic metadata | Tree may use only for deterministic ordering or evidence review, not placement quality, severity, or confidence | n/a | n/a |
-| `occurrenceType` | approved for a future enriched bridge version | Addressing | Addressed occurrence record occurrence-type vocabulary | `occurrenceType` | non-empty string from the Addressing-owned vocabulary, currently expected to include values such as `file` or `folder` | Optional when available | Omit when unavailable; do not invent `unknown`; invalid values are unsupported enrichment unless they break identity validation elsewhere | Preserve source spelling from the approved Addressing vocabulary; no Mapping to Tree `folderKind` | neutral context / compatibility | Tree may consume only as occurrence kind evidence; it must not be treated as Tree folder-kind policy | n/a | n/a |
 | `lineageKey` | deferred | Addressing, with Naming allowed to reference only after source is defined | No approved current source for bridge payload use | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not consume a Naming-computed lineage key as structural-home or semantic-home evidence | Addressing must define an opaque, deterministic lineage/grouping key source and collision semantics, or the bridge must choose `parentOccurrenceAddress` instead | n/a |
 | `contextPartitionKey` | deferred | Naming if semantic-evidence partitioning; Addressing if opaque occurrence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | semantic evidence partition candidate | Tree must not treat it as folder/home/placement policy | A later Naming-owned contract must define the partition purpose, stable algorithm, collision behavior, and proof it is folder-agnostic and not Tree policy | n/a |
 | `siblingContextKey` | deferred | Addressing preferred; Naming only if it can prove neutral evidence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not treat it as sibling placement quality or folder-kind evidence | Addressing must define sibling identity/group semantics, or a later Naming contract must define an opaque source-backed key without Tree-policy leakage | n/a |
@@ -122,7 +133,9 @@ Decision standard: approve only fields with a clear current source, a narrow sem
 | `evidenceStrength` | rejected for bridge payload use | Tree, if strength/confidence is ever interpreted; Naming may own only source facts | Tree confidence/severity policy, not a Naming bridge field | n/a | n/a | n/a | n/a | n/a | rejected Tree-policy/confidence candidate | Tree must not receive Naming-authored strength as bridge policy | n/a | It would encode confidence/strength policy and blur Tree-owned clean/usable evidence assessment, confidence, severity, and findings. |
 | `evidenceLimitNotes` | approved for a future enriched bridge version | Naming | Naming-owned bridge production and source limitation diagnostics | `evidenceLimitNotes` | array of objects, each `{ "code": "<non-empty-kebab-case-string>", "message": "<short deterministic string>", "source": "naming" }`; no severity/confidence/verdict fields | Optional | Omit when there are no limits; empty array is allowed only when a producer intentionally serializes empty containers; `null` is not allowed | Sort by `code`, then `message`, then `source`; remove exact duplicates; messages must be deterministic and not environment-specific | diagnostic metadata | Tree may consume only as source-limit evidence or diagnostics; Tree owns fallback and finding policy | n/a | n/a |
 
-Approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
+Existing optional v1 context/compatibility set: `occurrenceType`.
+
+Approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
 Deferred set: `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, and `role-like fields`.
 
@@ -169,7 +182,7 @@ Path fallback is current implementation reality and must not be removed in this 
 | Structural-addressing `addressPath` | Candidate compatibility/debug alias and possible initial source for `occurrenceAddress`; must be interpreted inside profile/snapshot namespace. |
 | Structural-addressing `profileId` | Candidate source for contract field `addressProfileId`; this spec uses the bridge field name `addressProfileId` for clarity. |
 | Structural-addressing `snapshotOutputId` | Related to `addressedSnapshotId`, but not identical by contract until a later slice decides whether output id is sufficient or an instance/source id is required. |
-| Structural-addressing `occurrenceType` | Approved future bridge enrichment field when available; it remains neutral occurrence kind evidence, not Tree folder-kind policy. |
+| Current Naming bridge `occurrenceType` / structural-addressing `occurrenceType` | Existing optional v1 neutral occurrence-context / compatibility evidence when the addressed occurrence record supplies it. It remains Addressing-owned occurrence-type data that Naming may echo; it is not part of the canonical durable observation identity tuple, is not Tree folder-kind policy, remains valid in v1, and does not require a bridge version bump. |
 | Structural-addressing `depth` | Approved future bridge enrichment source for `occurrenceDepth`; it remains neutral context evidence. |
 | Structural-addressing `orderIndex` | Approved future bridge enrichment source for `occurrenceOrderIndex`; it remains deterministic ordering/diagnostic evidence, not identity. |
 | Current Naming bridge `path` observations | Current runtime truth and temporary compatibility alias. Future bridge observations should preserve `repoRelativePath` / `path` compatibility during migration. |
@@ -212,6 +225,6 @@ This spec does not:
 
 ## 12. Recommended next implementation child
 
-Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity and path/source-trace compatibility while carrying only the approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
+Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity, optional v1 `occurrenceType`, and path/source-trace compatibility while carrying only the genuinely new approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
 That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape, version handling, unsupported-enrichment diagnostics, and explicit fallback behavior without removing the current path-based consumer path.

--- a/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
@@ -1,231 +1,150 @@
 # Naming Bridge Occurrence Identity Contract
 
-- **Classification:** Normative for the target contract direction; descriptive where explicitly labeled as current runtime truth.
+- **Classification:** Normative for the Naming occurrence bridge identity, field-eligibility, enrichment, versioning, and migration contract; descriptive only where explicitly labeled as **current runtime truth**.
 - **Applies to:** Cross-slice occurrence identity used by Addressing, Naming bridge observations, Tree evidence joins, and suite-core neutral transport.
-- **Status:** Contract/specification slice only for issue #621; no runtime behavior is changed by this artifact.
-- **Issue context:** Refs #621 and Refs #618.
-- **Repo-reality input:** `calculogic-validator/doc/Audits/occurrence-identity-and-naming-tree-bridge.audit.md` from issue #619 / PR #620.
+- **Status:** Contract/specification decision slice only for issue #651; no runtime behavior is changed by this artifact.
+- **Issue context:** Refs #651 and Refs #647. Earlier identity baseline: Refs #621, Refs #618, and Slice 1 audit #648 / PR #649.
+- **Repo-reality input:** `calculogic-validator/doc/Audits/occurrence-identity-and-naming-tree-bridge.audit.md` and `calculogic-validator/doc/Audits/addressing-backed-naming-tree-bridge-enrichment-surfaces.audit.md`.
 
 ## 1. Purpose and authority boundary
 
-This spec defines the neutral occurrence identity contract and the versioned Naming bridge envelope needed for future address-keyed Naming bridge evidence.
+This spec defines the neutral occurrence identity contract, the versioned Naming bridge envelope, and the normative decision gate for future enriched Naming occurrence bridge fields.
 
-This artifact is intentionally narrow. It defines contract names, ownership boundaries, migration expectations, and non-goals only. It does not implement the Naming bridge, does not change Tree joins, does not add runtime payload fields, does not wire Tree to the structural-addressing provider, and does not change CLI or report envelope behavior.
+This artifact is intentionally narrow. It defines contract names, ownership boundaries, approved future field shapes, deferred/rejected candidate status, migration expectations, and non-goals only. It does not implement Naming bridge enrichment, does not change Tree joins or consumption policy, does not add runtime payload fields, does not wire Tree to a different provider, does not extract shared join helpers, and does not change CLI or report envelope behavior.
 
 Authority posture:
 
-1. Current source files, tests, and the issue #619 audit remain the source for **current runtime truth**.
+1. Current source files, tests, and the issue #648 audit remain the source for **current runtime truth**.
 2. This spec defines the **target contract direction** for future implementation slices.
-3. Any field marked deferred is **deferred implementation work**, not current runtime truth.
+3. A field marked `approved for a future enriched bridge version` is approved for an additive future contract shape only; it is **not current runtime truth** until a later implementation slice emits and tests it.
+4. A field marked `deferred` is **deferred implementation work** that needs the named prerequisite before runtime payload use.
+5. A field marked `rejected for bridge payload use` must not be emitted by the Naming bridge payload as a contract field.
 
 ## 2. Current runtime truth
 
-Current runtime truth from the issue #619 / PR #620 audit:
+Current runtime truth from the issue #648 / PR #649 audit:
 
-- Naming bridge observations are path-keyed today. The current bridge projection emits `observations[]` records with `path`, `semanticName`, `familyRoot`, `semanticFamily`, and optional `familySubgroup`, `ambiguityFlags`, and `splitFamilyFlags`.
-- Naming bridge observations do not currently carry `addressProfileId`, `addressedSnapshotId`, `occurrenceAddress`, `addressPath`, `parentOccurrenceAddress`, `parentAddressPath`, `depth`, or root-lane fields.
-- Tree-local addressed occurrence records expose `addressPath` and `parentAddressPath`; they do not expose `occurrenceAddress`.
-- Structural-addressing currently has its own addressed snapshot shape with `profileId`, `snapshotOutputId`, `domainPrefix`, and occurrence records containing `address`, `addressPath`, `occurrenceType`, `path`, `parentAddressPath`, `depth`, and `orderIndex`.
-- Tree semantic-home evidence currently joins Naming semantic evidence by `path`; `occurrenceType` is only available as a tie-breaker when Naming evidence supplies it, and the current Naming bridge projection does not.
-- Tree runtime is not currently wired to `calculogic-validator/structural-addressing/**` as its canonical addressed snapshot provider.
+- Naming bridge observations can be emitted in a versioned occurrence bridge payload with `bridgeContractVersion: naming-occurrence-bridge.v1`.
+- The only resolved durable occurrence identity tuple for addressed Naming occurrence observations is `addressProfileId + addressedSnapshotId + occurrenceAddress`.
+- Naming occurrence bridge observations currently preserve path/source trace fields: `repoRelativePath`, `path`, and optional `addressPath`.
+- `path` and `repoRelativePath` remain compatibility/source-trace fields, not the preferred durable join identity.
+- `addressPath` remains a compatibility/debug mirror unless it is explicitly equal to `occurrenceAddress`; it must not become a second competing occurrence identity.
+- Current Naming bridge semantic evidence includes existing Naming-owned semantic fields such as `semanticName`, `familyRoot`, `semanticFamily`, optional `familySubgroup`, optional sorted `ambiguityFlags`, and optional sorted `splitFamilyFlags`.
+- The bridge does not currently emit enriched context partition fields such as `parentAddressPath`, `depth`, `orderIndex`, `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, `role-like fields`, `disambiguationNotes`, `evidenceStrength`, or `evidenceLimitNotes` merely because they may be useful.
+- Tree staged intake and address-keyed join preparation may inspect the v1 bridge, but current Tree contributor behavior preserves fallback to path-keyed semantic-family evidence unless address-keyed evidence is clean and usable under Tree-owned policy.
 
-## 3. Target contract direction
+## 3. Canonical occurrence identity contract
 
-Target contract direction:
-
-- Cross-slice joins should use address-backed occurrence identity in an explicit profile/snapshot namespace.
-- The minimum join identity is:
-
-```text
-addressProfileId + addressedSnapshotId + occurrenceAddress
-```
-
-- `repoRelativePath` remains a compatibility and diagnostic reference during migration; it is not the durable semantic identity.
-- Naming semantic payloads should be preserved where practical and identity fields should be added additively in later implementation slices.
-- Tree should prefer address-keyed joins when required identity fields are present and compatible, while retaining an explicit temporary path-based fallback during migration.
-
-## 4. Occurrence identity contract
-
-### 4.1 Namespace rule
+### 3.1 Namespace rule
 
 `occurrenceAddress` is interpreted only inside the namespace identified by `addressProfileId` and `addressedSnapshotId`.
 
-The tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` is a deterministic join identity for one addressed snapshot namespace. It is not a timeless global id, not a repo-wide immutable id across every profile, and not a semantic identity by itself.
+The tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` is the preferred durable join identity for one addressed snapshot namespace. It is not a timeless global id, not a repo-wide immutable id across every profile, and not a semantic identity by itself.
 
-### 4.2 Required first-slice identity fields
+### 3.2 Required durable identity tuple
 
-| Field | Requirement for first implementation slice | Owner | Contract meaning | Current runtime relationship |
+For an addressed Naming occurrence observation, all three fields are required either directly on the observation or by an explicitly validated envelope inheritance rule:
+
+| Field | Requirement | Owner | Contract meaning | Current runtime relationship |
 | --- | --- | --- | --- | --- |
-| `addressProfileId` | Required | Addressing | Identifier for the address profile whose grammar/provider semantics make `occurrenceAddress` meaningful. | Structural-addressing currently uses `profileId`; Tree-local snapshots do not carry this field. |
-| `addressedSnapshotId` | Required | Addressing | Identifier for the specific addressed snapshot namespace shared by the producer and consumers during a run or staged payload exchange. | Structural-addressing currently has `snapshotOutputId`; the audit records an unresolved question about whether that is an output-type id or a snapshot instance/source id. |
-| `occurrenceAddress` | Required | Addressing | Neutral occurrence address used for cross-slice joins inside the profile/snapshot namespace. | Current runtime fields are `addressPath` and structural-addressing `address`/`addressPath`; `occurrenceAddress` is not current runtime truth. |
-| `repoRelativePath` | Required compatibility/debug field | Suite-core transports; originating occurrence/address snapshot producer supplies | Repository-relative path for diagnostics, compatibility fallback, and human traceability. | Current Naming bridge uses `path`; Tree occurrence and structural-addressing records also expose path-like fields. |
-| `occurrenceType` | Required when available from the addressed occurrence record | Addressing supplies; Naming may echo only as identity/debug context | Bounded occurrence kind/type such as `file` or `folder`. | Current runtime uses `occurrenceType`; preserve this name rather than introducing `occurrenceKind` in the first implementation slice. |
+| `addressProfileId` | Required | Addressing | Identifier for the address profile whose grammar/provider semantics make `occurrenceAddress` meaningful. | Structural-addressing currently uses `profileId`; Naming bridge payloads normalize the contract field as `addressProfileId`. |
+| `addressedSnapshotId` | Required | Addressing | Identifier for the specific addressed snapshot namespace shared by the producer and consumers during a run or staged payload exchange. | Structural-addressing has `snapshotOutputId`; whether that is sufficient as the durable snapshot namespace remains a later provider decision. |
+| `occurrenceAddress` | Required | Addressing | Neutral occurrence address used for cross-slice joins inside the profile/snapshot namespace. | Current bridge payload construction can normalize an addressed occurrence `occurrenceAddress`, `address`, or `addressPath` into this field. |
 
-### 4.3 `occurrenceAddress` and current `addressPath`
+Normative identity rules:
 
-Target contract direction: use `occurrenceAddress` as the neutral bridge identity field.
+- The tuple remains the preferred durable join identity for addressed Naming occurrence observations.
+- `path` and `repoRelativePath` remain compatibility/source-trace fields.
+- `addressPath` remains a compatibility/debug mirror unless explicitly equal to `occurrenceAddress`.
+- No enrichment field may replace, weaken, override, or compete with the canonical observation identity tuple: `addressProfileId + addressedSnapshotId + occurrenceAddress`.
+- Consumers must not treat observation array index, path, semantic family, context partition key, diagnostic metadata, parent-reference evidence, or Tree placement evidence as a replacement identity. Parent-reference evidence is permitted only as optional containment evidence, never as the observation's own primary identity.
 
-Migration rule: current `addressPath` should be preserved and aliased first rather than renamed in runtime code. A later implementation slice may populate `occurrenceAddress` from the current Addressing-owned address field while preserving `addressPath` as a compatibility/debug alias until consumers are migrated.
+Explicit identity distinction:
 
-`addressPath` remains current runtime truth. `occurrenceAddress` is deferred implementation work and must not be added to runtime outputs in this docs-only slice.
+- Canonical observation identity: `addressProfileId + addressedSnapshotId + occurrenceAddress`. This required tuple identifies the observed occurrence.
+- Optional parent-reference identity evidence: `parentOccurrenceAddress`. This optional future enrichment field is neutral Addressing-owned containment evidence about the observed occurrence's parent.
+- `parentOccurrenceAddress` does not replace the observation's own `occurrenceAddress`, must remain inside the same validated `addressProfileId` and `addressedSnapshotId` namespace, and must not become a second primary identity for the observation. Tree may later consume it only as neutral evidence after Tree validates the canonical observation tuple and applies Tree-owned join policy.
 
-### 4.4 Deferred identity fields
+## 4. Versioned Naming bridge envelope contract
 
-The following fields are not required on every first-slice Naming bridge observation unless a later implementation slice documents a specific need:
+### 4.1 Current valid version
 
-- `parentOccurrenceAddress` or `parentAddressPath`
-- `depth`
-- `orderIndex`
-- `displayMarker`
-- `domainPrefix`
-- `scopeRootPath`
-- root-lane or repo-top/scope-top markers
-- lineage arrays or ancestor address paths
+`naming-occurrence-bridge.v1` remains valid. Existing v1 producers and consumers must continue to preserve the canonical identity tuple and path-keyed compatibility/source-trace fields during migration.
 
-These fields may belong on addressed occurrence records or addressed snapshot envelopes. They should not be copied into Naming bridge observations merely for convenience.
+### 4.2 Future enriched version decision
 
-## 5. Naming bridge envelope contract
+Approved enrichment fields in this spec require a future explicit version named `naming-occurrence-bridge.v2` unless a later contract slice intentionally chooses a separately named additive sidecar. The default path is an additive v2 bridge payload, not mutation of v1 semantics.
 
-### 5.1 Envelope shape
+The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, approved fields below are contract-approved but **not current runtime truth**.
 
-Target contract direction for a versioned Naming bridge payload:
+### 4.3 Version handling and unknown fields
 
-```json
-{
-  "bridgeContractVersion": "naming-occurrence-bridge.v1",
-  "bridgeSource": "calculogic-validator/naming",
-  "bridgeProducerId": "naming-semantic-family-bridge",
-  "addressProfileId": "tree-codebase",
-  "addressedSnapshotId": "<addressed snapshot namespace id>",
-  "sourceReportRef": "<optional source/report reference>",
-  "sourceSnapshotRef": "<optional source snapshot reference>",
-  "observations": []
-}
-```
+Version handling rules:
 
-### 5.2 Envelope fields
+- v1 consumers may ignore unknown enrichment fields only if those fields are not needed to validate identity and do not change v1 semantics.
+- Consumers that interpret v2 enrichment need an explicit v2-aware intake path or an explicitly documented sidecar intake path.
+- Unsupported bridge versions must be handled as unsupported future evidence, not as invalid identity by default.
+- Diagnostics must distinguish invalid identity from unsupported enrichment:
+  - **invalid identity:** missing, non-string, empty, mismatched, duplicate, or namespace-incompatible `addressProfileId`, `addressedSnapshotId`, or `occurrenceAddress`.
+  - **unsupported enrichment:** recognized identity with a bridge version, field, or sidecar that the consumer does not interpret.
+  - **unsupported version:** a bridge contract version outside the consumer's supported set.
+- Unsupported enrichment must not force fallback removal, shared-helper extraction, provider swaps, or Tree policy changes.
 
-| Field | Requirement for first implementation slice | Owner | Semantics |
-| --- | --- | --- | --- |
-| `bridgeContractVersion` | Required | Naming owns the bridge contract; suite-core may transport | Version field for the Naming bridge payload shape. Use this exact field name for the first versioned bridge. |
-| `bridgeSource` | Required | Naming | Stable source identity for the slice producing the bridge payload. |
-| `bridgeProducerId` | Required | Naming | Stable producer identity for the specific bridge projection routine or payload family. |
-| `addressProfileId` | Required | Addressing semantics; Naming references | Address profile namespace used by all observations in the envelope unless an observation explicitly overrides it in a future version. |
-| `addressedSnapshotId` | Required | Addressing semantics; Naming references | Addressed snapshot namespace shared by the envelope and observations. |
-| `sourceReportRef` | Deferred | Suite-core transport/report mechanics | Optional pointer to report metadata when needed for traceability. It must not become a semantic owner. |
-| `sourceSnapshotRef` | Deferred | Suite-core transport/source snapshot mechanics | Optional pointer to source snapshot metadata when needed for traceability. It must not replace `addressedSnapshotId`. |
-| `observations` | Required | Naming | Ordered container of Naming-owned semantic observations attached to occurrence identity and compatibility/debug context. |
-
-### 5.3 Observations container semantics
-
-`observations[]` contains Naming observations for occurrences in the addressed snapshot namespace declared by the envelope. The first implementation slice should require envelope-level `addressProfileId` and `addressedSnapshotId` and should not require per-observation overrides.
-
-Observation order should be deterministic for repeatable reports, but consumers must not treat array index as occurrence identity.
-
-## 6. Naming bridge observation contract
-
-### 6.1 Observation shape
-
-Target contract direction for one observation:
-
-```json
-{
-  "addressProfileId": "tree-codebase",
-  "addressedSnapshotId": "<addressed snapshot namespace id>",
-  "occurrenceAddress": "<address in the addressed snapshot namespace>",
-  "repoRelativePath": "calculogic-validator/example/path.md",
-  "path": "calculogic-validator/example/path.md",
-  "addressPath": "<compatibility/debug alias when populated>",
-  "occurrenceType": "file",
-  "semanticName": "example-path",
-  "familyRoot": "example",
-  "semanticFamily": "example-path",
-  "familySubgroup": "example",
-  "ambiguityFlags": [],
-  "splitFamilyFlags": [],
-  "disambiguation": {},
-  "findingRefs": []
-}
-```
-
-This illustrative object is not current runtime truth. It shows target field groupings and additive migration direction.
-
-### 6.2 Addressing / occurrence identity fields
-
-| Field | Requirement for first implementation slice | Notes |
-| --- | --- | --- |
-| `addressProfileId` | Required, or inherited from required envelope field | Per-observation field may be omitted only if inherited from the envelope by contract. |
-| `addressedSnapshotId` | Required, or inherited from required envelope field | Per-observation field may be omitted only if inherited from the envelope by contract. |
-| `occurrenceAddress` | Required | Neutral join field. It may initially be populated from an Addressing-owned `addressPath` alias, but runtime renaming is not part of this slice. |
-| `repoRelativePath` | Required compatibility/debug | Human-readable and fallback path reference. |
-| `occurrenceType` | Required when available | Use current runtime term `occurrenceType` for `file`/`folder`; do not introduce `occurrenceKind` unless a future contract intentionally renames it. |
-
-### 6.3 Compatibility/debug path fields
-
-| Field | Requirement | Notes |
-| --- | --- | --- |
-| `path` | Temporary compatibility alias | Current Naming bridge consumers expect `path`; preserve it during migration. |
-| `addressPath` | Temporary compatibility/debug alias when producer has it | Current Tree-local and structural-addressing surfaces expose `addressPath`; do not rename runtime code in this slice. |
-| `parentAddressPath` | Deferred; generally not on Naming observations | If needed, prefer addressed occurrence records as the source. |
-
-### 6.4 Naming-owned semantic fields
-
-Preserve current Naming semantic payloads where practical:
-
-- `semanticName`
-- `semanticFamily`
-- `familyRoot`
-- `familySubgroup`
-- `ambiguityFlags`
-- `splitFamilyFlags`
-
-Additional Naming-owned fields may include role parse and disambiguation metadata when a later Naming-owned implementation slice documents the exact shape:
-
-- `role`
-- `extension`
-- `roleStatus`
-- `roleCategory`
-- `disambiguation.roleLikeSemanticTokens`
-- `disambiguation.roleLikeFolderTokens`
-
-Naming owns these fields because they are filename-derived semantic interpretation, ambiguity, and disambiguation evidence. They are observations, not Tree placement conclusions.
-
-### 6.5 Finding/source references
-
-`findingRefs[]` or equivalent source references are deferred for the first implementation slice unless needed to preserve traceability from bridge observations to Naming findings.
-
-If added later, finding/source references may identify Naming findings or source report metadata. They must not be required for Tree to infer semantic-family meaning, and suite-core must only transport them neutrally.
-
-### 6.6 Fields not allowed on Naming bridge observations
-
-Naming bridge observations must not include Tree conclusions, including:
-
-- `structuralHome`
-- `semanticHome`
-- `folderKind`
-- `repoShape`
-- `placement`
-- `placementConfidence`
-- `scatterStatus`
-- `clusterStatus`
-- `driftStatus`
-- `expectedTopLevelFolder`
-- `allowedTopLevelFolder`
-- Tree advisory finding severity or verdict fields
-
-Tree may derive or attach those fields after joining Naming evidence to addressed occurrence records. Naming must not emit them as bridge semantics.
-
-## 7. Ownership matrix
+## 5. Ownership boundaries
 
 | Surface | Addressing | Naming | Tree | Suite-core |
 | --- | --- | --- | --- | --- |
-| Occurrence identity | Owns `occurrenceAddress`, address profile semantics, addressed snapshot semantics, and address grammar/provider semantics. | References identity to attach observations; does not define address grammar. | Consumes identity for joins; does not define Naming semantics. | Transports identity neutrally; does not own semantics. |
-| Bridge envelope | Owns profile/snapshot meaning referenced by the envelope. | Owns bridge version, producer identity, semantic payload, and observation production. | Owns supported consumer behavior and fallback policy after receiving payloads. | Owns orchestration, staging, target/scope transport, report envelope mechanics, and neutral payload guardrails. |
-| Semantic interpretation | Does not own Naming semantics. | Owns semantic-name, semantic-family, family root, family subgroup, role parse, ambiguity, and disambiguation. | Consumes Naming evidence for Tree-owned interpretation after joining. | May report metadata without semantic ownership. |
-| Tree conclusions | Does not own Tree placement conclusions. | Must not emit Tree conclusions. | Owns structural-home, semantic-home, folder kind, repo-shape, placement, scatter/cluster, and interpretation after joining. | May transport/report metadata without owning Tree conclusions. |
+| Occurrence identity | Owns `occurrenceAddress`, address profile semantics, address grammar, addressed snapshot/provider output rules, and parent/child/sibling identity facts. | References identity to attach observations; does not define address grammar. | Consumes identity for tuple matching and join preparation; does not define Naming semantics. | Transports identity neutrally; does not own semantics. |
+| Neutral occurrence context | Owns neutral lineage/depth/containment facts, parent/child/sibling identity facts, and deterministic occurrence ordering. | May copy approved neutral context as evidence when sourced from Addressing and shaped by this spec. | May consume neutral context only as evidence under Tree-owned qualification policy. | May stage opaque payloads without semantic ownership. |
+| Semantic interpretation | Does not own Naming semantics. | Owns semantic-name, family-root, semantic-family, family-subgroup, token interpretation, role interpretation, ambiguity flags, split-family flags, disambiguation interpretation, bridge observation production, and approved semantic-evidence partitioning representation. | Consumes Naming evidence for Tree-owned interpretation after joining. | May report metadata without semantic ownership. |
+| Tree conclusions | Does not own Tree placement conclusions. | Must not emit Tree conclusions. | Owns folder-kind interpretation, structural-home interpretation, semantic-home interpretation, placement reasoning, scatter/cluster reasoning, confidence, severity, findings, fallback selection, join diagnostics, and clean/usable evidence assessment. | May transport/report metadata without owning Tree conclusions. |
 
-Suite-core may stage, transport, validate envelope mechanics, or report bridge metadata, but suite-core must not become the owner of Naming, Tree, or Addressing semantics.
+Suite-core owns only runner orchestration, staging, target/scope transport, source metadata, report-envelope mechanics, and neutral opaque payload transport.
+
+## 6. Field eligibility table for future enriched bridge versions
+
+Decision standard: approve only fields with a clear current source, a narrow semantic purpose, a deterministic representation, and a concrete need for the first enriched Naming bridge version. Defer fields that require a new vocabulary, an opaque grouping strategy, a separate role/token model, unclear source authority, or likely Tree-policy leakage. Reject fields that would encode Tree placement, folder/home interpretation, severity, confidence policy, or findings.
+
+| Candidate | Decision status | Owner | Source of truth | Exact field name when approved | Value shape when approved | Required / optional when approved | Null / absence behavior when approved | Normalization and deterministic-order requirements when approved | Classification | Tree-consumption limitation | Explicit prerequisite when deferred | Reason when rejected |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `parentAddressPath` | approved for a future enriched bridge version | Addressing | Addressed occurrence record from the active `addressProfileId` / `addressedSnapshotId` namespace | `parentOccurrenceAddress` | string occurrence address in the same namespace as `occurrenceAddress`, or `null` for namespace roots | Optional | Omit when the source record does not provide parent identity; use `null` only for an addressed root whose source explicitly has no parent | Must equal the Addressing-owned parent occurrence identity in the same validated `addressProfileId` / `addressedSnapshotId` namespace; no Naming inference; stable string; no sorting role | neutral context / parent-reference identity evidence | Tree may later consume only as neutral evidence after Tree validates the canonical observation tuple and applies Tree-owned join policy; Tree must not infer folder kind, structural home, semantic home, placement, confidence, severity, diagnostics, or findings from Naming emission alone | n/a | n/a |
+| `depth` | approved for a future enriched bridge version | Addressing | Addressed occurrence record | `occurrenceDepth` | non-negative integer rooted at `0` in the addressed snapshot namespace | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; producer must not bucket, band, or semantically label depth | neutral context | Tree may consume only as neutral nesting evidence; Tree owns any placement or scatter/cluster interpretation | n/a | n/a |
+| `orderIndex` | approved for a future enriched bridge version | Addressing | Addressed occurrence record deterministic traversal output | `occurrenceOrderIndex` | non-negative integer stable for the addressed snapshot traversal | Optional | Omit when unavailable; do not use `null`; invalid negative/non-integer values invalidate only the enrichment field, not the identity tuple | Numeric integer; represents Addressing traversal order only; consumers must not treat it as identity | neutral context / diagnostic metadata | Tree may use only for deterministic ordering or evidence review, not placement quality, severity, or confidence | n/a | n/a |
+| `occurrenceType` | approved for a future enriched bridge version | Addressing | Addressed occurrence record occurrence-type vocabulary | `occurrenceType` | non-empty string from the Addressing-owned vocabulary, currently expected to include values such as `file` or `folder` | Optional when available | Omit when unavailable; do not invent `unknown`; invalid values are unsupported enrichment unless they break identity validation elsewhere | Preserve source spelling from the approved Addressing vocabulary; no Mapping to Tree `folderKind` | neutral context / compatibility | Tree may consume only as occurrence kind evidence; it must not be treated as Tree folder-kind policy | n/a | n/a |
+| `lineageKey` | deferred | Addressing, with Naming allowed to reference only after source is defined | No approved current source for bridge payload use | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not consume a Naming-computed lineage key as structural-home or semantic-home evidence | Addressing must define an opaque, deterministic lineage/grouping key source and collision semantics, or the bridge must choose `parentOccurrenceAddress` instead | n/a |
+| `contextPartitionKey` | deferred | Naming if semantic-evidence partitioning; Addressing if opaque occurrence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | semantic evidence partition candidate | Tree must not treat it as folder/home/placement policy | A later Naming-owned contract must define the partition purpose, stable algorithm, collision behavior, and proof it is folder-agnostic and not Tree policy | n/a |
+| `siblingContextKey` | deferred | Addressing preferred; Naming only if it can prove neutral evidence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not treat it as sibling placement quality or folder-kind evidence | Addressing must define sibling identity/group semantics, or a later Naming contract must define an opaque source-backed key without Tree-policy leakage | n/a |
+| `subtreeContextKey` | deferred | Addressing preferred; Naming only if it can prove neutral evidence partitioning | No approved current source or grouping strategy | n/a | n/a | n/a | n/a | n/a | neutral context candidate | Tree must not treat it as subtree ownership, structural home, semantic home, or placement evidence by itself | Addressing must define subtree grouping semantics and stability/collision rules, or a later sidecar must carry it as opaque evidence | n/a |
+| `semanticTokens` | deferred | Naming | Naming token interpretation model | n/a | n/a | n/a | n/a | n/a | semantic evidence candidate | Tree must not derive role/category/home policy from tokens without Tree-owned rules | Naming must define a token vocabulary, token source, normalization, ordering, duplicate handling, and relationship to `semanticName`, `familyRoot`, and `semanticFamily` | n/a |
+| `role` | deferred | Naming | Naming role parser / role registry | n/a | n/a | n/a | n/a | n/a | semantic evidence candidate | Tree must not derive folder/home/placement policy solely from role | Naming must define whether the bridge emits raw parsed role, normalized role, registry category/status, or all of these, and how provisional/deprecated roles serialize | n/a |
+| `role-like fields` | deferred | Naming | Naming disambiguation / role-like token interpretation | n/a | n/a | n/a | n/a | n/a | semantic evidence candidate | Tree must not treat role-like evidence as a role verdict or placement policy | Naming must define bounded field names and distinguish role verdicts from role-like hints, ambiguity flags, and disambiguation evidence | n/a |
+| `disambiguationNotes` | approved for a future enriched bridge version | Naming | Naming-owned disambiguation interpretation | `disambiguationNotes` | array of objects, each `{ "code": "<non-empty-kebab-case-string>", "message": "<short deterministic string>", "source": "naming" }`; no severity/confidence/verdict fields | Optional | Omit when there are no notes; empty array is allowed only when a producer intentionally serializes empty containers; `null` is not allowed | Sort by `code`, then `message`, then `source`; remove exact duplicates; messages must be deterministic and not environment-specific | diagnostic metadata / semantic evidence | Tree may consume only as Naming disambiguation evidence; Tree owns whether it is usable, diagnostic-only, or ignored | n/a | n/a |
+| `evidenceStrength` | rejected for bridge payload use | Tree, if strength/confidence is ever interpreted; Naming may own only source facts | Tree confidence/severity policy, not a Naming bridge field | n/a | n/a | n/a | n/a | n/a | rejected Tree-policy/confidence candidate | Tree must not receive Naming-authored strength as bridge policy | n/a | It would encode confidence/strength policy and blur Tree-owned clean/usable evidence assessment, confidence, severity, and findings. |
+| `evidenceLimitNotes` | approved for a future enriched bridge version | Naming | Naming-owned bridge production and source limitation diagnostics | `evidenceLimitNotes` | array of objects, each `{ "code": "<non-empty-kebab-case-string>", "message": "<short deterministic string>", "source": "naming" }`; no severity/confidence/verdict fields | Optional | Omit when there are no limits; empty array is allowed only when a producer intentionally serializes empty containers; `null` is not allowed | Sort by `code`, then `message`, then `source`; remove exact duplicates; messages must be deterministic and not environment-specific | diagnostic metadata | Tree may consume only as source-limit evidence or diagnostics; Tree owns fallback and finding policy | n/a | n/a |
+
+Approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
+
+Deferred set: `lineageKey`, `contextPartitionKey`, `siblingContextKey`, `subtreeContextKey`, `semanticTokens`, `role`, and `role-like fields`.
+
+Rejected set: `evidenceStrength`.
+
+## 7. Guardrails for approved future enrichment fields
+
+Every approved future enrichment field is governed by these rules:
+
+1. Naming remains folder-agnostic.
+2. The field is evidence, not Tree policy.
+3. No enrichment field may replace, weaken, override, or compete with the canonical observation identity tuple: `addressProfileId + addressedSnapshotId + occurrenceAddress`.
+4. `parentOccurrenceAddress`, when present, is optional neutral Addressing-owned parent-reference / containment identity evidence; it does not replace the observation's own `occurrenceAddress`, must remain inside the same validated `addressProfileId` and `addressedSnapshotId` namespace, and must not become a second primary identity for the observation.
+5. The field must not encode folder kind, structural home, semantic home, placement judgment, scatter/cluster judgment, confidence, severity, Tree-owned diagnostics, or findings. Naming-owned diagnostic metadata fields may carry deterministic source/disambiguation notes only when approved in the field table and must not carry Tree verdicts.
+6. Tree may consume the field only as evidence and retains all clean/usable evidence assessment, fallback selection, join diagnostics, placement reasoning, confidence, severity, Tree-owned diagnostics, and findings policy.
+7. Tree may later consume `parentOccurrenceAddress` only as neutral evidence after Tree validates the canonical observation tuple and applies Tree-owned join policy.
+8. The field does not move tuple matching or join preparation into Addressing.
+9. The field does not require shared join-helper extraction.
+10. The field must remain additive and versioned.
+11. The field must preserve current path-keyed compatibility during migration.
+12. A future implementation must not remove `path`, `repoRelativePath`, or path-keyed compatibility fallback solely because approved enrichment fields exist.
+13. A future implementation must validate enriched fields separately from the required identity tuple so unsupported enrichment can be reported without mislabeling valid identity as invalid.
 
 ## 8. Fallback and migration rule
 
@@ -233,9 +152,10 @@ Future implementation slices must follow this migration rule:
 
 1. Tree should prefer address-keyed joins when `addressProfileId`, `addressedSnapshotId`, and `occurrenceAddress` are present and match the addressed occurrence namespace being consumed.
 2. Path-based joins may remain as an explicit temporary compatibility fallback during migration.
-3. Fallback behavior must be documented, test-covered, and removable later.
+3. Fallback behavior must be documented, test-covered, and removable later by an explicit implementation slice.
 4. Fallback diagnostics should make it clear when Tree used path compatibility instead of address identity.
 5. Tree must not silently re-derive Naming semantic-family interpretation when Naming evidence is missing. Missing Naming evidence should remain missing, bounded, or diagnostic according to Tree-owned consumer policy.
+6. Future v2 enrichment does not by itself authorize provider swaps, Tree consumption changes, fallback removal, helper extraction, CLI changes, report-envelope changes, or runtime bridge production.
 
 Path fallback is current implementation reality and must not be removed in this contract slice.
 
@@ -244,25 +164,28 @@ Path fallback is current implementation reality and must not be removed in this 
 | Current audited field/surface | Relationship to this contract |
 | --- | --- |
 | Tree-local `addressPath` | Current runtime truth. Preserve as compatibility/debug alias during migration. Do not rename in runtime code as part of this contract. |
-| Tree-local `parentAddressPath` | Current runtime truth. Keep on addressed occurrence records; do not require on Naming observations in the first bridge shape. |
-| Structural-addressing `address` | Candidate source for neutral `occurrenceAddress`; exact aliasing requires a later implementation slice. |
+| Tree-local `parentAddressPath` | Current runtime truth on addressed occurrence records. Future enriched bridge payloads may emit `parentOccurrenceAddress` sourced from this parent identity, but the old source field name is not approved as the bridge field name. |
+| Structural-addressing `address` | Candidate source for neutral `occurrenceAddress`; exact aliasing remains an implementation-slice decision. |
 | Structural-addressing `addressPath` | Candidate compatibility/debug alias and possible initial source for `occurrenceAddress`; must be interpreted inside profile/snapshot namespace. |
-| Structural-addressing `profileId` | Candidate source for contract field `addressProfileId`; this spec chooses the bridge field name `addressProfileId` for clarity. |
+| Structural-addressing `profileId` | Candidate source for contract field `addressProfileId`; this spec uses the bridge field name `addressProfileId` for clarity. |
 | Structural-addressing `snapshotOutputId` | Related to `addressedSnapshotId`, but not identical by contract until a later slice decides whether output id is sufficient or an instance/source id is required. |
-| Structural-addressing `domainPrefix` | Address grammar/provider metadata. It is not required in every Naming observation. |
-| Current Naming bridge `path` observations | Current runtime truth and temporary compatibility alias. Future bridge observations should add `repoRelativePath` rather than remove `path` immediately. |
-| Current Tree semantic-home evidence join by `path` | Current runtime truth and temporary fallback path. Future Tree consumption should prefer address-keyed joins only when contract fields are present. |
+| Structural-addressing `occurrenceType` | Approved future bridge enrichment field when available; it remains neutral occurrence kind evidence, not Tree folder-kind policy. |
+| Structural-addressing `depth` | Approved future bridge enrichment source for `occurrenceDepth`; it remains neutral context evidence. |
+| Structural-addressing `orderIndex` | Approved future bridge enrichment source for `occurrenceOrderIndex`; it remains deterministic ordering/diagnostic evidence, not identity. |
+| Current Naming bridge `path` observations | Current runtime truth and temporary compatibility alias. Future bridge observations should preserve `repoRelativePath` / `path` compatibility during migration. |
+| Current Tree semantic-home evidence join by `path` | Current runtime truth and temporary fallback path. Future Tree consumption should prefer address-keyed joins only when contract fields are present and Tree-owned qualification accepts them. |
 
 ## 10. Unresolved naming and migration follow-up notes
 
 The following questions remain explicit follow-up work and are not resolved by runtime changes in this slice:
 
 1. Whether `addressedSnapshotId` should be a run/snapshot instance id, a content digest, a source snapshot id, or a constrained alias of current `snapshotOutputId`.
-2. Whether the first bridge implementation should emit per-observation `addressProfileId` and `addressedSnapshotId` redundantly, or rely on envelope-level inheritance plus validation.
-3. Whether structural-addressing `address` or `addressPath` should populate the first `occurrenceAddress` field, and which compatibility alias must be retained in reports.
-4. Whether `findingRefs[]`, `sourceReportRef`, or `sourceSnapshotRef` are needed in the first implementation slice for traceability.
-5. Which focused repeated-same-family fixtures should prove that address-keyed joins beat path/family bucket assumptions before fallback removal.
-6. Which producer is the authoritative addressed snapshot provider for the cross-slice bridge: Tree-local addressed occurrences, structural-addressing addressed snapshots, or a later compatibility bridge between them.
+2. Whether the future v2 bridge should emit approved enrichment fields directly on each observation, inside a nested `occurrenceContext` / `diagnostics` object, or in a separately named additive sidecar.
+3. Whether structural-addressing `address` or `addressPath` should populate the first `occurrenceAddress` field in every producer path, and which compatibility alias must be retained in reports.
+4. Which focused repeated-same-family fixtures should prove that address-keyed joins beat path/family bucket assumptions before fallback removal.
+5. Which producer is the authoritative addressed snapshot provider for the cross-slice bridge: Tree-local addressed occurrences, structural-addressing addressed snapshots, or a later compatibility bridge between them.
+6. Whether deferred partition keys should ever be emitted, and if so whether Addressing or Naming owns the exact grouping algorithm.
+7. Whether deferred Naming token and role evidence should be modeled as bridge fields, a Naming-owned sidecar, or remain outside the occurrence bridge.
 
 ## 11. Non-goals
 
@@ -271,14 +194,17 @@ This spec does not:
 - change runtime behavior;
 - change Naming bridge payloads;
 - change Tree join behavior;
-- add `occurrenceAddress` fields to runtime outputs;
+- add enriched fields to runtime outputs;
 - rename `addressPath` in runtime code;
-- wire Tree runtime to the structural-addressing provider;
+- wire Tree runtime to a different structural-addressing provider;
 - remove path fallback;
 - remove known-roots or revive known-roots;
 - promote Addressing to a standalone runnable validator slice;
 - move Addressing semantics into suite-core;
+- move tuple matching or join preparation into Addressing;
+- require shared join-helper extraction;
 - broaden Tree semantic-home, structural-home, scatter, cluster, or drift reasoning;
+- add Tree confidence, severity, findings, or report-envelope policy to Naming bridge payloads;
 - rework validator report envelopes;
 - change CLI behavior;
 - fix unrelated validator findings;
@@ -286,6 +212,6 @@ This spec does not:
 
 ## 12. Recommended next implementation child
 
-Recommended next implementation child: define and test a data-only, versioned Naming bridge payload shape that preserves the current semantic payload and `path` compatibility field while additively carrying `bridgeContractVersion`, `bridgeSource`, `bridgeProducerId`, `addressProfileId`, `addressedSnapshotId`, `occurrenceAddress`, `repoRelativePath`, and `occurrenceType` when an addressed occurrence namespace is available.
+Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity and path/source-trace compatibility while carrying only the approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `occurrenceType`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
-That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape and explicit fallback behavior without removing the current path-based consumer path.
+That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape, version handling, unsupported-enrichment diagnostics, and explicit fallback behavior without removing the current path-based consumer path.

--- a/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md
@@ -80,6 +80,10 @@ New approved enrichment fields in this spec require a future explicit version na
 
 The v2 bridge may keep the same top-level envelope fields as v1 and add an explicitly versioned observation enrichment block or direct observation fields for genuinely new approved fields that valid v1 observations do not already emit. A later implementation slice must choose the concrete serialization route before runtime emission. Until that slice lands, new approved fields below are contract-approved but **not current runtime truth**.
 
+Future v2 enrichment is additive to the current Naming semantic observation payload. Any future `naming-occurrence-bridge.v2` payload, or any additive sidecar strategy, must preserve the existing Naming-owned semantic observation fields and semantics, including at minimum `semanticName`, `familyRoot`, `semanticFamily`, `familySubgroup` when present, `ambiguityFlags` when present, `splitFamilyFlags` when present, existing Naming disambiguation evidence when present, existing path/source-trace compatibility fields, and optional existing v1 `occurrenceType` behavior when available. Future enrichment adds neutral occurrence context, approved Naming metadata, or versioned diagnostics around that semantic evidence; it must not replace, flatten, omit, or downgrade the current semantic interpretation.
+
+A sidecar approach must either preserve direct linkage to the complete current semantic observation payload or define an explicit deterministic association that leaves the existing semantic payload intact. Tree must still receive Naming semantic evidence plus any approved enrichment; Tree must not be forced to reconstruct semantic-family interpretation from raw names, paths, or enrichment fields.
+
 ### 4.3 Version handling and unknown fields
 
 Version handling rules:
@@ -100,7 +104,7 @@ Version handling rules:
 | --- | --- | --- | --- | --- |
 | Occurrence identity | Owns `occurrenceAddress`, address profile semantics, address grammar, addressed snapshot/provider output rules, and parent/child/sibling identity facts. | References identity to attach observations; does not define address grammar. | Consumes identity for tuple matching and join preparation; does not define Naming semantics. | Transports identity neutrally; does not own semantics. |
 | Neutral occurrence context | Owns neutral lineage/depth/containment facts, parent/child/sibling identity facts, and deterministic occurrence ordering. | May copy approved neutral context as evidence when sourced from Addressing and shaped by this spec. | May consume neutral context only as evidence under Tree-owned qualification policy. | May stage opaque payloads without semantic ownership. |
-| Semantic interpretation | Does not own Naming semantics. | Owns semantic-name, family-root, semantic-family, family-subgroup, token interpretation, role interpretation, ambiguity flags, split-family flags, disambiguation interpretation, bridge observation production, and approved semantic-evidence partitioning representation. | Consumes Naming evidence for Tree-owned interpretation after joining. | May report metadata without semantic ownership. |
+| Semantic interpretation | Does not own Naming semantics. | Owns semantic-name, family-root, semantic-family, family-subgroup, token interpretation, role interpretation, ambiguity flags, split-family flags, disambiguation interpretation, bridge observation production, preservation of current semantic observation payloads, and approved semantic-evidence partitioning representation. | Consumes Naming semantic evidence plus approved enrichment for Tree-owned structural interpretation after joining; does not reconstruct Naming semantic-family interpretation from raw names, paths, or enrichment fields. | May report metadata without semantic ownership. |
 | Tree conclusions | Does not own Tree placement conclusions. | Must not emit Tree conclusions. | Owns folder-kind interpretation, structural-home interpretation, semantic-home interpretation, placement reasoning, scatter/cluster reasoning, confidence, severity, findings, fallback selection, join diagnostics, and clean/usable evidence assessment. | May transport/report metadata without owning Tree conclusions. |
 
 Suite-core owns only runner orchestration, staging, target/scope transport, source metadata, report-envelope mechanics, and neutral opaque payload transport.
@@ -169,6 +173,8 @@ Future implementation slices must follow this migration rule:
 4. Fallback diagnostics should make it clear when Tree used path compatibility instead of address identity.
 5. Tree must not silently re-derive Naming semantic-family interpretation when Naming evidence is missing. Missing Naming evidence should remain missing, bounded, or diagnostic according to Tree-owned consumer policy.
 6. Future v2 enrichment does not by itself authorize provider swaps, Tree consumption changes, fallback removal, helper extraction, CLI changes, report-envelope changes, or runtime bridge production.
+7. Future v2 or sidecar migration must preserve the existing Naming-owned semantic observation payload, existing path/source-trace compatibility fields, and optional existing v1 `occurrenceType` behavior when available. It must not create an identity-and-enrichment-only payload that drops semantic evidence Tree currently consumes.
+8. Tree must continue receiving Naming semantic evidence plus any approved enrichment; it must not be forced to reconstruct semantic-family interpretation from raw names, paths, neutral occurrence context, or diagnostic metadata.
 
 Path fallback is current implementation reality and must not be removed in this contract slice.
 
@@ -205,7 +211,7 @@ The following questions remain explicit follow-up work and are not resolved by r
 This spec does not:
 
 - change runtime behavior;
-- change Naming bridge payloads;
+- change current v1 Naming bridge payload production;
 - change Tree join behavior;
 - add enriched fields to runtime outputs;
 - rename `addressPath` in runtime code;
@@ -225,6 +231,8 @@ This spec does not:
 
 ## 12. Recommended next implementation child
 
-Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity, optional v1 `occurrenceType`, and path/source-trace compatibility while carrying only the genuinely new approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`.
+Recommended next implementation child: define and test a data-only, explicitly versioned `naming-occurrence-bridge.v2` payload or additive sidecar that preserves v1 identity, the complete current Naming-owned semantic observation payload, optional v1 `occurrenceType`, and path/source-trace compatibility while carrying only the genuinely new approved first enriched bridge set: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`.
 
-That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape, version handling, unsupported-enrichment diagnostics, and explicit fallback behavior without removing the current path-based consumer path.
+The preserved semantic payload must include at minimum `semanticName`, `familyRoot`, `semanticFamily`, `familySubgroup` when present, `ambiguityFlags` when present, `splitFamilyFlags` when present, and existing Naming disambiguation evidence when present. A sidecar child must define direct linkage or deterministic association to the complete current semantic observation payload and must leave that payload intact.
+
+That child should still avoid Tree reasoning expansion. It should include focused tests for payload shape, semantic-payload preservation, version handling, unsupported-enrichment diagnostics, and explicit fallback behavior without removing the current path-based consumer path.


### PR DESCRIPTION
### Motivation
- Incorporate the #651 review correction to allow `parentOccurrenceAddress` as optional Addressing-owned parent-reference identity evidence while preserving the canonical observation identity tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` and the docs-only scope. 
- Remove overly broad guardrail language that would have forbidden any identity-like enrichment fields, replacing it with a targeted rule that no enrichment may replace, weaken, override, or compete with the canonical observation identity. 
- Treat `calculogic-validator/doc/ConventionRoutines/*` and the issue/audit artifacts (Refs #648, Refs #651, Refs #647) as the relevant authority and navigation inputs for this contract decision while keeping this slice purely normative/document-level and not a runtime change. 

### Description
- Updated `calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md` to explicitly distinguish the canonical observation identity (`addressProfileId + addressedSnapshotId + occurrenceAddress`) from optional parent-reference identity evidence (`parentOccurrenceAddress`) and to document namespace, null/absence, and consumption constraints for `parentOccurrenceAddress`.
- Revised the field-eligibility table and guardrails so `parentOccurrenceAddress` is approved for a future enriched bridge version with exact field name `parentOccurrenceAddress`, value shape, optional status, and deterministic normalization requirements, and clarified Tree-consumption limits. 
- Tightened diagnostic/ownership language so Naming-owned diagnostic metadata is allowed only in approved forms while Tree-owned diagnostics, findings, confidence, and placement policy remain explicitly Tree-owned. 
- Updated `calculogic-validator/doc/Indexes/validator-docs.index.md` entry copy to reflect the spec’s expanded scope (identity + enrichment eligibility + versioning/migration guardrails) and preserved the non-goal that runtime behavior is unchanged. 
- No runtime code, loader, or test code was modified as part of this docs-only contract slice. 

### Testing
- Ran `git diff --check` which completed with no whitespace errors and succeeded. 
- Ran `npm run validate:naming -- --scope=validator --target calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md` which succeeded and produced an informational canonical-file report for the targeted spec file. 
- Ran `npm run validate:tree -- --scope=validator --target calculogic-validator/doc/ValidatorSpecs/cross-cutting/naming-bridge-occurrence-identity-contract.spec.md` which succeeded and produced an advisory scan with no findings. 

Refs #651
Refs #647

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b48ab3f48331abf4bdb5167138ad)