### PR TITLE
feat(tree): add semantic naming→folder-type relationship for repo-top family roots (Refs #670)

### DIFF
--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -127,6 +127,10 @@ The relationship registry is Tree-owned because it describes Tree interpretation
 
 Repo-shape allowance remains separate from classification: an allowed top-level directory can be structurally classified, semantically classified through this relationship, or remain unspecified if the required Tree/Naming evidence is absent.
 
+Current implementation reality: the normal runner path stages package-root folder observations in the Naming-owned semantic-family bridge when Naming sees package-manifest evidence for a repository-top package folder. Those observations carry folder occurrence type, semantic identity fields, explicit `semanticEvidenceKind: semantic-family-root-folder`, explicit `familyRootQualification: package-root-folder`, and provenance back to the Naming finding that justified the observation. Tree consumes the addressed form of that bridge evidence after Addressing has supplied occurrence identity and lineage.
+
+When a folder remains unclassified in the internal prepared classification path, Tree may attach a bounded `classificationExplanation` object. That explanation is internal evidence, not a new finding or report-envelope change. Current reason codes include `missing-required-naming-observation`, `naming-observation-not-qualified-as-family-root`, `no-active-relationship-perspective-match`, `non-repository-top-descendant`, `ambiguous-or-conflicting-evidence`, and `unknown-or-unmodeled-folder-relationship`.
+
 
 ### Naming occurrence bridge intake boundary (Status: Current implementation reality)
 

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -127,9 +127,11 @@ The relationship registry is Tree-owned because it describes Tree interpretation
 
 Repo-shape allowance remains separate from classification: an allowed top-level directory can be structurally classified, semantically classified through this relationship, or remain unspecified if the required Tree/Naming evidence is absent.
 
+Current repository-top relationship explanations are scoped to repository-top folder occurrences that are not already classified by retained structural-home evidence; nested folders, files, and structural folders do not receive explanation records from this perspective.
+
 Current implementation reality: the normal runner path stages package-root folder observations in the Naming-owned semantic-family bridge when Naming sees package-manifest evidence for a repository-top package folder. Those observations carry folder occurrence type, semantic identity fields, explicit `semanticEvidenceKind: semantic-family-root-folder`, explicit `familyRootQualification: package-root-folder`, and provenance back to the Naming finding that justified the observation. Tree consumes the addressed form of that bridge evidence after Addressing has supplied occurrence identity and lineage.
 
-When a folder remains unclassified in the internal prepared classification path, Tree may attach a bounded `classificationExplanation` object. That explanation is internal evidence, not a new finding or report-envelope change. Current reason codes include `missing-required-naming-observation`, `naming-observation-not-qualified-as-family-root`, `no-active-relationship-perspective-match`, `non-repository-top-descendant`, `ambiguous-or-conflicting-evidence`, and `unknown-or-unmodeled-folder-relationship`.
+When a folder remains unclassified in the internal prepared classification path, Tree may attach a bounded `classificationExplanation` object. That explanation is internal evidence, not a new finding or report-envelope change. Current reason codes include `missing-required-naming-observation`, `naming-observation-not-qualified-as-family-root`, `no-active-relationship-perspective-match`, `ambiguous-or-conflicting-evidence`, and `unknown-or-unmodeled-folder-relationship`.
 
 
 ### Naming occurrence bridge intake boundary (Status: Current implementation reality)

--- a/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
+++ b/calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md
@@ -111,6 +111,23 @@ Bounded consumable naming bridge surfaces include:
 
 Tree advisor does **not** re-own naming validity judgments. Naming validity remains owned by naming conventions/specs and the naming validator slice.
 
+Tree now also consumes repository-top folder observations from that same Naming-owned evidence surface when Naming supplies semantic-family-root evidence for folder occurrences. Tree does not parse those folder names into semantic identity. Tree evaluates a Tree-owned relationship perspective between the Naming evidence and the folder occurrence context.
+
+Active relationship perspective for current runtime truth:
+
+```text
+Naming perspective: semantic-family-root
++ Tree perspective: repository-top folder
++ Tree condition: not a retained structural repository-top home
++ Tree repo-shape condition: allowed top-level directory
+→ Tree relationship perspective: semantic-repository-top-family-home
+```
+
+The relationship registry is Tree-owned because it describes Tree interpretation of folder role, repository-top position, structural-home status, and repo-shape context. It contains reusable relationship conventions only; it must not contain named semantic-home facts such as package-folder-name → semantic home. Naming remains the owner of `semanticName`, `familyRoot`, `semanticFamily`, and optional `familySubgroup`.
+
+Repo-shape allowance remains separate from classification: an allowed top-level directory can be structurally classified, semantically classified through this relationship, or remain unspecified if the required Tree/Naming evidence is absent.
+
+
 ### Naming occurrence bridge intake boundary (Status: Current implementation reality)
 
 Tree has a neutral intake boundary for a staged sibling `namingOccurrenceBridge` payload when that payload is explicitly supplied to Tree wiring or attached beside the path-keyed semantic-family bridge payload in tests/helper transport. The boundary recognizes address-keyed join identity tuples made from `addressProfileId` + `addressedSnapshotId` + `occurrenceAddress`; it preserves or summarizes Naming-originated bridge diagnostics and compatibility diagnostic counts; and the intake summary remains non-finding evidence that does not replace current Tree findings, placement reasoning, scatter/cluster logic, drift/advisory logic, structural-home reasoning, semantic-home reasoning, or folder-kind interpretation.
@@ -351,8 +368,8 @@ This section clarifies modeling intent for tree root registries without changing
   - generic surface-like roots such as `src`, `test`, `doc`, `docs`, `scripts`, `tools`, `public`, `bin`
   - these are interpreted by tree as structural folder surfaces
 - **Semantic/custom-style top roots**:
-  - top roots that encode semantic/package identity or repo-local ownership style
-  - examples can include package-style roots used by a specific repository architecture
+  - top roots whose semantic/package identity is supplied by Naming-owned evidence and interpreted by Tree through the semantic-naming-to-folder-type relationship perspective
+  - current runtime truth does not model these roots as Tree-owned named semantic-home registry entries
 
 ### 2) Builtin vs custom ownership
 

--- a/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
+++ b/calculogic-validator/naming/src/naming-occurrence-bridge-payload.logic.mjs
@@ -11,6 +11,9 @@ const NAMING_SEMANTIC_FIELDS = [
   'ambiguityFlags',
   'splitFamilyFlags',
   'disambiguation',
+  'semanticEvidenceKind',
+  'familyRootQualification',
+  'evidenceSource',
 ];
 
 const toOptionalNonEmptyString = (value) => (typeof value === 'string' && value.length > 0 ? value : null);
@@ -122,6 +125,9 @@ const toAddressAttachedObservation = ({
       ? { occurrenceType: occurrenceRecord.occurrenceType }
       : {}),
     ...copyNamingSemanticPayload(semanticObservation),
+    ...(isPlainObject(semanticObservation.evidenceProvenance)
+      ? { evidenceProvenance: { ...semanticObservation.evidenceProvenance } }
+      : {}),
   };
 };
 

--- a/calculogic-validator/naming/src/naming-semantic-evidence-bridge.logic.mjs
+++ b/calculogic-validator/naming/src/naming-semantic-evidence-bridge.logic.mjs
@@ -1,3 +1,7 @@
+const clonePlainObject = (value) => (
+  value && typeof value === 'object' && !Array.isArray(value) ? { ...value } : null
+);
+
 const toSortedUniqueStringValues = (values) =>
   Array.from(
     new Set(values.filter((value) => typeof value === 'string' && value.length > 0)),
@@ -29,7 +33,25 @@ const toNamingSemanticEvidenceRecord = (observation) => {
   ]);
 
   return {
-    path: observation.path,
+    path: observation.repoRelativePath ?? observation.path,
+    ...(typeof observation.repoRelativePath === 'string' && observation.repoRelativePath.length > 0
+      ? { repoRelativePath: observation.repoRelativePath }
+      : {}),
+    ...(typeof observation.occurrenceType === 'string' && observation.occurrenceType.length > 0
+      ? { occurrenceType: observation.occurrenceType }
+      : {}),
+    ...(typeof observation.addressProfileId === 'string' && observation.addressProfileId.length > 0
+      ? { addressProfileId: observation.addressProfileId }
+      : {}),
+    ...(typeof observation.addressedSnapshotId === 'string' && observation.addressedSnapshotId.length > 0
+      ? { addressedSnapshotId: observation.addressedSnapshotId }
+      : {}),
+    ...(typeof observation.occurrenceAddress === 'string' && observation.occurrenceAddress.length > 0
+      ? { occurrenceAddress: observation.occurrenceAddress }
+      : {}),
+    ...(typeof observation.addressPath === 'string' && observation.addressPath.length > 0
+      ? { addressPath: observation.addressPath }
+      : {}),
     semanticName: observation.semanticName,
     semanticFamily: observation.semanticFamily,
     familyRoot: observation.familyRoot,
@@ -42,6 +64,18 @@ const toNamingSemanticEvidenceRecord = (observation) => {
     evidenceStrength: splitMarkers.length === 0 ? 'high' : 'bounded',
     ambiguityStatus: splitMarkers.length === 0 ? 'none' : 'present',
     ...(splitMarkers.length > 0 ? { splitMarkers } : {}),
+    ...(typeof observation.semanticEvidenceKind === 'string' && observation.semanticEvidenceKind.length > 0
+      ? { semanticEvidenceKind: observation.semanticEvidenceKind }
+      : {}),
+    ...(typeof observation.familyRootQualification === 'string' && observation.familyRootQualification.length > 0
+      ? { familyRootQualification: observation.familyRootQualification }
+      : {}),
+    ...(typeof observation.evidenceSource === 'string' && observation.evidenceSource.length > 0
+      ? { evidenceSource: observation.evidenceSource }
+      : {}),
+    ...(clonePlainObject(observation.evidenceProvenance)
+      ? { evidenceProvenance: clonePlainObject(observation.evidenceProvenance) }
+      : {}),
   };
 };
 

--- a/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
+++ b/calculogic-validator/naming/src/naming-semantic-family-bridge-projection.logic.mjs
@@ -3,6 +3,26 @@ const toSortedUniqueStringFlags = (flags) =>
     new Set(flags.filter((flag) => typeof flag === 'string' && flag.length > 0)),
   ).sort((left, right) => left.localeCompare(right));
 
+const PACKAGE_MANIFEST_FILE_NAME = 'package.json';
+
+const toPackageRootSemanticTokens = (packageJsonPath) => {
+  if (typeof packageJsonPath !== 'string' || !packageJsonPath.endsWith(`/${PACKAGE_MANIFEST_FILE_NAME}`)) {
+    return null;
+  }
+
+  const packageRootPath = packageJsonPath.slice(0, -`/${PACKAGE_MANIFEST_FILE_NAME}`.length);
+  if (!packageRootPath || packageRootPath.includes('/')) {
+    return null;
+  }
+
+  const [familyRoot] = packageRootPath.split('-');
+  if (!familyRoot) {
+    return null;
+  }
+
+  return { packageRootPath, semanticName: packageRootPath, semanticFamily: packageRootPath, familyRoot };
+};
+
 const cloneEvidenceLimitNotes = (evidenceLimitNotes) =>
   Array.isArray(evidenceLimitNotes)
     ? evidenceLimitNotes
@@ -27,7 +47,7 @@ const toDisambiguationPayload = (disambiguation) => {
   return Object.keys(payload).length > 0 ? payload : null;
 };
 
-const toBridgeObservationFromFinding = (finding) => {
+const toCanonicalBridgeObservationFromFinding = (finding) => {
   if (!finding || typeof finding !== 'object' || Array.isArray(finding)) {
     return null;
   }
@@ -78,15 +98,55 @@ const toBridgeObservationFromFinding = (finding) => {
   };
 };
 
+const toFolderFamilyRootObservationFromFinding = (finding) => {
+  if (!finding || typeof finding !== 'object' || Array.isArray(finding)) {
+    return null;
+  }
+
+  if (finding.code !== 'NAMING_ALLOWED_SPECIAL_CASE') {
+    return null;
+  }
+
+  if (finding.details?.specialCaseType !== 'ecosystem-required') {
+    return null;
+  }
+
+  const packageRootTokens = toPackageRootSemanticTokens(finding.path);
+  if (!packageRootTokens) {
+    return null;
+  }
+
+  return {
+    path: packageRootTokens.packageRootPath,
+    repoRelativePath: packageRootTokens.packageRootPath,
+    occurrenceType: 'folder',
+    semanticName: packageRootTokens.semanticName,
+    familyRoot: packageRootTokens.familyRoot,
+    semanticFamily: packageRootTokens.semanticFamily,
+    semanticEvidenceKind: 'semantic-family-root-folder',
+    familyRootQualification: 'package-root-folder',
+    evidenceSource: 'naming-semantic-family-bridge-projection',
+    evidenceProvenance: {
+      sourceFindingCode: finding.code,
+      sourceFindingPath: finding.path,
+      sourceSpecialCaseType: finding.details.specialCaseType,
+    },
+  };
+};
+
 export const projectNamingSemanticFamilyBridge = (namingRuntimeOrReportOutput = {}) => {
   const findings = Array.isArray(namingRuntimeOrReportOutput.findings)
     ? namingRuntimeOrReportOutput.findings
     : [];
 
   return {
-    observations: findings
-      .map(toBridgeObservationFromFinding)
-      .filter(Boolean)
-      .sort((left, right) => left.path.localeCompare(right.path)),
+    observations: [
+      ...findings.map(toCanonicalBridgeObservationFromFinding).filter(Boolean),
+      ...findings.map(toFolderFamilyRootObservationFromFinding).filter(Boolean),
+    ].sort((left, right) =>
+      left.path.localeCompare(right.path) ||
+      (left.occurrenceType ?? '').localeCompare(right.occurrenceType ?? '') ||
+      left.semanticName.localeCompare(right.semanticName),
+    ),
   };
 };

--- a/calculogic-validator/naming/test/naming-semantic-family-bridge-projection.test.mjs
+++ b/calculogic-validator/naming/test/naming-semantic-family-bridge-projection.test.mjs
@@ -49,3 +49,43 @@ test('naming bridge projection emits bounded semantic-family observation fields 
 test('naming bridge projection tolerates missing findings arrays with empty observations', () => {
   assert.deepEqual(projectNamingSemanticFamilyBridge({}), { observations: [] });
 });
+
+test('naming bridge projection emits package-root folder semantic-family-root observations', () => {
+  const projected = projectNamingSemanticFamilyBridge({
+    findings: [
+      {
+        code: 'NAMING_ALLOWED_SPECIAL_CASE',
+        severity: 'info',
+        path: 'calculogic-validator/package.json',
+        classification: 'allowed-special-case',
+        details: { specialCaseType: 'ecosystem-required' },
+      },
+      {
+        code: 'NAMING_ALLOWED_SPECIAL_CASE',
+        severity: 'info',
+        path: 'package.json',
+        classification: 'allowed-special-case',
+        details: { specialCaseType: 'ecosystem-required' },
+      },
+    ],
+  });
+
+  assert.deepEqual(projected.observations, [
+    {
+      path: 'calculogic-validator',
+      repoRelativePath: 'calculogic-validator',
+      occurrenceType: 'folder',
+      semanticName: 'calculogic-validator',
+      familyRoot: 'calculogic',
+      semanticFamily: 'calculogic-validator',
+      semanticEvidenceKind: 'semantic-family-root-folder',
+      familyRootQualification: 'package-root-folder',
+      evidenceSource: 'naming-semantic-family-bridge-projection',
+      evidenceProvenance: {
+        sourceFindingCode: 'NAMING_ALLOWED_SPECIAL_CASE',
+        sourceFindingPath: 'calculogic-validator/package.json',
+        sourceSpecialCaseType: 'ecosystem-required',
+      },
+    },
+  ]);
+});

--- a/calculogic-validator/tree/src/registries/_builtin/semantic-naming-folder-type-relationships.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/semantic-naming-folder-type-relationships.registry.json
@@ -1,0 +1,14 @@
+{
+  "version": "1",
+  "semanticNamingFolderTypeRelationships": [
+    {
+      "relationshipPerspective": "semantic-repository-top-family-home",
+      "status": "active",
+      "namingPerspective": "semantic-family-root",
+      "treeFolderType": "repository-top-folder",
+      "structuralHomeCondition": "not-structural-home",
+      "repoShapeCondition": "allowed-top-level-directory",
+      "definition": "A repository-top folder with Naming-owned semantic-family-root evidence and no retained Tree structural-home evidence is interpreted by Tree as a semantic repository-top family home."
+    }
+  ]
+}

--- a/calculogic-validator/tree/src/registries/_builtin/structural-homes.registry.json
+++ b/calculogic-validator/tree/src/registries/_builtin/structural-homes.registry.json
@@ -17,16 +17,6 @@
       "definition": "Executable command or package-bin surface home."
     },
     {
-      "structuralHome": "calculogic-doc-engine",
-      "status": "active",
-      "definition": "Repository-owned document-engine package root home."
-    },
-    {
-      "structuralHome": "calculogic-validator",
-      "status": "active",
-      "definition": "Repository-owned validator package root home."
-    },
-    {
       "structuralHome": "compat",
       "status": "active",
       "definition": "Compatibility, shim, adapter, or transition-support home."

--- a/calculogic-validator/tree/src/registries/tree-semantic-naming-folder-type-relationships-registry.logic.mjs
+++ b/calculogic-validator/tree/src/registries/tree-semantic-naming-folder-type-relationships-registry.logic.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const BUILTIN_REGISTRY_ROOT = new URL('./_builtin/', import.meta.url);
+
+export const BUILTIN_SEMANTIC_NAMING_FOLDER_TYPE_RELATIONSHIPS_REGISTRY_PATH = fileURLToPath(
+  new URL('semantic-naming-folder-type-relationships.registry.json', BUILTIN_REGISTRY_ROOT),
+);
+
+let cachedBuiltinRelationshipsRegistry = null;
+
+const assertValidRegistry = (payload) => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Invalid builtin semantic naming folder-type relationships registry: expected object payload.');
+  }
+
+  if (!Array.isArray(payload.semanticNamingFolderTypeRelationships)) {
+    throw new Error('Invalid builtin semantic naming folder-type relationships registry: semanticNamingFolderTypeRelationships must be an array.');
+  }
+
+  return payload;
+};
+
+export const getBuiltinSemanticNamingFolderTypeRelationshipsRegistry = () => {
+  if (!cachedBuiltinRelationshipsRegistry) {
+    cachedBuiltinRelationshipsRegistry = assertValidRegistry(
+      JSON.parse(fs.readFileSync(BUILTIN_SEMANTIC_NAMING_FOLDER_TYPE_RELATIONSHIPS_REGISTRY_PATH, 'utf8')),
+    );
+  }
+
+  return cachedBuiltinRelationshipsRegistry;
+};

--- a/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
@@ -97,6 +97,16 @@ const assertReplacementRuntimeInput = (input) => {
     throw new Error('Tree occurrence classification replacement runtime treeFolderKindEvidence.evidenceRecords must be an array.');
   }
 
+  if (
+    input.treeSemanticNamingFolderTypeRelationshipEvidence !== undefined &&
+    (!input.treeSemanticNamingFolderTypeRelationshipEvidence ||
+      typeof input.treeSemanticNamingFolderTypeRelationshipEvidence !== 'object' ||
+      Array.isArray(input.treeSemanticNamingFolderTypeRelationshipEvidence) ||
+      !Array.isArray(input.treeSemanticNamingFolderTypeRelationshipEvidence.unclassifiedRelationshipRecords))
+  ) {
+    throw new Error('Tree occurrence classification replacement runtime treeSemanticNamingFolderTypeRelationshipEvidence.unclassifiedRelationshipRecords must be an array when provided.');
+  }
+
   if (!input.treeRepoShapePolicy || typeof input.treeRepoShapePolicy !== 'object' || Array.isArray(input.treeRepoShapePolicy)) {
     throw new Error('Tree occurrence classification replacement runtime input must include treeRepoShapePolicy object.');
   }
@@ -106,7 +116,7 @@ const assertReplacementRuntimeInput = (input) => {
   }
 };
 
-const toReplacementRootClassification = ({ folderKind, structuralHome, semanticHome, isRepoShapeAllowedTopLevelDirectory }) => {
+const toReplacementRootClassification = ({ folderKind, structuralHome, semanticHome, isRepoShapeAllowedTopLevelDirectory, classificationExplanation }) => {
   if (folderKind === 'structural' || structuralHome) {
     return {
       structuralClass: 'repo-top-structural-root',
@@ -131,12 +141,13 @@ const toReplacementRootClassification = ({ folderKind, structuralHome, semanticH
     structuralClass: 'unclassified',
     structuralKind: 'unknown',
     isRepoShapeAllowedTopLevelDirectory,
+    ...(classificationExplanation ? { classificationExplanation } : {}),
     isStructuralRoot: false,
     isSemanticRoot: false,
   };
 };
 
-const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, semanticHomeLookup, folderKindLookup, allowedTopLevelDirectorySet }) => {
+const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, semanticHomeLookup, folderKindLookup, relationshipExplanationLookup, allowedTopLevelDirectorySet }) => {
   if (!occurrenceRecord || typeof occurrenceRecord !== 'object') {
     return {
       structuralClass: 'unclassified',
@@ -167,6 +178,7 @@ const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, 
         structuralHome: lookupFirstAvailable(structuralHomeLookup, occurrenceRecord),
         semanticHome: lookupFirstAvailable(semanticHomeLookup, occurrenceRecord),
         isRepoShapeAllowedTopLevelDirectory: allowedTopLevelDirectorySet.has(resolvedPath),
+        classificationExplanation: lookupFirstAvailable(relationshipExplanationLookup, occurrenceRecord),
       }),
       isRepoTopOccurrence,
       isScopedRootOccurrence,
@@ -187,12 +199,15 @@ const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, 
     };
   }
 
+  const relationshipExplanation = lookupFirstAvailable(relationshipExplanationLookup, occurrenceRecord);
+
   return {
     structuralClass: 'unclassified',
     structuralKind: 'unknown',
     isRepoTopOccurrence,
     isScopedRootOccurrence,
     isRepoShapeAllowedTopLevelDirectory: false,
+    ...(relationshipExplanation ? { classificationExplanation: relationshipExplanation } : {}),
     isStructuralRoot: false,
     isSemanticRoot: false,
     isSubtreePartitionCandidate,
@@ -205,6 +220,10 @@ export const prepareTreeOccurrenceClassificationReplacementRuntime = (input) => 
   const structuralHomeLookup = toEvidenceLookup(input.treeStructuralHomeEvidence.evidenceRecords, 'structuralHome');
   const semanticHomeLookup = toEvidenceLookup(input.treeSemanticHomeEvidence.evidenceRecords, 'semanticHome');
   const folderKindLookup = toEvidenceLookup(input.treeFolderKindEvidence.evidenceRecords, 'folderKind');
+  const relationshipExplanationLookup = toEvidenceLookup(
+    input.treeSemanticNamingFolderTypeRelationshipEvidence?.unclassifiedRelationshipRecords ?? [],
+    'classificationExplanation',
+  );
   const allowedTopLevelDirectorySet = toAllowedTopLevelDirectorySet(
     input.treeRepoShapePolicy.allowedTopLevelDirectories,
   );
@@ -223,6 +242,7 @@ export const prepareTreeOccurrenceClassificationReplacementRuntime = (input) => 
           structuralHomeLookup,
           semanticHomeLookup,
           folderKindLookup,
+          relationshipExplanationLookup,
           allowedTopLevelDirectorySet,
         }),
       }));

--- a/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
+++ b/calculogic-validator/tree/src/tree-occurrence-classification.logic.mjs
@@ -106,7 +106,7 @@ const assertReplacementRuntimeInput = (input) => {
   }
 };
 
-const toReplacementRootClassification = ({ folderKind, structuralHome, semanticHome }) => {
+const toReplacementRootClassification = ({ folderKind, structuralHome, semanticHome, isRepoShapeAllowedTopLevelDirectory }) => {
   if (folderKind === 'structural' || structuralHome) {
     return {
       structuralClass: 'repo-top-structural-root',
@@ -130,13 +130,13 @@ const toReplacementRootClassification = ({ folderKind, structuralHome, semanticH
   return {
     structuralClass: 'unclassified',
     structuralKind: 'unknown',
-    isRepoShapeAllowedTopLevelDirectory: false,
+    isRepoShapeAllowedTopLevelDirectory,
     isStructuralRoot: false,
     isSemanticRoot: false,
   };
 };
 
-const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, semanticHomeLookup, folderKindLookup }) => {
+const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, semanticHomeLookup, folderKindLookup, allowedTopLevelDirectorySet }) => {
   if (!occurrenceRecord || typeof occurrenceRecord !== 'object') {
     return {
       structuralClass: 'unclassified',
@@ -166,6 +166,7 @@ const classifyWithPreparedEvidence = ({ occurrenceRecord, structuralHomeLookup, 
         folderKind: lookupFirstAvailable(folderKindLookup, occurrenceRecord),
         structuralHome: lookupFirstAvailable(structuralHomeLookup, occurrenceRecord),
         semanticHome: lookupFirstAvailable(semanticHomeLookup, occurrenceRecord),
+        isRepoShapeAllowedTopLevelDirectory: allowedTopLevelDirectorySet.has(resolvedPath),
       }),
       isRepoTopOccurrence,
       isScopedRootOccurrence,
@@ -222,6 +223,7 @@ export const prepareTreeOccurrenceClassificationReplacementRuntime = (input) => 
           structuralHomeLookup,
           semanticHomeLookup,
           folderKindLookup,
+          allowedTopLevelDirectorySet,
         }),
       }));
     },

--- a/calculogic-validator/tree/src/tree-semantic-home-evidence.logic.mjs
+++ b/calculogic-validator/tree/src/tree-semantic-home-evidence.logic.mjs
@@ -12,6 +12,16 @@ const assertValidInput = (input) => {
   if (!Array.isArray(input.namingSemanticEvidenceRecords)) {
     throw new Error('Tree semantic-home evidence input namingSemanticEvidenceRecords must be an array.');
   }
+
+  if (
+    input.treeSemanticNamingFolderTypeRelationshipEvidence !== undefined &&
+    (!input.treeSemanticNamingFolderTypeRelationshipEvidence ||
+      typeof input.treeSemanticNamingFolderTypeRelationshipEvidence !== 'object' ||
+      Array.isArray(input.treeSemanticNamingFolderTypeRelationshipEvidence) ||
+      !Array.isArray(input.treeSemanticNamingFolderTypeRelationshipEvidence.relationshipRecords))
+  ) {
+    throw new Error('Tree semantic-home evidence input treeSemanticNamingFolderTypeRelationshipEvidence.relationshipRecords must be an array when provided.');
+  }
 };
 
 const toDeterministicNamingRecordsByPath = (namingSemanticEvidenceRecords) => {
@@ -75,6 +85,26 @@ const pickSafePathMatch = (occurrenceRecord, pathMatches) => {
   return pathMatches[0];
 };
 
+const isRepoTopFolder = (occurrenceRecord) => (
+  occurrenceRecord?.occurrenceType === 'folder' &&
+  typeof occurrenceRecord.path === 'string' &&
+  occurrenceRecord.path.length > 0 &&
+  !occurrenceRecord.path.includes('/') &&
+  !occurrenceRecord.path.includes('\\')
+);
+
+const toRelationshipRecordsByPath = (relationshipRecords = []) => {
+  const recordsByPath = new Map();
+  for (const record of relationshipRecords) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
+    if (typeof record.path !== 'string' || record.path.length === 0) continue;
+    if (record.relationshipPerspective !== 'semantic-repository-top-family-home') continue;
+    if (!recordsByPath.has(record.path)) recordsByPath.set(record.path, []);
+    recordsByPath.get(record.path).push(record);
+  }
+  return recordsByPath;
+};
+
 const toEvidenceRecord = (occurrenceRecord, namingRecord) => ({
   addressPath: occurrenceRecord.addressPath ?? null,
   parentAddressPath: occurrenceRecord.parentAddressPath ?? null,
@@ -90,14 +120,21 @@ const toEvidenceRecord = (occurrenceRecord, namingRecord) => ({
   ...(typeof namingRecord.familySubgroup === 'string' && namingRecord.familySubgroup.length > 0
     ? { familySubgroup: namingRecord.familySubgroup }
     : {}),
-  namingEvidenceSource: namingRecord.evidenceSource ?? 'namingSemanticFamilyBridge',
-  rationale: 'Tree joined addressed occurrence path with Naming-prepared semantic evidence path.',
+  namingEvidenceSource: namingRecord.evidenceSource ?? namingRecord.namingEvidenceSource ?? 'namingSemanticFamilyBridge',
+  ...(typeof namingRecord.relationshipPerspective === 'string' ? { relationshipPerspective: namingRecord.relationshipPerspective } : {}),
+  ...(typeof namingRecord.relationshipSource === 'string' ? { relationshipSource: namingRecord.relationshipSource } : {}),
+  rationale: typeof namingRecord.relationshipPerspective === 'string'
+    ? 'Tree semantic-home evidence consumed semantic-naming-to-folder-type relationship interpretation.'
+    : 'Tree joined addressed occurrence path with Naming-prepared semantic evidence path.',
 });
 
 export const prepareTreeSemanticHomeEvidence = (input) => {
   assertValidInput(input);
 
   const namingRecordsByPath = toDeterministicNamingRecordsByPath(input.namingSemanticEvidenceRecords);
+  const relationshipRecordsByPath = toRelationshipRecordsByPath(
+    input.treeSemanticNamingFolderTypeRelationshipEvidence?.relationshipRecords,
+  );
   const evidenceRecords = [];
 
   for (const occurrenceRecord of input.addressedOccurrenceRecords) {
@@ -109,7 +146,12 @@ export const prepareTreeSemanticHomeEvidence = (input) => {
       continue;
     }
 
-    const safeMatch = pickSafePathMatch(occurrenceRecord, namingRecordsByPath.get(occurrenceRecord.path));
+    const relationshipMatch = pickSafePathMatch(occurrenceRecord, relationshipRecordsByPath.get(occurrenceRecord.path));
+    const safeMatch = relationshipMatch ?? (
+      isRepoTopFolder(occurrenceRecord)
+        ? null
+        : pickSafePathMatch(occurrenceRecord, namingRecordsByPath.get(occurrenceRecord.path))
+    );
     if (!safeMatch) {
       continue;
     }

--- a/calculogic-validator/tree/src/tree-semantic-naming-folder-type-relationship.logic.mjs
+++ b/calculogic-validator/tree/src/tree-semantic-naming-folder-type-relationship.logic.mjs
@@ -1,0 +1,113 @@
+const SOURCE_ID = 'tree-semantic-naming-folder-type-relationship';
+
+const toIdentityKeys = (record) => {
+  const keys = [];
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return keys;
+  if (typeof record.addressPath === 'string' && record.addressPath.length > 0) keys.push(`address:${record.addressPath}`);
+  if (typeof record.path === 'string' && record.path.length > 0 && typeof record.occurrenceType === 'string') {
+    keys.push(`path-type:${record.path}::${record.occurrenceType}`);
+  }
+  if (typeof record.path === 'string' && record.path.length > 0) keys.push(`path:${record.path}`);
+  return keys;
+};
+
+const toEvidenceLookup = (records) => {
+  const lookup = new Map();
+  for (const record of records) {
+    for (const key of toIdentityKeys(record)) {
+      if (!lookup.has(key)) lookup.set(key, record);
+    }
+  }
+  return lookup;
+};
+
+const lookupEvidence = (lookup, occurrenceRecord) => {
+  for (const key of toIdentityKeys(occurrenceRecord)) {
+    if (lookup.has(key)) return lookup.get(key);
+  }
+  return null;
+};
+
+const isRepoTopFolder = (occurrenceRecord) => (
+  occurrenceRecord?.occurrenceType === 'folder' &&
+  typeof occurrenceRecord.path === 'string' &&
+  occurrenceRecord.path.length > 0 &&
+  !occurrenceRecord.path.includes('/') &&
+  !occurrenceRecord.path.includes('\\')
+);
+
+const toAllowedTopLevelDirectorySet = (treeRepoShapePolicy) => new Set(
+  (treeRepoShapePolicy?.allowedTopLevelDirectories ?? [])
+    .filter((directoryName) => typeof directoryName === 'string' && directoryName.length > 0),
+);
+
+const toActiveRepositoryTopFamilyHomeRule = (registry) => (
+  registry.semanticNamingFolderTypeRelationships ?? []
+).find((rule) => (
+  rule?.status === 'active' &&
+  rule.relationshipPerspective === 'semantic-repository-top-family-home' &&
+  rule.namingPerspective === 'semantic-family-root' &&
+  rule.treeFolderType === 'repository-top-folder' &&
+  rule.structuralHomeCondition === 'not-structural-home'
+));
+
+const hasSemanticFamilyRootEvidence = (namingRecord) => (
+  namingRecord &&
+  typeof namingRecord === 'object' &&
+  !Array.isArray(namingRecord) &&
+  typeof namingRecord.semanticName === 'string' && namingRecord.semanticName.length > 0 &&
+  typeof namingRecord.semanticFamily === 'string' && namingRecord.semanticFamily.length > 0 &&
+  typeof namingRecord.familyRoot === 'string' && namingRecord.familyRoot.length > 0
+);
+
+const assertValidInput = (input) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('Tree semantic naming folder-type relationship input must be an object.');
+  if (!Array.isArray(input.addressedOccurrenceRecords)) throw new Error('Tree semantic naming folder-type relationship input addressedOccurrenceRecords must be an array.');
+  if (!Array.isArray(input.namingSemanticEvidenceRecords)) throw new Error('Tree semantic naming folder-type relationship input namingSemanticEvidenceRecords must be an array.');
+  if (!input.treeStructuralHomeEvidence || !Array.isArray(input.treeStructuralHomeEvidence.evidenceRecords)) throw new Error('Tree semantic naming folder-type relationship input treeStructuralHomeEvidence.evidenceRecords must be an array.');
+  if (!input.relationshipsRegistry || !Array.isArray(input.relationshipsRegistry.semanticNamingFolderTypeRelationships)) throw new Error('Tree semantic naming folder-type relationship input relationshipsRegistry.semanticNamingFolderTypeRelationships must be an array.');
+};
+
+export const prepareTreeSemanticNamingFolderTypeRelationshipEvidence = (input) => {
+  assertValidInput(input);
+
+  const rule = toActiveRepositoryTopFamilyHomeRule(input.relationshipsRegistry);
+  if (!rule) return { source: SOURCE_ID, relationshipRecords: [] };
+
+  const namingLookup = toEvidenceLookup(input.namingSemanticEvidenceRecords);
+  const structuralLookup = toEvidenceLookup(input.treeStructuralHomeEvidence.evidenceRecords);
+  const allowedTopLevelDirectorySet = toAllowedTopLevelDirectorySet(input.treeRepoShapePolicy);
+  const relationshipRecords = [];
+
+  for (const occurrenceRecord of input.addressedOccurrenceRecords) {
+    if (!isRepoTopFolder(occurrenceRecord)) continue;
+    if (structuralLookup.has(`path:${occurrenceRecord.path}`) || lookupEvidence(structuralLookup, occurrenceRecord)) continue;
+    if (rule.repoShapeCondition === 'allowed-top-level-directory' && !allowedTopLevelDirectorySet.has(occurrenceRecord.path)) continue;
+
+    const namingRecord = lookupEvidence(namingLookup, occurrenceRecord);
+    if (!hasSemanticFamilyRootEvidence(namingRecord)) continue;
+
+    relationshipRecords.push({
+      addressPath: occurrenceRecord.addressPath ?? null,
+      parentAddressPath: occurrenceRecord.parentAddressPath ?? null,
+      path: occurrenceRecord.path,
+      name: occurrenceRecord.name ?? null,
+      occurrenceType: occurrenceRecord.occurrenceType ?? null,
+      relationshipPerspective: rule.relationshipPerspective,
+      relationshipSource: SOURCE_ID,
+      relationshipEvidenceStrength: namingRecord.evidenceStrength ?? 'bounded',
+      namingPerspective: rule.namingPerspective,
+      treeFolderType: rule.treeFolderType,
+      structuralHomeCondition: rule.structuralHomeCondition,
+      repoShapeCondition: rule.repoShapeCondition ?? null,
+      semanticName: namingRecord.semanticName,
+      semanticFamily: namingRecord.semanticFamily,
+      familyRoot: namingRecord.familyRoot,
+      ...(typeof namingRecord.familySubgroup === 'string' && namingRecord.familySubgroup.length > 0 ? { familySubgroup: namingRecord.familySubgroup } : {}),
+      namingEvidenceSource: namingRecord.evidenceSource ?? 'namingSemanticFamilyBridge',
+      rationale: 'Tree interpreted Naming semantic-family-root evidence against repository-top folder context and retained structural-home evidence.',
+    });
+  }
+
+  return { source: SOURCE_ID, relationshipRecords };
+};

--- a/calculogic-validator/tree/src/tree-semantic-naming-folder-type-relationship.logic.mjs
+++ b/calculogic-validator/tree/src/tree-semantic-naming-folder-type-relationship.logic.mjs
@@ -99,7 +99,6 @@ export const prepareTreeSemanticNamingFolderTypeRelationshipEvidence = (input) =
 
   const rule = toActiveRepositoryTopFamilyHomeRule(input.relationshipsRegistry);
 
-
   const namingLookup = toEvidenceLookup(input.namingSemanticEvidenceRecords);
   const structuralLookup = toEvidenceLookup(input.treeStructuralHomeEvidence.evidenceRecords);
   const allowedTopLevelDirectorySet = toAllowedTopLevelDirectorySet(input.treeRepoShapePolicy);
@@ -108,14 +107,7 @@ export const prepareTreeSemanticNamingFolderTypeRelationshipEvidence = (input) =
 
   for (const occurrenceRecord of input.addressedOccurrenceRecords) {
     if (occurrenceRecord?.occurrenceType !== 'folder') continue;
-    if (!isRepoTopFolder(occurrenceRecord)) {
-      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
-        occurrenceRecord,
-        reason: 'non-repository-top-descendant',
-        diagnostic: 'The repository-top family-root relationship applies only to repository-top folder occurrences.',
-      }));
-      continue;
-    }
+    if (!isRepoTopFolder(occurrenceRecord)) continue;
     if (lookupEvidence(structuralLookup, occurrenceRecord)) continue;
     if (!rule) {
       unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({

--- a/calculogic-validator/tree/src/tree-semantic-naming-folder-type-relationship.logic.mjs
+++ b/calculogic-validator/tree/src/tree-semantic-naming-folder-type-relationship.logic.mjs
@@ -13,20 +13,28 @@ const toIdentityKeys = (record) => {
 
 const toEvidenceLookup = (records) => {
   const lookup = new Map();
+  const ambiguousKeys = new Set();
   for (const record of records) {
     for (const key of toIdentityKeys(record)) {
-      if (!lookup.has(key)) lookup.set(key, record);
+      if (lookup.has(key)) {
+        ambiguousKeys.add(key);
+        continue;
+      }
+      lookup.set(key, record);
     }
   }
-  return lookup;
+  return { lookup, ambiguousKeys };
 };
 
-const lookupEvidence = (lookup, occurrenceRecord) => {
+const lookupEvidence = (evidenceLookup, occurrenceRecord) => {
   for (const key of toIdentityKeys(occurrenceRecord)) {
-    if (lookup.has(key)) return lookup.get(key);
+    if (evidenceLookup.lookup.has(key)) return evidenceLookup.lookup.get(key);
   }
   return null;
 };
+
+const hasAmbiguousEvidence = (evidenceLookup, occurrenceRecord) =>
+  toIdentityKeys(occurrenceRecord).some((key) => evidenceLookup.ambiguousKeys.has(key));
 
 const isRepoTopFolder = (occurrenceRecord) => (
   occurrenceRecord?.occurrenceType === 'folder' &&
@@ -51,7 +59,7 @@ const toActiveRepositoryTopFamilyHomeRule = (registry) => (
   rule.structuralHomeCondition === 'not-structural-home'
 ));
 
-const hasSemanticFamilyRootEvidence = (namingRecord) => (
+const hasRequiredSemanticFields = (namingRecord) => (
   namingRecord &&
   typeof namingRecord === 'object' &&
   !Array.isArray(namingRecord) &&
@@ -59,6 +67,24 @@ const hasSemanticFamilyRootEvidence = (namingRecord) => (
   typeof namingRecord.semanticFamily === 'string' && namingRecord.semanticFamily.length > 0 &&
   typeof namingRecord.familyRoot === 'string' && namingRecord.familyRoot.length > 0
 );
+
+const isQualifiedSemanticFamilyRootObservation = (namingRecord) => (
+  hasRequiredSemanticFields(namingRecord) &&
+  namingRecord.occurrenceType === 'folder' &&
+  namingRecord.semanticEvidenceKind === 'semantic-family-root-folder' &&
+  namingRecord.familyRootQualification === 'package-root-folder'
+);
+
+const toUnclassifiedRelationshipRecord = ({ occurrenceRecord, reason, diagnostic }) => ({
+  addressPath: occurrenceRecord.addressPath ?? null,
+  parentAddressPath: occurrenceRecord.parentAddressPath ?? null,
+  path: occurrenceRecord.path ?? null,
+  name: occurrenceRecord.name ?? null,
+  occurrenceType: occurrenceRecord.occurrenceType ?? null,
+  relationshipPerspective: null,
+  relationshipSource: SOURCE_ID,
+  classificationExplanation: { reason, diagnostic },
+});
 
 const assertValidInput = (input) => {
   if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('Tree semantic naming folder-type relationship input must be an object.');
@@ -72,20 +98,69 @@ export const prepareTreeSemanticNamingFolderTypeRelationshipEvidence = (input) =
   assertValidInput(input);
 
   const rule = toActiveRepositoryTopFamilyHomeRule(input.relationshipsRegistry);
-  if (!rule) return { source: SOURCE_ID, relationshipRecords: [] };
+
 
   const namingLookup = toEvidenceLookup(input.namingSemanticEvidenceRecords);
   const structuralLookup = toEvidenceLookup(input.treeStructuralHomeEvidence.evidenceRecords);
   const allowedTopLevelDirectorySet = toAllowedTopLevelDirectorySet(input.treeRepoShapePolicy);
   const relationshipRecords = [];
+  const unclassifiedRelationshipRecords = [];
 
   for (const occurrenceRecord of input.addressedOccurrenceRecords) {
-    if (!isRepoTopFolder(occurrenceRecord)) continue;
-    if (structuralLookup.has(`path:${occurrenceRecord.path}`) || lookupEvidence(structuralLookup, occurrenceRecord)) continue;
-    if (rule.repoShapeCondition === 'allowed-top-level-directory' && !allowedTopLevelDirectorySet.has(occurrenceRecord.path)) continue;
+    if (occurrenceRecord?.occurrenceType !== 'folder') continue;
+    if (!isRepoTopFolder(occurrenceRecord)) {
+      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
+        occurrenceRecord,
+        reason: 'non-repository-top-descendant',
+        diagnostic: 'The repository-top family-root relationship applies only to repository-top folder occurrences.',
+      }));
+      continue;
+    }
+    if (lookupEvidence(structuralLookup, occurrenceRecord)) continue;
+    if (!rule) {
+      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
+        occurrenceRecord,
+        reason: 'no-active-relationship-perspective-match',
+        diagnostic: 'No active Tree relationship perspective matched this Naming and folder-type evidence combination.',
+      }));
+      continue;
+    }
+    if (rule.repoShapeCondition === 'allowed-top-level-directory' && !allowedTopLevelDirectorySet.has(occurrenceRecord.path)) {
+      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
+        occurrenceRecord,
+        reason: 'unknown-or-unmodeled-folder-relationship',
+        diagnostic: 'The folder is not allowed by repo-shape policy and has no registered semantic repository-top relationship.',
+      }));
+      continue;
+    }
+    if (hasAmbiguousEvidence(namingLookup, occurrenceRecord)) {
+      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
+        occurrenceRecord,
+        reason: 'ambiguous-or-conflicting-evidence',
+        diagnostic: 'Multiple Naming evidence records matched this folder occurrence, so Tree did not choose a semantic repository-top relationship.',
+      }));
+      continue;
+    }
 
     const namingRecord = lookupEvidence(namingLookup, occurrenceRecord);
-    if (!hasSemanticFamilyRootEvidence(namingRecord)) continue;
+    if (!namingRecord) {
+      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
+        occurrenceRecord,
+        reason: 'missing-required-naming-observation',
+        diagnostic: 'No semantic repository-top family-home relationship was established because Tree received no addressed Naming semantic-family-root observation for this folder occurrence.',
+      }));
+      continue;
+    }
+    if (!isQualifiedSemanticFamilyRootObservation(namingRecord)) {
+      unclassifiedRelationshipRecords.push(toUnclassifiedRelationshipRecord({
+        occurrenceRecord,
+        reason: hasRequiredSemanticFields(namingRecord) ? 'naming-observation-not-qualified-as-family-root' : 'missing-required-naming-observation',
+        diagnostic: hasRequiredSemanticFields(namingRecord)
+          ? 'Naming evidence exists for this folder, but it does not identify the folder occurrence itself as a semantic-family-root observation.'
+          : 'Naming evidence for this folder is missing required semantic-family-root fields.',
+      }));
+      continue;
+    }
 
     relationshipRecords.push({
       addressPath: occurrenceRecord.addressPath ?? null,
@@ -105,9 +180,15 @@ export const prepareTreeSemanticNamingFolderTypeRelationshipEvidence = (input) =
       familyRoot: namingRecord.familyRoot,
       ...(typeof namingRecord.familySubgroup === 'string' && namingRecord.familySubgroup.length > 0 ? { familySubgroup: namingRecord.familySubgroup } : {}),
       namingEvidenceSource: namingRecord.evidenceSource ?? 'namingSemanticFamilyBridge',
-      rationale: 'Tree interpreted Naming semantic-family-root evidence against repository-top folder context and retained structural-home evidence.',
+      semanticEvidenceKind: namingRecord.semanticEvidenceKind,
+      familyRootQualification: namingRecord.familyRootQualification,
+      ...(namingRecord.addressProfileId ? { addressProfileId: namingRecord.addressProfileId } : {}),
+      ...(namingRecord.addressedSnapshotId ? { addressedSnapshotId: namingRecord.addressedSnapshotId } : {}),
+      ...(namingRecord.occurrenceAddress ? { occurrenceAddress: namingRecord.occurrenceAddress } : {}),
+      ...(namingRecord.evidenceProvenance ? { evidenceProvenance: { ...namingRecord.evidenceProvenance } } : {}),
+      rationale: 'Tree interpreted an explicitly qualified Naming semantic-family-root folder observation against repository-top folder context and retained structural-home evidence.',
     });
   }
 
-  return { source: SOURCE_ID, relationshipRecords };
+  return { source: SOURCE_ID, relationshipRecords, unclassifiedRelationshipRecords };
 };

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -13,6 +13,7 @@ import { prepareTreeOccurrenceSnapshot } from './tree-occurrence-snapshot.logic.
 import { prepareTreeStructuralAddressSnapshot } from './tree-structural-address-snapshot.logic.mjs';
 import { prepareTreeStructuralHomeEvidence } from './tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from './tree-semantic-home-evidence.logic.mjs';
+import { prepareTreeSemanticNamingFolderTypeRelationshipEvidence } from './tree-semantic-naming-folder-type-relationship.logic.mjs';
 import { prepareTreeFolderKindEvidence } from './tree-folder-kind-evidence.logic.mjs';
 import {
   prepareTreeOccurrenceClassificationReplacementRuntime,
@@ -29,6 +30,7 @@ import { prepareTreeNamingOccurrenceBridgeIntake } from './tree-naming-occurrenc
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from './registries/tree-folder-kinds-registry.logic.mjs';
 import { getBuiltinTreeRepoShapePolicy } from './registries/tree-repo-shape-policy-registry.logic.mjs';
+import { getBuiltinSemanticNamingFolderTypeRelationshipsRegistry } from './registries/tree-semantic-naming-folder-type-relationships-registry.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
 const WALK_EXCLUDED_DIRECTORIES = new Set([
@@ -80,6 +82,7 @@ export const prepareTreeStructureAdvisorInputs = (
   const structuralHomesRegistry = getBuiltinStructuralHomesRegistry();
   const folderKindsRegistry = getBuiltinFolderKindsRegistry();
   const treeRepoShapePolicy = getBuiltinTreeRepoShapePolicy();
+  const semanticNamingFolderTypeRelationshipsRegistry = getBuiltinSemanticNamingFolderTypeRelationshipsRegistry();
   const namingSemanticEvidenceBridge = namingSemanticFamilyBridge
     ? prepareNamingSemanticEvidenceBridge(namingSemanticFamilyBridge)
     : { observations: [] };
@@ -92,9 +95,17 @@ export const prepareTreeStructureAdvisorInputs = (
     addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
     structuralHomesRegistry,
   });
+  const treeSemanticNamingFolderTypeRelationshipEvidence = prepareTreeSemanticNamingFolderTypeRelationshipEvidence({
+    addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+    namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+    treeStructuralHomeEvidence,
+    treeRepoShapePolicy,
+    relationshipsRegistry: semanticNamingFolderTypeRelationshipsRegistry,
+  });
   const treeSemanticHomeEvidence = prepareTreeSemanticHomeEvidence({
     addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
     namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+    treeSemanticNamingFolderTypeRelationshipEvidence,
   });
   const treeFolderKindEvidence = prepareTreeFolderKindEvidence({
     addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
@@ -156,6 +167,7 @@ export const prepareTreeStructureAdvisorInputs = (
     structuralAddressSnapshot,
     preparedDependencies: {
       treeStructuralHomeEvidence,
+      treeSemanticNamingFolderTypeRelationshipEvidence,
       treeSemanticHomeEvidence,
       treeFolderKindEvidence,
       treeRepoShapePolicy,

--- a/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
+++ b/calculogic-validator/tree/src/tree-structure-advisor.wiring.mjs
@@ -26,6 +26,7 @@ import { recommendTreeOccurrenceClassificationReplacement } from './tree-occurre
 import { planTreeOccurrenceClassificationRuntimeEvaluation } from './tree-occurrence-classification-runtime-evaluation-plan.logic.mjs';
 import { planTreeOccurrenceClassificationRuntimeExecutionContract } from './tree-occurrence-classification-runtime-execution-contract.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
+import { createNamingOccurrenceBridgePayload } from '../../naming/src/naming-occurrence-bridge-payload.logic.mjs';
 import { prepareTreeNamingOccurrenceBridgeIntake } from './tree-naming-occurrence-intake.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from './registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from './registries/tree-folder-kinds-registry.logic.mjs';
@@ -33,6 +34,9 @@ import { getBuiltinTreeRepoShapePolicy } from './registries/tree-repo-shape-poli
 import { getBuiltinSemanticNamingFolderTypeRelationshipsRegistry } from './registries/tree-semantic-naming-folder-type-relationships-registry.logic.mjs';
 
 const TOP_LEVEL_SCAN_EXCLUSIONS = new Set(['.git', 'node_modules']);
+const TREE_ADDRESS_PROFILE_ID = 'tree-structure-advisor-address-profile';
+const TREE_ADDRESSED_SNAPSHOT_ID = 'tree-structure-advisor-current-snapshot';
+
 const WALK_EXCLUDED_DIRECTORIES = new Set([
   '.git',
   '.next',
@@ -86,8 +90,18 @@ export const prepareTreeStructureAdvisorInputs = (
   const namingSemanticEvidenceBridge = namingSemanticFamilyBridge
     ? prepareNamingSemanticEvidenceBridge(namingSemanticFamilyBridge)
     : { observations: [] };
+  const addressedOccurrenceNamespace = {
+    addressProfileId: TREE_ADDRESS_PROFILE_ID,
+    addressedSnapshotId: TREE_ADDRESSED_SNAPSHOT_ID,
+    occurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
+  };
+  const addressedNamingOccurrenceBridge = namingOccurrenceBridge ?? createNamingOccurrenceBridgePayload({
+    namingSemanticFamilyBridge: namingSemanticEvidenceBridge,
+    addressedOccurrenceNamespace,
+  });
+  const addressedNamingSemanticEvidenceBridge = prepareNamingSemanticEvidenceBridge(addressedNamingOccurrenceBridge);
   const treeNamingOccurrenceBridgeIntake = prepareTreeNamingOccurrenceBridgeIntake({
-    namingOccurrenceBridge,
+    namingOccurrenceBridge: addressedNamingOccurrenceBridge,
     namingSemanticFamilyBridge,
   });
 
@@ -97,14 +111,14 @@ export const prepareTreeStructureAdvisorInputs = (
   });
   const treeSemanticNamingFolderTypeRelationshipEvidence = prepareTreeSemanticNamingFolderTypeRelationshipEvidence({
     addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
-    namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+    namingSemanticEvidenceRecords: addressedNamingSemanticEvidenceBridge.observations,
     treeStructuralHomeEvidence,
     treeRepoShapePolicy,
     relationshipsRegistry: semanticNamingFolderTypeRelationshipsRegistry,
   });
   const treeSemanticHomeEvidence = prepareTreeSemanticHomeEvidence({
     addressedOccurrenceRecords: structuralAddressSnapshot.occurrenceRecords,
-    namingSemanticEvidenceRecords: namingSemanticEvidenceBridge.observations,
+    namingSemanticEvidenceRecords: addressedNamingSemanticEvidenceBridge.observations,
     treeSemanticNamingFolderTypeRelationshipEvidence,
   });
   const treeFolderKindEvidence = prepareTreeFolderKindEvidence({
@@ -116,6 +130,7 @@ export const prepareTreeStructureAdvisorInputs = (
   const treeOccurrenceClassificationReplacementRuntime = prepareTreeOccurrenceClassificationReplacementRuntime({
     treeStructuralHomeEvidence,
     treeSemanticHomeEvidence,
+    treeSemanticNamingFolderTypeRelationshipEvidence,
     treeFolderKindEvidence,
     treeRepoShapePolicy,
   });
@@ -128,6 +143,7 @@ export const prepareTreeStructureAdvisorInputs = (
     currentOccurrenceClassificationRecords,
     treeStructuralHomeEvidence,
     treeSemanticHomeEvidence,
+    treeSemanticNamingFolderTypeRelationshipEvidence,
     treeFolderKindEvidence,
   });
 
@@ -167,6 +183,8 @@ export const prepareTreeStructureAdvisorInputs = (
     structuralAddressSnapshot,
     preparedDependencies: {
       treeStructuralHomeEvidence,
+      addressedNamingOccurrenceBridge,
+      addressedNamingSemanticEvidenceBridge,
       treeSemanticNamingFolderTypeRelationshipEvidence,
       treeSemanticHomeEvidence,
       treeFolderKindEvidence,

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -566,7 +566,9 @@ test('tree semantic naming folder-type relationship classifies only repository-t
   assert.equal(recordsByPath['calculogic-doc-engine'].structuralClass, 'repo-top-semantic-root');
   assert.equal(recordsByPath['calculogic-doc-engine'].isSemanticRoot, true);
   assert.equal(recordsByPath['calculogic-validator/tree'].structuralClass, 'unclassified');
+  assert.equal(Object.hasOwn(recordsByPath['calculogic-validator/tree'], 'classificationExplanation'), false);
   assert.equal(recordsByPath['calculogic-validator/tree/src'].structuralClass, 'unclassified');
+  assert.equal(Object.hasOwn(recordsByPath['calculogic-validator/tree/src'], 'classificationExplanation'), false);
   assert.equal(recordsByPath['unmatched-package'].structuralClass, 'unclassified');
   assert.equal(recordsByPath['unmatched-package'].isRepoShapeAllowedTopLevelDirectory, false);
   assert.deepEqual(
@@ -589,7 +591,31 @@ test('tree semantic naming folder-type relationship classifies only repository-t
   );
 
   assert.equal(missingReasonsByPath['calculogic-validator'], 'missing-required-naming-observation');
-  assert.equal(missingReasonsByPath['calculogic-validator/tree'], 'non-repository-top-descendant');
+
+  const unqualifiedRelationshipEvidence = prepareTreeSemanticNamingFolderTypeRelationshipEvidence({
+    addressedOccurrenceRecords,
+    namingSemanticEvidenceRecords: [
+      {
+        path: 'calculogic-validator',
+        occurrenceType: 'folder',
+        semanticName: 'calculogic-validator',
+        semanticFamily: 'calculogic-validator',
+        familyRoot: 'calculogic',
+      },
+    ],
+    treeStructuralHomeEvidence: structuralHomeEvidence,
+    treeRepoShapePolicy: getBuiltinTreeRepoShapePolicy(),
+    relationshipsRegistry: getBuiltinSemanticNamingFolderTypeRelationshipsRegistry(),
+  });
+  const unqualifiedCalculogicValidatorRecord = unqualifiedRelationshipEvidence.unclassifiedRelationshipRecords.find(
+    (record) => record.path === 'calculogic-validator',
+  );
+  assert.equal(
+    unqualifiedCalculogicValidatorRecord.classificationExplanation.reason,
+    'naming-observation-not-qualified-as-family-root',
+  );
+  assert.equal(Object.hasOwn(missingReasonsByPath, 'calculogic-validator/tree'), false);
+  assert.equal(Object.hasOwn(missingReasonsByPath, 'calculogic-validator/tree/src'), false);
   assert.equal(missingReasonsByPath['unmatched-package'], 'unknown-or-unmodeled-folder-relationship');
 });
 

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -12,6 +12,7 @@ import { runTreeStructureAdvisor as runTreeStructureAdvisorRuntime } from '../sr
 import { collectShimCompatFindings } from '../src/tree-shim-detection.logic.mjs';
 import { prepareTreeStructuralHomeEvidence } from '../src/tree-structural-home-evidence.logic.mjs';
 import { prepareTreeSemanticHomeEvidence } from '../src/tree-semantic-home-evidence.logic.mjs';
+import { prepareTreeSemanticNamingFolderTypeRelationshipEvidence } from '../src/tree-semantic-naming-folder-type-relationship.logic.mjs';
 import { prepareTreeFolderKindEvidence } from '../src/tree-folder-kind-evidence.logic.mjs';
 import {
   prepareTreeOccurrenceClassificationReplacementRuntime,
@@ -25,6 +26,8 @@ import { planTreeOccurrenceClassificationRuntimeEvaluation } from '../src/tree-o
 import { planTreeOccurrenceClassificationRuntimeExecutionContract } from '../src/tree-occurrence-classification-runtime-execution-contract.logic.mjs';
 import { getBuiltinStructuralHomesRegistry } from '../src/registries/tree-structural-homes-registry.logic.mjs';
 import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kinds-registry.logic.mjs';
+import { getBuiltinTreeRepoShapePolicy } from '../src/registries/tree-repo-shape-policy-registry.logic.mjs';
+import { getBuiltinSemanticNamingFolderTypeRelationshipsRegistry } from '../src/registries/tree-semantic-naming-folder-type-relationships-registry.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
 import { listRegisteredValidators } from '../../src/core/validator-registry.knowledge.mjs';
 import { getValidatorScopeProfile } from '../../src/core/validator-scopes.logic.mjs';
@@ -457,7 +460,7 @@ test('tree-structure-advisor wiring prepares semantic-home evidence using naming
     assert.deepEqual(preparedInputs.preparedDependencies.treeSemanticHomeEvidence, expectedSemanticHomeEvidence);
     assert.equal(
       preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords.some((record) => record.path === 'src'),
-      true,
+      false,
     );
     assert.equal(
       preparedInputs.preparedDependencies.treeSemanticHomeEvidence.evidenceRecords.some(
@@ -488,6 +491,83 @@ test('tree-structure-advisor wiring prepares semantic-home evidence using naming
   } finally {
     await fs.rm(fixtureDir, { recursive: true, force: true });
   }
+});
+
+
+
+test('tree semantic naming folder-type relationship classifies only repository-top family roots through Naming evidence', () => {
+  const addressedOccurrenceRecords = [
+    { addressPath: 'A.1', parentAddressPath: null, path: 'src', resolvedPath: 'src', actualName: 'src', name: 'src', occurrenceType: 'folder' },
+    { addressPath: 'A.2', parentAddressPath: null, path: 'calculogic-validator', resolvedPath: 'calculogic-validator', actualName: 'calculogic-validator', name: 'calculogic-validator', occurrenceType: 'folder' },
+    { addressPath: 'A.2.1', parentAddressPath: 'A.2', path: 'calculogic-validator/tree', resolvedPath: 'calculogic-validator/tree', actualName: 'tree', name: 'tree', occurrenceType: 'folder' },
+    { addressPath: 'A.2.1.1', parentAddressPath: 'A.2.1', path: 'calculogic-validator/tree/src', resolvedPath: 'calculogic-validator/tree/src', actualName: 'src', name: 'src', occurrenceType: 'folder' },
+    { addressPath: 'A.3', parentAddressPath: null, path: 'calculogic-doc-engine', resolvedPath: 'calculogic-doc-engine', actualName: 'calculogic-doc-engine', name: 'calculogic-doc-engine', occurrenceType: 'folder' },
+    { addressPath: 'A.4', parentAddressPath: null, path: 'unmatched-package', resolvedPath: 'unmatched-package', actualName: 'unmatched-package', name: 'unmatched-package', occurrenceType: 'folder' },
+  ];
+  const namingSemanticEvidenceRecords = [
+    { path: 'calculogic-validator', occurrenceType: 'folder', semanticName: 'calculogic-validator', semanticFamily: 'calculogic-validator', familyRoot: 'calculogic' },
+    { path: 'calculogic-validator/tree', occurrenceType: 'folder', semanticName: 'tree', semanticFamily: 'tree', familyRoot: 'tree' },
+    { path: 'calculogic-validator/tree/src', occurrenceType: 'folder', semanticName: 'src', semanticFamily: 'src', familyRoot: 'src' },
+    { path: 'calculogic-doc-engine', occurrenceType: 'folder', semanticName: 'calculogic-doc-engine', semanticFamily: 'calculogic-doc-engine', familyRoot: 'calculogic' },
+  ];
+  const structuralHomeEvidence = prepareTreeStructuralHomeEvidence({
+    addressedOccurrenceRecords,
+    structuralHomesRegistry: getBuiltinStructuralHomesRegistry(),
+  });
+
+  const relationshipEvidence = prepareTreeSemanticNamingFolderTypeRelationshipEvidence({
+    addressedOccurrenceRecords,
+    namingSemanticEvidenceRecords,
+    treeStructuralHomeEvidence: structuralHomeEvidence,
+    treeRepoShapePolicy: getBuiltinTreeRepoShapePolicy(),
+    relationshipsRegistry: getBuiltinSemanticNamingFolderTypeRelationshipsRegistry(),
+  });
+  const semanticHomeEvidence = prepareTreeSemanticHomeEvidence({
+    addressedOccurrenceRecords,
+    namingSemanticEvidenceRecords,
+    treeSemanticNamingFolderTypeRelationshipEvidence: relationshipEvidence,
+  });
+  const folderKindEvidence = prepareTreeFolderKindEvidence({
+    addressedOccurrenceRecords,
+    treeStructuralHomeEvidence: structuralHomeEvidence,
+    treeSemanticHomeEvidence: semanticHomeEvidence,
+    folderKindsRegistry: getBuiltinFolderKindsRegistry(),
+  });
+  const replacementRuntime = prepareTreeOccurrenceClassificationReplacementRuntime({
+    treeStructuralHomeEvidence: structuralHomeEvidence,
+    treeSemanticHomeEvidence: semanticHomeEvidence,
+    treeFolderKindEvidence: folderKindEvidence,
+    treeRepoShapePolicy: getBuiltinTreeRepoShapePolicy(),
+  });
+  const recordsByPath = Object.fromEntries(replacementRuntime.classifyOccurrenceRecords(addressedOccurrenceRecords).map((record) => [record.path, record]));
+
+  assert.equal(structuralHomeEvidence.evidenceRecords.some((record) => record.path === 'src'), true);
+  assert.equal(structuralHomeEvidence.evidenceRecords.some((record) => record.path === 'calculogic-validator'), false);
+  assert.equal(structuralHomeEvidence.evidenceRecords.some((record) => record.path === 'calculogic-doc-engine'), false);
+  assert.deepEqual(relationshipEvidence.relationshipRecords.map((record) => record.path), ['calculogic-validator', 'calculogic-doc-engine']);
+  assert.equal(relationshipEvidence.relationshipRecords.every((record) => record.relationshipPerspective === 'semantic-repository-top-family-home'), true);
+  assert.equal(
+    JSON.stringify(getBuiltinSemanticNamingFolderTypeRelationshipsRegistry()).includes('calculogic-validator'),
+    false,
+  );
+  assert.equal(
+    JSON.stringify(getBuiltinSemanticNamingFolderTypeRelationshipsRegistry()).includes('calculogic-doc-engine'),
+    false,
+  );
+  assert.equal(recordsByPath.src.structuralClass, 'repo-top-structural-root');
+  assert.equal(recordsByPath.src.isStructuralRoot, true);
+  assert.equal(recordsByPath['calculogic-validator'].structuralClass, 'repo-top-semantic-root');
+  assert.equal(recordsByPath['calculogic-validator'].isSemanticRoot, true);
+  assert.equal(recordsByPath['calculogic-doc-engine'].structuralClass, 'repo-top-semantic-root');
+  assert.equal(recordsByPath['calculogic-doc-engine'].isSemanticRoot, true);
+  assert.equal(recordsByPath['calculogic-validator/tree'].structuralClass, 'unclassified');
+  assert.equal(recordsByPath['calculogic-validator/tree/src'].structuralClass, 'unclassified');
+  assert.equal(recordsByPath['unmatched-package'].structuralClass, 'unclassified');
+  assert.equal(recordsByPath['unmatched-package'].isRepoShapeAllowedTopLevelDirectory, false);
+  assert.deepEqual(
+    replacementRuntime.collectUnexpectedTopLevelDirectoryNames(['src', 'calculogic-validator', 'calculogic-doc-engine', 'unmatched-package']),
+    ['unmatched-package'],
+  );
 });
 
 test('tree-structure-advisor runtime report output remains unchanged by structural-address handoff presence', async () => {
@@ -701,6 +781,61 @@ test('tree-structure-advisor top-level advisory falls back when ready replacemen
   assert.equal(result.findings[0].path, 'experiments');
   assert.equal(result.findings[0].code, 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER');
   assert.equal(result.totalFilesScanned, 0);
+});
+
+
+
+test('tree-structure-advisor ready route keeps semantic package roots non-unexpected through active classification', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-semantic-ready-route-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await fs.mkdir(path.join(fixtureDir, 'unmatched-package'), { recursive: true });
+    await fs.writeFile(path.join(fixtureDir, 'unmatched-package', 'index.logic.mjs'), 'export const unmatched = true\n', 'utf8');
+
+    const namingSemanticFamilyBridge = {
+      observations: [
+        { path: 'calculogic-validator', occurrenceType: 'folder', semanticName: 'calculogic-validator', semanticFamily: 'calculogic-validator', familyRoot: 'calculogic' },
+        { path: 'calculogic-doc-engine', occurrenceType: 'folder', semanticName: 'calculogic-doc-engine', semanticFamily: 'calculogic-doc-engine', familyRoot: 'calculogic' },
+      ],
+    };
+
+    const preparedInputs = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'repo', namingSemanticFamilyBridge });
+    const classificationsByPath = Object.fromEntries(
+      preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime
+        .classifyOccurrenceRecords(preparedInputs.structuralAddressSnapshot.occurrenceRecords)
+        .filter((record) => record.occurrenceType === 'folder')
+        .map((record) => [record.path, record]),
+    );
+
+    assert.equal(classificationsByPath.src.structuralClass, 'repo-top-structural-root');
+    assert.equal(classificationsByPath['calculogic-validator'].structuralClass, 'repo-top-semantic-root');
+    assert.equal(classificationsByPath['calculogic-doc-engine'].structuralClass, 'repo-top-semantic-root');
+    assert.equal(classificationsByPath['calculogic-validator'].isRepoShapeAllowedTopLevelDirectory, true);
+    assert.equal(classificationsByPath['calculogic-doc-engine'].isRepoShapeAllowedTopLevelDirectory, true);
+    assert.equal(classificationsByPath['unmatched-package'].structuralClass, 'unclassified');
+
+    const fallbackUnexpected = preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime
+      .collectUnexpectedTopLevelDirectoryNames(preparedInputs.topLevelDirectoryNames);
+    assert.deepEqual(fallbackUnexpected, ['unmatched-package']);
+
+    const readyInputs = {
+      ...preparedInputs,
+      preparedDependencies: {
+        ...preparedInputs.preparedDependencies,
+        treeOccurrenceClassificationRuntimeExecutionContract: READY_OCCURRENCE_CLASSIFICATION_EXECUTION_CONTRACT,
+        treeOccurrenceClassificationReplacementReadiness: READY_OCCURRENCE_CLASSIFICATION_REPLACEMENT_READINESS,
+      },
+    };
+    const readyResult = runTreeStructureAdvisorRuntime(readyInputs);
+    const unexpectedTopLevelPaths = readyResult.findings
+      .filter((finding) => finding.code === 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER')
+      .map((finding) => finding.path);
+
+    assert.deepEqual(unexpectedTopLevelPaths, ['unmatched-package']);
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
 });
 
 test('tree-structure-advisor non-empty structural-home repo-top folder remains unexpected when repo-shape disallows it', async () => {

--- a/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
+++ b/calculogic-validator/tree/test/tree-structure-advisor.test.mjs
@@ -29,8 +29,10 @@ import { getBuiltinFolderKindsRegistry } from '../src/registries/tree-folder-kin
 import { getBuiltinTreeRepoShapePolicy } from '../src/registries/tree-repo-shape-policy-registry.logic.mjs';
 import { getBuiltinSemanticNamingFolderTypeRelationshipsRegistry } from '../src/registries/tree-semantic-naming-folder-type-relationships-registry.logic.mjs';
 import { prepareNamingSemanticEvidenceBridge } from '../../naming/src/naming-semantic-evidence-bridge.logic.mjs';
+import { runNamingValidator, projectNamingSemanticFamilyBridge } from '../../naming/src/naming-validator.wiring.mjs';
 import { listRegisteredValidators } from '../../src/core/validator-registry.knowledge.mjs';
 import { getValidatorScopeProfile } from '../../src/core/validator-scopes.logic.mjs';
+import { runValidatorRunner } from '../../src/core/validator-runner.logic.mjs';
 
 const writeJson = async (filePath, value) => {
   await fs.writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
@@ -340,8 +342,11 @@ test('tree-structure-advisor wiring carries neutral structural-address snapshot 
       preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime.source,
       expectedOccurrenceClassificationReplacementRuntime.source,
     );
+    const omitClassificationExplanation = (records) => records.map(({ classificationExplanation: _classificationExplanation, ...record }) => record);
     assert.deepEqual(
-      preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime.classifyOccurrenceRecords(snapshot.occurrenceRecords),
+      omitClassificationExplanation(
+        preparedInputs.preparedDependencies.treeOccurrenceClassificationReplacementRuntime.classifyOccurrenceRecords(snapshot.occurrenceRecords),
+      ),
       expectedOccurrenceClassificationReplacementRuntime.classifyOccurrenceRecords(snapshot.occurrenceRecords),
     );
     const runtimeExecutionContract = preparedInputs.preparedDependencies.treeOccurrenceClassificationRuntimeExecutionContract;
@@ -505,10 +510,10 @@ test('tree semantic naming folder-type relationship classifies only repository-t
     { addressPath: 'A.4', parentAddressPath: null, path: 'unmatched-package', resolvedPath: 'unmatched-package', actualName: 'unmatched-package', name: 'unmatched-package', occurrenceType: 'folder' },
   ];
   const namingSemanticEvidenceRecords = [
-    { path: 'calculogic-validator', occurrenceType: 'folder', semanticName: 'calculogic-validator', semanticFamily: 'calculogic-validator', familyRoot: 'calculogic' },
+    { path: 'calculogic-validator', occurrenceType: 'folder', semanticName: 'calculogic-validator', semanticFamily: 'calculogic-validator', familyRoot: 'calculogic', semanticEvidenceKind: 'semantic-family-root-folder', familyRootQualification: 'package-root-folder' },
     { path: 'calculogic-validator/tree', occurrenceType: 'folder', semanticName: 'tree', semanticFamily: 'tree', familyRoot: 'tree' },
     { path: 'calculogic-validator/tree/src', occurrenceType: 'folder', semanticName: 'src', semanticFamily: 'src', familyRoot: 'src' },
-    { path: 'calculogic-doc-engine', occurrenceType: 'folder', semanticName: 'calculogic-doc-engine', semanticFamily: 'calculogic-doc-engine', familyRoot: 'calculogic' },
+    { path: 'calculogic-doc-engine', occurrenceType: 'folder', semanticName: 'calculogic-doc-engine', semanticFamily: 'calculogic-doc-engine', familyRoot: 'calculogic', semanticEvidenceKind: 'semantic-family-root-folder', familyRootQualification: 'package-root-folder' },
   ];
   const structuralHomeEvidence = prepareTreeStructuralHomeEvidence({
     addressedOccurrenceRecords,
@@ -568,6 +573,24 @@ test('tree semantic naming folder-type relationship classifies only repository-t
     replacementRuntime.collectUnexpectedTopLevelDirectoryNames(['src', 'calculogic-validator', 'calculogic-doc-engine', 'unmatched-package']),
     ['unmatched-package'],
   );
+
+  const missingNamingRelationshipEvidence = prepareTreeSemanticNamingFolderTypeRelationshipEvidence({
+    addressedOccurrenceRecords,
+    namingSemanticEvidenceRecords: [],
+    treeStructuralHomeEvidence: structuralHomeEvidence,
+    treeRepoShapePolicy: getBuiltinTreeRepoShapePolicy(),
+    relationshipsRegistry: getBuiltinSemanticNamingFolderTypeRelationshipsRegistry(),
+  });
+  const missingReasonsByPath = Object.fromEntries(
+    missingNamingRelationshipEvidence.unclassifiedRelationshipRecords.map((record) => [
+      record.path,
+      record.classificationExplanation.reason,
+    ]),
+  );
+
+  assert.equal(missingReasonsByPath['calculogic-validator'], 'missing-required-naming-observation');
+  assert.equal(missingReasonsByPath['calculogic-validator/tree'], 'non-repository-top-descendant');
+  assert.equal(missingReasonsByPath['unmatched-package'], 'unknown-or-unmodeled-folder-relationship');
 });
 
 test('tree-structure-advisor runtime report output remains unchanged by structural-address handoff presence', async () => {
@@ -785,6 +808,59 @@ test('tree-structure-advisor top-level advisory falls back when ready replacemen
 
 
 
+
+
+test('tree-structure-advisor runner staging receives addressed Naming package-root observations', async () => {
+  const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-runner-package-root-'));
+
+  try {
+    await writeBaseFixtureRepo(fixtureDir);
+    await writeJson(path.join(fixtureDir, 'calculogic-validator', 'package.json'), { name: '@calculogic/validator' });
+    await writeJson(path.join(fixtureDir, 'calculogic-doc-engine', 'package.json'), { name: '@calculogic/doc-engine' });
+    await fs.mkdir(path.join(fixtureDir, 'unmatched-package'), { recursive: true });
+    await fs.writeFile(path.join(fixtureDir, 'unmatched-package', 'index.logic.mjs'), 'export const unmatched = true\n', 'utf8');
+
+    const runnerReport = runValidatorRunner(fixtureDir, {
+      scope: 'repo',
+      validators: ['tree-structure-advisor'],
+    });
+    const treeReport = runnerReport.validators.find((entry) => entry.id === 'tree-structure-advisor');
+    const unexpectedTopLevelPaths = treeReport.findings
+      .filter((finding) => finding.code === 'TREE_UNEXPECTED_TOP_LEVEL_FOLDER')
+      .map((finding) => finding.path);
+
+    assert.deepEqual(unexpectedTopLevelPaths, ['unmatched-package']);
+
+    const namingResult = runNamingValidator(fixtureDir, { scope: 'repo' });
+    const namingSemanticFamilyBridge = projectNamingSemanticFamilyBridge(namingResult);
+    assert.deepEqual(
+      namingSemanticFamilyBridge.observations
+        .filter((observation) => observation.semanticEvidenceKind === 'semantic-family-root-folder')
+        .map((observation) => [observation.path, observation.familyRootQualification]),
+      [
+        ['calculogic-doc-engine', 'package-root-folder'],
+        ['calculogic-validator', 'package-root-folder'],
+      ],
+    );
+
+    const preparedInputs = prepareTreeStructureAdvisorInputs(fixtureDir, { scope: 'repo', namingSemanticFamilyBridge });
+    const addressedFolderObservations = preparedInputs.preparedDependencies.addressedNamingSemanticEvidenceBridge.observations
+      .filter((observation) => observation.semanticEvidenceKind === 'semantic-family-root-folder');
+
+    assert.equal(addressedFolderObservations.every((observation) => observation.occurrenceAddress), true);
+    assert.deepEqual(
+      preparedInputs.preparedDependencies.treeSemanticNamingFolderTypeRelationshipEvidence.relationshipRecords
+        .map((record) => [record.path, record.relationshipPerspective, record.familyRootQualification]),
+      [
+        ['calculogic-doc-engine', 'semantic-repository-top-family-home', 'package-root-folder'],
+        ['calculogic-validator', 'semantic-repository-top-family-home', 'package-root-folder'],
+      ],
+    );
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test('tree-structure-advisor ready route keeps semantic package roots non-unexpected through active classification', async () => {
   const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tree-structure-semantic-ready-route-'));
 
@@ -795,8 +871,8 @@ test('tree-structure-advisor ready route keeps semantic package roots non-unexpe
 
     const namingSemanticFamilyBridge = {
       observations: [
-        { path: 'calculogic-validator', occurrenceType: 'folder', semanticName: 'calculogic-validator', semanticFamily: 'calculogic-validator', familyRoot: 'calculogic' },
-        { path: 'calculogic-doc-engine', occurrenceType: 'folder', semanticName: 'calculogic-doc-engine', semanticFamily: 'calculogic-doc-engine', familyRoot: 'calculogic' },
+        { path: 'calculogic-validator', occurrenceType: 'folder', semanticName: 'calculogic-validator', semanticFamily: 'calculogic-validator', familyRoot: 'calculogic', semanticEvidenceKind: 'semantic-family-root-folder', familyRootQualification: 'package-root-folder' },
+        { path: 'calculogic-doc-engine', occurrenceType: 'folder', semanticName: 'calculogic-doc-engine', semanticFamily: 'calculogic-doc-engine', familyRoot: 'calculogic', semanticEvidenceKind: 'semantic-family-root-folder', familyRootQualification: 'package-root-folder' },
       ],
     };
 


### PR DESCRIPTION
### Motivation
- Implement the Tree-owned relationship perspective requested by issue #670 to interpret Naming-owned semantic-family-root evidence against repository-top folder context. 
- Replace the retired approach of a Tree-owned semantic-home registry (PR #671 direction) with a relationship rule that expresses conventions, not named semantic-home facts. 
- Preserve Naming ownership of semantic identity while letting Tree own the folder-to-naming relationship interpretation, and keep repo-shape allowance distinct from classification. 
- Runtime authority: treated `calculogic-validator/doc/ValidatorSpecs/tree-structure-advisor-validator.spec.md` and `calculogic-validator/doc/ConventionRoutines/ValidatorLoaderConverterRuntimeOwnership-Contract.md` as runtime/spec authority; treated `tree-documentation-map-and-reorg-inventory.md` as navigation-only and other referenced validator docs as task-scoped supporting context. 

### Description
- Added a Tree-owned relationship registry and loader at `calculogic-validator/tree/src/registries/_builtin/semantic-naming-folder-type-relationships.registry.json` and `tree-semantic-naming-folder-type-relationships-registry.logic.mjs` that encodes relationship conventions only (no named semantic homes). 
- Implemented the relationship resolver `tree-semantic-naming-folder-type-relationship.logic.mjs` which evaluates the first active perspective `semantic-family-root + repository-top-folder + not-structural-home + allowed-top-level-directory -> semantic-repository-top-family-home`. 
- Wired the relationship evidence into the Tree runtime path by preparing relationship evidence in `tree-structure-advisor.wiring.mjs`, feeding it to `prepareTreeSemanticHomeEvidence`, then into `prepareTreeFolderKindEvidence` and the occurrence-classification replacement runtime. 
- Adjusted `tree-semantic-home-evidence.logic.mjs` and `tree-occurrence-classification.logic.mjs` to consume relationship evidence and to preserve the distinction between repo-shape allowance and classification; removed `calculogic-validator` and `calculogic-doc-engine` from `structural-homes.registry.json` per migration requirement. 
- Added a focused test surface and assertions in `calculogic-validator/tree/test/tree-structure-advisor.test.mjs` (and kept/updated related unit tests) covering repo-top semantic roots, retained structural `src`, descendant non-repo-top folders remaining unclassified, unmatched folder behavior, and both fallback and ready/classified unexpected-top-level routes. 
- Updated the Tree validator spec (`tree-structure-advisor-validator.spec.md`) to document that Naming owns semantic identity, Tree owns the interpretation relationship, and repo-shape allowance remains separate from classification. 

### Testing
- Ran `git diff --check` and confirmed no whitespace/format errors (passed). 
- Ran the unit tests via: `node --test calculogic-validator/tree/test/tree-semantic-home-evidence.logic.test.mjs calculogic-validator/tree/test/tree-occurrence-classification.test.mjs calculogic-validator/tree/test/tree-structure-advisor.test.mjs calculogic-validator/tree/test/tree-naming-occurrence-intake.test.mjs calculogic-validator/naming/test/naming-semantic-evidence-bridge.logic.test.mjs` and verified they passed. 
- Ran the validator suite check: `npm run validate:tree -- --scope=validator` and verified it completed successfully (it reported the repository advisory findings that are part of existing validator behavior but exited without error). 
- Result summary: all added/modified Tree unit tests and the `validate:tree` run passed; the change set enforces the relationship-based semantic repo-top behavior and the two incorrect structural-home entries were removed as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c628bee3c83318c8d22505932dd33)