### PR TITLE
Tree: attach optional Naming occurrence enrichment sidecar (naming-occurrence-bridge-enrichment.v1)

### DIFF
--- a/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
+++ b/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
@@ -235,6 +235,72 @@ const validateEnrichmentEnvelope = (payload) => {
   return { status: 'recognized', records: sidecar.enrichedObservations, diagnostics };
 };
 
+
+const toAuthoritativeOccurrenceContext = (occurrenceRecord) => ({
+  parentOccurrenceAddress:
+    occurrenceRecord.parentOccurrenceAddress !== undefined
+      ? occurrenceRecord.parentOccurrenceAddress
+      : occurrenceRecord.parentAddressPath,
+  occurrenceDepth: occurrenceRecord.occurrenceDepth !== undefined ? occurrenceRecord.occurrenceDepth : occurrenceRecord.depth,
+  occurrenceOrderIndex:
+    occurrenceRecord.occurrenceOrderIndex !== undefined ? occurrenceRecord.occurrenceOrderIndex : occurrenceRecord.orderIndex,
+});
+
+const pushContextMismatchDiagnostic = ({ enrichmentDiagnostics, identityTuple, fieldName, sidecarValue, authoritativeOccurrenceValue }) => {
+  enrichmentDiagnostics.push({
+    reason: 'enrichment-context-mismatch',
+    identityTuple: toSafeIdentityTupleDiagnostic(identityTuple),
+    fieldName,
+    sidecarValue,
+    authoritativeOccurrenceValue,
+  });
+};
+
+const validateEnrichmentContextAgainstOccurrence = ({ record, identityTuple, occurrenceRecord, enrichmentDiagnostics }) => {
+  const authoritativeContext = toAuthoritativeOccurrenceContext(occurrenceRecord);
+
+  if (
+    record.parentOccurrenceAddress !== undefined &&
+    record.parentOccurrenceAddress !== authoritativeContext.parentOccurrenceAddress
+  ) {
+    pushContextMismatchDiagnostic({
+      enrichmentDiagnostics,
+      identityTuple,
+      fieldName: 'parentOccurrenceAddress',
+      sidecarValue: record.parentOccurrenceAddress,
+      authoritativeOccurrenceValue: authoritativeContext.parentOccurrenceAddress,
+    });
+    return false;
+  }
+
+  if (record.occurrenceDepth !== undefined && record.occurrenceDepth !== authoritativeContext.occurrenceDepth) {
+    pushContextMismatchDiagnostic({
+      enrichmentDiagnostics,
+      identityTuple,
+      fieldName: 'occurrenceDepth',
+      sidecarValue: record.occurrenceDepth,
+      authoritativeOccurrenceValue: authoritativeContext.occurrenceDepth,
+    });
+    return false;
+  }
+
+  if (
+    record.occurrenceOrderIndex !== undefined &&
+    record.occurrenceOrderIndex !== authoritativeContext.occurrenceOrderIndex
+  ) {
+    pushContextMismatchDiagnostic({
+      enrichmentDiagnostics,
+      identityTuple,
+      fieldName: 'occurrenceOrderIndex',
+      sidecarValue: record.occurrenceOrderIndex,
+      authoritativeOccurrenceValue: authoritativeContext.occurrenceOrderIndex,
+    });
+    return false;
+  }
+
+  return true;
+};
+
 const normalizeEnrichmentRecord = ({ record, identityTuple, enrichmentDiagnostics }) => {
   const addressingContext = {};
   if (record.parentOccurrenceAddress !== undefined) {
@@ -326,6 +392,9 @@ const toOccurrenceEvidence = (occurrenceRecord, identityTuple) => ({
   name: occurrenceRecord.name ?? occurrenceRecord.actualName ?? null,
   occurrenceType: occurrenceRecord.occurrenceType ?? null,
   addressPath: occurrenceRecord.addressPath ?? occurrenceRecord.occurrenceAddress ?? null,
+  parentAddressPath: occurrenceRecord.parentAddressPath ?? occurrenceRecord.parentOccurrenceAddress ?? null,
+  depth: occurrenceRecord.depth ?? occurrenceRecord.occurrenceDepth ?? null,
+  orderIndex: occurrenceRecord.orderIndex ?? occurrenceRecord.occurrenceOrderIndex ?? null,
 });
 
 const sortJoinEntries = (entries) =>
@@ -489,9 +558,16 @@ export const prepareTreeNamingOccurrenceAddressJoinEvidence = ({
       }
 
       const occurrenceContextEnrichment = normalizeEnrichmentRecord({ record, identityTuple, enrichmentDiagnostics });
-      if (occurrenceContextEnrichment) {
-        joinedEntry.occurrenceContextEnrichment = occurrenceContextEnrichment;
+      if (!occurrenceContextEnrichment) {
+        continue;
       }
+
+      const occurrenceRecord = joinedEntry.occurrenceRecord;
+      if (!validateEnrichmentContextAgainstOccurrence({ record, identityTuple, occurrenceRecord, enrichmentDiagnostics })) {
+        continue;
+      }
+
+      joinedEntry.occurrenceContextEnrichment = occurrenceContextEnrichment;
     }
   }
 

--- a/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
+++ b/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
@@ -1,4 +1,5 @@
 const BRIDGE_CONTRACT_VERSION = 'naming-occurrence-bridge.v1';
+const ENRICHMENT_CONTRACT_VERSION = 'naming-occurrence-bridge-enrichment.v1';
 
 const isPlainObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 
@@ -151,6 +152,138 @@ const IDENTITY_TUPLE_FIELDS = ['addressProfileId', 'addressedSnapshotId', 'occur
 
 const toIdentityTupleKey = ({ addressProfileId, addressedSnapshotId, occurrenceAddress }) =>
   `${addressProfileId}\u0000${addressedSnapshotId}\u0000${occurrenceAddress}`;
+
+const toSafeIdentityTupleDiagnostic = (identityTuple) =>
+  identityTuple
+    ? {
+        addressProfileId: identityTuple.addressProfileId ?? null,
+        addressedSnapshotId: identityTuple.addressedSnapshotId ?? null,
+        occurrenceAddress: identityTuple.occurrenceAddress ?? null,
+      }
+    : null;
+
+const isNonNegativeInteger = (value) => Number.isInteger(value) && value >= 0;
+
+const isContractValidNamingNote = (note) =>
+  isPlainObject(note) &&
+  typeof note.code === 'string' &&
+  /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(note.code) &&
+  typeof note.message === 'string' &&
+  note.message.length > 0 &&
+  note.source === 'naming';
+
+const normalizeContractNotes = ({ value, fieldName, identityTuple, enrichmentDiagnostics }) => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || value.some((note) => !isContractValidNamingNote(note))) {
+    enrichmentDiagnostics.push({
+      reason: 'invalid-enrichment-field',
+      fieldName,
+      identityTuple: toSafeIdentityTupleDiagnostic(identityTuple),
+    });
+    return null;
+  }
+
+  return value.map((note) => ({ code: note.code, message: note.message, source: note.source }));
+};
+
+const validateEnrichmentEnvelope = (payload) => {
+  const sidecar = payload?.occurrenceContextEnrichment;
+  if (sidecar === undefined) {
+    return { status: 'absent', records: [], diagnostics: [] };
+  }
+
+  if (!isPlainObject(sidecar)) {
+    return {
+      status: 'malformed',
+      records: [],
+      diagnostics: [{ reason: 'malformed-enrichment-sidecar', fieldName: 'occurrenceContextEnrichment' }],
+    };
+  }
+
+  const diagnostics = [];
+  if (sidecar.enrichmentContractVersion !== ENRICHMENT_CONTRACT_VERSION) {
+    diagnostics.push({
+      reason: 'unsupported-enrichment-sidecar-version',
+      enrichmentContractVersion: sidecar.enrichmentContractVersion ?? null,
+      expectedEnrichmentContractVersion: ENRICHMENT_CONTRACT_VERSION,
+    });
+  }
+
+  if (
+    !Array.isArray(sidecar.identityTupleFields) ||
+    sidecar.identityTupleFields.length !== IDENTITY_TUPLE_FIELDS.length ||
+    sidecar.identityTupleFields.some((field, index) => field !== IDENTITY_TUPLE_FIELDS[index])
+  ) {
+    diagnostics.push({
+      reason: 'malformed-enrichment-sidecar',
+      fieldName: 'identityTupleFields',
+      expectedIdentityTupleFields: IDENTITY_TUPLE_FIELDS,
+    });
+  }
+
+  if (!Array.isArray(sidecar.enrichedObservations)) {
+    diagnostics.push({ reason: 'malformed-enrichment-sidecar', fieldName: 'enrichedObservations' });
+  }
+
+  if (diagnostics.length > 0) {
+    return { status: 'invalid', records: [], diagnostics };
+  }
+
+  return { status: 'recognized', records: sidecar.enrichedObservations, diagnostics };
+};
+
+const normalizeEnrichmentRecord = ({ record, identityTuple, enrichmentDiagnostics }) => {
+  const addressingContext = {};
+  if (record.parentOccurrenceAddress !== undefined) {
+    if (record.parentOccurrenceAddress === null) {
+      addressingContext.parentOccurrenceAddress = null;
+    } else if (typeof record.parentOccurrenceAddress === 'string' && record.parentOccurrenceAddress.length > 0) {
+      addressingContext.parentOccurrenceAddress = record.parentOccurrenceAddress;
+    } else {
+      enrichmentDiagnostics.push({
+        reason: 'invalid-enrichment-field',
+        fieldName: 'parentOccurrenceAddress',
+        identityTuple: toSafeIdentityTupleDiagnostic(identityTuple),
+      });
+      return null;
+    }
+  }
+
+  for (const fieldName of ['occurrenceDepth', 'occurrenceOrderIndex']) {
+    if (record[fieldName] !== undefined) {
+      if (!isNonNegativeInteger(record[fieldName])) {
+        enrichmentDiagnostics.push({
+          reason: 'invalid-enrichment-field',
+          fieldName,
+          identityTuple: toSafeIdentityTupleDiagnostic(identityTuple),
+        });
+        return null;
+      }
+      addressingContext[fieldName] = record[fieldName];
+    }
+  }
+
+  const namingMetadata = {};
+  for (const fieldName of ['disambiguationNotes', 'evidenceLimitNotes']) {
+    const notes = normalizeContractNotes({ value: record[fieldName], fieldName, identityTuple, enrichmentDiagnostics });
+    if (notes === null) {
+      return null;
+    }
+    if (notes !== undefined) {
+      namingMetadata[fieldName] = notes;
+    }
+  }
+
+  return {
+    evidenceType: 'tree-local-naming-occurrence-context-enrichment',
+    sourceIdentityTuple: { ...identityTuple },
+    addressingContext,
+    namingMetadata,
+  };
+};
 
 const normalizeOccurrenceRecordIdentityTuple = ({ occurrenceRecord, addressProfileId, addressedSnapshotId }) => {
   if (!isPlainObject(occurrenceRecord)) {
@@ -316,6 +449,52 @@ export const prepareTreeNamingOccurrenceAddressJoinEvidence = ({
     });
   }
 
+  const joinedEvidenceByTuple = new Map(joinedEvidence.map((entry) => [toIdentityTupleKey(entry.identityTuple), entry]));
+  const enrichmentDiagnostics = [];
+  const enrichmentEnvelope = validateEnrichmentEnvelope(payload);
+  enrichmentDiagnostics.push(...enrichmentEnvelope.diagnostics);
+
+  if (enrichmentEnvelope.status === 'recognized') {
+    const enrichmentTupleCounts = new Map();
+    for (const record of enrichmentEnvelope.records) {
+      const identityTuple = normalizeObservationIdentityTuple(record);
+      if (identityTuple) {
+        const key = toIdentityTupleKey(identityTuple);
+        enrichmentTupleCounts.set(key, (enrichmentTupleCounts.get(key) ?? 0) + 1);
+      }
+    }
+
+    for (const record of enrichmentEnvelope.records) {
+      if (!isPlainObject(record)) {
+        enrichmentDiagnostics.push({ reason: 'invalid-enrichment-identity-tuple', identityTuple: null });
+        continue;
+      }
+
+      const identityTuple = normalizeObservationIdentityTuple(record);
+      if (!identityTuple) {
+        enrichmentDiagnostics.push({ reason: 'invalid-enrichment-identity-tuple', identityTuple: null });
+        continue;
+      }
+
+      const key = toIdentityTupleKey(identityTuple);
+      if ((enrichmentTupleCounts.get(key) ?? 0) > 1) {
+        enrichmentDiagnostics.push({ reason: 'duplicate-enrichment-identity-tuple', identityTuple });
+        continue;
+      }
+
+      const joinedEntry = joinedEvidenceByTuple.get(key);
+      if (!joinedEntry) {
+        enrichmentDiagnostics.push({ reason: 'unmatched-enrichment-identity-tuple', identityTuple });
+        continue;
+      }
+
+      const occurrenceContextEnrichment = normalizeEnrichmentRecord({ record, identityTuple, enrichmentDiagnostics });
+      if (occurrenceContextEnrichment) {
+        joinedEntry.occurrenceContextEnrichment = occurrenceContextEnrichment;
+      }
+    }
+  }
+
   const status = diagnostics.length > 0 || skippedJoins.length > 0
     ? 'joined-with-skips'
     : joinedEvidence.length > 0
@@ -330,5 +509,6 @@ export const prepareTreeNamingOccurrenceAddressJoinEvidence = ({
     joinedEvidence: sortJoinEntries(joinedEvidence),
     skippedJoins: sortJoinEntries(skippedJoins),
     diagnostics,
+    enrichmentDiagnostics: sortJoinEntries(enrichmentDiagnostics),
   };
 };

--- a/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
@@ -487,3 +487,134 @@ test('Tree v1 intake ignores versioned Naming enrichment sidecar and preserves p
   assert.equal(intake.usedForCurrentTreeJoins, false);
   assert.deepEqual(withEnrichment, findingCodes(pathKeyedSemanticBridge));
 });
+
+test('Tree address join attaches valid enrichment to exact occurrence tuple without changing join readiness', () => {
+  const bridge = {
+    ...addressBridge,
+    occurrenceContextEnrichment: {
+      enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+      identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+      enrichedObservations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.1',
+          parentOccurrenceAddress: null,
+          occurrenceDepth: 0,
+          occurrenceOrderIndex: 0,
+          disambiguationNotes: [{ code: 'role-like-folder-token', message: 'Role-like folder token.', source: 'naming' }],
+          evidenceLimitNotes: [{ code: 'limited-context', message: 'Limited deterministic context.', source: 'naming' }],
+        },
+      ],
+    },
+  };
+
+  const withoutEnrichment = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: addressBridge,
+    addressedOccurrenceNamespace,
+  });
+  const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: bridge,
+    addressedOccurrenceNamespace,
+  });
+
+  assert.equal(prepared.status, withoutEnrichment.status);
+  assert.equal(prepared.usedForCurrentTreeJoins, withoutEnrichment.usedForCurrentTreeJoins);
+  assert.deepEqual(prepared.diagnostics, withoutEnrichment.diagnostics);
+  assert.deepEqual(prepared.skippedJoins, withoutEnrichment.skippedJoins);
+  assert.deepEqual(prepared.enrichmentDiagnostics, []);
+  assert.deepEqual(prepared.joinedEvidence[0].occurrenceContextEnrichment, {
+    evidenceType: 'tree-local-naming-occurrence-context-enrichment',
+    sourceIdentityTuple: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A.1',
+    },
+    addressingContext: {
+      parentOccurrenceAddress: null,
+      occurrenceDepth: 0,
+      occurrenceOrderIndex: 0,
+    },
+    namingMetadata: {
+      disambiguationNotes: [{ code: 'role-like-folder-token', message: 'Role-like folder token.', source: 'naming' }],
+      evidenceLimitNotes: [{ code: 'limited-context', message: 'Limited deterministic context.', source: 'naming' }],
+    },
+  });
+  assert.equal(prepared.joinedEvidence[0].namingObservation.semanticFamily, 'shared-runtime');
+});
+
+test('Tree enrichment sidecar keeps same-family nested occurrences isolated by canonical tuple', () => {
+  const sameFamilyBridge = {
+    bridgeContractVersion: 'naming-occurrence-bridge.v1',
+    observations: [
+      { ...addressBridge.observations[0], occurrenceAddress: 'A.1', path: 'src/alpha/shared.logic.ts' },
+      { ...addressBridge.observations[0], occurrenceAddress: 'A.2', path: 'src/beta/shared.logic.ts' },
+    ],
+    occurrenceContextEnrichment: {
+      enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+      identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+      enrichedObservations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.2',
+          parentOccurrenceAddress: 'A',
+          occurrenceDepth: 2,
+          occurrenceOrderIndex: 1,
+        },
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.1',
+          parentOccurrenceAddress: null,
+          occurrenceDepth: 1,
+          occurrenceOrderIndex: 0,
+        },
+      ],
+    },
+  };
+
+  const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: sameFamilyBridge,
+    addressedOccurrenceNamespace,
+  });
+
+  assert.equal(prepared.status, 'joined');
+  assert.deepEqual(
+    prepared.joinedEvidence.map((entry) => [
+      entry.identityTuple.occurrenceAddress,
+      entry.namingObservation.semanticFamily,
+      entry.occurrenceContextEnrichment.addressingContext,
+    ]),
+    [
+      ['A.1', 'shared-runtime', { parentOccurrenceAddress: null, occurrenceDepth: 1, occurrenceOrderIndex: 0 }],
+      ['A.2', 'shared-runtime', { parentOccurrenceAddress: 'A', occurrenceDepth: 2, occurrenceOrderIndex: 1 }],
+    ],
+  );
+});
+
+test('Tree enrichment sidecar failures are isolated from v1 joins and path-keyed fallback', () => {
+  const cases = [
+    { occurrenceContextEnrichment: { enrichmentContractVersion: 'other', identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'], enrichedObservations: [] }, reason: 'unsupported-enrichment-sidecar-version' },
+    { occurrenceContextEnrichment: { enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1', identityTupleFields: ['addressedSnapshotId', 'addressProfileId', 'occurrenceAddress'], enrichedObservations: [] }, reason: 'malformed-enrichment-sidecar' },
+    { occurrenceContextEnrichment: { enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1', identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'], enrichedObservations: [{ addressProfileId: '', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A.1' }] }, reason: 'invalid-enrichment-identity-tuple' },
+    { occurrenceContextEnrichment: { enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1', identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'], enrichedObservations: [{ addressProfileId: 'tree-codebase', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A.1' }, { addressProfileId: 'tree-codebase', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A.1' }] }, reason: 'duplicate-enrichment-identity-tuple' },
+    { occurrenceContextEnrichment: { enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1', identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'], enrichedObservations: [{ addressProfileId: 'tree-codebase', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A.999' }] }, reason: 'unmatched-enrichment-identity-tuple' },
+    { occurrenceContextEnrichment: { enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1', identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'], enrichedObservations: [{ addressProfileId: 'tree-codebase', addressedSnapshotId: 'snapshot-001', occurrenceAddress: 'A.1', occurrenceDepth: -1 }] }, reason: 'invalid-enrichment-field' },
+  ];
+
+  for (const { occurrenceContextEnrichment, reason } of cases) {
+    const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+      namingOccurrenceBridge: { ...addressBridge, occurrenceContextEnrichment },
+      addressedOccurrenceNamespace,
+    });
+    assert.equal(prepared.status, 'joined');
+    assert.equal(prepared.usedForCurrentTreeJoins, true);
+    assert.equal(prepared.joinedEvidence.length, 1);
+    assert.equal(prepared.enrichmentDiagnostics.some((diagnostic) => diagnostic.reason === reason), true);
+    assert.deepEqual(
+      findingCodes({ ...pathKeyedSemanticBridge, namingOccurrenceBridge: { ...addressBridge, occurrenceContextEnrichment } }),
+      findingCodes(pathKeyedSemanticBridge),
+    );
+  }
+});

--- a/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
@@ -201,6 +201,9 @@ const addressedOccurrenceNamespace = {
       resolvedPath: 'src/alpha/shared.logic.ts',
       name: 'shared.logic.ts',
       occurrenceType: 'file',
+      parentAddressPath: null,
+      depth: 0,
+      orderIndex: 0,
     },
     {
       occurrenceAddress: 'A.2',
@@ -209,6 +212,9 @@ const addressedOccurrenceNamespace = {
       resolvedPath: 'src/beta/shared.logic.ts',
       name: 'shared.logic.ts',
       occurrenceType: 'file',
+      parentAddressPath: 'A',
+      depth: 1,
+      orderIndex: 1,
     },
   ],
 };
@@ -469,7 +475,7 @@ test('Tree v1 intake ignores versioned Naming enrichment sidecar and preserves p
           addressedSnapshotId: 'snapshot-001',
           occurrenceAddress: 'O.1',
           parentOccurrenceAddress: 'O',
-          occurrenceDepth: 2,
+          occurrenceDepth: 1,
           occurrenceOrderIndex: 1,
           disambiguationNotes: [{ code: 'role-like-folder-token', message: 'Role-like folder token: host', source: 'naming' }],
         },
@@ -559,7 +565,7 @@ test('Tree enrichment sidecar keeps same-family nested occurrences isolated by c
           addressedSnapshotId: 'snapshot-001',
           occurrenceAddress: 'A.2',
           parentOccurrenceAddress: 'A',
-          occurrenceDepth: 2,
+          occurrenceDepth: 1,
           occurrenceOrderIndex: 1,
         },
         {
@@ -567,7 +573,7 @@ test('Tree enrichment sidecar keeps same-family nested occurrences isolated by c
           addressedSnapshotId: 'snapshot-001',
           occurrenceAddress: 'A.1',
           parentOccurrenceAddress: null,
-          occurrenceDepth: 1,
+          occurrenceDepth: 0,
           occurrenceOrderIndex: 0,
         },
       ],
@@ -587,8 +593,8 @@ test('Tree enrichment sidecar keeps same-family nested occurrences isolated by c
       entry.occurrenceContextEnrichment.addressingContext,
     ]),
     [
-      ['A.1', 'shared-runtime', { parentOccurrenceAddress: null, occurrenceDepth: 1, occurrenceOrderIndex: 0 }],
-      ['A.2', 'shared-runtime', { parentOccurrenceAddress: 'A', occurrenceDepth: 2, occurrenceOrderIndex: 1 }],
+      ['A.1', 'shared-runtime', { parentOccurrenceAddress: null, occurrenceDepth: 0, occurrenceOrderIndex: 0 }],
+      ['A.2', 'shared-runtime', { parentOccurrenceAddress: 'A', occurrenceDepth: 1, occurrenceOrderIndex: 1 }],
     ],
   );
 });
@@ -617,4 +623,142 @@ test('Tree enrichment sidecar failures are isolated from v1 joins and path-keyed
       findingCodes(pathKeyedSemanticBridge),
     );
   }
+});
+
+test('Tree enrichment context mismatch rejects entire record and naming notes for parent depth and order', () => {
+  for (const { fieldName, sidecarPatch, authoritativeOccurrenceValue, sidecarValue } of [
+    { fieldName: 'parentOccurrenceAddress', sidecarPatch: { parentOccurrenceAddress: 'Z' }, authoritativeOccurrenceValue: null, sidecarValue: 'Z' },
+    { fieldName: 'occurrenceDepth', sidecarPatch: { occurrenceDepth: 1 }, authoritativeOccurrenceValue: 0, sidecarValue: 1 },
+    { fieldName: 'occurrenceOrderIndex', sidecarPatch: { occurrenceOrderIndex: 7 }, authoritativeOccurrenceValue: 0, sidecarValue: 7 },
+  ]) {
+    const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+      namingOccurrenceBridge: {
+        ...addressBridge,
+        occurrenceContextEnrichment: {
+          enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+          identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+          enrichedObservations: [
+            {
+              addressProfileId: 'tree-codebase',
+              addressedSnapshotId: 'snapshot-001',
+              occurrenceAddress: 'A.1',
+              parentOccurrenceAddress: null,
+              occurrenceDepth: 0,
+              occurrenceOrderIndex: 0,
+              disambiguationNotes: [{ code: 'should-not-attach', message: 'Should not attach.', source: 'naming' }],
+              evidenceLimitNotes: [{ code: 'should-not-attach', message: 'Should not attach.', source: 'naming' }],
+              ...sidecarPatch,
+            },
+          ],
+        },
+      },
+      addressedOccurrenceNamespace,
+    });
+
+    assert.equal(prepared.status, 'joined');
+    assert.equal(prepared.usedForCurrentTreeJoins, true);
+    assert.equal(prepared.joinedEvidence[0].occurrenceContextEnrichment, undefined);
+    assert.deepEqual(prepared.enrichmentDiagnostics, [
+      {
+        reason: 'enrichment-context-mismatch',
+        identityTuple: {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.1',
+        },
+        fieldName,
+        sidecarValue,
+        authoritativeOccurrenceValue,
+      },
+    ]);
+  }
+});
+
+test('Tree enrichment accepts root null parent only when authoritative parent is null', () => {
+  const acceptedRoot = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: {
+      ...addressBridge,
+      occurrenceContextEnrichment: {
+        enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+        identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+        enrichedObservations: [
+          {
+            addressProfileId: 'tree-codebase',
+            addressedSnapshotId: 'snapshot-001',
+            occurrenceAddress: 'A.1',
+            parentOccurrenceAddress: null,
+          },
+        ],
+      },
+    },
+    addressedOccurrenceNamespace,
+  });
+  const rejectedNested = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: {
+      bridgeContractVersion: 'naming-occurrence-bridge.v1',
+      observations: [{ ...addressBridge.observations[0], occurrenceAddress: 'A.2' }],
+      occurrenceContextEnrichment: {
+        enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+        identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+        enrichedObservations: [
+          {
+            addressProfileId: 'tree-codebase',
+            addressedSnapshotId: 'snapshot-001',
+            occurrenceAddress: 'A.2',
+            parentOccurrenceAddress: null,
+          },
+        ],
+      },
+    },
+    addressedOccurrenceNamespace,
+  });
+
+  assert.equal(acceptedRoot.joinedEvidence[0].occurrenceContextEnrichment.addressingContext.parentOccurrenceAddress, null);
+  assert.equal(rejectedNested.joinedEvidence[0].occurrenceContextEnrichment, undefined);
+  assert.equal(rejectedNested.enrichmentDiagnostics[0].reason, 'enrichment-context-mismatch');
+  assert.equal(rejectedNested.enrichmentDiagnostics[0].fieldName, 'parentOccurrenceAddress');
+});
+
+test('Tree enrichment permits omitted neutral fields and isolates mismatch to one same-family tuple', () => {
+  const sameFamilyBridge = {
+    bridgeContractVersion: 'naming-occurrence-bridge.v1',
+    observations: [
+      { ...addressBridge.observations[0], occurrenceAddress: 'A.1', path: 'src/alpha/shared.logic.ts' },
+      { ...addressBridge.observations[0], occurrenceAddress: 'A.2', path: 'src/beta/shared.logic.ts' },
+    ],
+    occurrenceContextEnrichment: {
+      enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+      identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+      enrichedObservations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.1',
+          occurrenceDepth: 0,
+        },
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.2',
+          parentOccurrenceAddress: 'wrong-parent',
+          occurrenceDepth: 1,
+          occurrenceOrderIndex: 1,
+        },
+      ],
+    },
+  };
+
+  const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: sameFamilyBridge,
+    addressedOccurrenceNamespace,
+  });
+
+  assert.equal(prepared.joinedEvidence[0].identityTuple.occurrenceAddress, 'A.1');
+  assert.deepEqual(prepared.joinedEvidence[0].occurrenceContextEnrichment.addressingContext, { occurrenceDepth: 0 });
+  assert.equal(prepared.joinedEvidence[1].identityTuple.occurrenceAddress, 'A.2');
+  assert.equal(prepared.joinedEvidence[1].occurrenceContextEnrichment, undefined);
+  assert.equal(prepared.enrichmentDiagnostics.length, 1);
+  assert.equal(prepared.enrichmentDiagnostics[0].reason, 'enrichment-context-mismatch');
+  assert.equal(prepared.enrichmentDiagnostics[0].identityTuple.occurrenceAddress, 'A.2');
+  assert.deepEqual(findingCodes({ ...pathKeyedSemanticBridge, namingOccurrenceBridge: sameFamilyBridge }), findingCodes(pathKeyedSemanticBridge));
 });


### PR DESCRIPTION
### Motivation
- Accept an optional Naming occurrence enrichment sidecar and attach accepted records as additive Tree-local occurrence evidence scoped to the canonical identity tuple `addressProfileId + addressedSnapshotId + occurrenceAddress` without changing existing Tree conclusions. 
- Preserve current `naming-occurrence-bridge.v1` intake, path-keyed compatibility fallback, and all existing Tree findings, severity, confidence, and placement behavior when the sidecar is absent, malformed, unsupported, or partially matched. 
- Keep the scope strictly Tree-local: validation, deterministic attachment, and minimal diagnostics only, per the referenced contract and audits (Refs #657, Refs #655, Refs #651, Refs #647). 

### Description
- Added sidecar handling by introducing `ENRICHMENT_CONTRACT_VERSION` and functions `validateEnrichmentEnvelope` and `normalizeEnrichmentRecord`, plus tuple/diagnostic helpers, and integrated them into `prepareTreeNamingOccurrenceAddressJoinEvidence` to collect `enrichmentDiagnostics` and attach accepted enrichment to joined evidence; change in `calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs`. 
- Matching and attachment are deterministic and tuple-only: enrichment records are eligible only when the full canonical tuple matches exactly one prepared occurrence; accepted enrichment is attached on `joinedEvidence[].occurrenceContextEnrichment` and preserves `sourceIdentityTuple`, an `addressingContext` (neutral fields: `parentOccurrenceAddress`, `occurrenceDepth`, `occurrenceOrderIndex`), and `namingMetadata` (`disambiguationNotes`, `evidenceLimitNotes`) without being flattened or merged into semantic-family buckets. 
- Validation rules enforce envelope shape (contract version, exact `identityTupleFields` order, `enrichedObservations` array) and per-record constraints (non-empty tuple fields, non-negative integers for depth/index, and contract-valid naming notes where notes must be objects with a kebab-case `code`, non-empty `message`, and `source: 'naming'`); malformed/unsupported sidecars or invalid records are reported via isolated `enrichmentDiagnostics` and are skipped. 
- Added focused tests and assertions in `calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` proving exact-tuple attachment, same-family isolation by address, neutral vs Naming metadata separation, deterministic handling of duplicates/unmatched/invalid records, and preservation of v1/path-keyed fallback. 

### Testing
- Ran the focused tree intake tests with `node --test calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs`, which passed (22 tests passed, 0 failed). 
- Ran `git diff --check` which passed and changes were committed with message `Implement tree enrichment sidecar intake`. 
- Ran validator suite commands: `npm run validate:naming -- --scope=validator` exited with non-zero `2` due to pre-existing naming informational/legacy findings (counts reported: canonical=178, allowed-special-case=83, legacy-exception=27, invalid-ambiguous=8), while `npm run validate:tree -- --scope=validator` passed; `npm run validate:all -- --scope=validator` exited `2` for the same pre-existing naming findings and not due to these Tree changes. 
- Changed files: `calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs` and `calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` and tests confirm that no Tree findings, placement, severity, confidence, or semantic/structural outputs were altered by sidecar attachment. 

Refs #657
Refs #655
Refs #651
Refs #647

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381bcb78c483318edf73f79509b1e2)