### PR TITLE
Prepare Tree semantic-home occurrence evidence

### DIFF
--- a/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
+++ b/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
@@ -386,6 +386,9 @@ const toCleanObservationEvidence = (observation) => ({
   familyRoot: observation.familyRoot ?? null,
   semanticFamily: observation.semanticFamily ?? null,
   familySubgroup: observation.familySubgroup ?? null,
+  role: observation.role ?? null,
+  semanticRole: observation.semanticRole ?? null,
+  ambiguity: observation.ambiguity ?? null,
   ambiguityFlags: normalizeStringFlags(observation.ambiguityFlags),
   splitFamilyFlags: normalizeStringFlags(observation.splitFamilyFlags),
 });
@@ -406,6 +409,68 @@ const toOccurrenceEvidence = (occurrenceRecord, identityTuple) => ({
   occurrenceOrderIndex: firstDefinedAliasValue(occurrenceRecord, ['occurrenceOrderIndex', 'orderIndex']),
   orderIndex: firstDefinedAliasValue(occurrenceRecord, ['orderIndex', 'occurrenceOrderIndex']),
 });
+
+
+const toPreparedAddressingContext = (joinedOccurrenceEntry) => {
+  const enrichedAddressingContext = joinedOccurrenceEntry.occurrenceContextEnrichment?.addressingContext;
+  if (isPlainObject(enrichedAddressingContext) && Object.keys(enrichedAddressingContext).length > 0) {
+    return { ...enrichedAddressingContext };
+  }
+
+  const occurrenceRecord = joinedOccurrenceEntry.occurrenceRecord;
+  if (!isPlainObject(occurrenceRecord)) {
+    return undefined;
+  }
+
+  const addressingContext = {};
+  for (const fieldName of [
+    'resolvedPath',
+    'path',
+    'name',
+    'occurrenceType',
+    'addressPath',
+    'parentOccurrenceAddress',
+    'parentAddressPath',
+    'occurrenceDepth',
+    'depth',
+    'occurrenceOrderIndex',
+    'orderIndex',
+  ]) {
+    if (occurrenceRecord[fieldName] !== undefined) {
+      addressingContext[fieldName] = occurrenceRecord[fieldName];
+    }
+  }
+
+  return Object.keys(addressingContext).length > 0 ? addressingContext : undefined;
+};
+
+export const prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence = (joinedOccurrenceEntry) => {
+  if (!isPlainObject(joinedOccurrenceEntry)) {
+    return null;
+  }
+
+  const sourceIdentityTuple = joinedOccurrenceEntry.identityTuple ?? joinedOccurrenceEntry.sourceIdentityTuple;
+  if (!isPlainObject(sourceIdentityTuple) || !isPlainObject(joinedOccurrenceEntry.namingObservation)) {
+    return null;
+  }
+
+  const prepared = {
+    sourceIdentityTuple: { ...sourceIdentityTuple },
+    namingObservation: { ...joinedOccurrenceEntry.namingObservation },
+  };
+
+  const addressingContext = toPreparedAddressingContext(joinedOccurrenceEntry);
+  if (addressingContext) {
+    prepared.addressingContext = addressingContext;
+  }
+
+  const namingMetadata = joinedOccurrenceEntry.occurrenceContextEnrichment?.namingMetadata;
+  if (isPlainObject(namingMetadata) && Object.keys(namingMetadata).length > 0) {
+    prepared.namingMetadata = { ...namingMetadata };
+  }
+
+  return prepared;
+};
 
 const sortJoinEntries = (entries) =>
   entries.sort((left, right) =>
@@ -521,12 +586,14 @@ export const prepareTreeNamingOccurrenceAddressJoinEvidence = ({
       continue;
     }
 
-    joinedEvidence.push({
+    const joinedEntry = {
       evidenceType: 'tree-prepared-naming-occurrence-address-join',
       identityTuple,
       namingObservation: toCleanObservationEvidence(observation),
       occurrenceRecord: toOccurrenceEvidence(occurrenceEntry.occurrenceRecord, occurrenceEntry.identityTuple),
-    });
+    };
+    joinedEntry.preparedSemanticHomeEvidence = prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence(joinedEntry);
+    joinedEvidence.push(joinedEntry);
   }
 
   const joinedEvidenceByTuple = new Map(joinedEvidence.map((entry) => [toIdentityTupleKey(entry.identityTuple), entry]));
@@ -576,6 +643,7 @@ export const prepareTreeNamingOccurrenceAddressJoinEvidence = ({
       });
       if (occurrenceContextEnrichment) {
         joinedEntry.occurrenceContextEnrichment = occurrenceContextEnrichment;
+        joinedEntry.preparedSemanticHomeEvidence = prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence(joinedEntry);
       }
     }
   }

--- a/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
+++ b/calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs
@@ -412,33 +412,32 @@ const toOccurrenceEvidence = (occurrenceRecord, identityTuple) => ({
 
 
 const toPreparedAddressingContext = (joinedOccurrenceEntry) => {
+  const occurrenceRecord = joinedOccurrenceEntry.occurrenceRecord;
+  const addressingContext = {};
+
+  if (isPlainObject(occurrenceRecord)) {
+    for (const fieldName of [
+      'resolvedPath',
+      'path',
+      'name',
+      'occurrenceType',
+      'addressPath',
+      'parentOccurrenceAddress',
+      'parentAddressPath',
+      'occurrenceDepth',
+      'depth',
+      'occurrenceOrderIndex',
+      'orderIndex',
+    ]) {
+      if (occurrenceRecord[fieldName] !== undefined) {
+        addressingContext[fieldName] = occurrenceRecord[fieldName];
+      }
+    }
+  }
+
   const enrichedAddressingContext = joinedOccurrenceEntry.occurrenceContextEnrichment?.addressingContext;
   if (isPlainObject(enrichedAddressingContext) && Object.keys(enrichedAddressingContext).length > 0) {
-    return { ...enrichedAddressingContext };
-  }
-
-  const occurrenceRecord = joinedOccurrenceEntry.occurrenceRecord;
-  if (!isPlainObject(occurrenceRecord)) {
-    return undefined;
-  }
-
-  const addressingContext = {};
-  for (const fieldName of [
-    'resolvedPath',
-    'path',
-    'name',
-    'occurrenceType',
-    'addressPath',
-    'parentOccurrenceAddress',
-    'parentAddressPath',
-    'occurrenceDepth',
-    'depth',
-    'occurrenceOrderIndex',
-    'orderIndex',
-  ]) {
-    if (occurrenceRecord[fieldName] !== undefined) {
-      addressingContext[fieldName] = occurrenceRecord[fieldName];
-    }
+    Object.assign(addressingContext, enrichedAddressingContext);
   }
 
   return Object.keys(addressingContext).length > 0 ? addressingContext : undefined;

--- a/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import {
   prepareTreeNamingOccurrenceAddressJoinEvidence,
   prepareTreeNamingOccurrenceBridgeIntake,
+  prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence,
 } from '../src/tree-naming-occurrence-intake.logic.mjs';
 import { collectNamingSemanticFamilyBridgeFindings } from '../src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs';
 
@@ -1126,4 +1127,115 @@ test('Tree enrichment absent sidecar remains unchanged without empty attachment 
   assert.equal(prepared.usedForCurrentTreeJoins, true);
   assert.equal(Object.hasOwn(prepared.joinedEvidence[0], 'occurrenceContextEnrichment'), false);
   assert.deepEqual(prepared.enrichmentDiagnostics, []);
+});
+
+
+test('Tree prepared semantic-home input retains tuple, Naming observation, context, and metadata', () => {
+  const bridge = {
+    ...addressBridge,
+    observations: [{ ...addressBridge.observations[0], role: 'logic', ambiguity: { status: 'none' } }],
+    occurrenceContextEnrichment: {
+      enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+      identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+      enrichedObservations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.1',
+          parentOccurrenceAddress: null,
+          occurrenceDepth: 0,
+          occurrenceOrderIndex: 0,
+          disambiguationNotes: [{ code: 'role-like-folder-token', message: 'Role-like folder token.', source: 'naming' }],
+          evidenceLimitNotes: [{ code: 'limited-context', message: 'Limited deterministic context.', source: 'naming' }],
+        },
+      ],
+    },
+  };
+
+  const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: bridge,
+    addressedOccurrenceNamespace,
+  });
+  const joinedEntry = prepared.joinedEvidence[0];
+
+  assert.deepEqual(joinedEntry.preparedSemanticHomeEvidence, {
+    sourceIdentityTuple: {
+      addressProfileId: 'tree-codebase',
+      addressedSnapshotId: 'snapshot-001',
+      occurrenceAddress: 'A.1',
+    },
+    namingObservation: joinedEntry.namingObservation,
+    addressingContext: {
+      parentOccurrenceAddress: null,
+      occurrenceDepth: 0,
+      occurrenceOrderIndex: 0,
+    },
+    namingMetadata: {
+      disambiguationNotes: [{ code: 'role-like-folder-token', message: 'Role-like folder token.', source: 'naming' }],
+      evidenceLimitNotes: [{ code: 'limited-context', message: 'Limited deterministic context.', source: 'naming' }],
+    },
+  });
+  assert.equal(joinedEntry.preparedSemanticHomeEvidence.namingObservation.role, 'logic');
+  assert.deepEqual(joinedEntry.preparedSemanticHomeEvidence.namingObservation.ambiguity, { status: 'none' });
+});
+
+test('Tree prepared semantic-home input keeps same-family occurrences distinct without metadata leakage', () => {
+  const sameFamilyBridge = {
+    bridgeContractVersion: 'naming-occurrence-bridge.v1',
+    observations: [
+      { ...addressBridge.observations[0], occurrenceAddress: 'A.1', path: 'src/alpha/shared.logic.ts' },
+      { ...addressBridge.observations[0], occurrenceAddress: 'A.2', path: 'src/beta/shared.logic.ts' },
+    ],
+    occurrenceContextEnrichment: {
+      enrichmentContractVersion: 'naming-occurrence-bridge-enrichment.v1',
+      identityTupleFields: ['addressProfileId', 'addressedSnapshotId', 'occurrenceAddress'],
+      enrichedObservations: [
+        {
+          addressProfileId: 'tree-codebase',
+          addressedSnapshotId: 'snapshot-001',
+          occurrenceAddress: 'A.2',
+          parentOccurrenceAddress: 'A',
+          occurrenceDepth: 2,
+          occurrenceOrderIndex: 1,
+          disambiguationNotes: [{ code: 'beta-context', message: 'Beta context only.', source: 'naming' }],
+        },
+      ],
+    },
+  };
+
+  const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: sameFamilyBridge,
+    addressedOccurrenceNamespace,
+  });
+
+  assert.deepEqual(
+    prepared.joinedEvidence.map((entry) => [
+      entry.preparedSemanticHomeEvidence.sourceIdentityTuple.occurrenceAddress,
+      entry.preparedSemanticHomeEvidence.namingObservation.semanticFamily,
+      entry.preparedSemanticHomeEvidence.addressingContext.parentOccurrenceAddress,
+      entry.preparedSemanticHomeEvidence.namingMetadata?.disambiguationNotes?.[0]?.code ?? null,
+    ]),
+    [
+      ['A.1', 'shared-runtime', undefined, null],
+      ['A.2', 'shared-runtime', 'A', 'beta-context'],
+    ],
+  );
+});
+
+test('Tree prepared semantic-home input falls back to v1 joined observation when enrichment is absent', () => {
+  const prepared = prepareTreeNamingOccurrenceAddressJoinEvidence({
+    namingOccurrenceBridge: addressBridge,
+    addressedOccurrenceNamespace,
+  });
+  const preparedSemanticHomeEvidence = prepared.joinedEvidence[0].preparedSemanticHomeEvidence;
+
+  assert.deepEqual(preparedSemanticHomeEvidence.sourceIdentityTuple, prepared.joinedEvidence[0].identityTuple);
+  assert.deepEqual(preparedSemanticHomeEvidence.namingObservation, prepared.joinedEvidence[0].namingObservation);
+  assert.equal(preparedSemanticHomeEvidence.addressingContext.path, 'src/alpha/shared.logic.ts');
+  assert.equal(Object.hasOwn(preparedSemanticHomeEvidence, 'namingMetadata'), false);
+});
+
+test('Tree prepared semantic-home helper rejects malformed joined entries without synthesizing Naming semantics', () => {
+  assert.equal(prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence(null), null);
+  assert.equal(prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence({ identityTuple: { occurrenceAddress: 'A.1' } }), null);
 });

--- a/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs
@@ -1166,6 +1166,11 @@ test('Tree prepared semantic-home input retains tuple, Naming observation, conte
     },
     namingObservation: joinedEntry.namingObservation,
     addressingContext: {
+      resolvedPath: 'src/alpha/shared.logic.ts',
+      path: 'src/alpha/shared.logic.ts',
+      name: 'shared.logic.ts',
+      occurrenceType: 'file',
+      addressPath: 'A.1',
       parentOccurrenceAddress: null,
       occurrenceDepth: 0,
       occurrenceOrderIndex: 0,
@@ -1212,12 +1217,15 @@ test('Tree prepared semantic-home input keeps same-family occurrences distinct w
     prepared.joinedEvidence.map((entry) => [
       entry.preparedSemanticHomeEvidence.sourceIdentityTuple.occurrenceAddress,
       entry.preparedSemanticHomeEvidence.namingObservation.semanticFamily,
+      entry.preparedSemanticHomeEvidence.addressingContext.path,
+      entry.preparedSemanticHomeEvidence.addressingContext.addressPath,
       entry.preparedSemanticHomeEvidence.addressingContext.parentOccurrenceAddress,
+      entry.preparedSemanticHomeEvidence.addressingContext.occurrenceDepth,
       entry.preparedSemanticHomeEvidence.namingMetadata?.disambiguationNotes?.[0]?.code ?? null,
     ]),
     [
-      ['A.1', 'shared-runtime', undefined, null],
-      ['A.2', 'shared-runtime', 'A', 'beta-context'],
+      ['A.1', 'shared-runtime', 'src/alpha/shared.logic.ts', 'A.1', undefined, undefined, null],
+      ['A.2', 'shared-runtime', 'src/beta/shared.logic.ts', 'A.2', 'A', 2, 'beta-context'],
     ],
   );
 });


### PR DESCRIPTION
### Motivation
- Prepare a deterministic, occurrence-local semantic-home input from already-joined Naming evidence while preserving ownership boundaries and not changing any Tree findings or fallback behavior. 

### Description
- Add a small Tree-owned helper `prepareTreeSemanticHomeEvidenceInputFromJoinedOccurrence` in `calculogic-validator/tree/src/tree-naming-occurrence-intake.logic.mjs` that accepts a joined occurrence entry and returns the prepared semantic-home input containing `sourceIdentityTuple`, `namingObservation`, optional `addressingContext`, and optional `namingMetadata`.
- Preserve Naming-owned fields in the prepared input (semantic name/family/subgroup, role/semanticRole, ambiguity, `ambiguityFlags`, `splitFamilyFlags`) by extending the joined observation shape and avoiding any re-derivation from filenames or path-only signals.
- Attach `preparedSemanticHomeEvidence` at the minimal Tree-owned seam (each `tree-prepared-naming-occurrence-address-join` entry) and refresh it only when valid occurrence-local enrichment is attached, leaving diagnostics and skipped-join behavior unchanged.
- Add focused regression tests in `calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` covering: valid enrichment retention, same-family occurrence isolation (no metadata leakage), fallback to v1 join when enrichment absent, and helper rejection for malformed inputs.

### Testing
- Ran `git diff --check` which reported no whitespace/errors.
- Ran unit tests with `node --test calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` and the updated test file passed locally (45 tests, 0 failures).
- Ran validator workflows: `npm run validate:naming -- --scope=validator` which exited `2` due to existing repository-wide naming informational/legacy findings (pre-existing and not introduced by this change). `npm run validate:tree -- --scope=validator` exited `0` with Tree informational findings unchanged from prior runs. `npm run validate:all -- --scope=validator` exited `2` (same existing naming findings caused non-zero exit; Tree outputs unchanged).
- Confirmation: Tree-only behavior and reporting were not changed by this work; the new prepared evidence is a preparation-only surface and does not alter findings, severity, confidence, placement policy, or existing fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38702097108331aaeef88047414cfd)