### PR TITLE
Implement Naming occurrence enrichment sidecar

### DIFF
--- a/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
+++ b/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
@@ -126,36 +126,89 @@ const toAddressAttachedObservation = ({
 };
 
 
+const isKebabCaseString = (value) =>
+  typeof value === 'string' && /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u.test(value);
+
+const sortContractNotes = (notes) =>
+  Array.from(
+    new Map(
+      notes
+        .filter(
+          (note) =>
+            isPlainObject(note) &&
+            isKebabCaseString(note.code) &&
+            toOptionalNonEmptyString(note.message) &&
+            note.source === 'naming',
+        )
+        .map((note) => [
+          `${note.code}\u0000${note.message}\u0000${note.source}`,
+          { code: note.code, message: note.message, source: 'naming' },
+        ]),
+    ).values(),
+  ).sort(
+    (left, right) =>
+      left.code.localeCompare(right.code) ||
+      left.message.localeCompare(right.message) ||
+      left.source.localeCompare(right.source),
+  );
+
+const toDisambiguationNotes = (disambiguation) => {
+  if (!isPlainObject(disambiguation)) {
+    return [];
+  }
+
+  const roleLikeFolderTokens = toSortedUniqueStrings(disambiguation.roleLikeFolderTokens);
+  const roleLikeSemanticTokens = toSortedUniqueStrings(disambiguation.roleLikeSemanticTokens);
+
+  return sortContractNotes([
+    ...(roleLikeFolderTokens?.map((token) => ({
+      code: 'role-like-folder-token',
+      message: `Role-like folder token: ${token}`,
+      source: 'naming',
+    })) ?? []),
+    ...(roleLikeSemanticTokens?.map((token) => ({
+      code: 'role-like-semantic-token',
+      message: `Role-like semantic token: ${token}`,
+      source: 'naming',
+    })) ?? []),
+  ]);
+};
+
+const toEvidenceLimitNote = (note) => {
+  if (!isPlainObject(note)) {
+    return null;
+  }
+
+  if (isKebabCaseString(note.code) && toOptionalNonEmptyString(note.message) && note.source === 'naming') {
+    return { code: note.code, message: note.message, source: 'naming' };
+  }
+
+  if (isKebabCaseString(note.noteType)) {
+    const detail = toOptionalNonEmptyString(note.detail);
+    return {
+      code: note.noteType,
+      message: detail ?? note.noteType,
+      source: 'naming',
+    };
+  }
+
+  return null;
+};
+
 const toNamingMetadataNotes = (semanticObservation) => {
   const notes = {};
+  const disambiguationNotes = toDisambiguationNotes(semanticObservation.disambiguation);
 
-  if (isPlainObject(semanticObservation.disambiguation)) {
-    const roleLikeFolderTokens = toSortedUniqueStrings(semanticObservation.disambiguation.roleLikeFolderTokens);
-    const roleLikeSemanticTokens = toSortedUniqueStrings(semanticObservation.disambiguation.roleLikeSemanticTokens);
-    const disambiguationNotes = [
-      ...(roleLikeFolderTokens?.map((token) => ({ noteType: 'role-like-folder-token', token })) ?? []),
-      ...(roleLikeSemanticTokens?.map((token) => ({ noteType: 'role-like-semantic-token', token })) ?? []),
-    ].sort((left, right) => left.noteType.localeCompare(right.noteType) || left.token.localeCompare(right.token));
-
-    if (disambiguationNotes.length > 0) {
-      notes.disambiguationNotes = disambiguationNotes;
-    }
+  if (disambiguationNotes.length > 0) {
+    notes.disambiguationNotes = disambiguationNotes;
   }
 
   const evidenceLimitNotes = Array.isArray(semanticObservation.evidenceLimitNotes)
-    ? semanticObservation.evidenceLimitNotes
-        .filter((note) => isPlainObject(note) && toOptionalNonEmptyString(note.noteType))
-        .map((note) => ({
-          noteType: note.noteType,
-          ...(toOptionalNonEmptyString(note.detail) ? { detail: note.detail } : {}),
-        }))
-        .sort((left, right) => left.noteType.localeCompare(right.noteType) || (left.detail ?? '').localeCompare(right.detail ?? ''))
+    ? sortContractNotes(semanticObservation.evidenceLimitNotes.map(toEvidenceLimitNote).filter(Boolean))
     : [];
 
   if (evidenceLimitNotes.length > 0) {
-    notes.evidenceLimitNotes = Array.from(
-      new Map(evidenceLimitNotes.map((note) => [`${note.noteType}\u0000${note.detail ?? ''}`, note])).values(),
-    );
+    notes.evidenceLimitNotes = evidenceLimitNotes;
   }
 
   return notes;

--- a/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
+++ b/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
@@ -1,4 +1,5 @@
 const BRIDGE_CONTRACT_VERSION = 'naming-occurrence-bridge.v1';
+const ENRICHMENT_SIDECAR_VERSION = 'naming-occurrence-bridge-enrichment.v1';
 const BRIDGE_SOURCE = 'calculogic-validator/naming';
 const BRIDGE_PRODUCER_ID = 'naming-semantic-family-occurrence-bridge';
 
@@ -9,12 +10,25 @@ const NAMING_SEMANTIC_FIELDS = [
   'familySubgroup',
   'ambiguityFlags',
   'splitFamilyFlags',
+  'disambiguation',
 ];
 
 const toOptionalNonEmptyString = (value) => (typeof value === 'string' && value.length > 0 ? value : null);
 
 const cloneStringArray = (value) =>
   Array.isArray(value) ? value.filter((item) => typeof item === 'string' && item.length > 0) : null;
+
+const toSortedUniqueStrings = (value) =>
+  Array.isArray(value)
+    ? Array.from(new Set(value.filter((item) => typeof item === 'string' && item.length > 0))).sort((left, right) =>
+        left.localeCompare(right),
+      )
+    : null;
+
+const toOptionalNonNegativeInteger = (value) =>
+  Number.isInteger(value) && value >= 0 ? value : null;
+
+const isPlainObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
 const toPathKey = (value) => toOptionalNonEmptyString(value);
 
@@ -45,6 +59,23 @@ const copyNamingSemanticPayload = (observation) => {
       const clonedFlags = cloneStringArray(observation[field]);
       if (clonedFlags) {
         payload[field] = clonedFlags;
+      }
+      continue;
+    }
+
+    if (field === 'disambiguation') {
+      if (isPlainObject(observation.disambiguation)) {
+        payload.disambiguation = {
+          ...(toSortedUniqueStrings(observation.disambiguation.roleLikeFolderTokens)
+            ? { roleLikeFolderTokens: toSortedUniqueStrings(observation.disambiguation.roleLikeFolderTokens) }
+            : {}),
+          ...(toSortedUniqueStrings(observation.disambiguation.roleLikeSemanticTokens)
+            ? { roleLikeSemanticTokens: toSortedUniqueStrings(observation.disambiguation.roleLikeSemanticTokens) }
+            : {}),
+        };
+        if (Object.keys(payload.disambiguation).length === 0) {
+          delete payload.disambiguation;
+        }
       }
       continue;
     }
@@ -94,6 +125,76 @@ const toAddressAttachedObservation = ({
   };
 };
 
+
+const toNamingMetadataNotes = (semanticObservation) => {
+  const notes = {};
+
+  if (isPlainObject(semanticObservation.disambiguation)) {
+    const roleLikeFolderTokens = toSortedUniqueStrings(semanticObservation.disambiguation.roleLikeFolderTokens);
+    const roleLikeSemanticTokens = toSortedUniqueStrings(semanticObservation.disambiguation.roleLikeSemanticTokens);
+    const disambiguationNotes = [
+      ...(roleLikeFolderTokens?.map((token) => ({ noteType: 'role-like-folder-token', token })) ?? []),
+      ...(roleLikeSemanticTokens?.map((token) => ({ noteType: 'role-like-semantic-token', token })) ?? []),
+    ].sort((left, right) => left.noteType.localeCompare(right.noteType) || left.token.localeCompare(right.token));
+
+    if (disambiguationNotes.length > 0) {
+      notes.disambiguationNotes = disambiguationNotes;
+    }
+  }
+
+  const evidenceLimitNotes = Array.isArray(semanticObservation.evidenceLimitNotes)
+    ? semanticObservation.evidenceLimitNotes
+        .filter((note) => isPlainObject(note) && toOptionalNonEmptyString(note.noteType))
+        .map((note) => ({
+          noteType: note.noteType,
+          ...(toOptionalNonEmptyString(note.detail) ? { detail: note.detail } : {}),
+        }))
+        .sort((left, right) => left.noteType.localeCompare(right.noteType) || (left.detail ?? '').localeCompare(right.detail ?? ''))
+    : [];
+
+  if (evidenceLimitNotes.length > 0) {
+    notes.evidenceLimitNotes = Array.from(
+      new Map(evidenceLimitNotes.map((note) => [`${note.noteType}\u0000${note.detail ?? ''}`, note])).values(),
+    );
+  }
+
+  return notes;
+};
+
+const toEnrichmentRecord = ({ observation, semanticObservation, occurrenceRecord }) => {
+  const enrichment = {
+    addressProfileId: observation.addressProfileId,
+    addressedSnapshotId: observation.addressedSnapshotId,
+    occurrenceAddress: observation.occurrenceAddress,
+  };
+
+  const parentOccurrenceAddressSource = occurrenceRecord.parentOccurrenceAddress ?? occurrenceRecord.parentAddressPath;
+  if (parentOccurrenceAddressSource === null) {
+    enrichment.parentOccurrenceAddress = null;
+  } else {
+    const parentOccurrenceAddress = toOptionalNonEmptyString(parentOccurrenceAddressSource);
+    if (parentOccurrenceAddress) {
+      enrichment.parentOccurrenceAddress = parentOccurrenceAddress;
+    }
+  }
+
+  const occurrenceDepth = toOptionalNonNegativeInteger(occurrenceRecord.occurrenceDepth ?? occurrenceRecord.depth);
+  if (occurrenceDepth !== null) {
+    enrichment.occurrenceDepth = occurrenceDepth;
+  }
+
+  const occurrenceOrderIndex = toOptionalNonNegativeInteger(
+    occurrenceRecord.occurrenceOrderIndex ?? occurrenceRecord.orderIndex,
+  );
+  if (occurrenceOrderIndex !== null) {
+    enrichment.occurrenceOrderIndex = occurrenceOrderIndex;
+  }
+
+  Object.assign(enrichment, toNamingMetadataNotes(semanticObservation));
+
+  return Object.keys(enrichment).length > 3 ? enrichment : null;
+};
+
 const toMissingIdentityDiagnostic = ({ semanticObservation, reason }) => ({
   diagnosticType: 'missing-occurrence-identity',
   reason,
@@ -140,6 +241,7 @@ export const createNamingOccurrenceBridgePayload = ({
   const occurrenceByPath = buildOccurrenceByPath(addressedOccurrenceNamespace.occurrenceRecords);
 
   const observations = [];
+  const enrichedObservations = [];
   const diagnostics = toInvalidAddressedNamespaceDiagnostics({ addressProfileId, addressedSnapshotId });
   const hasValidAddressedNamespace = diagnostics.length === 0;
 
@@ -174,6 +276,11 @@ export const createNamingOccurrenceBridgePayload = ({
       }
 
       observations.push(observation);
+
+      const enrichedObservation = toEnrichmentRecord({ observation, semanticObservation, occurrenceRecord });
+      if (enrichedObservation) {
+        enrichedObservations.push(enrichedObservation);
+      }
     }
   }
 
@@ -200,6 +307,8 @@ export const createNamingOccurrenceBridgePayload = ({
         (diagnostic) => diagnostic.diagnosticType === 'missing-occurrence-identity',
       ).length,
       totalDiagnosticCount: diagnostics.length,
+      enrichmentSidecarVersion: ENRICHMENT_SIDECAR_VERSION,
+      enrichmentObservationCount: enrichedObservations.length,
     },
     observations: observations.sort((left, right) =>
       left.addressProfileId.localeCompare(right.addressProfileId) ||
@@ -207,6 +316,20 @@ export const createNamingOccurrenceBridgePayload = ({
       left.occurrenceAddress.localeCompare(right.occurrenceAddress) ||
       left.repoRelativePath.localeCompare(right.repoRelativePath),
     ),
+    ...(enrichedObservations.length > 0
+      ? {
+          occurrenceContextEnrichment: {
+            enrichmentContractVersion: ENRICHMENT_SIDECAR_VERSION,
+            identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+            // Sidecar route preserves v1 payload semantics while keeping enrichment safely ignorable by Tree v1 intake.
+            enrichedObservations: enrichedObservations.sort((left, right) =>
+              left.addressProfileId.localeCompare(right.addressProfileId) ||
+              left.addressedSnapshotId.localeCompare(right.addressedSnapshotId) ||
+              left.occurrenceAddress.localeCompare(right.occurrenceAddress),
+            ),
+          },
+        }
+      : {}),
     ...(diagnostics.length > 0 ? { diagnostics } : {}),
   };
 };

--- a/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
+++ b/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
@@ -3,6 +3,13 @@ const toSortedUniqueStringFlags = (flags) =>
     new Set(flags.filter((flag) => typeof flag === 'string' && flag.length > 0)),
   ).sort((left, right) => left.localeCompare(right));
 
+const cloneEvidenceLimitNotes = (evidenceLimitNotes) =>
+  Array.isArray(evidenceLimitNotes)
+    ? evidenceLimitNotes
+        .filter((note) => note && typeof note === 'object' && !Array.isArray(note))
+        .map((note) => ({ ...note }))
+    : null;
+
 const toDisambiguationPayload = (disambiguation) => {
   if (!disambiguation || typeof disambiguation !== 'object' || Array.isArray(disambiguation)) {
     return null;
@@ -49,6 +56,9 @@ const toBridgeObservationFromFinding = (finding) => {
     return null;
   }
 
+  const disambiguationPayload = toDisambiguationPayload(details.disambiguation);
+  const evidenceLimitNotes = cloneEvidenceLimitNotes(details.evidenceLimitNotes);
+
   return {
     path: finding.path,
     semanticName: details.semanticName,
@@ -63,9 +73,8 @@ const toBridgeObservationFromFinding = (finding) => {
     ...(Array.isArray(details.splitFamilyFlags)
       ? { splitFamilyFlags: toSortedUniqueStringFlags(details.splitFamilyFlags) }
       : {}),
-    ...(toDisambiguationPayload(details.disambiguation)
-      ? { disambiguation: toDisambiguationPayload(details.disambiguation) }
-      : {}),
+    ...(disambiguationPayload ? { disambiguation: disambiguationPayload } : {}),
+    ...(evidenceLimitNotes ? { evidenceLimitNotes } : {}),
   };
 };
 

--- a/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
+++ b/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
@@ -3,6 +3,23 @@ const toSortedUniqueStringFlags = (flags) =>
     new Set(flags.filter((flag) => typeof flag === 'string' && flag.length > 0)),
   ).sort((left, right) => left.localeCompare(right));
 
+const toDisambiguationPayload = (disambiguation) => {
+  if (!disambiguation || typeof disambiguation !== 'object' || Array.isArray(disambiguation)) {
+    return null;
+  }
+
+  const payload = {
+    ...(Array.isArray(disambiguation.roleLikeFolderTokens)
+      ? { roleLikeFolderTokens: toSortedUniqueStringFlags(disambiguation.roleLikeFolderTokens) }
+      : {}),
+    ...(Array.isArray(disambiguation.roleLikeSemanticTokens)
+      ? { roleLikeSemanticTokens: toSortedUniqueStringFlags(disambiguation.roleLikeSemanticTokens) }
+      : {}),
+  };
+
+  return Object.keys(payload).length > 0 ? payload : null;
+};
+
 const toBridgeObservationFromFinding = (finding) => {
   if (!finding || typeof finding !== 'object' || Array.isArray(finding)) {
     return null;
@@ -45,6 +62,9 @@ const toBridgeObservationFromFinding = (finding) => {
       : {}),
     ...(Array.isArray(details.splitFamilyFlags)
       ? { splitFamilyFlags: toSortedUniqueStringFlags(details.splitFamilyFlags) }
+      : {}),
+    ...(toDisambiguationPayload(details.disambiguation)
+      ? { disambiguation: toDisambiguationPayload(details.disambiguation) }
       : {}),
   };
 };

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
@@ -229,3 +229,202 @@ test('createNamingOccurrenceBridgePayload does not emit Tree-owned conclusion fi
     }
   }
 });
+
+const deferredOrRejectedEnrichmentFields = [
+  'lineageKey',
+  'contextPartitionKey',
+  'siblingContextKey',
+  'subtreeContextKey',
+  'semanticTokens',
+  'role',
+  'evidenceStrength',
+];
+
+const collectObjectKeys = (value) => {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectObjectKeys);
+  }
+
+  return [
+    ...Object.keys(value),
+    ...Object.values(value).flatMap(collectObjectKeys),
+  ];
+};
+
+test('createNamingOccurrenceBridgePayload emits explicitly versioned additive enrichment sidecar without changing v1 observations', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [
+        {
+          path: 'src/host/app.logic.mjs',
+          semanticName: 'app',
+          semanticFamily: 'app',
+          familyRoot: 'app',
+          disambiguation: {
+            roleLikeFolderTokens: ['host', 'host'],
+            roleLikeSemanticTokens: ['wiring', 'host'],
+          },
+          evidenceLimitNotes: [
+            { noteType: 'naming-source-bounded', detail: 'canonical-finding-only' },
+            { noteType: 'naming-source-bounded', detail: 'canonical-finding-only' },
+          ],
+        },
+      ],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [
+        {
+          occurrenceAddress: 'A.1.1',
+          addressPath: 'A.1.1',
+          parentAddressPath: 'A.1',
+          path: 'src/host/app.logic.mjs',
+          occurrenceType: 'file',
+          depth: 2,
+          orderIndex: 7,
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.bridgeContractVersion, 'naming-occurrence-bridge.v1');
+  assert.equal(result.compatibility.enrichmentSidecarVersion, 'naming-occurrence-bridge-enrichment.v1');
+  assert.equal(result.occurrenceContextEnrichment.enrichmentContractVersion, 'naming-occurrence-bridge-enrichment.v1');
+  assert.deepEqual(result.occurrenceContextEnrichment.identityTupleFields, [
+    'addressProfileId',
+    'addressedSnapshotId',
+    'occurrenceAddress',
+  ]);
+  assert.deepEqual(result.observations, [
+    {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A.1.1',
+      repoRelativePath: 'src/host/app.logic.mjs',
+      path: 'src/host/app.logic.mjs',
+      addressPath: 'A.1.1',
+      occurrenceType: 'file',
+      semanticName: 'app',
+      semanticFamily: 'app',
+      familyRoot: 'app',
+      disambiguation: {
+        roleLikeFolderTokens: ['host'],
+        roleLikeSemanticTokens: ['host', 'wiring'],
+      },
+    },
+  ]);
+  assert.deepEqual(result.occurrenceContextEnrichment.enrichedObservations, [
+    {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A.1.1',
+      parentOccurrenceAddress: 'A.1',
+      occurrenceDepth: 2,
+      occurrenceOrderIndex: 7,
+      disambiguationNotes: [
+        { noteType: 'role-like-folder-token', token: 'host' },
+        { noteType: 'role-like-semantic-token', token: 'host' },
+        { noteType: 'role-like-semantic-token', token: 'wiring' },
+      ],
+      evidenceLimitNotes: [{ noteType: 'naming-source-bounded', detail: 'canonical-finding-only' }],
+    },
+  ]);
+
+  const emittedEnrichmentKeys = collectObjectKeys(result.occurrenceContextEnrichment);
+  for (const field of deferredOrRejectedEnrichmentFields) {
+    assert.equal(emittedEnrichmentKeys.includes(field), false, `${field} must not be emitted`);
+  }
+});
+
+test('createNamingOccurrenceBridgePayload omits invalid or unavailable enrichment fields while preserving occurrence identity', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [
+        { path: 'src/root.logic.mjs', semanticName: 'root', semanticFamily: 'root', familyRoot: 'root' },
+        { path: 'src/child.logic.mjs', semanticName: 'child', semanticFamily: 'child', familyRoot: 'child' },
+      ],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [
+        {
+          occurrenceAddress: 'A',
+          addressPath: 'A',
+          parentAddressPath: null,
+          path: 'src/root.logic.mjs',
+          depth: 0,
+          orderIndex: 0,
+        },
+        {
+          occurrenceAddress: 'A.1',
+          addressPath: 'A.1',
+          path: 'src/child.logic.mjs',
+          depth: -1,
+          orderIndex: 1.5,
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(result.occurrenceContextEnrichment.enrichedObservations, [
+    {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A',
+      parentOccurrenceAddress: null,
+      occurrenceDepth: 0,
+      occurrenceOrderIndex: 0,
+    },
+  ]);
+  assert.deepEqual(
+    result.observations.map(({ addressProfileId, addressedSnapshotId, occurrenceAddress }) => ({
+      addressProfileId,
+      addressedSnapshotId,
+      occurrenceAddress,
+    })),
+    [
+      { addressProfileId: 'tree-codebase', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A' },
+      { addressProfileId: 'tree-codebase', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A.1' },
+    ],
+  );
+});
+
+test('createNamingOccurrenceBridgePayload keeps same-family nested observations distinct by occurrence identity', () => {
+  const result = createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: {
+      observations: [
+        { path: 'src/alpha/shared.logic.mjs', semanticName: 'shared', semanticFamily: 'shared-runtime', familyRoot: 'shared' },
+        { path: 'src/alpha/nested/shared.logic.mjs', semanticName: 'shared', semanticFamily: 'shared-runtime', familyRoot: 'shared' },
+      ],
+    },
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [
+        { occurrenceAddress: 'A.1', addressPath: 'A.1', path: 'src/alpha/shared.logic.mjs', parentAddressPath: 'A', depth: 2, orderIndex: 3 },
+        { occurrenceAddress: 'A.1.1', addressPath: 'A.1.1', path: 'src/alpha/nested/shared.logic.mjs', parentAddressPath: 'A.1', depth: 3, orderIndex: 4 },
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    result.occurrenceContextEnrichment.enrichedObservations.map((observation) => [
+      observation.occurrenceAddress,
+      observation.parentOccurrenceAddress,
+      observation.occurrenceDepth,
+      observation.occurrenceOrderIndex,
+    ]),
+    [
+      ['A.1', 'A', 2, 3],
+      ['A.1.1', 'A.1', 3, 4],
+    ],
+  );
+  assert.equal(new Set(result.observations.map((observation) => observation.semanticFamily)).size, 1);
+  assert.equal(new Set(result.observations.map((observation) => observation.occurrenceAddress)).size, 2);
+});

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs
@@ -238,6 +238,15 @@ const deferredOrRejectedEnrichmentFields = [
   'semanticTokens',
   'role',
   'evidenceStrength',
+  'noteType',
+  'token',
+  'detail',
+  'severity',
+  'confidence',
+  'finding',
+  'structuralHome',
+  'semanticHome',
+  'placement',
 ];
 
 const collectObjectKeys = (value) => {
@@ -269,8 +278,14 @@ test('createNamingOccurrenceBridgePayload emits explicitly versioned additive en
             roleLikeSemanticTokens: ['wiring', 'host'],
           },
           evidenceLimitNotes: [
-            { noteType: 'naming-source-bounded', detail: 'canonical-finding-only' },
-            { noteType: 'naming-source-bounded', detail: 'canonical-finding-only' },
+            { code: 'z-limit', message: 'Z limit', source: 'naming' },
+            { code: 'naming-source-bounded', message: 'Canonical finding only', source: 'naming' },
+            { code: 'naming-source-bounded', message: 'Canonical finding only', source: 'naming' },
+            { noteType: 'legacy-limit-note', detail: 'Legacy deterministic detail' },
+            { noteType: 'legacy-empty-detail' },
+            { code: 'tree-policy', message: 'Tree policy conclusion', source: 'tree' },
+            { noteType: 'badLegacy', detail: 'invalid code' },
+            { severity: 'warning', confidence: 'high', detail: 'must not emit' },
           ],
         },
       ],
@@ -327,11 +342,16 @@ test('createNamingOccurrenceBridgePayload emits explicitly versioned additive en
       occurrenceDepth: 2,
       occurrenceOrderIndex: 7,
       disambiguationNotes: [
-        { noteType: 'role-like-folder-token', token: 'host' },
-        { noteType: 'role-like-semantic-token', token: 'host' },
-        { noteType: 'role-like-semantic-token', token: 'wiring' },
+        { code: 'role-like-folder-token', message: 'Role-like folder token: host', source: 'naming' },
+        { code: 'role-like-semantic-token', message: 'Role-like semantic token: host', source: 'naming' },
+        { code: 'role-like-semantic-token', message: 'Role-like semantic token: wiring', source: 'naming' },
       ],
-      evidenceLimitNotes: [{ noteType: 'naming-source-bounded', detail: 'canonical-finding-only' }],
+      evidenceLimitNotes: [
+        { code: 'legacy-empty-detail', message: 'legacy-empty-detail', source: 'naming' },
+        { code: 'legacy-limit-note', message: 'Legacy deterministic detail', source: 'naming' },
+        { code: 'naming-source-bounded', message: 'Canonical finding only', source: 'naming' },
+        { code: 'z-limit', message: 'Z limit', source: 'naming' },
+      ],
     },
   ]);
 

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
@@ -170,7 +170,7 @@ test('projectNamingOccurrenceBridge preserves existing Naming disambiguation evi
     roleLikeSemanticTokens: ['host'],
   });
   assert.deepEqual(occurrenceBridge.occurrenceContextEnrichment.enrichedObservations[0].disambiguationNotes, [
-    { noteType: 'role-like-folder-token', token: 'host' },
-    { noteType: 'role-like-semantic-token', token: 'host' },
+    { code: 'role-like-folder-token', message: 'Role-like folder token: host', source: 'naming' },
+    { code: 'role-like-semantic-token', message: 'Role-like semantic token: host', source: 'naming' },
   ]);
 });

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
@@ -130,3 +130,47 @@ test('runNamingValidator stages occurrence bridge only when an addressed namespa
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
+
+test('projectNamingOccurrenceBridge preserves existing Naming disambiguation evidence when present', () => {
+  const runtimeOutput = {
+    findings: [
+      {
+        path: 'src/host/app-host.logic.mjs',
+        classification: 'canonical',
+        details: {
+          semanticName: 'app-host',
+          familyRoot: 'app',
+          semanticFamily: 'app-host',
+          disambiguation: {
+            roleLikeFolderTokens: ['host'],
+            roleLikeSemanticTokens: ['host'],
+          },
+        },
+      },
+    ],
+  };
+
+  const occurrenceBridge = projectNamingOccurrenceBridge(runtimeOutput, {
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [
+        {
+          repoRelativePath: 'src/host/app-host.logic.mjs',
+          path: 'src/host/app-host.logic.mjs',
+          occurrenceAddress: 'A.2',
+          addressPath: 'A.2',
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(occurrenceBridge.observations[0].disambiguation, {
+    roleLikeFolderTokens: ['host'],
+    roleLikeSemanticTokens: ['host'],
+  });
+  assert.deepEqual(occurrenceBridge.occurrenceContextEnrichment.enrichedObservations[0].disambiguationNotes, [
+    { noteType: 'role-like-folder-token', token: 'host' },
+    { noteType: 'role-like-semantic-token', token: 'host' },
+  ]);
+});

--- a/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
+++ b/calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs
@@ -126,6 +126,7 @@ test('runNamingValidator stages occurrence bridge only when an addressed namespa
 
     assert.equal(withNamespace.namingOccurrenceBridge.bridgeContractVersion, 'naming-occurrence-bridge.v1');
     assert.equal(withNamespace.namingOccurrenceBridge.observations.length, 1);
+    assert.equal(Object.hasOwn(withNamespace.namingOccurrenceBridge, 'occurrenceContextEnrichment'), false);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -173,4 +174,54 @@ test('projectNamingOccurrenceBridge preserves existing Naming disambiguation evi
     { code: 'role-like-folder-token', message: 'Role-like folder token: host', source: 'naming' },
     { code: 'role-like-semantic-token', message: 'Role-like semantic token: host', source: 'naming' },
   ]);
+});
+
+
+test('projectNamingOccurrenceBridge forwards evidenceLimitNotes from canonical findings through normal projection', () => {
+  const runtimeOutput = {
+    findings: [
+      {
+        path: 'src/limited-source.logic.mjs',
+        classification: 'canonical',
+        details: {
+          semanticName: 'limited-source',
+          familyRoot: 'limited',
+          semanticFamily: 'limited-source',
+          evidenceLimitNotes: [
+            { code: 'z-limit', message: 'Z limit', source: 'naming' },
+            { code: 'source-limit', message: 'Source limit', source: 'naming' },
+            { code: 'source-limit', message: 'Source limit', source: 'naming' },
+          ],
+        },
+      },
+    ],
+  };
+
+  const projectedBridge = projectNamingSemanticFamilyBridge(runtimeOutput);
+  assert.deepEqual(projectedBridge.observations[0].evidenceLimitNotes, [
+    { code: 'z-limit', message: 'Z limit', source: 'naming' },
+    { code: 'source-limit', message: 'Source limit', source: 'naming' },
+    { code: 'source-limit', message: 'Source limit', source: 'naming' },
+  ]);
+
+  const occurrenceBridge = projectNamingOccurrenceBridge(runtimeOutput, {
+    addressedOccurrenceNamespace: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceRecords: [
+        {
+          repoRelativePath: 'src/limited-source.logic.mjs',
+          path: 'src/limited-source.logic.mjs',
+          occurrenceAddress: 'A.3',
+          addressPath: 'A.3',
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(occurrenceBridge.occurrenceContextEnrichment.enrichedObservations[0].evidenceLimitNotes, [
+    { code: 'source-limit', message: 'Source limit', source: 'naming' },
+    { code: 'z-limit', message: 'Z limit', source: 'naming' },
+  ]);
+  assert.equal(Object.hasOwn(occurrenceBridge.observations[0], 'evidenceLimitNotes'), false);
 });

--- a/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
@@ -471,7 +471,7 @@ test('Tree v1 intake ignores versioned Naming enrichment sidecar and preserves p
           parentOccurrenceAddress: 'O',
           occurrenceDepth: 2,
           occurrenceOrderIndex: 1,
-          disambiguationNotes: [{ noteType: 'role-like-folder-token', token: 'host' }],
+          disambiguationNotes: [{ code: 'role-like-folder-token', message: 'Role-like folder token: host', source: 'naming' }],
         },
       ],
     },

--- a/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
@@ -456,3 +456,34 @@ test('Tree address join exposes malformed occurrence records even when another r
     true,
   );
 });
+
+test('Tree v1 intake ignores versioned Naming enrichment sidecar and preserves path fallback findings', () => {
+  const enrichedOccurrenceBridge = {
+    ...occurrenceBridge,
+    occurrenceContextEnrichment: {
+      enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+      identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+      enrichedObservations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'O.1',
+          parentOccurrenceAddress: 'O',
+          occurrenceDepth: 2,
+          occurrenceOrderIndex: 1,
+          disambiguationNotes: [{ noteType: 'role-like-folder-token', token: 'host' }],
+        },
+      ],
+    },
+  };
+
+  const intake = prepareTreeNamingOccurrenceBridgeIntake({ namingOccurrenceBridge: enrichedOccurrenceBridge });
+  const withEnrichment = findingCodes({
+    ...pathKeyedSemanticBridge,
+    namingOccurrenceBridge: enrichedOccurrenceBridge,
+  });
+
+  assert.equal(intake.status, 'recognized-future-evidence-only');
+  assert.equal(intake.usedForCurrentTreeJoins, false);
+  assert.deepEqual(withEnrichment, findingCodes(pathKeyedSemanticBridge));
+});


### PR DESCRIPTION
### Motivation

- Implement the approved additive, versioned Naming occurrence enrichment contract while preserving the existing `naming-occurrence-bridge.v1` semantics and Tree fallback behavior. 
- Emit only approved enrichment evidence (parent/depth/order + deterministic Naming notes) without adding rejected/deferred fields or moving Tree reasoning into Naming. 
- Choose the smallest compatibility-preserving route so existing Tree consumers remain unchanged and the enrichment is safely ignorable by v1 intake.

### Description

- Added an explicitly versioned enrichment sidecar `occurrenceContextEnrichment` with contract version `naming-occurrence-bridge-enrichment.v1` while keeping the primary envelope `bridgeContractVersion: naming-occurrence-bridge.v1`. 
- Implemented enrichment extraction in `calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs`, preserving the full v1 observation payload and optional `occurrenceType`, and producing sidecar records that include only the approved fields `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`, `disambiguationNotes`, and `evidenceLimitNotes`. 
- Preserved Naming-owned semantic payload and added deterministic handling for existing `disambiguation` and `evidenceLimitNotes` into normalized `disambiguationNotes` and `evidenceLimitNotes`; projection updated in `calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs`. 
- Added focused tests and wiring checks to assert: v1 observations unchanged; enrichment sidecar is explicitly versioned and linked by `addressProfileId + addressedSnapshotId + occurrenceAddress`; approved fields present only when valid sources exist; deferred/rejected fields do not appear; same-family fixtures remain distinct by occurrence identity; and Tree v1 intake ignores the sidecar. 
- Files changed: `calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs`, `calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs`, `calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs`, `calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs`, and `calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs`.

Refs #655
Refs #651
Refs #647

### Testing

- Unit tests: ran `node --test calculogic-validator/naming/test/naming-occurrence-bridge-payload.logic.test.mjs calculogic-validator/naming/test/naming-occurrence-bridge-wiring.test.mjs calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` and all added/updated tests passed. 
- Sanity checks: ran `git diff --check` which returned no whitespace/overlap issues. 
- Validator runs (recorded exact commands and outcomes): ran `npm run validate:naming -- --scope=validator` which exited with status `2` due to pre-existing informational naming findings in validator scope (no failures introduced by this change), ran `npm run validate:tree -- --scope=validator` which exited `0` (tree validation passed with informational advisories), and ran `npm run validate:all -- --scope=validator` which exited `2` because the naming validator reports the same pre-existing informational findings; these validator outcomes are unrelated to the new enrichment sidecar logic. 
- Focused assertions in tests confirm Tree v1 intake ignores the enrichment sidecar and path-keyed fallback behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36e7cfa42483319e426983e154b46a)