### PR TITLE
Surface occurrence-local semantic-home evidence in Tree semantic-family advisories

### DIFF
--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -493,7 +493,9 @@ const toNormalizedSemanticHomeOccurrenceEvidence = (preparedSemanticHomeEvidence
     : [];
   const occurrenceEvidence = {
     sourceIdentityTuple: { ...preparedSemanticHomeEvidence.sourceIdentityTuple },
-    path: addressingContext.path ?? addressingContext.resolvedPath ?? preparedSemanticHomeEvidence.namingObservation?.path ?? null,
+    path: addressingContext.path ?? null,
+    resolvedPath: addressingContext.resolvedPath ?? null,
+    name: addressingContext.name ?? null,
     occurrenceType: addressingContext.occurrenceType ?? null,
     addressPath: addressingContext.addressPath ?? null,
     parentOccurrenceAddress: addressingContext.parentOccurrenceAddress ?? addressingContext.parentAddressPath ?? null,
@@ -797,7 +799,8 @@ const toFamilyBroaderSpreadInterpretation = (familyAnalysis) => {
   };
 };
 
-const toSharedRootLaneObservation = (observation) => {
+const toSharedRootLaneObservation = (familyEntry) => {
+  const { observation } = familyEntry;
   for (const sharedRoot of SHARED_ROOT_SEMANTIC_GROUPING_SUPPORTED_ROOTS) {
     const sharedRootPrefix = `${sharedRoot}/`;
     if (!observation.path.startsWith(sharedRootPrefix)) {
@@ -815,6 +818,7 @@ const toSharedRootLaneObservation = (observation) => {
       lanePartition,
       path: observation.path,
       semanticFamily: observation.semanticFamily,
+      familyEntry,
     };
   }
 
@@ -1015,7 +1019,7 @@ const collectFamilySubgroupOpportunityFindings = (familySharedSpineAnalysisEntri
 const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnalysisEntries) =>
   familySharedSpineAnalysisEntries.flatMap(({ familyAnalysis, broaderSpreadInterpretation }) => {
     const sharedFamilyObservations = familyAnalysis.familyEntries
-      .map(({ observation }) => toSharedRootLaneObservation(observation))
+      .map((familyEntry) => toSharedRootLaneObservation(familyEntry))
       .filter(Boolean);
     const observationsBySharedRoot = new Map();
 
@@ -1065,7 +1069,7 @@ const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnal
               localFirstInterpretation,
               broaderSpreadInterpretation,
               sharedRootLaneInterpretation,
-              ...toSemanticHomeEvidenceDetails(familyAnalysis.familyEntries),
+              ...toSemanticHomeEvidenceDetails(sharedRootObservations.map(({ familyEntry }) => familyEntry)),
               familySharedSpineRouting: {
                 model: 'shared-local-first-family-interpretation',
                 sharedRootOutcome: sharedRootLaneInterpretation.classification,

--- a/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
+++ b/calculogic-validator/tree/src/contributors/tree-naming-semantic-family-bridge-contributor.logic.mjs
@@ -411,7 +411,7 @@ const toNormalizedBridgeObservation = (observation) => {
     }
   }
 
-  return {
+  const normalizedObservation = {
     path: observation.path,
     semanticName: observation.semanticName,
     familyRoot: observation.familyRoot,
@@ -426,6 +426,98 @@ const toNormalizedBridgeObservation = (observation) => {
       ? { splitFamilyFlags: toSortedUniqueStringFlags(observation.splitFamilyFlags) }
       : {}),
   };
+
+  const semanticHomeEvidence = toNormalizedSemanticHomeOccurrenceEvidence(observation.preparedSemanticHomeEvidence);
+  if (semanticHomeEvidence) {
+    normalizedObservation.semanticHomeEvidence = semanticHomeEvidence;
+  }
+
+  return normalizedObservation;
+};
+
+const toSourceIdentityTupleSortKey = (sourceIdentityTuple = {}) =>
+  [
+    sourceIdentityTuple.addressProfileId ?? '',
+    sourceIdentityTuple.addressedSnapshotId ?? '',
+    sourceIdentityTuple.occurrenceAddress ?? '',
+  ].join('\u0000');
+
+const toNamingQualificationLabel = ({ disambiguationNotes, evidenceLimitNotes }) => {
+  const hasDisambiguationNotes = Array.isArray(disambiguationNotes) && disambiguationNotes.length > 0;
+  const hasEvidenceLimitNotes = Array.isArray(evidenceLimitNotes) && evidenceLimitNotes.length > 0;
+
+  if (hasDisambiguationNotes && hasEvidenceLimitNotes) {
+    return 'disambiguation-noted-and-evidence-limited';
+  }
+
+  if (hasDisambiguationNotes) {
+    return 'disambiguation-noted';
+  }
+
+  if (hasEvidenceLimitNotes) {
+    return 'evidence-limited';
+  }
+
+  return 'no-explicit-naming-qualification';
+};
+
+const toNormalizedSemanticHomeOccurrenceEvidence = (preparedSemanticHomeEvidence) => {
+  if (
+    !preparedSemanticHomeEvidence ||
+    typeof preparedSemanticHomeEvidence !== 'object' ||
+    Array.isArray(preparedSemanticHomeEvidence) ||
+    !preparedSemanticHomeEvidence.sourceIdentityTuple ||
+    typeof preparedSemanticHomeEvidence.sourceIdentityTuple !== 'object' ||
+    Array.isArray(preparedSemanticHomeEvidence.sourceIdentityTuple)
+  ) {
+    return null;
+  }
+
+  const addressingContext =
+    preparedSemanticHomeEvidence.addressingContext &&
+    typeof preparedSemanticHomeEvidence.addressingContext === 'object' &&
+    !Array.isArray(preparedSemanticHomeEvidence.addressingContext)
+      ? preparedSemanticHomeEvidence.addressingContext
+      : {};
+  const namingMetadata =
+    preparedSemanticHomeEvidence.namingMetadata &&
+    typeof preparedSemanticHomeEvidence.namingMetadata === 'object' &&
+    !Array.isArray(preparedSemanticHomeEvidence.namingMetadata)
+      ? preparedSemanticHomeEvidence.namingMetadata
+      : {};
+  const disambiguationNotes = Array.isArray(namingMetadata.disambiguationNotes)
+    ? namingMetadata.disambiguationNotes
+    : [];
+  const evidenceLimitNotes = Array.isArray(namingMetadata.evidenceLimitNotes)
+    ? namingMetadata.evidenceLimitNotes
+    : [];
+  const occurrenceEvidence = {
+    sourceIdentityTuple: { ...preparedSemanticHomeEvidence.sourceIdentityTuple },
+    path: addressingContext.path ?? addressingContext.resolvedPath ?? preparedSemanticHomeEvidence.namingObservation?.path ?? null,
+    occurrenceType: addressingContext.occurrenceType ?? null,
+    addressPath: addressingContext.addressPath ?? null,
+    parentOccurrenceAddress: addressingContext.parentOccurrenceAddress ?? addressingContext.parentAddressPath ?? null,
+    occurrenceDepth: addressingContext.occurrenceDepth ?? addressingContext.depth ?? null,
+    occurrenceOrderIndex: addressingContext.occurrenceOrderIndex ?? addressingContext.orderIndex ?? null,
+    qualification: toNamingQualificationLabel({ disambiguationNotes, evidenceLimitNotes }),
+    disambiguationNotes,
+    evidenceLimitNotes,
+  };
+
+  return occurrenceEvidence;
+};
+
+const toSemanticHomeEvidenceDetails = (familyEntries) => {
+  const occurrences = familyEntries
+    .map(({ observation }) => observation.semanticHomeEvidence)
+    .filter(Boolean)
+    .sort((left, right) =>
+      toSourceIdentityTupleSortKey(left.sourceIdentityTuple).localeCompare(toSourceIdentityTupleSortKey(right.sourceIdentityTuple)) ||
+      (left.addressPath ?? '').localeCompare(right.addressPath ?? '') ||
+      (left.path ?? '').localeCompare(right.path ?? ''),
+    );
+
+  return occurrences.length > 0 ? { semanticHomeEvidence: { occurrences } } : {};
 };
 
 export const prepareNamingSemanticFamilyBridge = (bridgePayload) => {
@@ -838,6 +930,7 @@ const collectFamilyScatterFindings = (familySharedSpineAnalysisEntries) =>
             observedStructuralRootKinds: toSortedUnique(familyAnalysis.placements.map((placement) => placement.structuralRootKind)),
             localFirstInterpretation: familyAnalysis.localFirstInterpretation,
             broaderSpreadInterpretation,
+            ...toSemanticHomeEvidenceDetails(familyAnalysis.familyEntries),
             allowedCrossContainerPatterns: {
               structuralRootPairings: ALLOWED_STRUCTURAL_ROOT_PAIRINGS,
               canonicalDocAuthorityRuntimePairing: 'calculogic-validator/doc/** <-> calculogic-validator/<semantic-container>/**',
@@ -874,6 +967,7 @@ const collectFamilyClusterFindings = (familySharedSpineAnalysisEntries) =>
             observedCount: familyAnalysis.sortedPaths.length,
             observedPaths: familyAnalysis.sortedPaths,
             localFirstInterpretation: familyAnalysis.localFirstInterpretation,
+            ...toSemanticHomeEvidenceDetails(familyAnalysis.familyEntries),
             threshold: {
               minFamilyFilesForClusterObservation: FAMILY_CLUSTER_INFO_MIN_FILES,
             },
@@ -906,6 +1000,7 @@ const collectFamilySubgroupOpportunityFindings = (familySharedSpineAnalysisEntri
             observedContainerLocalHomes: familyAnalysis.observedContainerLocalHomes,
             lowerLevelGroupingSignalPresent: familyAnalysis.lowerLevelGroupingSignalPresent,
             localFirstInterpretation: familyAnalysis.localFirstInterpretation,
+            ...toSemanticHomeEvidenceDetails(familyAnalysis.familyEntries),
             thresholds: {
               minFilesInContainer: FAMILY_SUBGROUP_OPPORTUNITY_MIN_FILES_IN_CONTAINER,
               minDistinctContainerLocalHomes: FAMILY_SUBGROUP_OPPORTUNITY_MIN_DISTINCT_CONTAINER_LOCAL_HOMES,
@@ -970,6 +1065,7 @@ const collectSharedRootFamilyScatterAcrossLanesFindings = (familySharedSpineAnal
               localFirstInterpretation,
               broaderSpreadInterpretation,
               sharedRootLaneInterpretation,
+              ...toSemanticHomeEvidenceDetails(familyAnalysis.familyEntries),
               familySharedSpineRouting: {
                 model: 'shared-local-first-family-interpretation',
                 sharedRootOutcome: sharedRootLaneInterpretation.classification,
@@ -1014,6 +1110,9 @@ const toAddressKeyedBridgePayload = (preparedAddressKeyedJoinEvidence) => ({
       : {}),
     ...(Array.isArray(joinEntry.namingObservation?.splitFamilyFlags)
       ? { splitFamilyFlags: joinEntry.namingObservation.splitFamilyFlags }
+      : {}),
+    ...(joinEntry.preparedSemanticHomeEvidence
+      ? { preparedSemanticHomeEvidence: joinEntry.preparedSemanticHomeEvidence }
       : {}),
   })),
 });

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -1478,6 +1478,52 @@ const addressJoinEntry = ({ occurrenceAddress, path, semanticName, familyRoot, s
   },
 });
 
+const addressJoinEntryWithPreparedEvidence = ({
+  occurrenceAddress,
+  path,
+  semanticName = 'qualified-family',
+  familyRoot = 'qualified',
+  semanticFamily = 'qualified-family',
+  occurrenceType = 'file',
+  addressPath = occurrenceAddress,
+  parentOccurrenceAddress = 'A',
+  occurrenceDepth = 2,
+  occurrenceOrderIndex = 0,
+  disambiguationNotes,
+  evidenceLimitNotes,
+}) => {
+  const joinedEntry = addressJoinEntry({ occurrenceAddress, path, semanticName, familyRoot, semanticFamily });
+  joinedEntry.occurrenceRecord = {
+    ...joinedEntry.occurrenceRecord,
+    name: path.split('/').at(-1),
+    occurrenceType,
+    addressPath,
+    parentOccurrenceAddress,
+    occurrenceDepth,
+    occurrenceOrderIndex,
+  };
+  joinedEntry.preparedSemanticHomeEvidence = {
+    sourceIdentityTuple: { ...joinedEntry.identityTuple },
+    namingObservation: { ...joinedEntry.namingObservation },
+    addressingContext: {
+      path,
+      resolvedPath: path,
+      name: joinedEntry.occurrenceRecord.name,
+      occurrenceType,
+      addressPath,
+      parentOccurrenceAddress,
+      occurrenceDepth,
+      occurrenceOrderIndex,
+    },
+    namingMetadata: {
+      ...(disambiguationNotes ? { disambiguationNotes } : {}),
+      ...(evidenceLimitNotes ? { evidenceLimitNotes } : {}),
+    },
+  };
+
+  return joinedEntry;
+};
+
 const pathKeyedFallbackBridge = {
   observations: [
     {
@@ -1670,4 +1716,179 @@ test('tree naming bridge contributor distinguishes duplicate same-family occurre
     'src/features/build/duplicate-family.results.ts',
     'src/shared/build/duplicate-family.logic.ts',
   ]);
+});
+
+test('tree naming bridge contributor carries prepared occurrence-local evidence into advisory details without policy changes', () => {
+  const disambiguationNotes = [{ code: 'role-like-folder-token', message: 'Role-like folder token.', source: 'naming' }];
+  const evidenceLimitNotes = [{ code: 'limited-context', message: 'Limited deterministic context.', source: 'naming' }];
+  const baseline = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence([
+      addressJoinEntry({
+        occurrenceAddress: 'A.1',
+        path: 'src/shared/build/qualified-family.logic.ts',
+        semanticName: 'qualified-family',
+        familyRoot: 'qualified',
+        semanticFamily: 'qualified-family',
+      }),
+      addressJoinEntry({
+        occurrenceAddress: 'A.2',
+        path: 'src/features/build/qualified-family.results.ts',
+        semanticName: 'qualified-family',
+        familyRoot: 'qualified',
+        semanticFamily: 'qualified-family',
+      }),
+      addressJoinEntry({
+        occurrenceAddress: 'A.3',
+        path: 'src/features/build/qualified-family.knowledge.ts',
+        semanticName: 'qualified-family',
+        familyRoot: 'qualified',
+        semanticFamily: 'qualified-family',
+      }),
+      addressJoinEntry({
+        occurrenceAddress: 'A.4',
+        path: 'src/features/build/qualified-family.build.tsx',
+        semanticName: 'qualified-family',
+        familyRoot: 'qualified',
+        semanticFamily: 'qualified-family',
+      }),
+    ]),
+  });
+  const findings = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence([
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.1',
+        path: 'src/shared/build/qualified-family.logic.ts',
+        occurrenceOrderIndex: 1,
+        disambiguationNotes,
+        evidenceLimitNotes,
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.2',
+        path: 'src/features/build/qualified-family.results.ts',
+        occurrenceOrderIndex: 2,
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.3',
+        path: 'src/features/build/qualified-family.knowledge.ts',
+        occurrenceOrderIndex: 3,
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.4',
+        path: 'src/features/build/qualified-family.build.tsx',
+        occurrenceOrderIndex: 4,
+      }),
+    ]),
+  });
+
+  assert.deepEqual(
+    findings.map(({ details, ...finding }) => ({ ...finding, details: { ...details, semanticHomeEvidence: undefined } })),
+    baseline.map(({ details, ...finding }) => ({ ...finding, details: { ...details, semanticHomeEvidence: undefined } })),
+  );
+  const occurrence = findings[0].details.semanticHomeEvidence.occurrences[0];
+  assert.deepEqual(occurrence.sourceIdentityTuple, {
+    addressProfileId: 'tree-codebase',
+    addressedSnapshotId: 'snapshot-001',
+    occurrenceAddress: 'A.1',
+  });
+  assert.equal(occurrence.path, 'src/shared/build/qualified-family.logic.ts');
+  assert.equal(occurrence.occurrenceType, 'file');
+  assert.equal(occurrence.addressPath, 'A.1');
+  assert.equal(occurrence.parentOccurrenceAddress, 'A');
+  assert.equal(occurrence.occurrenceDepth, 2);
+  assert.equal(occurrence.occurrenceOrderIndex, 1);
+  assert.equal(occurrence.qualification, 'disambiguation-noted-and-evidence-limited');
+  assert.deepEqual(occurrence.disambiguationNotes, disambiguationNotes);
+  assert.deepEqual(occurrence.evidenceLimitNotes, evidenceLimitNotes);
+});
+
+test('tree naming bridge contributor derives each descriptive qualification label from Naming note presence', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence([
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.1',
+        path: 'src/shared/build/qualification-family.logic.ts',
+        semanticName: 'qualification-family',
+        familyRoot: 'qualification',
+        semanticFamily: 'qualification-family',
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.2',
+        path: 'src/features/build/qualification-family.results.ts',
+        semanticName: 'qualification-family',
+        familyRoot: 'qualification',
+        semanticFamily: 'qualification-family',
+        disambiguationNotes: [{ code: 'disambiguated', message: 'Disambiguated.', source: 'naming' }],
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.3',
+        path: 'src/features/build/qualification-family.knowledge.ts',
+        semanticName: 'qualification-family',
+        familyRoot: 'qualification',
+        semanticFamily: 'qualification-family',
+        evidenceLimitNotes: [{ code: 'limited', message: 'Limited.', source: 'naming' }],
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.4',
+        path: 'src/features/build/qualification-family.build.tsx',
+        semanticName: 'qualification-family',
+        familyRoot: 'qualification',
+        semanticFamily: 'qualification-family',
+        disambiguationNotes: [{ code: 'disambiguated', message: 'Disambiguated.', source: 'naming' }],
+        evidenceLimitNotes: [{ code: 'limited', message: 'Limited.', source: 'naming' }],
+      }),
+    ]),
+  });
+
+  assert.deepEqual(
+    findings[0].details.semanticHomeEvidence.occurrences.map((occurrence) => occurrence.qualification),
+    [
+      'no-explicit-naming-qualification',
+      'disambiguation-noted',
+      'evidence-limited',
+      'disambiguation-noted-and-evidence-limited',
+    ],
+  );
+});
+
+test('tree naming bridge contributor keeps same-family occurrence metadata isolated by address', () => {
+  const findings = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence([
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.1',
+        path: 'src/shared/build/isolated-family.logic.ts',
+        semanticName: 'isolated-family',
+        familyRoot: 'isolated',
+        semanticFamily: 'isolated-family',
+        disambiguationNotes: [{ code: 'first-only', message: 'First only.', source: 'naming' }],
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.2',
+        path: 'src/features/build/isolated-family.results.ts',
+        semanticName: 'isolated-family',
+        familyRoot: 'isolated',
+        semanticFamily: 'isolated-family',
+        evidenceLimitNotes: [{ code: 'second-only', message: 'Second only.', source: 'naming' }],
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.3',
+        path: 'src/features/build/isolated-family.knowledge.ts',
+        semanticName: 'isolated-family',
+        familyRoot: 'isolated',
+        semanticFamily: 'isolated-family',
+      }),
+      addressJoinEntryWithPreparedEvidence({
+        occurrenceAddress: 'A.4',
+        path: 'src/features/build/isolated-family.build.tsx',
+        semanticName: 'isolated-family',
+        familyRoot: 'isolated',
+        semanticFamily: 'isolated-family',
+      }),
+    ]),
+  });
+
+  const occurrences = findings[0].details.semanticHomeEvidence.occurrences;
+  assert.deepEqual(occurrences[0].disambiguationNotes.map((note) => note.code), ['first-only']);
+  assert.deepEqual(occurrences[0].evidenceLimitNotes, []);
+  assert.deepEqual(occurrences[1].disambiguationNotes, []);
+  assert.deepEqual(occurrences[1].evidenceLimitNotes.map((note) => note.code), ['second-only']);
 });

--- a/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
+++ b/calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs
@@ -1489,13 +1489,16 @@ const addressJoinEntryWithPreparedEvidence = ({
   parentOccurrenceAddress = 'A',
   occurrenceDepth = 2,
   occurrenceOrderIndex = 0,
+  resolvedPath = path,
+  name = path.split('/').at(-1),
   disambiguationNotes,
   evidenceLimitNotes,
 }) => {
   const joinedEntry = addressJoinEntry({ occurrenceAddress, path, semanticName, familyRoot, semanticFamily });
   joinedEntry.occurrenceRecord = {
     ...joinedEntry.occurrenceRecord,
-    name: path.split('/').at(-1),
+    name,
+    resolvedPath,
     occurrenceType,
     addressPath,
     parentOccurrenceAddress,
@@ -1507,8 +1510,8 @@ const addressJoinEntryWithPreparedEvidence = ({
     namingObservation: { ...joinedEntry.namingObservation },
     addressingContext: {
       path,
-      resolvedPath: path,
-      name: joinedEntry.occurrenceRecord.name,
+      resolvedPath,
+      name,
       occurrenceType,
       addressPath,
       parentOccurrenceAddress,
@@ -1758,6 +1761,8 @@ test('tree naming bridge contributor carries prepared occurrence-local evidence 
       addressJoinEntryWithPreparedEvidence({
         occurrenceAddress: 'A.1',
         path: 'src/shared/build/qualified-family.logic.ts',
+        resolvedPath: 'workspace/src/shared/build/qualified-family.logic.ts',
+        name: 'qualified-family-addressed.logic.ts',
         occurrenceOrderIndex: 1,
         disambiguationNotes,
         evidenceLimitNotes,
@@ -1791,6 +1796,8 @@ test('tree naming bridge contributor carries prepared occurrence-local evidence 
     occurrenceAddress: 'A.1',
   });
   assert.equal(occurrence.path, 'src/shared/build/qualified-family.logic.ts');
+  assert.equal(occurrence.resolvedPath, 'workspace/src/shared/build/qualified-family.logic.ts');
+  assert.equal(occurrence.name, 'qualified-family-addressed.logic.ts');
   assert.equal(occurrence.occurrenceType, 'file');
   assert.equal(occurrence.addressPath, 'A.1');
   assert.equal(occurrence.parentOccurrenceAddress, 'A');
@@ -1891,4 +1898,65 @@ test('tree naming bridge contributor keeps same-family occurrence metadata isola
   assert.deepEqual(occurrences[0].evidenceLimitNotes, []);
   assert.deepEqual(occurrences[1].disambiguationNotes, []);
   assert.deepEqual(occurrences[1].evidenceLimitNotes.map((note) => note.code), ['second-only']);
+});
+
+test('tree shared-root lane advisory scopes semantic-home evidence to its observed path set', () => {
+  const semanticFields = {
+    semanticName: 'lane-scope-family',
+    familyRoot: 'lane',
+    semanticFamily: 'lane-scope-family',
+  };
+  const sharedRootJoinEntries = [
+    {
+      occurrenceAddress: 'A.1',
+      path: 'src/shared/build/lane-scope-family.logic.ts',
+      occurrenceOrderIndex: 1,
+    },
+    {
+      occurrenceAddress: 'A.2',
+      path: 'src/shared/docs/lane-scope-family.docs.ts',
+      occurrenceOrderIndex: 2,
+    },
+    {
+      occurrenceAddress: 'A.3',
+      path: 'src/shared/logic/lane-scope-family.results.ts',
+      occurrenceOrderIndex: 3,
+    },
+    {
+      occurrenceAddress: 'A.4',
+      path: 'src/features/build/lane-scope-family.build.tsx',
+      occurrenceOrderIndex: 4,
+    },
+  ];
+  const baselineFinding = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence(
+      sharedRootJoinEntries.map((entry) => addressJoinEntry({ ...semanticFields, ...entry })),
+    ),
+  }).find((finding) => finding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES');
+  const finding = collectNamingSemanticFamilyBridgeFindings({ observations: [] }, {
+    preparedAddressKeyedJoinEvidence: cleanAddressJoinEvidence(
+      sharedRootJoinEntries.map((entry) => addressJoinEntryWithPreparedEvidence({ ...semanticFields, ...entry })),
+    ),
+  }).find((candidateFinding) => candidateFinding.code === 'TREE_SHARED_FAMILY_SCATTERED_ACROSS_LANES');
+
+  assert.equal(finding.code, baselineFinding.code);
+  assert.equal(finding.severity, baselineFinding.severity);
+  assert.equal(finding.classification, baselineFinding.classification);
+  assert.equal(finding.path, baselineFinding.path);
+  assert.deepEqual(finding.details.observedPaths, baselineFinding.details.observedPaths);
+  assert.deepEqual(finding.details.observedPaths, [
+    'src/shared/build/lane-scope-family.logic.ts',
+    'src/shared/docs/lane-scope-family.docs.ts',
+    'src/shared/logic/lane-scope-family.results.ts',
+  ]);
+  assert.deepEqual(
+    finding.details.semanticHomeEvidence.occurrences.map((occurrence) => occurrence.path),
+    finding.details.observedPaths,
+  );
+  assert.equal(
+    finding.details.semanticHomeEvidence.occurrences.some(
+      (occurrence) => occurrence.path === 'src/features/build/lane-scope-family.build.tsx',
+    ),
+    false,
+  );
 });


### PR DESCRIPTION
### Motivation
- Make Tree surface already-prepared occurrence-local semantic-home evidence in existing semantic-family advisory details so advisory findings can explain their deterministic Naming provenance without changing policy.
- Preserve strict ownership boundaries: keep Naming as semantic source-of-truth, Addressing as canonical tuple/occurrence identity, and Tree as consumer/presenter only.

### Description
- Added normalization and qualification helpers to consume `preparedSemanticHomeEvidence` and derive a deterministic `qualification` label (one of `no-explicit-naming-qualification`, `disambiguation-noted`, `evidence-limited`, `disambiguation-noted-and-evidence-limited`).
- Threaded `preparedSemanticHomeEvidence` from clean address-keyed joined evidence into the bridge payload selection path and preserved existing clean-vs-fallback selection rules.
- Extended advisory `details` for existing semantic-family findings to optionally include a `semanticHomeEvidence` block containing occurrence entries that preserve `sourceIdentityTuple`, neutral addressing context fields (path, resolvedPath, name, occurrenceType, addressPath, parentOccurrenceAddress, occurrenceDepth, occurrenceOrderIndex), and separate `namingMetadata` notes (`disambiguationNotes` and `evidenceLimitNotes`) without merging or reinterpreting them.
- Added focused tests exercising evidence presence, preservation of exact tuple provenance and addressing context, deterministic qualification derivation, isolation of same-family occurrences by tuple, and unchanged finding output when evidence is absent.

### Testing
- `git diff --check` — PASS (no whitespace or diff-check issues).
- `node --test calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs` — PASS (all tests passed).
- `node --test calculogic-validator/tree/test/tree-naming-semantic-family-bridge-contributor.test.mjs` — PASS (all tests passed, including new evidence/detail tests).
- `npm run validate:naming -- --scope=validator` — EXPECTED NONZERO (exited `2` due to pre-existing naming findings in validator scope; unrelated to these changes).
- `npm run validate:tree -- --scope=validator` — PASS (tree validator run succeeded and advisory outputs preserved expected behavior).
- `npm run validate:all -- --scope=validator` — EXPECTED NONZERO (exited `2` because `naming` still reports pre-existing validator-scope findings; this is pre-existing and not introduced by this change).

Refs #663
Refs #662
Refs #660
Refs #657
Refs #655
Refs #651
Follows #647

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38dde07af483318505c46e0a0a543c)